### PR TITLE
Handle subcommands

### DIFF
--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -31,21 +31,12 @@ public struct OutputFileMap: Equatable {
       return output
     }
 
-    // Create a temporary file
-    let baseName: String
-    switch inputFile {
-    case .absolute(let path):
-      baseName = path.basenameWithoutExt
-    case .relative(let path), .temporary(let path):
-      baseName = path.basenameWithoutExt
-    case .standardInput:
-      baseName = ""
-    case .standardOutput:
+    if inputFile == .standardOutput {
       fatalError("Standard output cannot be an input file")
     }
 
     // Form the virtual path.
-    return .temporary(RelativePath(baseName.appendingFileTypeExtension(outputType)))
+    return .temporary(RelativePath(inputFile.basenameWithoutExt.appendingFileTypeExtension(outputType)))
   }
 
   public func existingOutput(inputFile: VirtualPath, outputType: FileType) -> VirtualPath? {

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -79,6 +79,18 @@ public enum VirtualPath: Hashable {
     default: return nil
     }
   }
+
+  /// Retrieve the basename of the path without the extension.
+  public var basenameWithoutExt: String {
+    switch self {
+    case .absolute(let path):
+      return path.basenameWithoutExt
+    case .relative(let path), .temporary(let path):
+      return path.basenameWithoutExt
+    case .standardInput, .standardOutput:
+      return ""
+    }
+  }
 }
 
 extension VirtualPath: Codable {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -47,6 +47,43 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testInvocationRunModes() throws {
+
+    let driver1 = try Driver.invocationRunMode(forArgs: ["swift"])
+    XCTAssertEqual(driver1.mode, .normal(isRepl: false))
+    XCTAssertEqual(driver1.args, ["swift"])
+
+    let driver2 = try Driver.invocationRunMode(forArgs: ["swift", "-buzz"])
+    XCTAssertEqual(driver2.mode, .normal(isRepl: false))
+    XCTAssertEqual(driver2.args, ["swift", "-buzz"])
+
+    let driver3 = try Driver.invocationRunMode(forArgs: ["swift", "/"])
+    XCTAssertEqual(driver3.mode, .normal(isRepl: false))
+    XCTAssertEqual(driver3.args, ["swift", "/"])
+
+    let driver4 = try Driver.invocationRunMode(forArgs: ["swift", "./foo"])
+    XCTAssertEqual(driver4.mode, .normal(isRepl: false))
+    XCTAssertEqual(driver4.args, ["swift", "./foo"])
+
+    let driver5 = try Driver.invocationRunMode(forArgs: ["swift", "repl"])
+    XCTAssertEqual(driver5.mode, .normal(isRepl: true))
+    XCTAssertEqual(driver5.args, ["swift"])
+
+    let driver6 = try Driver.invocationRunMode(forArgs: ["swift", "foo", "bar"])
+    XCTAssertEqual(driver6.mode, .subcommand("swift-foo"))
+    XCTAssertEqual(driver6.args, ["swift-foo", "bar"])
+  }
+
+  func testSubcommandsHandling() throws {
+
+    XCTAssertNoThrow(try Driver(args: ["swift"]))
+    XCTAssertNoThrow(try Driver(args: ["swift", "-I=foo"]))
+    XCTAssertNoThrow(try Driver(args: ["swift", ".foo"]))
+    XCTAssertNoThrow(try Driver(args: ["swift", "/foo"]))
+
+    XCTAssertThrowsError(try Driver(args: ["swift", "foo"]))
+  }
+
   func testDriverKindParsing() throws {
     func assertArgs(
       _ args: String...,


### PR DESCRIPTION
This tries to implement the handling of subcommands based on the original driver. I must admit I'm a little out of my depth here so I'd appreciate some guidance:
- in the original driver, the subcommand check happens before the actual driver is even created ([here](https://github.com/apple/swift/blob/348fa2145e675ec4e396a1da54c2201a366a37da/tools/driver/driver.cpp#L234)) - I put the code in the init, because the FIXME was there, but should an init be invoking `exec`?
- related to the above, is `exec` the right function to use here?
- similarly, is `Process.findExecutable` the right method to use in place of `getExecutablePath`?
- there is a slight difference in behavior between `llvm::sys::path::stem` and `basenameWithoutExt` - namely `basenameWithoutExt` will return `.txt` for `/foo/.txt`, while `llvm::sys::path::stem` will return an empty string. Is this a problem? If so, should I implement something like `stem` on `VirtualPath`? 

Thank you very much for your time 🙂 