### PR TITLE
Rename 'isAcceptedBy(_:)' to 'isAccepted(by:)'.

### DIFF
--- a/Sources/SwiftDriver/Driver/DriverKind.swift
+++ b/Sources/SwiftDriver/Driver/DriverKind.swift
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-/// Describes which mode the driver is in, which dictates
+
+/// Describes which mode the driver is in.
 public enum DriverKind {
   case interactive
   case batch

--- a/Sources/SwiftDriver/Options/Option.swift
+++ b/Sources/SwiftDriver/Options/Option.swift
@@ -130,8 +130,8 @@ extension Option {
 }
 
 extension Option {
-  /// Whether this option is accepted by the
-  public func isAcceptedBy(_ driverKind: DriverKind) -> Bool {
+  /// Whether this option is accepted by a driver of the given kind.
+  public func isAccepted(by driverKind: DriverKind) -> Bool {
     switch driverKind {
     case .autolinkExtract:
       return attributes.contains(.autolinkExtract)


### PR DESCRIPTION
This PR applies method naming conventions to `Option.isAcceptedBy(_:)`, move preposition "by" from the base name to the first argument label.

Also fixes some unfinished documentation comments.