### PR TITLE
Adjust batch partition count calculation

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -293,12 +293,23 @@ extension Driver {
     // pre-batch-mode 1000. I.e. it's still running 96% fewer
     // subprocesses than before. And significantly: it's doing so while
     // not exceeding the RAM of a typical 2-core laptop.
+
+    // An explanation of why the partition calculation isn't integer
+    // division. Using an example, a module of 26 files exceeds the
+    // limit of 25 and must be compiled in 2 batches. Integer division
+    // yields 26/25 = 1 batch, but a single batch of 26 exceeds the
+    // limit. The calculation must round up, which can be calculated
+    // using: `(x + y - 1) / y`
+    let divideUp = { num, div in
+        return (num + div - 1) / div
+    }
+
     let defaultSizeLimit = 25
     let numInputFiles = swiftInputFiles.count
     let sizeLimit = info.sizeLimit ?? defaultSizeLimit
 
     let numTasks = numParallelJobs ?? 1
-    return max(numTasks, numInputFiles / sizeLimit)
+    return max(numTasks, divideUp(numInputFiles, sizeLimit))
   }
 
   /// Describes the partitions used when batching.

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -300,7 +300,7 @@ extension Driver {
     // yields 26/25 = 1 batch, but a single batch of 26 exceeds the
     // limit. The calculation must round up, which can be calculated
     // using: `(x + y - 1) / y`
-    let divideUp = { num, div in
+    let divideRoundingUp = { num, div in
         return (num + div - 1) / div
     }
 
@@ -309,7 +309,7 @@ extension Driver {
     let sizeLimit = info.sizeLimit ?? defaultSizeLimit
 
     let numTasks = numParallelJobs ?? 1
-    return max(numTasks, divideUp(numInputFiles, sizeLimit))
+    return max(numTasks, divideRoundingUp(numInputFiles, sizeLimit))
   }
 
   /// Describes the partitions used when batching.


### PR DESCRIPTION
This mirrors the batch partition calculation change in https://github.com/apple/swift/pull/28972. See below for an explanation.

---

While exploring how to optimize global build times, I noticed that the batch sizing logic wasn't producing multiple batches until a module had 50 files. Based on @graydon's [detailed batch calculation comment](https://github.com/apple/swift/blob/746b58e8e1c1ef1ac09d8031875fd2a08b65597c/lib/Driver/Compilation.cpp#L1269-L1362) (which says "cap the batch size ... at ... 25"), and based on the variable names ("`SizeLimit`"), I believe the batch calculation implementation is off.

The simple example is a module of 26 files. With the existing batch calculation, the result is a `26/25=1` batch. However this is larger than the `DefaultSizeLimit`. This calculation continues to yield `1` for modules up to 49 files. Only at modules of 50 files does the batch calculation produce two batches.

Here's a table showing the effects of the current partition count calculation:

| Num Files | Num Batches  | Min Batch Size | Max Batch Size |
| --- | --- | --- | --- |
| 1-49 | 1 | 1 | 49 |
| 50-74 | 2 | 25 | 37 |
| 75-99 | 3 | 25 | 33 |
| 100-124 | 4 | 25 | 31 |

This table shows that the max batch size is inversely proportional with the number of files. Smaller modules have a higher max batch size, and as a module gets larger, its max batch size trends toward 25. It also shows that after 50, the minimum batch size is consistently 25.

With this proposed change to the batch count calculation, the math is now:

| Num Files | Num Batches  | Min Batch Size | Max Batch Size |
| --- | --- | --- | --- |
| 1-25 | 1 | 1 | 25 |
| 26-50 | 2 | 13 | 25 |
| 51-75 | 3 | 17 | 25 |
| 76-100 | 4 | 19 | 25 |
| 101-125 | 5 | 21 | 25 |

This table shows that the batch size is in fact capped to 25, independent of how many files are in the module. It also show the minimum batch size increases with module size.