### PR TITLE
Add support for Clang module emission via -emit-pcm

### DIFF
--- a/Sources/SwiftDriver/Driver/CompilerMode.swift
+++ b/Sources/SwiftDriver/Driver/CompilerMode.swift
@@ -26,6 +26,9 @@ public enum CompilerMode: Equatable {
 
   /// Compile and execute the inputs immediately.
   case immediate
+
+  /// Compile a Clang module (.pcm).
+  case compilePcm
 }
 
 /// Information about batch mode, which is used to determine how to form
@@ -40,7 +43,7 @@ extension CompilerMode {
   /// Whether this compilation mode uses -primary-file to specify its inputs.
   public var usesPrimaryFileInputs: Bool {
     switch self {
-    case .immediate, .repl, .singleCompile:
+    case .immediate, .repl, .singleCompile, .compilePcm:
       return false
 
     case .standardCompile, .batchCompile:
@@ -54,7 +57,7 @@ extension CompilerMode {
     case .immediate, .repl, .standardCompile, .batchCompile:
       return false
 
-    case .singleCompile:
+    case .singleCompile, .compilePcm:
       return true
     }
   }
@@ -62,18 +65,19 @@ extension CompilerMode {
 
 extension CompilerMode: CustomStringConvertible {
     public var description: String {
-        switch self {
-
-        case .standardCompile:
-            return "standard compilation"
-        case .batchCompile:
-            return "batch compilation"
-        case .singleCompile:
-            return "whole module optimization"
-        case .repl:
-            return "read-eval-print-loop compilation"
-        case .immediate:
-            return "immediate compilation"
-        }
+      switch self {
+      case .standardCompile:
+        return "standard compilation"
+      case .batchCompile:
+        return "batch compilation"
+      case .singleCompile:
+        return "whole module optimization"
+      case .repl:
+        return "read-eval-print-loop compilation"
+      case .immediate:
+        return "immediate compilation"
+      case .compilePcm:
+        return "compile Clang module (.pcm)"
+      }
   }
 }

--- a/Sources/SwiftDriver/Driver/CompilerMode.swift
+++ b/Sources/SwiftDriver/Driver/CompilerMode.swift
@@ -28,7 +28,7 @@ public enum CompilerMode: Equatable {
   case immediate
 
   /// Compile a Clang module (.pcm).
-  case compilePcm
+  case compilePCM
 }
 
 /// Information about batch mode, which is used to determine how to form
@@ -43,7 +43,7 @@ extension CompilerMode {
   /// Whether this compilation mode uses -primary-file to specify its inputs.
   public var usesPrimaryFileInputs: Bool {
     switch self {
-    case .immediate, .repl, .singleCompile, .compilePcm:
+    case .immediate, .repl, .singleCompile, .compilePCM:
       return false
 
     case .standardCompile, .batchCompile:
@@ -57,7 +57,7 @@ extension CompilerMode {
     case .immediate, .repl, .standardCompile, .batchCompile:
       return false
 
-    case .singleCompile, .compilePcm:
+    case .singleCompile, .compilePCM:
       return true
     }
   }
@@ -76,7 +76,7 @@ extension CompilerMode: CustomStringConvertible {
         return "read-eval-print-loop compilation"
       case .immediate:
         return "immediate compilation"
-      case .compilePcm:
+      case .compilePCM:
         return "compile Clang module (.pcm)"
       }
   }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -701,6 +701,9 @@ extension Driver {
       case .repl, .deprecatedIntegratedRepl, .lldbRepl:
         return .repl
 
+      case .emitPcm:
+        return .compilePcm
+
       default:
         // Output flag doesn't determine the compiler mode.
         break
@@ -859,6 +862,9 @@ extension Driver {
 
       case .emitPch:
         compilerOutputType = .pch
+
+      case .emitPcm:
+        compilerOutputType = .pcm
 
       case .emitImportedModules:
         compilerOutputType = .importedModules

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -702,7 +702,7 @@ extension Driver {
         return .repl
 
       case .emitPcm:
-        return .compilePcm
+        return .compilePCM
 
       default:
         // Output flag doesn't determine the compiler mode.

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -154,7 +154,7 @@ fileprivate extension CompilerMode {
   var supportsIncrementalCompilation: Bool {
     switch self {
     case .standardCompile, .immediate, .repl, .batchCompile: return true
-    case .singleCompile, .compilePcm: return false
+    case .singleCompile, .compilePCM: return false
     }
   }
 }

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -154,7 +154,7 @@ fileprivate extension CompilerMode {
   var supportsIncrementalCompilation: Bool {
     switch self {
     case .standardCompile, .immediate, .repl, .batchCompile: return true
-    case .singleCompile: return false
+    case .singleCompile, .compilePcm: return false
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -21,13 +21,29 @@ fileprivate func shouldColorDiagnostics() -> Bool {
 }
 
 extension Driver {
+  /// How the bridging header should be handled.
+  enum BridgingHeaderHandling {
+    /// Ignore the bridging header entirely.
+    case ignored
+
+    /// Parse the bridging header, even if other jobs will use a precompiled
+    /// bridging header.
+    ///
+    /// This is typically used only when precompiling the bridging header.
+    case parsed
+
+    /// Use the precompiled bridging header.
+    case precompiled
+  }
   /// Add frontend options that are common to different frontend invocations.
-  mutating func addCommonFrontendOptions(commandLine: inout [Job.ArgTemplate],
-                                         requestPrecompiledObjCHeader: Bool = true) throws {
+  mutating func addCommonFrontendOptions(
+    commandLine: inout [Job.ArgTemplate],
+    bridgingHeaderHandling: BridgingHeaderHandling = .precompiled
+  ) throws {
     // Only pass -target to the REPL or immediate modes if it was explicitly
     // specified on the command line.
     switch compilerMode {
-    case .standardCompile, .singleCompile, .batchCompile:
+    case .standardCompile, .singleCompile, .batchCompile, .compilePcm:
       commandLine.appendFlag(.target)
       commandLine.appendFlag(targetTriple.triple)
 
@@ -156,9 +172,11 @@ extension Driver {
     try commandLine.appendAll(.Xllvm, from: &parsedOptions)
     try commandLine.appendAll(.Xcc, from: &parsedOptions)
 
-    if let importedObjCHeader = importedObjCHeader {
+    if let importedObjCHeader = importedObjCHeader,
+        bridgingHeaderHandling != .ignored {
       commandLine.appendFlag(.importObjcHeader)
-      if requestPrecompiledObjCHeader, let pch = bridgingPrecompiledHeader {
+      if bridgingHeaderHandling == .precompiled,
+          let pch = bridgingPrecompiledHeader {
         if parsedOptions.contains(.pchOutputDir) {
           commandLine.appendPath(importedObjCHeader)
           try commandLine.appendLast(.pchOutputDir, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -43,7 +43,7 @@ extension Driver {
     // Only pass -target to the REPL or immediate modes if it was explicitly
     // specified on the command line.
     switch compilerMode {
-    case .standardCompile, .singleCompile, .batchCompile, .compilePcm:
+    case .standardCompile, .singleCompile, .batchCompile, .compilePCM:
       commandLine.appendFlag(.target)
       commandLine.appendFlag(targetTriple.triple)
 

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -22,7 +22,10 @@ extension Driver {
 
     commandLine.appendFlag("-frontend")
     
-    try addCommonFrontendOptions(commandLine: &commandLine, requestPrecompiledObjCHeader: false)
+    try addCommonFrontendOptions(
+      commandLine: &commandLine, bridgingHeaderHandling: .parsed)
+    
+    try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
 
     // TODO: Should this just be pch output with extension changed?
     if parsedOptions.hasArgument(.serializeDiagnostics), let outputDirectory = parsedOptions.getLastArgument(.pchOutputDir)?.asSingle {

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -1,0 +1,63 @@
+//===--------------- GeneratePCMJob.swift - Generate PCM Job ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Driver {
+  /// Create a job that generates a Clang module (.pcm) that is suitable for
+  /// use.
+  ///
+  /// The input is a Clang module map
+  /// (https://clang.llvm.org/docs/Modules.html#module-map-language) and the
+  /// output is a compiled module that also includes the additional information
+  /// needed by Swift's Clang importer, e.g., the Swift name lookup tables.
+  mutating func generatePCMJob(input: TypedVirtualPath) throws -> Job {
+    var inputs = [TypedVirtualPath]()
+    var outputs = [TypedVirtualPath]()
+
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+
+    commandLine.appendFlag("-frontend")
+    commandLine.appendFlag(.emitPcm)
+
+    // Input module map.
+    inputs.append(input)
+    commandLine.appendPath(input.file)
+
+    // Compute the output file.
+    let output: TypedVirtualPath
+    if let outputArg = parsedOptions.getLastArgument(.o) {
+      output = .init(file: try VirtualPath(path: outputArg.asSingle),
+                     type: .pcm)
+    } else {
+      output = .init(
+        file: try VirtualPath(path: moduleName + "." + FileType.pcm.name),
+        type: .pcm)
+    }
+
+    outputs.append(output)
+    commandLine.appendFlag(.o)
+    commandLine.appendPath(output.file)
+
+    try addCommonFrontendOptions(
+      commandLine: &commandLine, bridgingHeaderHandling: .ignored)
+
+    try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
+
+    return Job(
+      kind: .generatePCM,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      displayInputs: [],
+      inputs: inputs,
+      outputs: outputs
+    )
+  }
+}

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -38,7 +38,8 @@ extension Driver {
                      type: .pcm)
     } else {
       output = .init(
-        file: try VirtualPath(path: moduleName + "." + FileType.pcm.name),
+        file: try VirtualPath(
+          path: moduleName.appendingFileTypeExtension(.pcm)),
         type: .pcm)
     }
 

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -21,6 +21,9 @@ public struct Job: Codable, Equatable {
     case autolinkExtract = "autolink-extract"
     case emitModule = "emit-module"
     case generatePCH = "generate-pch"
+
+    /// Generate a compiled Clang module.
+    case generatePCM = "generate-pcm"
     case interpret
     case repl
     case verifyDebugInfo = "verify-debug-info"

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -67,7 +67,7 @@ extension Driver {
     case .batchCompile(let batchInfo):
       partitions = batchPartitions(batchInfo)
 
-    case .immediate, .repl, .compilePcm:
+    case .immediate, .repl, .compilePCM:
       fatalError("compiler mode \(compilerMode) is handled elsewhere")
 
     case .singleCompile:
@@ -181,7 +181,7 @@ extension Driver {
     case .standardCompile, .batchCompile, .singleCompile:
       return try planStandardCompile()
 
-    case .compilePcm:
+    case .compilePCM:
       if inputFiles.count != 1 {
         throw PlanningError.emitPCMWrongInputFiles
       }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -12,11 +12,15 @@
 
 public enum PlanningError: Error, DiagnosticData {
   case replReceivedInput
+  case emitPCMWrongInputFiles
 
   public var description: String {
     switch self {
     case .replReceivedInput:
       return "REPL mode requires no input files"
+
+    case .emitPCMWrongInputFiles:
+      return "Clang module emission requires exactly one input file (the module map)"
     }
   }
 }
@@ -45,7 +49,8 @@ extension Driver {
         }
       }
     }
-    
+
+    // Precompile the bridging header if needed.
     if let importedObjCHeader = importedObjCHeader,
       let bridgingPrecompiledHeader = bridgingPrecompiledHeader {
       jobs.append(try generatePCHJob(input: .init(file: importedObjCHeader, type: .objcHeader),
@@ -62,8 +67,8 @@ extension Driver {
     case .batchCompile(let batchInfo):
       partitions = batchPartitions(batchInfo)
 
-    case .immediate, .repl:
-      fatalError("immediate and REPL modes are currently unsupported")
+    case .immediate, .repl, .compilePcm:
+      fatalError("compiler mode \(compilerMode) is handled elsewhere")
 
     case .singleCompile:
       // Create a single compile job for all of the files, none of which
@@ -157,8 +162,6 @@ extension Driver {
       }
     }
 
-    // FIXME: Lots of follow-up actions for merging modules, etc.
-
     return jobs
   }
 
@@ -177,6 +180,12 @@ extension Driver {
 
     case .standardCompile, .batchCompile, .singleCompile:
       return try planStandardCompile()
+
+    case .compilePcm:
+      if inputFiles.count != 1 {
+        throw PlanningError.emitPCMWrongInputFiles
+      }
+      return [try generatePCMJob(input: inputFiles.first!)]
     }
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1202,7 +1202,7 @@ final class SwiftDriverTests: XCTestCase {
     let driver2 = try Driver(args: ["swift", "main.swift"], env: env)
     XCTAssertNoThrow(try driver2.toolchain.getToolPath(.dsymutil))
   }
-  
+
   func testPCHGeneration() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-typecheck", "-import-objc-header", "TestInputHeader.h", "foo.swift"])
@@ -1436,6 +1436,20 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[1].kind, .compile)
       XCTAssertEqual(plannedJobs[1].inputs.count, 1)
       XCTAssertEqual(plannedJobs[1].inputs[0].file, try VirtualPath(path: "foo.swift"))
+    }
+  }
+
+  func testPCMGeneration() throws {
+     do {
+       var driver = try Driver(args: ["swiftc", "-emit-pcm", "module.modulemap", "-module-name", "Test"])
+       let plannedJobs = try driver.planBuild()
+       XCTAssertEqual(plannedJobs.count, 1)
+
+       XCTAssertEqual(plannedJobs[0].kind, .generatePCM)
+       XCTAssertEqual(plannedJobs[0].inputs.count, 1)
+       XCTAssertEqual(plannedJobs[0].inputs[0].file, .relative(RelativePath("module.modulemap")))
+       XCTAssertEqual(plannedJobs[0].outputs.count, 1)
+       XCTAssertEqual(plannedJobs[0].outputs[0].file, .relative(RelativePath("Test.pcm")))
     }
   }
 }


### PR DESCRIPTION
Teach the driver to emit Clang modules based on the with `-emit-pcm` command-line argument, where the input is the module map.