### PR TITLE
Remove unnecessary linux skip for test

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -887,11 +887,8 @@ final class SwiftDriverTests: XCTestCase {
   }
   
   func testToolchainUtilities() throws {
-    // FIXME: This doesn't work on Linux.
-  #if os(macOS)
     let swiftVersion = try DarwinToolchain(env: ProcessEnv.vars).swiftCompilerVersion()
     assertString(swiftVersion, contains: "Swift version ")
-  #endif
   }
 }
 


### PR DESCRIPTION
I looked for low-haning Linux tests to fix since I was already in that sphere, and I saw this test. It ran fine on my system. Better to have it run on Linux since it can! :)