### PR TITLE
NFC: Add missing copyright headers.

### DIFF
--- a/Sources/SwiftDriver/Options/Options.swift
+++ b/Sources/SwiftDriver/Options/Options.swift
@@ -1,3 +1,14 @@
+//===--------------- Options.swift - Swift Driver Options -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 extension Option {
   public static let INPUT: Option = Option("<input>", .input, attributes: [.argumentIsPath])

--- a/Sources/SwiftDriver/Utilities/PrefixTrie.swift
+++ b/Sources/SwiftDriver/Utilities/PrefixTrie.swift
@@ -1,3 +1,15 @@
+//==------------------ PrefixTrie.swift - Prefix Trie ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 /// A prefix trie is a data structure for quickly matching prefixes of strings.
 /// It's a tree structure where each node in the tree corresponds to another
 /// element in the prefix of whatever you're looking for.

--- a/Sources/makeOptions/makeOptions.cpp
+++ b/Sources/makeOptions/makeOptions.cpp
@@ -214,7 +214,19 @@ int makeOptions_main() {
 
   // Add static properties to Option for each of the options.
   auto &out = std::cout;
-  out << "\n";
+
+  out <<
+      "//===--------------- Options.swift - Swift Driver Options -----------------===//\n"
+      "//\n"
+      "// This source file is part of the Swift.org open source project\n"
+      "//\n"
+      "// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors\n"
+      "// Licensed under Apache License v2.0 with Runtime Library Exception\n"
+      "//\n"
+      "// See https://swift.org/LICENSE.txt for license information\n"
+      "// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors\n"
+      "//\n"
+      "//===----------------------------------------------------------------------===//\n\n";
   out << "extension Option {\n";
   forEachOption([&](const RawOption &option) {
     // Look through each spelling of the option.


### PR DESCRIPTION
Add missing copyright headers in Options/Options.swift and Utilities/PrefixTrie.swift.