### PR TITLE
Diagnose -i arg

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -688,8 +688,7 @@ extension Driver {
         compilerOutputType = nil
 
       case .i:
-        // FIXME: diagnose this
-        break
+        diagnosticsEngine.emit(.error_i_mode(driverKind))
 
       case .repl, .deprecatedIntegratedRepl, .lldbRepl:
         compilerOutputType = nil
@@ -704,6 +703,17 @@ extension Driver {
     }
 
     return (compilerOutputType, linkerOutputType)
+  }
+}
+
+extension Diagnostic.Message {
+  public static func error_i_mode(_ driverKind: DriverKind) -> Diagnostic.Message {
+    .error(
+      """
+      the flag '-i' is no longer required and has been removed;
+      use '\(driverKind.usage) input-filename'
+      """
+    )
   }
 }
 

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -710,7 +710,7 @@ extension Diagnostic.Message {
   public static func error_i_mode(_ driverKind: DriverKind) -> Diagnostic.Message {
     .error(
       """
-      the flag '-i' is no longer required and has been removed;
+      the flag '-i' is no longer required and has been removed; \
       use '\(driverKind.usage) input-filename'
       """
     )

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -142,6 +142,12 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(driver3.linkerOutputType, .staticLibrary)
   }
 
+  func testPrimaryOutputKindsDiagnostics() throws {
+      try assertDriverDiagnostics(args: "swift", "-i") {
+          $1.expect(.error_i_mode(.interactive))
+      }
+  }
+
   func testDebugSettings() throws {
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module") { driver in
       XCTAssertNil(driver.debugInfoLevel)


### PR DESCRIPTION
Addresses [this FIXME](https://github.com/apple/swift-driver/blob/1e1c30534eb6af42bf66763c5ed6d918e2f56a60/Sources/SwiftDriver/Driver/Driver.swift#L691). 

I created a new test for this as the assert didn't seem to fit into `testPrimaryOutputKinds`, but I'll of course change it if desired.

I'm not exactly sure if `DriverKind.usage` should be used here, but the values seem to correspond to [this code](https://github.com/apple/swift/blob/d930599394b27fcac77a90b63e23372c6b31cd7a/lib/Driver/Driver.cpp#L95) in the original driver.