### PR TITLE
Diagnose unsupported options and add descriptions for option-parsing errors

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -191,11 +191,11 @@ public struct Driver {
   public init(
     args: [String],
     env: [String: String] = ProcessEnv.vars,
-    diagnosticsHandler: @escaping DiagnosticsEngine.DiagnosticsHandler = Driver.stderrDiagnosticsHandler
+    diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
   ) throws {
     self.env = env
 
-    self.diagnosticEngine = DiagnosticsEngine(handlers: [diagnosticsHandler])
+    self.diagnosticEngine = diagnosticsEngine
 
     if case .subcommand = try Self.invocationRunMode(forArgs: args).mode {
       throw Error.subcommandPassedToDriver

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -205,7 +205,7 @@ public struct Driver {
 
     self.driverKind = try Self.determineDriverKind(args: &args)
     self.optionTable = OptionTable()
-    self.parsedOptions = try optionTable.parse(Array(args), forInteractiveMode: self.driverKind == .interactive)
+    self.parsedOptions = try optionTable.parse(Array(args), for: self.driverKind)
 
     let explicitTarget = (self.parsedOptions.getLastArgument(.target)?.asSingle)
       .map {

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -16,6 +16,7 @@ import TSCBasic
 import TSCUtility
 
 var intHandler: InterruptHandler?
+let diagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
 
 do {
   let processSet = ProcessSet()
@@ -39,7 +40,7 @@ do {
     try exec(path: subcommandPath?.pathString ?? "", args: Array(arguments.dropFirst()))
   }
 
-  var driver = try Driver(args: arguments)
+  var driver = try Driver(args: arguments, diagnosticsEngine: diagnosticsEngine)
   let resolver = try ArgsResolver()
   try driver.run(resolver: resolver, processSet: processSet)
 
@@ -48,6 +49,8 @@ do {
   }
 } catch Diagnostics.fatalError {
   exit(EXIT_FAILURE)
+} catch let diagnosticData as DiagnosticData {
+  diagnosticsEngine.emit(.error(diagnosticData))
 } catch {
   print("error: \(error)")
   exit(EXIT_FAILURE)

--- a/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
+++ b/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
@@ -23,7 +23,7 @@ fileprivate func assertDriverDiagnostics(
   let matcher = DiagnosticVerifier()
   defer { matcher.verify(file: file, line: line) }
   
-  var driver = try Driver(args: args, env: env, diagnosticsHandler: matcher.emit(_:))
+  var driver = try Driver(args: args, env: env, diagnosticsEngine: DiagnosticsEngine(handlers: [matcher.emit(_:)]))
   try body(&driver, matcher)
 }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -46,11 +46,11 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     XCTAssertThrowsError(try options.parse(["-o"], for: .interactive)) { error in
-      XCTAssertEqual(error as? OptionParseError, .unsupportedOption(index: 0, option: .o))
+      XCTAssertEqual(error as? OptionParseError, .unsupportedOption(index: 0, argument: "-o", option: .o, currentDriverKind: .interactive))
     }
 
     XCTAssertThrowsError(try options.parse(["-repl"], for: .batch)) { error in
-      XCTAssertEqual(error as? OptionParseError, .unsupportedOption(index: 0, option: .repl))
+      XCTAssertEqual(error as? OptionParseError, .unsupportedOption(index: 0, argument: "-repl", option: .repl, currentDriverKind: .batch))
     }
 
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -21,7 +21,7 @@ final class SwiftDriverTests: XCTestCase {
       let results = try options.parse([
         "input1", "-color-diagnostics", "-Ifoo", "-I", "bar spaces",
         "-I=wibble", "input2", "-module-name", "main",
-        "-sanitize=a,b,c", "--", "-foo", "-bar"])
+        "-sanitize=a,b,c", "--", "-foo", "-bar"], for: .batch)
       XCTAssertEqual(results.description,
                      "input1 -color-diagnostics -I foo -I 'bar spaces' -I=wibble input2 -module-name main -sanitize=a,b,c -- -foo -bar")
     }
@@ -29,21 +29,30 @@ final class SwiftDriverTests: XCTestCase {
   func testParseErrors() {
     let options = OptionTable()
 
-    XCTAssertThrowsError(try options.parse(["-unrecognized"])) { error in
+    XCTAssertThrowsError(try options.parse(["-unrecognized"], for: .batch)) { error in
       XCTAssertEqual(error as? OptionParseError, .unknownOption(index: 0, argument: "-unrecognized"))
     }
 
-    XCTAssertThrowsError(try options.parse(["-I"])) { error in
+    XCTAssertThrowsError(try options.parse(["-I"], for: .batch)) { error in
       XCTAssertEqual(error as? OptionParseError, .missingArgument(index: 0, argument: "-I"))
     }
 
-    XCTAssertThrowsError(try options.parse(["-color-diagnostics", "-I"])) { error in
+    XCTAssertThrowsError(try options.parse(["-color-diagnostics", "-I"], for: .batch)) { error in
       XCTAssertEqual(error as? OptionParseError, .missingArgument(index: 1, argument: "-I"))
     }
 
-    XCTAssertThrowsError(try options.parse(["-module-name"])) { error in
+    XCTAssertThrowsError(try options.parse(["-module-name"], for: .batch)) { error in
       XCTAssertEqual(error as? OptionParseError, .missingArgument(index: 0, argument: "-module-name"))
     }
+
+    XCTAssertThrowsError(try options.parse(["-o"], for: .interactive)) { error in
+      XCTAssertEqual(error as? OptionParseError, .unsupportedOption(index: 0, option: .o))
+    }
+
+    XCTAssertThrowsError(try options.parse(["-repl"], for: .batch)) { error in
+      XCTAssertEqual(error as? OptionParseError, .unsupportedOption(index: 0, option: .repl))
+    }
+
   }
 
   func testInvocationRunModes() throws {
@@ -293,7 +302,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(driver.moduleName, "main")
     }
     
-    try assertNoDriverDiagnostics(args: "swiftc", "-repl") { driver in
+    try assertNoDriverDiagnostics(args: "swift", "-repl") { driver in
       XCTAssertNil(driver.moduleOutput)
       XCTAssertEqual(driver.moduleName, "REPL")
     }


### PR DESCRIPTION
I changed error handling a little bit in the process. Now, any error caught at the top level will be emitted through the diagnostics engine if it conforms to `DiagnosticData`.