### PR TITLE
Infer module output path from '-o' where applicable

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1203,8 +1203,14 @@ extension Driver {
       // The module path was specified.
       moduleOutputPath = try VirtualPath(path: modulePathArg.asSingle)
     } else if moduleOutputKind == .topLevel {
-      // FIXME: Logic to infer from -o, primary outputs, etc.
-      moduleOutputPath = try .init(path: moduleName.appendingFileTypeExtension(.swiftModule))
+      // FIXME: Logic to infer from primary outputs, etc.
+      let moduleFilename = moduleName.appendingFileTypeExtension(.swiftModule)
+      if let outputArg = parsedOptions.getLastArgument(.o)?.asSingle, let lastSeparatorIndex = outputArg.lastIndex(of: "/") {
+        // Put the module next to the top-level output.
+        moduleOutputPath = try .init(path: outputArg[outputArg.startIndex...lastSeparatorIndex] + moduleFilename)
+      } else {
+        moduleOutputPath = try .init(path: moduleFilename)
+      }
     } else {
       moduleOutputPath = .temporary(RelativePath(moduleName.appendingFileTypeExtension(.swiftModule)))
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -309,6 +309,18 @@ final class SwiftDriverTests: XCTestCase {
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-library", "-o", "libWibble.so", "-module-name", "Swift") {
         $1.expect(.error("module name \"Swift\" is reserved for the standard library"))
     }
+
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-module", "-emit-library", "-o", "some/dir/libFoo.so", "-module-name", "MyModule") { driver in
+      XCTAssertEqual(driver.moduleOutput, ModuleOutput.topLevel(try VirtualPath(path: "some/dir/MyModule.swiftmodule")))
+    }
+
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-module", "-emit-library", "-o", "/", "-module-name", "MyModule") { driver in
+      XCTAssertEqual(driver.moduleOutput, ModuleOutput.topLevel(try VirtualPath(path: "/MyModule.swiftmodule")))
+    }
+
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-module", "-emit-library", "-o", "../../some/other/dir/libFoo.so", "-module-name", "MyModule") { driver in
+      XCTAssertEqual(driver.moduleOutput, ModuleOutput.topLevel(try VirtualPath(path: "../../some/other/dir/MyModule.swiftmodule")))
+    }
   }
   
   func testModuleNameFallbacks() throws {


### PR DESCRIPTION
We're still not taking the file output map or primary outputs into consideration, but this is enough to get a few more integration tests up and running. 