### PR TITLE
Internalize diagnostics

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -160,7 +160,7 @@ fileprivate extension CompilerMode {
   }
 }
 
-public extension Diagnostic.Message {
+extension Diagnostic.Message {
   static var warning_incremental_requires_output_file_map: Diagnostic.Message {
     .warning("ignoring -incremental (currently requires an output file map)")
   }

--- a/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
@@ -169,7 +169,7 @@ public extension InputInfoMap {
 }
 
 
-public extension Diagnostic.Message {
+extension Diagnostic.Message {
   static func remark_could_not_read_build_record(_ error: Error) -> Diagnostic.Message {
     .remark("Incremental compilation could not read build record: \(error.localizedDescription).")
   }

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -14,31 +14,31 @@ import TSCBasic
 public typealias Diagnostic = TSCBasic.Diagnostic
 
 extension Diagnostic.Message {
-  public static var error_static_emit_executable_disallowed: Diagnostic.Message {
+  static var error_static_emit_executable_disallowed: Diagnostic.Message {
     .error("-static may not be used with -emit-executable")
   }
 
-  public static func error_option_missing_required_argument(option: Option, requiredArg: Option) -> Diagnostic.Message {
+  static func error_option_missing_required_argument(option: Option, requiredArg: Option) -> Diagnostic.Message {
     .error("option '\(option.spelling)' is missing a required argument (\(requiredArg.spelling))")
   }
 
-  public static func error_invalid_arg_value(arg: Option, value: String) -> Diagnostic.Message {
+  static func error_invalid_arg_value(arg: Option, value: String) -> Diagnostic.Message {
     .error("invalid value '\(value)' in '\(arg.spelling)'")
   }
 
-  public static func error_argument_not_allowed_with(arg: String, other: String) -> Diagnostic.Message {
+  static func error_argument_not_allowed_with(arg: String, other: String) -> Diagnostic.Message {
     .error("argument '\(arg)' is not allowed with '\(other)'")
   }
 
-  public static func error_unsupported_opt_for_target(arg: String, target: Triple) -> Diagnostic.Message {
+  static func error_unsupported_opt_for_target(arg: String, target: Triple) -> Diagnostic.Message {
     .error("unsupported option '\(arg)' for target '\(target.triple)'")
   }
 
-  public static var error_mode_cannot_emit_module: Diagnostic.Message {
+  static var error_mode_cannot_emit_module: Diagnostic.Message {
     .error("this mode does not support emitting modules")
   }
 
-  public static func error_bad_module_name(
+  static func error_bad_module_name(
     moduleName: String,
     explicitModuleName: Bool
   ) -> Diagnostic.Message {
@@ -52,7 +52,7 @@ extension Diagnostic.Message {
     return .error("module name \"\(moduleName)\" is not a valid identifier\(suffix)")
   }
 
-  public static func error_stdlib_module_name(
+  static func error_stdlib_module_name(
     moduleName: String,
     explicitModuleName: Bool
   ) -> Diagnostic.Message {
@@ -66,11 +66,11 @@ extension Diagnostic.Message {
     return .error("module name \"\(moduleName)\" is reserved for the standard library\(suffix)")
   }
 
-  public static func warning_no_such_sdk(_ path: String) -> Diagnostic.Message {
+  static func warning_no_such_sdk(_ path: String) -> Diagnostic.Message {
     .warning("no such SDK: \(path)")
   }
 
-  public static func error_unknown_target(_ target: String) -> Diagnostic.Message {
+  static func error_unknown_target(_ target: String) -> Diagnostic.Message {
     .error("unknown target '\(target)'")
   }
 }

--- a/Tests/SwiftDriverTests/AssertDiagnosticsTests.swift
+++ b/Tests/SwiftDriverTests/AssertDiagnosticsTests.swift
@@ -113,26 +113,26 @@ class AssertDiagnosticsTests: FailableTestCase {
     try assertNoDriverDiagnostics(args: "swiftc", "test.swift")
     
     try assertDriverDiagnostics(args: "swiftc", "test.swift") { driver, verify in
-      driver.diagnosticEngine.emit(.error_mode_cannot_emit_module)
-      verify.expect(.error_mode_cannot_emit_module)
+      driver.diagnosticEngine.emit(.error("this mode does not support emitting modules"))
+      verify.expect(.error("this mode does not support emitting modules"))
     }
     
     try assertFails {
       try assertDriverDiagnostics(args: "swiftc", "test.swift") { driver, verify in
-        verify.expect(.error_mode_cannot_emit_module)
+        verify.expect(.error("this mode does not support emitting modules"))
       }
     }
     
     try assertFails {
       try assertDriverDiagnostics(args: "swiftc", "test.swift") { driver, verify in
-        driver.diagnosticEngine.emit(.error_mode_cannot_emit_module)
+        driver.diagnosticEngine.emit(.error("this mode does not support emitting modules"))
       }
     }
     
     try assertFails(times: 2) {
       try assertDriverDiagnostics(args: "swiftc", "test.swift") { driver, verify in
-        driver.diagnosticEngine.emit(.error_mode_cannot_emit_module)
-        verify.expect(.error_static_emit_executable_disallowed)
+        driver.diagnosticEngine.emit(.error("this mode does not support emitting modules"))
+        verify.expect(.error("-static may not be used with -emit-executable"))
       }
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -178,7 +178,7 @@ final class SwiftDriverTests: XCTestCase {
     func testMultithreadingDiagnostics() throws {
 
       try assertDriverDiagnostics(args: "swift", "-num-threads", "-1") {
-        $1.expect(.error_invalid_arg_value(arg: .numThreads, value: "-1"))
+        $1.expect(.error("invalid value '-1' in '-num-threads'"))
       }
 
       try assertDriverDiagnostics(args: "swiftc", "-enable-batch-mode", "-num-threads", "4") {
@@ -186,7 +186,7 @@ final class SwiftDriverTests: XCTestCase {
       }
 
       try assertDriverDiagnostics(args: "swiftc", "-j", "0") {
-        $1.expect(.error_invalid_arg_value(arg: .j, value: "0"))
+        $1.expect(.error("invalid value '0' in '-j'"))
       }
 
       try assertDriverDiagnostics(
@@ -267,7 +267,7 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-library", "-o", "libWibble.so", "-module-name", "Swift") {
-      $1.expect(.error_stdlib_module_name(moduleName: "Swift", explicitModuleName: true))
+        $1.expect(.error("module name \"Swift\" is reserved for the standard library"))
     }
   }
   


### PR DESCRIPTION
Based on previous discussion, this makes all diagnostics declared in the project internal. Tests now compare the message strings directly.

Do we want to move the various extensions of `Diagnostic.Message` to `Diagnostics.swift`? Right now, they are sprinkled into various files based on relevance, but in `Driver.swift` there are now 5 separate extensions.