### PR TITLE
Keep xcrunFind on DarwinToolchain only

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -15,10 +15,12 @@ fileprivate func envVarName(forExecutable toolName: String) -> String {
   return "SWIFT_DRIVER_\(toolName.uppercased())_EXEC"
 }
 
-// FIXME: This should be in DarwinToolchain, but GenericUnixToolchain is
-// currently using it too for some reason.
-extension Toolchain {
-  /// Utility function to lookup an executable using xcrun.
+/// Toolchain for Darwin-based platforms, such as macOS and iOS.
+///
+/// FIXME: This class is not thread-safe.
+public final class DarwinToolchain: Toolchain {
+  public let env: [String: String]
+
   func xcrunFind(exec: String) throws -> AbsolutePath {
     if let overrideString = env[envVarName(forExecutable: exec)] {
       return try AbsolutePath(validating: overrideString)
@@ -35,14 +37,7 @@ extension Toolchain {
     return AbsolutePath("/usr/bin/" + exec)
   #endif
   }
-}
 
-/// Toolchain for Darwin-based platforms, such as macOS and iOS.
-///
-/// FIXME: This class is not thread-safe.
-public final class DarwinToolchain: Toolchain {
-  public let env: [String: String]
-  
   /// Retrieve the absolute path for a given tool.
   public func getToolPath(_ tool: Tool) throws -> AbsolutePath {
     switch tool {

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -34,7 +34,7 @@ public final class GenericUnixToolchain: Toolchain {
     // If we happen to be on a macOS host, some tools might not be in our
     // PATH, so we'll just use xcrun to find them too.
     #if os(macOS)
-    return try xcrunFind(exec: exec)
+    return try DarwinToolchain(env: self.env).xcrunFind(exec: exec)
     #else
     throw Error.unableToFind(tool: exec)
     #endif


### PR DESCRIPTION
Hi, this is my first pull request to this repo, so I'm not 100 % sure what direction you guys want everything to go in. Let me know of any changes you want.

This change removes xcrunFind from Toolchain, and only keeps it on
DarwinToolchain. There is a special case on GenericUnixToolchain where
we check if we are on macOS, and if so we use xcrunFind. This change
solves that by initializing a new DarwinToolchain to return the correct
path.