### PR TITLE
Handle -version argument

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -570,6 +570,15 @@ extension Driver {
       return
     }
 
+    if parsedOptions.hasArgument(.version) || parsedOptions.hasArgument(.version_) {
+      // Follow gcc/clang behavior and use stdout for --version and stderr for -v.
+      try printVersion(outputStream: &stdoutStream)
+      return
+    }
+    if parsedOptions.hasArgument(.v) {
+      try printVersion(outputStream: &stderrStream)
+    }
+
     // Plan the build.
     let jobs = try planBuild()
     if jobs.isEmpty { return }
@@ -631,6 +640,11 @@ extension Driver {
     }
 
     return try exec(path: tool, args: arguments)
+  }
+
+  private func printVersion<S: OutputByteStream>(outputStream: inout S) throws {
+    outputStream.write(try Process.checkNonZeroExit(args: swiftCompiler.pathString, "--version"))
+    outputStream.flush()
   }
 }
 


### PR DESCRIPTION
Currently we have the following for getting the compiler version. The issue with this is that I'm getting into a state where `getToolPath(.swiftCompiler)` is `/tmp/swift` my symlink to my `swift-driver`. This is causing an infinite loop because `swiftCompilerVersion` is called from `Driver.init`.
```
public func swiftCompilerVersion() throws -> String {
    try Process.checkNonZeroExit(
      args: getToolPath(.swiftCompiler).pathString, "-version",
      environment: env
    ).split(separator: "\n").first.map(String.init) ?? ""
  }
```

So taking a step back:
Should `getToolPath(.swiftCompiler)` ever point to my symlink?
If no, what am I doing wrong (was following the README).
If yes, then the implementation needs to change, the code below is in `Basic/Version.cpp`. Are these constants something we could have access to when building the driver? Does it even make sense for the driver to know about all these versions?

```
std::string getSwiftFullVersion(Version effectiveVersion) {
  std::string buf;
  llvm::raw_string_ostream OS(buf);

#ifdef SWIFT_VENDOR
  OS << SWIFT_VENDOR " ";
#endif

  OS << "Swift version " SWIFT_VERSION_STRING;
#ifndef SWIFT_COMPILER_VERSION
  OS << "-dev";
#endif

  if (!(effectiveVersion == Version::getCurrentLanguageVersion())) {
    OS << " effective-" << effectiveVersion;
  }

#if defined(SWIFT_COMPILER_VERSION)
  OS << " (swiftlang-" SWIFT_COMPILER_VERSION;
#if defined(CLANG_COMPILER_VERSION)
  OS << " clang-" CLANG_COMPILER_VERSION;
#endif
  OS << ")";
#elif defined(LLVM_REVISION) || defined(CLANG_REVISION) || \
      defined(SWIFT_REVISION)
  OS << " (";
  printFullRevisionString(OS);
  OS << ")";
#endif

  // Suppress unused function warning
  (void)&printFullRevisionString;

  return OS.str();
}
```