### PR TITLE
Handle all FileTypes in OutputFileMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The goal of the new Swift driver is to provide a drop-in replacement for the exi
   * [x] Parseable output, as used by SwiftPM
   * [x] Response files
   * [ ] Input and primary input file lists
-  * [ ] Complete `OutputFileMap` implementation to handle all file types uniformly
+  * [x] Complete `OutputFileMap` implementation to handle all file types uniformly
 * Testing
   * [ ] Build stuff with SwiftPM or Xcode or your favorite build system, using `swift-driver`. Were the results identical? What changed?
   * [x] Shim in `swift-driver` so it can run the Swift repository's [driver test suite](https://github.com/apple/swift/tree/master/test/Driver).

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -349,7 +349,7 @@ extension FileType {
 
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
-         .optimizationRecord,.swiftInterface:
+         .optimizationRecord, .swiftInterface, .swiftSourceInfoFile:
       fatalError("Output type can never be a primary output")
     }
   }

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -12,7 +12,7 @@
 
 /// Describes the kinds of files that the driver understands.
 ///
-/// The raw values for these enumerations describe the default extension for]
+/// The raw values for these enumerations describe the default extension for
 /// the file type.
 public enum FileType: String, Hashable, CaseIterable, Codable {
   /// Swift source file.
@@ -45,11 +45,14 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// A compiled Swift module file.
   case swiftModule = "swiftmodule"
 
-  /// Swift documentation for amodule.
+  /// Swift documentation for a module.
   case swiftDocumentation = "swiftdoc"
 
   /// A textual Swift interface file.
   case swiftInterface = "swiftinterface"
+
+  /// Serialized source information.
+  case swiftSourceInfoFile = "swiftsourceinfo"
 
   /// Assembler source.
   case assembly = "s"
@@ -110,7 +113,7 @@ extension FileType: CustomStringConvertible {
   public var description: String {
     switch self {
     case .swift, .sil, .sib, .image, .object, .dSYM, .dependencies, .autolink,
-         .swiftModule, .swiftDocumentation, .swiftInterface, .assembly,
+         .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile, .assembly,
          .remap, .tbd, .pcm, .pch:
       return rawValue
 
@@ -163,8 +166,83 @@ extension FileType {
     case .object, .pch, .ast, .llvmIR, .llvmBitcode, .assembly, .swiftModule,
          .importedModules, .indexData, .remap, .dSYM, .autolink, .dependencies,
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
-         .swiftDeps, .moduleTrace, .tbd, .optimizationRecord, .swiftInterface:
+         .swiftDeps, .moduleTrace, .tbd, .optimizationRecord, .swiftInterface, .swiftSourceInfoFile:
       return false
+    }
+  }
+}
+
+extension FileType {
+
+  private static let typesByName = Dictionary(uniqueKeysWithValues: FileType.allCases.map { ($0.name, $0) })
+
+  init?(name: String) {
+    guard let type = Self.typesByName[name] else { return nil }
+
+    self = type
+  }
+
+  /// The NAME values as specified in FileTypes.def
+  var name: String {
+    switch self {
+    case .swift:
+      return "swift"
+    case .sil:
+      return "sil"
+    case .sib:
+      return "sib"
+    case .image:
+      return "image"
+    case .object:
+      return "object"
+    case .dSYM:
+      return "dSYM"
+    case .dependencies:
+      return "dependencies"
+    case .autolink:
+      return "autolink"
+    case .swiftModule:
+      return "swiftmodule"
+    case .swiftDocumentation:
+      return "swiftdoc"
+    case .swiftInterface:
+      return "swiftinterface"
+    case .swiftSourceInfoFile:
+      return "swiftsourceinfo"
+    case .assembly:
+      return "assembly"
+    case .remap:
+      return "remap"
+    case .tbd:
+      return "tbd"
+    case .pcm:
+      return "pcm"
+    case .pch:
+      return "pch"
+    case .ast:
+      return "ast-dump"
+    case .raw_sil:
+      return "raw-sil"
+    case .raw_sib:
+      return "raw-sib"
+    case .llvmIR:
+      return "llvm-ir"
+    case .llvmBitcode:
+      return "llvm-bc"
+    case .objcHeader:
+      return "objc-header"
+    case .swiftDeps:
+      return "swift-dependencies"
+    case .importedModules:
+      return "imported-modules"
+    case .moduleTrace:
+      return "module-trace"
+    case .indexData:
+      return "index-data"
+    case .optimizationRecord:
+      return "opt-record"
+    case .diagnostics:
+      return "diagnostics"
     }
   }
 }


### PR DESCRIPTION
This replaces the specific properties in `Entry` with a dictionary keyed by `FileType` and adds a custom implementation of `Codable`.

Originally, I wanted to just use `FileType`'s `description` property, but some of the cases just return `rawValue`, which is not compatible in all cases ("o" vs "object", in particular). Instead I added the `name` property with values from [FileTypes.def](https://github.com/apple/swift/blob/master/include/swift/Basic/FileTypes.def). While there, I noticed that `FileType` doesn't currently have a case for `swiftsourceinfo`, so I added that as well.