### PR TITLE
[Driver] - jobFinished method now emits to stderr

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -51,11 +51,10 @@ public struct ToolExecutionDelegate: JobExecutorDelegate {
   public func jobFinished(job: Job, result: ProcessResult, pid: Int) {
     switch mode {
     case .regular, .verbose:
-      // FIXME: Check what the current driver does.
       let output = (try? result.utf8Output() + result.utf8stderrOutput()) ?? ""
       if !output.isEmpty {
-        stdoutStream <<< output
-        stdoutStream.flush()
+        stderrStream <<< output
+        stderrStream.flush()
       }
 
     case .parsableOutput:


### PR DESCRIPTION
Update `jobFinished(job:result:pid:)` method to emit output to `stderr` instead of `stdout`.

This reflects the implementation of the current Driver as we can see [here](https://github.com/apple/swift/blob/d930599394b27fcac77a90b63e23372c6b31cd7a/lib/Driver/Compilation.cpp#L594)

