### PR TITLE
[Driver] Clean up platform minimum flag generation code

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -114,27 +114,7 @@ extension DarwinToolchain {
     targetTriple: Triple
   ) {
     // FIXME: Properly handle deployment targets.
-    
-    let flag: String
-    
-    switch targetTriple.darwinPlatform! {
-    case .iOS(.device):
-      flag = "-iphoneos_version_min"
-    case .iOS(.simulator):
-      flag = "-ios_simulator_version_min"
-    case .macOS:
-      flag = "-macosx_version_min"
-    case .tvOS(.device):
-      flag = "-tvos_version_min"
-    case .tvOS(.simulator):
-      flag = "-tvos_simulator_version_min"
-    case .watchOS(.device):
-      flag = "-watchos_version_min"
-    case .watchOS(.simulator):
-      flag = "-watchos_simulator_version_min"
-    }
-    
-    commandLine.appendFlag(flag)
+    commandLine.appendFlag(targetTriple.darwinPlatform!.platformVersionMinFlag)
     commandLine.appendFlag(targetTriple.version().description)
   }
   

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -83,6 +83,26 @@ public enum DarwinPlatform: Hashable {
       return "watchsimulator"
     }
   }
+
+  /// The platform minimum version flag
+  public var platformVersionMinFlag: String {
+    switch self {
+    case .iOS(.device):
+      return "-iphoneos_version_min"
+    case .iOS(.simulator):
+      return "-ios_simulator_version_min"
+    case .macOS:
+      return "-macosx_version_min"
+    case .tvOS(.device):
+      return "-tvos_version_min"
+    case .tvOS(.simulator):
+      return "-tvos_simulator_version_min"
+    case .watchOS(.device):
+      return "-watchos_version_min"
+    case .watchOS(.simulator):
+      return "-watchos_simulator_version_min"
+    }
+  }
   
   /// The name used to identify this platform in compiler_rt file names.
   public var libraryNameSuffix: String {


### PR DESCRIPTION
The DarwinPlatform code provides a few derived vars
to determine the library name suffixes and platform
names based on the type of DarwinPlatform.  This commit
moves some code to determine platform minimum version
flags into that type.