### PR TITLE
Add Linux docker for debugging info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ $ SWIFT_DRIVER_ENABLE_INTEGRATION_TESTS=1 \
   swift test --parallel
 ```
 
+#### Preparing a Linux docker for debug
+
+When developing on macOS without quick access to a Linux machine, using a Linux Docker is often helpful when debugging.
+
+To get a docker up and running to the following:
+- Install Docker for Mac.
+- Get the newest swift docker image `docker pull swift`.
+- Run the following command to start a docker
+```
+$ docker run -v /path/to/swift-driver:/home/swift-driver \
+  --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+  --security-opt apparmor=unconfined -it swift:latest bash
+```
+- Install dependencies by running
+```
+$ apt-get update
+$ apt-get install libsqlite3-dev
+$ apt-get install libncurses-dev
+```
+- You can now go to `/home/swift-driver` and run `swift test --parallel` to run your tests.
+
+
 ### Rebuilding `Options.swift`
 
 `Options.swift`, which contains the complete set of options that can be parsed by the driver, is automatically generated from the [option tables in the Swift compiler](https://github.com/apple/swift/tree/master/include/swift/Option). If you need to regenerate `Options.swift`, you will need to [build the Swift compiler](https://github.com/apple/swift#building-swift) and then build `makeOptions` program with a `-I` that allows the generated `Options.inc` to


### PR DESCRIPTION
I'm not sure what policies you have regarding adding this type of information to your README, however using Docker for running my tests on Linux was very helpful for me, so I thought I'ld add it to the readme.

This commit adds a short paragraph explaining how to create a quick and
easy Docker for testing your changes in a Linux environment when you
don't have an easy access to a Linux device.