### PR TITLE
[Parseable output] Use FileType's description for the file type.

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -32,7 +32,7 @@ public struct ToolExecutionDelegate: JobExecutorDelegate {
 
       // Compute the outputs for the message.
       let outputs: [BeganMessage.Output] = job.outputs.map {
-        .init(path: $0.file.name, type: $0.type.rawValue)
+        .init(path: $0.file.name, type: $0.type.description)
       }
 
       let beganMessage = BeganMessage(

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -111,7 +111,7 @@ extension FileType: CustomStringConvertible {
     switch self {
     case .swift, .sil, .sib, .image, .object, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .assembly,
-         .diagnostics, .remap, .tbd, .pcm, .pch:
+         .remap, .tbd, .pcm, .pch:
       return rawValue
 
     case .ast:
@@ -146,6 +146,9 @@ extension FileType: CustomStringConvertible {
 
     case .optimizationRecord:
       return "opt-record"
+
+    case .diagnostics:
+      return "diagnostics"
     }
   }
 }


### PR DESCRIPTION
`FileType.description` provides the "external" name for each file type,
which is used for parsable output and output file maps, among other
things. Fix the description for serialized diagnostics files... so now
diagnostics show up properly in Xcode.