### PR TITLE
Add a bare-bones implementation of immediate mode

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -205,7 +205,7 @@ public struct Driver {
 
     self.driverKind = try Self.determineDriverKind(args: &args)
     self.optionTable = OptionTable()
-    self.parsedOptions = try optionTable.parse(Array(args))
+    self.parsedOptions = try optionTable.parse(Array(args), forInteractiveMode: self.driverKind == .interactive)
 
     let explicitTarget = (self.parsedOptions.getLastArgument(.target)?.asSingle)
       .map {
@@ -842,6 +842,9 @@ extension Driver {
         diagnosticsEngine.emit(.error_i_mode(driverKind))
 
       case .repl, .deprecatedIntegratedRepl, .lldbRepl:
+        compilerOutputType = nil
+
+      case .interpret:
         compilerOutputType = nil
 
       default:

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -1,0 +1,49 @@
+//===--------------- InterpretJob.swift - Swift Immediate Mode ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Driver {
+  mutating func interpretJob(inputs allInputs: [TypedVirtualPath]) throws -> Job {
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    var inputs: [TypedVirtualPath] = []
+
+    commandLine.appendFlags("-frontend", "-interpret")
+
+    // Add the inputs.
+    for input in allInputs {
+      commandLine.append(.path(input.file))
+      inputs.append(input)
+    }
+
+    if parsedOptions.hasArgument(.parseStdlib) {
+      commandLine.appendFlag(.disableObjcAttrRequiresFoundationModule)
+    }
+
+    try addCommonFrontendOptions(commandLine: &commandLine)
+    // FIXME: MSVC runtime flags
+
+    try commandLine.appendLast(.parseSil, from: &parsedOptions)
+    try commandLine.appendAll(.l, .framework, from: &parsedOptions)
+
+    // The immediate arguments must be last.
+    try commandLine.appendLast(.DASHDASH, from: &parsedOptions)
+
+    // FIXME: Set [DY]LD_LIBRARY_PATH, DYLD_FRAMEWORK_PATH if needed.
+
+    return Job(
+      kind: .interpret,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      inputs:inputs,
+      outputs: []
+    )
+  }
+}

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -20,6 +20,7 @@ public struct Job: Codable, Equatable {
     case generateDSYM = "generate-dsym"
     case autolinkExtract = "autolink-extract"
     case emitModule = "emit-module"
+    case interpret
   }
 
   public enum ArgTemplate: Equatable {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -144,8 +144,11 @@ extension Driver {
   public mutating func planBuild() throws -> [Job] {
     // Plan the build.
     switch compilerMode {
-    case .immediate, .repl:
+    case .repl:
       fatalError("Not yet supported")
+
+    case .immediate:
+      return [try interpretJob(inputs: inputFiles)]
 
     case .standardCompile, .batchCompile, .singleCompile:
       return try planStandardCompile()

--- a/Sources/SwiftDriver/Options/OptionParsing.swift
+++ b/Sources/SwiftDriver/Options/OptionParsing.swift
@@ -18,7 +18,8 @@ extension OptionTable {
   /// Parse the given command-line arguments into a set of options.
   ///
   /// Throws an error if the command line contains any errors.
-  public func parse(_ arguments: [String]) throws -> ParsedOptions {
+  public func parse(_ arguments: [String],
+                    forInteractiveMode isInteractiveMode: Bool = false) throws -> ParsedOptions {
     var trie = PrefixTrie<String.UTF8View, Option>()
     for opt in options {
       trie[opt.spelling.utf8] = opt
@@ -39,6 +40,13 @@ extension OptionTable {
       // If this is not a flag, record it as an input.
       if argument == "-" || argument.first! != "-" {
         parsedOptions.addInput(argument)
+
+        // In interactive mode, synthesize a "--" argument for all args after the first input.
+        if isInteractiveMode && index < arguments.endIndex {
+          parsedOptions.addOption(.DASHDASH, argument: .multiple(Array(arguments[index...])))
+          break
+        }
+
         continue
       }
 


### PR DESCRIPTION
This is an initial implementation of immediate mode. The big missing piece right now is setting [DY]LD_LIBRARY_PATH and DYLD_FRAMEWORK_PATH when needed. Before implementing that I think it's worth figuring out how the driver should run single job build plans for immediate mode and the REPL. I'm not sure if we should bypass the JobExecutor or not when executing in-place. If anyone has a strong opinion I could implement that in this PR or a follow up. I haven't made any changes yet so right now this just spawns a new process. 