### PR TITLE
Replace 'ParsableMessage' factory methods with an initializer.

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -54,7 +54,7 @@ public struct ToolExecutionDelegate: JobExecutorDelegate {
         commandArguments: arguments[1...].map{ String($0) }
       )
 
-      let message = ParsableMessage.beganMessage(name: job.kind.rawValue, message: beganMessage)
+      let message = ParsableMessage(name: job.kind.rawValue, kind: .began(beganMessage))
       emit(message)
     }
   }
@@ -75,12 +75,12 @@ public struct ToolExecutionDelegate: JobExecutorDelegate {
       switch result.exitStatus {
       case .terminated(let code):
         let finishedMessage = FinishedMessage(exitStatus: Int(code), pid: pid, output: output)
-        message = ParsableMessage.finishedMessage(name: job.kind.rawValue, message: finishedMessage)
+        message = ParsableMessage(name: job.kind.rawValue, kind: .finished(finishedMessage))
 
       case .signalled(let signal):
         let errorMessage = strsignal(signal).map { String(cString: $0) } ?? ""
         let signalledMessage = SignalledMessage(pid: pid, output: output, errorMessage: errorMessage, signal: Int(signal))
-        message = ParsableMessage.signalledMessage(name: job.kind.rawValue, message: signalledMessage)
+        message = ParsableMessage(name: job.kind.rawValue, kind: .signalled(signalledMessage))
       }
       emit(message)
     }

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -54,7 +54,7 @@ public struct ToolExecutionDelegate: JobExecutorDelegate {
         commandArguments: arguments[1...].map{ String($0) }
       )
 
-      let message = ParsableMessage.beganMessage(name: job.kind.rawValue, msg: beganMessage)
+      let message = ParsableMessage.beganMessage(name: job.kind.rawValue, message: beganMessage)
       emit(message)
     }
   }
@@ -75,12 +75,12 @@ public struct ToolExecutionDelegate: JobExecutorDelegate {
       switch result.exitStatus {
       case .terminated(let code):
         let finishedMessage = FinishedMessage(exitStatus: Int(code), pid: pid, output: output)
-        message = ParsableMessage.finishedMessage(name: job.kind.rawValue, msg: finishedMessage)
+        message = ParsableMessage.finishedMessage(name: job.kind.rawValue, message: finishedMessage)
 
       case .signalled(let signal):
         let errorMessage = strsignal(signal).map { String(cString: $0) } ?? ""
         let signalledMessage = SignalledMessage(pid: pid, output: output, errorMessage: errorMessage, signal: Int(signal))
-        message = ParsableMessage.signalledMessage(name: job.kind.rawValue, msg: signalledMessage)
+        message = ParsableMessage.signalledMessage(name: job.kind.rawValue, message: signalledMessage)
       }
       emit(message)
     }

--- a/Sources/SwiftDriver/Execution/ParsableOutput.swift
+++ b/Sources/SwiftDriver/Execution/ParsableOutput.swift
@@ -25,23 +25,23 @@ public struct ParsableMessage {
 
   public static func beganMessage(
     name: String,
-    msg: BeganMessage
+    message: BeganMessage
   ) -> ParsableMessage {
-    return ParsableMessage(name: name, kind: .began(msg))
+    return ParsableMessage(name: name, kind: .began(message))
   }
 
   public static func finishedMessage(
     name: String,
-    msg: FinishedMessage
+    message: FinishedMessage
   ) -> ParsableMessage {
-    return ParsableMessage(name: name, kind: .finished(msg))
+    return ParsableMessage(name: name, kind: .finished(message))
   }
 
   public static func signalledMessage(
     name: String,
-    msg: SignalledMessage
+    message: SignalledMessage
   ) -> ParsableMessage {
-    return ParsableMessage(name: name, kind: .signalled(msg))
+    return ParsableMessage(name: name, kind: .signalled(message))
   }
 
   public func toJSON() throws -> Data {

--- a/Sources/SwiftDriver/Execution/ParsableOutput.swift
+++ b/Sources/SwiftDriver/Execution/ParsableOutput.swift
@@ -23,25 +23,9 @@ public struct ParsableMessage {
   public let name: String
   public let kind: Kind
 
-  public static func beganMessage(
-    name: String,
-    message: BeganMessage
-  ) -> ParsableMessage {
-    return ParsableMessage(name: name, kind: .began(message))
-  }
-
-  public static func finishedMessage(
-    name: String,
-    message: FinishedMessage
-  ) -> ParsableMessage {
-    return ParsableMessage(name: name, kind: .finished(message))
-  }
-
-  public static func signalledMessage(
-    name: String,
-    message: SignalledMessage
-  ) -> ParsableMessage {
-    return ParsableMessage(name: name, kind: .signalled(message))
+  public init(name: String, kind: Kind) {
+    self.name = name
+    self.kind = kind
   }
 
   public func toJSON() throws -> Data {

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -26,7 +26,7 @@ final class ParsableMessageTests: XCTestCase {
       commandArguments: ["-frontend", "compile"]
     )
 
-    let beganMessage = ParsableMessage.beganMessage(name: "compile", message: message)
+    let beganMessage = ParsableMessage(name: "compile", kind: .began(message))
 
     let encoded = try beganMessage.toJSON()
     let string = String(data: encoded, encoding: .utf8)!
@@ -56,7 +56,7 @@ final class ParsableMessageTests: XCTestCase {
 
   func testFinishedMessage() throws {
     let message = FinishedMessage(exitStatus: 1, pid: 1, output: "hello")
-    let finishedMessage = ParsableMessage.finishedMessage(name: "compile", message: message)
+    let finishedMessage = ParsableMessage(name: "compile", kind: .finished(message))
     let encoded = try finishedMessage.toJSON()
     let string = String(data: encoded, encoding: .utf8)!
 
@@ -73,7 +73,7 @@ final class ParsableMessageTests: XCTestCase {
 
     func testSignalledMessage() throws {
       let message = SignalledMessage(pid: 2, output: "sig", errorMessage: "err", signal: 3)
-      let signalledMessage = ParsableMessage.signalledMessage(name: "compile", message: message)
+      let signalledMessage = ParsableMessage(name: "compile", kind: .signalled(message))
       let encoded = try signalledMessage.toJSON()
       let string = String(data: encoded, encoding: .utf8)!
 

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -16,7 +16,7 @@ import SwiftDriver
 
 final class ParsableMessageTests: XCTestCase {
   func testBeganMessage() throws {
-    let msg = BeganMessage(
+    let message = BeganMessage(
       pid: 1,
       inputs: ["/path/to/foo.swift"],
       outputs: [
@@ -26,7 +26,7 @@ final class ParsableMessageTests: XCTestCase {
       commandArguments: ["-frontend", "compile"]
     )
 
-    let beganMessage = ParsableMessage.beganMessage(name: "compile", msg: msg)
+    let beganMessage = ParsableMessage.beganMessage(name: "compile", message: message)
 
     let encoded = try beganMessage.toJSON()
     let string = String(data: encoded, encoding: .utf8)!
@@ -55,8 +55,8 @@ final class ParsableMessageTests: XCTestCase {
   }
 
   func testFinishedMessage() throws {
-    let msg = FinishedMessage(exitStatus: 1, pid: 1, output: "hello")
-    let finishedMessage = ParsableMessage.finishedMessage(name: "compile", msg: msg)
+    let message = FinishedMessage(exitStatus: 1, pid: 1, output: "hello")
+    let finishedMessage = ParsableMessage.finishedMessage(name: "compile", message: message)
     let encoded = try finishedMessage.toJSON()
     let string = String(data: encoded, encoding: .utf8)!
 
@@ -72,8 +72,8 @@ final class ParsableMessageTests: XCTestCase {
   }
 
     func testSignalledMessage() throws {
-      let msg = SignalledMessage(pid: 2, output: "sig", errorMessage: "err", signal: 3)
-      let signalledMessage = ParsableMessage.signalledMessage(name: "compile", msg: msg)
+      let message = SignalledMessage(pid: 2, output: "sig", errorMessage: "err", signal: 3)
+      let signalledMessage = ParsableMessage.signalledMessage(name: "compile", message: message)
       let encoded = try signalledMessage.toJSON()
       let string = String(data: encoded, encoding: .utf8)!
 


### PR DESCRIPTION
This PR uses an initializer `init(name:kind:)` to unify multiple factory methods.