### PR TITLE
[Driver] - Tokenization for response files

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -313,7 +313,7 @@ extension Driver {
     if line.isEmpty { return nil }
     
     // Support double dash comments only if they start at the beginning of a line.
-    if line.first == "/", line.count > 1, line[line.index(after: line.startIndex)] == "/" { return nil }
+    if line.hasPrefix("//") { return nil }
     
     var result: String = ""
     /// Indicates if we just parsed an escaping backslash.

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -344,7 +344,7 @@ extension Driver {
   /// - Parameter content: response file's content to be tokenized.
   private static func tokenizeResponseFile(_ content: String) -> [String] {
     return content
-      .split(separator: "\n").map { $0 }
+      .split(separator: "\n")
       .compactMap { tokenizeResponseFileLine($0) }
   }
   

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -348,19 +348,20 @@ extension Driver {
       .map { tokenizeResponseFileLine($0) }
       .filter { !$0.isEmpty }
   }
-    
+  
+  /// Recursively expands the response files.
+  /// - Parameter visitedResponseFiles: Set containing visited response files to detect recursive parsing.
   private static func expandResponseFiles(
     _ args: [String],
     diagnosticsEngine: DiagnosticsEngine,
     visitedResponseFiles: inout Set<AbsolutePath>
   ) throws -> [String] {
-    // FIXME: This is very very prelimary. Need to look at how Swift compiler expands response file.
-
     var result: [String] = []
 
     // Go through each arg and add arguments from response files.
     for arg in args {
       if arg.first == "@", let responseFile = try? AbsolutePath(validating: String(arg.dropFirst())) {
+        // Guard against infinity parsing loop.
         guard visitedResponseFiles.insert(responseFile).inserted else {
           diagnosticsEngine.emit(.warn_recursive_response_file(responseFile))
           continue


### PR DESCRIPTION
This PR tries to address the "Implement proper tokenization for response files" to-do item that is on the README.

**Now we can correctly parse:**

- Double slash comments.
- Quotes.
- Escaping characters.
- Espaces.
 
This matches the current behavior of the [LLVM tokenization method](https://llvm.org/doxygen/namespacellvm_1_1cl.html#ac14be339a38954dac57ac3352c948c1f) _(the Swift compiler is currently using the LLVM method)._

Also, after reading LLVM's [ExpandResponseFiles method](https://llvm.org/doxygen/namespacellvm_1_1cl.html#a80bb7b995361b8d2c104983f15cf06a0), I think our current implementation has all we need.

_Note:_ we need to update this implementation once we get Windows support. 

_For "documentation" purposes_
What are `Response files`? Files that contains a list of command line arguments.
For more info search for "response files" in [this document](https://buildmedia.readthedocs.org/media/pdf/argo/latest/argo.pdf)