### PR TITLE
Fix direct invocation of non-compiler driver kinds

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -548,7 +548,7 @@ extension Driver {
     // We just need to invoke the corresponding tool if the kind isn't Swift compiler.
     guard driverKind.isSwiftCompiler else {
       let swiftCompiler = try getSwiftCompilerPath()
-      return try exec(path: swiftCompiler.pathString, args: ["swift"] + parsedOptions.commandLine)
+      return try exec(path: swiftCompiler.pathString, args: driverKind.usageArgs + parsedOptions.commandLine)
     }
 
     if parsedOptions.contains(.help) || parsedOptions.contains(.helpHidden) {

--- a/Sources/SwiftDriver/Driver/DriverKind.swift
+++ b/Sources/SwiftDriver/Driver/DriverKind.swift
@@ -48,6 +48,28 @@ extension DriverKind {
     }
   }
 
+  public var usageArgs: [String] {
+    switch self {
+    case .autolinkExtract:
+      return ["swift-autolink-extract"]
+
+    case .batch:
+      return ["swiftc"]
+
+    case .frontend:
+      return ["swift", "-frontend"]
+
+    case .indent:
+      return ["swift-indent"]
+
+    case .interactive:
+      return ["swift"]
+
+    case .moduleWrap:
+      return ["swift-modulewrap"]
+    }
+  }
+
   public var title: String {
     switch self {
     case .autolinkExtract:


### PR DESCRIPTION
This is enough to fix ~2/3 of the failures in the interpreter and stdlib lit test suites, making it easier to focus on the driver-related failures. 