### PR TITLE
[Lint] Remove unused declarations and imports

### DIFF
--- a/Sources/SwiftDriver/Execution/ParsableOutput.swift
+++ b/Sources/SwiftDriver/Execution/ParsableOutput.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 
 import Foundation
 

--- a/Sources/SwiftDriver/Execution/llbuild.swift
+++ b/Sources/SwiftDriver/Execution/llbuild.swift
@@ -12,12 +12,7 @@
 
 // FIXME: This is directly copied from SwiftPM, consider moving this to llbuild.
 
-// We either export the llbuildSwift shared library or the llbuild framework.
-#if canImport(llbuildSwift)
 @_exported import llbuildSwift
-#else
-@_exported import llbuild
-#endif
 
 import Foundation
 

--- a/Sources/SwiftDriver/Execution/llbuild.swift
+++ b/Sources/SwiftDriver/Execution/llbuild.swift
@@ -15,7 +15,6 @@
 // We either export the llbuildSwift shared library or the llbuild framework.
 #if canImport(llbuildSwift)
 @_exported import llbuildSwift
-@_exported import llbuild
 #else
 @_exported import llbuild
 #endif

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 import Foundation
 
 // FIXME: rename to something like IncrementalCompilationInitialState

--- a/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 import Foundation
 @_implementationOnly import Yams
 
@@ -172,8 +171,5 @@ public extension InputInfoMap {
 extension Diagnostic.Message {
   static func remark_could_not_read_build_record(_ error: Error) -> Diagnostic.Message {
     .remark("Incremental compilation could not read build record: \(error.localizedDescription).")
-  }
-  static var remark_incremental_compilation_not_implemented_yet: Diagnostic.Message {
-    .remark("Incremental compilation not implemented yet")
   }
 }

--- a/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
@@ -9,8 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
-import TSCUtility
 import Foundation
 
 public struct InputInfo: Equatable {
@@ -22,8 +20,6 @@ public struct InputInfo: Equatable {
     self.status = status
     self.previousModTime = previousModTime
   }
-
-  static let newlyAdded = Self(status: .newlyAdded, previousModTime: Date.distantFuture)
 }
 
 public extension InputInfo {

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 
 extension Driver {
   mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 
 extension DarwinToolchain {
   private func findARCLiteLibPath() throws -> AbsolutePath? {

--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -9,8 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
-import TSCUtility
 
 extension Driver {
   func generateDSYMJob(inputs: [TypedVirtualPath]) throws -> Job {

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 
 extension GenericUnixToolchain {
   private func defaultLinker(for targetTriple: Triple) -> String? {

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -83,16 +83,6 @@ extension Job: CustomStringConvertible {
   }
 }
 
-/// The type of action.
-enum ActionType {
-  case compile
-  case mergeModule
-  case dynamicLink
-  case generateDSYM
-  case generatePCH
-  case verifyDebugInfo
-}
-
 // MARK: - Job.ArgTemplate + Codable
 
 extension Job.ArgTemplate: Codable {

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 
 extension Driver {
   mutating func mergeModuleJob(inputs allInputs: [TypedVirtualPath]) throws -> Job {

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 
 extension Toolchain {
   // MARK: - Path computation

--- a/Sources/SwiftDriver/Options/OptionTable.swift
+++ b/Sources/SwiftDriver/Options/OptionTable.swift
@@ -24,16 +24,6 @@ public struct OptionTable {
   }()
 }
 
-extension String {
-  fileprivate func canonicalizedForArgName() -> String {
-    var result = self
-    while result.first != nil && result.first! == "-" {
-      result = String(result.dropFirst())
-    }
-    return result.lowercased()
-  }
-}
-
 extension OptionTable {
   /// Print help information to the terminal.
   public func printHelp(usage: String, title: String, includeHidden: Bool) {

--- a/Sources/SwiftDriver/Utilities/DOTJobGraphSerializer.swift
+++ b/Sources/SwiftDriver/Utilities/DOTJobGraphSerializer.swift
@@ -13,7 +13,6 @@ import TSCBasic
 
 /// Serializes the job graph to a .dot file
 public struct DOTJobGraphSerializer {
-  var lines = [String]()
   var kindCounter = [Job.Kind: Int]()
   var hasEmittedStyling = Set<String>()
   let jobs: [Job]

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import TSCBasic
-import TSCUtility
 
 import SwiftDriver
 

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -12,7 +12,6 @@
 import XCTest
 import TSCBasic
 
-import SwiftDriver
 
 #if os(macOS)
 private func bundleRoot() -> AbsolutePath {

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -22,12 +22,6 @@ extension Job.ArgTemplate: ExpressibleByStringLiteral {
 
 class JobCollectingDelegate: JobExecutorDelegate {
   struct StubProcess: ProcessProtocol {
-    static func launchProcess(
-      arguments: [String]
-    ) throws -> ProcessProtocol {
-      return StubProcess()
-    }
-
     var processID: TSCBasic.Process.ProcessID { .init(-1) }
 
     func waitUntilExit() throws -> ProcessResult {

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 import Foundation
-import TSCBasic
 
 import SwiftDriver
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -12,7 +12,6 @@
 import XCTest
 import SwiftDriver
 import TSCBasic
-import TSCUtility
 
 final class SwiftDriverTests: XCTestCase {
     func testParsing() throws {

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -12,7 +12,6 @@
 import XCTest
 
 import SwiftDriver
-import TSCBasic
 
 final class TripleTests: XCTestCase {
   func testBasics() throws {


### PR DESCRIPTION
Found using SwiftLint's unused declaration and unused import rules.

I'm not sure how maintainers feel about keeping unused code or imports around if it's expected to be used at some point in the future.

I'm happy to close this if everything found here is ok to keep around.

I was looking for some low hanging fruit to contribute to this project and cleaning up unused stuff seemed like a good start.