### PR TITLE
Respect -driver-use-frontend-path throughout job creation

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -286,7 +286,8 @@ public struct Driver {
       moduleOutput: self.moduleOutput,
       inputFiles: inputFiles,
       diagnosticEngine: diagnosticEngine,
-      actualSwiftVersion: try? toolchain.swiftCompilerVersion()
+      actualSwiftVersion:
+        try? toolchain.swiftCompilerVersion(self.swiftCompiler)
     )
 
     self.sdkPath = Self.computeSDKPath(&parsedOptions, compilerMode: compilerMode, toolchain: toolchain, diagnosticsEngine: diagnosticEngine, env: env)

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -557,8 +557,7 @@ extension Driver {
   ) throws {
     // We just need to invoke the corresponding tool if the kind isn't Swift compiler.
     guard driverKind.isSwiftCompiler else {
-      let swiftCompiler = try getSwiftCompilerPath()
-      return try exec(path: swiftCompiler.pathString, args: driverKind.usageArgs + parsedOptions.commandLine)
+      return try exec(path: swiftCompiler.name, args: driverKind.usageArgs + parsedOptions.commandLine)
     }
 
     if parsedOptions.contains(.help) || parsedOptions.contains(.helpHidden) {
@@ -601,12 +600,6 @@ extension Driver {
         processSet: processSet
     )
     try jobExecutor.execute(env: env)
-  }
-
-  /// Returns the path to the Swift binary.
-  func getSwiftCompilerPath() throws -> AbsolutePath {
-    // FIXME: This is very preliminary. Need to figure out how to get the actual Swift executable path.
-    try toolchain.getToolPath(.swiftCompiler)
   }
 
   public mutating func createToolExecutionDelegate() -> ToolExecutionDelegate {

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -154,7 +154,7 @@ extension Driver {
 
     return Job(
       kind: .compile,
-      tool: swiftCompiler,
+      tool: .absolute(swiftCompiler),
       commandLine: commandLine,
       displayInputs: primaryInputs,
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -13,6 +13,7 @@ import TSCBasic
 
 extension DarwinToolchain {
   private func findARCLiteLibPath() throws -> AbsolutePath? {
+    // FIXME: Thread the driver's swiftCompiler path here.
     let path = try getToolPath(.swiftCompiler)
       .parentDirectory // 'swift'
       .parentDirectory // 'bin'

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -70,7 +70,7 @@ extension Driver {
 
     return Job(
       kind: .emitModule,
-      tool: swiftCompiler,
+      tool: .absolute(swiftCompiler),
       commandLine: commandLine,
       inputs: inputs,
       outputs: outputs

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -70,7 +70,7 @@ extension Driver {
 
     return Job(
       kind: .emitModule,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: swiftCompiler,
       commandLine: commandLine,
       inputs: inputs,
       outputs: outputs

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -58,7 +58,7 @@ extension Driver {
     
     return Job(
       kind: .generatePCH,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: swiftCompiler,
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -58,7 +58,7 @@ extension Driver {
     
     return Job(
       kind: .generatePCH,
-      tool: swiftCompiler,
+      tool: .absolute(swiftCompiler),
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -50,7 +50,8 @@ extension GenericUnixToolchain {
     outputFile: VirtualPath,
     sdkPath: String?,
     sanitizers: Set<Sanitizer>,
-    targetTriple: Triple
+    targetTriple: Triple,
+    swiftCompiler: AbsolutePath
   ) throws -> AbsolutePath {
     switch linkerOutputType {
     case .dynamicLibrary:
@@ -129,7 +130,7 @@ extension GenericUnixToolchain {
       let runtimePaths = try runtimeLibraryPaths(
         for: targetTriple,
         parsedOptions: &parsedOptions,
-        sdkPath: sdkPath,
+        sdkPath: sdkPath, swiftCompiler: swiftCompiler,
         isShared: hasRuntimeArgs
       )
 
@@ -147,6 +148,7 @@ extension GenericUnixToolchain {
       let sharedResourceDirPath = try computeResourceDirPath(
         for: targetTriple,
         parsedOptions: &parsedOptions,
+        swiftCompiler: swiftCompiler,
         isShared: true
       )
 
@@ -192,6 +194,7 @@ extension GenericUnixToolchain {
       var linkFilePath: AbsolutePath? = try computeResourceDirPath(
         for: targetTriple,
         parsedOptions: &parsedOptions,
+        swiftCompiler: swiftCompiler,
         isShared: false
       )
 

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -38,11 +38,11 @@ extension Driver {
 
     let extraEnvironment = try toolchain.platformSpecificInterpreterEnvironmentVariables(
       env: self.env, parsedOptions: &parsedOptions, sdkPath: self.sdkPath,
-      targetTriple: self.targetTriple)
+      targetTriple: self.targetTriple, swiftCompiler: self.swiftCompiler)
 
     return Job(
       kind: .interpret,
-      tool: swiftCompiler,
+      tool: .absolute(swiftCompiler),
       commandLine: commandLine,
       inputs:inputs,
       outputs: [],

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -42,7 +42,7 @@ extension Driver {
 
     return Job(
       kind: .interpret,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: swiftCompiler,
       commandLine: commandLine,
       inputs:inputs,
       outputs: [],

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -48,7 +48,8 @@ extension Driver {
       outputFile: outputFile,
       sdkPath: sdkPath,
       sanitizers: enabledSanitizers,
-      targetTriple: targetTriple
+      targetTriple: targetTriple,
+      swiftCompiler: swiftCompiler
     )
 
     return Job(

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -51,7 +51,7 @@ extension Driver {
 
     return Job(
       kind: .mergeModule,
-      tool: swiftCompiler,
+      tool: .absolute(swiftCompiler),
       commandLine: commandLine,
       inputs: inputs,
       outputs: outputs

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -51,7 +51,7 @@ extension Driver {
 
     return Job(
       kind: .mergeModule,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: swiftCompiler,
       commandLine: commandLine,
       inputs: inputs,
       outputs: outputs

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -41,7 +41,7 @@ extension Driver {
       commandLine.appendFlags("-module-name", moduleName)
       return Job(
         kind: .repl,
-        tool: swiftCompiler,
+        tool: .absolute(swiftCompiler),
         commandLine: commandLine,
         inputs: [],
         outputs: [],

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -41,7 +41,7 @@ extension Driver {
       commandLine.appendFlags("-module-name", moduleName)
       return Job(
         kind: .repl,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        tool: swiftCompiler,
         commandLine: commandLine,
         inputs: [],
         outputs: [],

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
+import TSCBasic
 
 extension Toolchain {
   func addPathEnvironmentVariableIfNeeded(
@@ -33,13 +34,14 @@ extension DarwinToolchain {
     env: [String : String],
     parsedOptions: inout ParsedOptions,
     sdkPath: String?,
-    targetTriple: Triple) throws -> [String: String] {
+    targetTriple: Triple,
+    swiftCompiler: AbsolutePath) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
     let runtimePaths = try runtimeLibraryPaths(
       for: targetTriple,
       parsedOptions: &parsedOptions,
-      sdkPath: sdkPath,
+      sdkPath: sdkPath, swiftCompiler: swiftCompiler,
       isShared: true
     ).map { $0.pathString }
 
@@ -61,13 +63,15 @@ extension GenericUnixToolchain {
     env: [String : String],
     parsedOptions: inout ParsedOptions,
     sdkPath: String?,
-    targetTriple: Triple) throws -> [String: String] {
+    targetTriple: Triple,
+    swiftCompiler: AbsolutePath) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
     let runtimePaths = try runtimeLibraryPaths(
       for: targetTriple,
       parsedOptions: &parsedOptions,
       sdkPath: sdkPath,
+      swiftCompiler: swiftCompiler,
       isShared: true
     ).map { $0.pathString }
 

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -17,6 +17,7 @@ extension Toolchain {
   func computeResourceDirPath(
     for triple: Triple,
     parsedOptions: inout ParsedOptions,
+    swiftCompiler: AbsolutePath,
     isShared: Bool
   ) throws -> AbsolutePath {
     // FIXME: This almost certainly won't be an absolute path in practice...
@@ -29,8 +30,7 @@ extension Toolchain {
         .appending(components: "usr", "lib",
                    isShared ? "swift" : "swift_static")
     } else {
-      // FIXME: Thread the driver's swiftCompiler path here.
-      resourceDirBase = try getToolPath(.swiftCompiler)
+      resourceDirBase = swiftCompiler
         .parentDirectory // remove /swift
         .parentDirectory // remove /bin
         .appending(components: "lib", isShared ? "swift" : "swift_static")
@@ -40,10 +40,12 @@ extension Toolchain {
 
   func clangLibraryPath(
     for triple: Triple,
+    swiftCompiler: AbsolutePath,
     parsedOptions: inout ParsedOptions
   ) throws -> AbsolutePath {
     return try computeResourceDirPath(for: triple,
                                       parsedOptions: &parsedOptions,
+                                      swiftCompiler: swiftCompiler,
                                       isShared: true)
       .parentDirectory // Remove platform name.
       .appending(components: "clang", "lib",
@@ -54,9 +56,12 @@ extension Toolchain {
     for triple: Triple,
     parsedOptions: inout ParsedOptions,
     sdkPath: String?,
+    swiftCompiler: AbsolutePath,
     isShared: Bool
   ) throws -> [AbsolutePath] {
-    var result = [try computeResourceDirPath(for: triple, parsedOptions: &parsedOptions, isShared: isShared)]
+    var result = [try computeResourceDirPath(
+      for: triple, parsedOptions: &parsedOptions,
+      swiftCompiler: swiftCompiler, isShared: isShared)]
 
     if let path = sdkPath {
       result.append(AbsolutePath(path).appending(RelativePath("usr/lib/swift")))
@@ -69,9 +74,12 @@ extension Toolchain {
     named name: String,
     to commandLine: inout [Job.ArgTemplate],
     for triple: Triple,
-    parsedOptions: inout ParsedOptions
+    parsedOptions: inout ParsedOptions,
+    swiftCompiler: AbsolutePath
   ) throws {
-    let path = try clangLibraryPath(for: triple, parsedOptions: &parsedOptions)
+    let path = try clangLibraryPath(
+      for: triple, swiftCompiler: swiftCompiler,
+      parsedOptions: &parsedOptions)
       .appending(component: name)
     commandLine.appendPath(path)
   }
@@ -80,6 +88,7 @@ extension Toolchain {
     for sanitizer: Sanitizer,
     targetTriple: Triple,
     parsedOptions: inout ParsedOptions,
+    swiftCompiler: AbsolutePath,
     isShared: Bool
   ) throws -> Bool {
     let runtimeName = try runtimeLibraryName(
@@ -89,6 +98,7 @@ extension Toolchain {
     )
     let path = try clangLibraryPath(
       for: targetTriple,
+      swiftCompiler: swiftCompiler,
       parsedOptions: &parsedOptions
     ).appending(component: runtimeName)
     return localFileSystem.exists(path)
@@ -102,7 +112,8 @@ extension DarwinToolchain {
       to commandLine: inout [Job.ArgTemplate],
       parsedOptions: inout ParsedOptions,
       sdkPath: String?,
-      targetTriple: Triple
+      targetTriple: Triple,
+      swiftCompiler: AbsolutePath
     ) throws {
 
       // Link compatibility libraries, if we're deploying back to OSes that
@@ -162,6 +173,7 @@ extension DarwinToolchain {
         for: targetTriple,
         parsedOptions: &parsedOptions,
         sdkPath: sdkPath,
+        swiftCompiler: swiftCompiler,
         isShared: true
       )
       for path in runtimePaths {

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -29,6 +29,7 @@ extension Toolchain {
         .appending(components: "usr", "lib",
                    isShared ? "swift" : "swift_static")
     } else {
+      // FIXME: Thread the driver's swiftCompiler path here.
       resourceDirBase = try getToolPath(.swiftCompiler)
         .parentDirectory // remove /swift
         .parentDirectory // remove /bin

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -53,7 +53,8 @@ public protocol Toolchain {
     outputFile: VirtualPath,
     sdkPath: String?,
     sanitizers: Set<Sanitizer>,
-    targetTriple: Triple
+    targetTriple: Triple,
+    swiftCompiler: AbsolutePath
   ) throws -> AbsolutePath
 
   func runtimeLibraryName(
@@ -66,7 +67,8 @@ public protocol Toolchain {
     env: [String: String],
     parsedOptions: inout ParsedOptions,
     sdkPath: String?,
-    targetTriple: Triple) throws -> [String: String]
+    targetTriple: Triple,
+    swiftCompiler: AbsolutePath) throws -> [String: String]
 }
 
 extension Toolchain {
@@ -74,10 +76,10 @@ extension Toolchain {
     getEnvSearchPaths(pathString: env["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
   }
   
-  public func swiftCompilerVersion(_ swiftCompiler: VirtualPath) throws -> String {
+  public func swiftCompilerVersion(_ swiftCompiler: AbsolutePath) throws -> String {
     // FIXME: Thread the driver's swiftCompiler path here.
     try Process.checkNonZeroExit(
-      args: swiftCompiler.name, "-version",
+      args: swiftCompiler.pathString, "-version",
       environment: env
     ).split(separator: "\n").first.map(String.init) ?? ""
   }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -74,10 +74,10 @@ extension Toolchain {
     getEnvSearchPaths(pathString: env["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
   }
   
-  public func swiftCompilerVersion() throws -> String {
+  public func swiftCompilerVersion(_ swiftCompiler: VirtualPath) throws -> String {
     // FIXME: Thread the driver's swiftCompiler path here.
     try Process.checkNonZeroExit(
-      args: getToolPath(.swiftCompiler).pathString, "-version",
+      args: swiftCompiler.name, "-version",
       environment: env
     ).split(separator: "\n").first.map(String.init) ?? ""
   }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -75,6 +75,7 @@ extension Toolchain {
   }
   
   public func swiftCompilerVersion() throws -> String {
+    // FIXME: Thread the driver's swiftCompiler path here.
     try Process.checkNonZeroExit(
       args: getToolPath(.swiftCompiler).pathString, "-version",
       environment: env

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -77,7 +77,6 @@ extension Toolchain {
   }
   
   public func swiftCompilerVersion(_ swiftCompiler: AbsolutePath) throws -> String {
-    // FIXME: Thread the driver's swiftCompiler path here.
     try Process.checkNonZeroExit(
       args: swiftCompiler.pathString, "-version",
       environment: env

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1170,10 +1170,10 @@ final class SwiftDriverTests: XCTestCase {
   func testToolchainUtilities() throws {
     let darwinToolchain = DarwinToolchain(env: ProcessEnv.vars)
     let darwinSwiftVersion = try darwinToolchain.swiftCompilerVersion(
-      .absolute(darwinToolchain.getToolPath(.swiftCompiler)))
+      darwinToolchain.getToolPath(.swiftCompiler))
     let unixToolchain =  GenericUnixToolchain(env: ProcessEnv.vars)
     let unixSwiftVersion = try unixToolchain.swiftCompilerVersion(
-      .absolute(unixToolchain.getToolPath(.swiftCompiler)))
+      unixToolchain.getToolPath(.swiftCompiler))
     assertString(darwinSwiftVersion, contains: "Swift version ")
     assertString(unixSwiftVersion, contains: "Swift version ")
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1168,8 +1168,12 @@ final class SwiftDriverTests: XCTestCase {
   }
   
   func testToolchainUtilities() throws {
-    let darwinSwiftVersion = try DarwinToolchain(env: ProcessEnv.vars).swiftCompilerVersion()
-    let unixSwiftVersion = try GenericUnixToolchain(env: ProcessEnv.vars).swiftCompilerVersion()
+    let darwinToolchain = DarwinToolchain(env: ProcessEnv.vars)
+    let darwinSwiftVersion = try darwinToolchain.swiftCompilerVersion(
+      .absolute(darwinToolchain.getToolPath(.swiftCompiler)))
+    let unixToolchain =  GenericUnixToolchain(env: ProcessEnv.vars)
+    let unixSwiftVersion = try unixToolchain.swiftCompilerVersion(
+      .absolute(unixToolchain.getToolPath(.swiftCompiler)))
     assertString(darwinSwiftVersion, contains: "Swift version ")
     assertString(unixSwiftVersion, contains: "Swift version ")
   }


### PR DESCRIPTION
A number of job-creation functions were asking the toolchain for the frontend path, rather than using the frontend path computed by the `Driver` instance. Fix them, and thread the Driver-computed Swift frontend path everywhere. We might want to change the way things are layered here in the future.