### PR TITLE
Use response files when running subcommands if needed

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -476,12 +476,8 @@ extension Driver {
     #if !os(macOS) && !os(Linux)
       #warning("Response file tokenization unimplemented for platform; behavior may be incorrect")
     #endif
-    var array: [String] = []
-    array.reserveCapacity(256)
-    content.split { $0 == "\n" || $0 == "\r\n" }
-           .map { tokenizeResponseFileLine($0) }
-           .forEach { array += $0 }
-    return array
+    return content.split { $0 == "\n" || $0 == "\r\n" }
+           .flatMap { tokenizeResponseFileLine($0) }
   }
   
   /// Recursively expands the response files.

--- a/Sources/SwiftDriver/Execution/JobExecutor.swift
+++ b/Sources/SwiftDriver/Execution/JobExecutor.swift
@@ -68,7 +68,7 @@ public struct ArgsResolver {
       (job.supportsResponseFiles && !commandLineFitsWithinSystemLimits(path: resolvedArguments[0], args: resolvedArguments)) {
       assert(!forceResponseFiles || job.supportsResponseFiles,
              "Platform does not support response files for job: \(job)")
-      let responseFilePath = temporaryDirectory.appending(component: "arguments-\(job.hashValue).resp")
+      let responseFilePath = temporaryDirectory.appending(component: "arguments-\(abs(job.hashValue)).resp")
       try localFileSystem.writeFileContents(responseFilePath) { $0 <<< resolvedArguments[1...].map{ $0.spm_shellEscaped() }.joined(separator: "\n") }
       resolvedArguments = [resolvedArguments[0], "@\(responseFilePath.pathString)"]
     }

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -33,7 +33,8 @@ extension Driver {
       tool: .absolute(try toolchain.getToolPath(.swiftAutolinkExtract)),
       commandLine: commandLine,
       inputs: inputs,
-      outputs: [.init(file: output, type: .autolink)]
+      outputs: [.init(file: output, type: .autolink)],
+      supportsResponseFiles: true
     )
   }
 }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -158,7 +158,8 @@ extension Driver {
       commandLine: commandLine,
       displayInputs: primaryInputs,
       inputs: inputs,
-      outputs: outputs
+      outputs: outputs,
+      supportsResponseFiles: true
     )
   }
 }

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -67,7 +67,8 @@ extension Driver {
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,
-      outputs: outputs
+      outputs: outputs,
+      supportsResponseFiles: true
     )
   }
 }

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -47,7 +47,8 @@ extension Driver {
       inputs:inputs,
       outputs: [],
       extraEnvironment: extraEnvironment,
-      requiresInPlaceExecution: true
+      requiresInPlaceExecution: true,
+      supportsResponseFiles: true
     )
   }
 }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -12,7 +12,7 @@
 import TSCBasic
 
 /// A job represents an individual subprocess that should be invoked during compilation.
-public struct Job: Codable, Equatable {
+public struct Job: Codable, Equatable, Hashable {
   public enum Kind: String, Codable {
     case compile
     case mergeModule = "merge-module"
@@ -29,7 +29,7 @@ public struct Job: Codable, Equatable {
     case verifyDebugInfo = "verify-debug-info"
   }
 
-  public enum ArgTemplate: Equatable {
+  public enum ArgTemplate: Equatable, Hashable {
     /// Represents a command-line flag that is substitued as-is.
     case flag(String)
 
@@ -42,6 +42,9 @@ public struct Job: Codable, Equatable {
 
   /// The command-line arguments of the job.
   public var commandLine: [ArgTemplate]
+
+  /// Whether or not the job supports using response files to pass command line arguments.
+  public var supportsResponseFiles: Bool
 
   /// The list of inputs to use for displaying purposes.
   public var displayInputs: [TypedVirtualPath]
@@ -69,7 +72,8 @@ public struct Job: Codable, Equatable {
     inputs: [TypedVirtualPath],
     outputs: [TypedVirtualPath],
     extraEnvironment: [String: String] = [:],
-    requiresInPlaceExecution: Bool = false
+    requiresInPlaceExecution: Bool = false,
+    supportsResponseFiles: Bool = false
   ) {
     self.kind = kind
     self.tool = tool
@@ -79,21 +83,7 @@ public struct Job: Codable, Equatable {
     self.outputs = outputs
     self.extraEnvironment = extraEnvironment
     self.requiresInPlaceExecution = requiresInPlaceExecution
-  }
-}
-
-extension Job: CustomStringConvertible {
-  public var description: String {
-    var result: String = "\(tool.name) \(commandLine.joinedArguments)"
-
-    if !self.extraEnvironment.isEmpty {
-      result += " #"
-      for (envVar, val) in extraEnvironment {
-        result += " \(envVar)=\(val)"
-      }
-    }
-
-    return result
+    self.supportsResponseFiles = supportsResponseFiles
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -51,6 +51,7 @@ extension Driver {
       targetTriple: targetTriple
     )
 
+    // TODO: some, but not all, linkers support response files.
     return Job(
       kind: .link,
       tool: .absolute(toolPath),

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -54,7 +54,8 @@ extension Driver {
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,
       inputs: inputs,
-      outputs: outputs
+      outputs: outputs,
+      supportsResponseFiles: true
     )
   }
 }

--- a/Sources/SwiftDriver/Utilities/StringAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/StringAdditions.swift
@@ -133,3 +133,9 @@ extension Unicode.Scalar {
     }
   }
 }
+
+extension Character {
+  var isShellQuote: Bool {
+    return self == "\"" || self == "'"
+  }
+}

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -19,7 +19,7 @@ import Glibc
 #if os(macOS) || os(Linux)
 // Adapted from llvm::sys::commandLineFitsWithinSystemLimits.
 func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
-  let upperBound = sysconf(_SC_ARG_MAX)
+  let upperBound = sysconf(Int32(_SC_ARG_MAX))
   guard upperBound != -1 else {
     // The system reports no limit.
     return true
@@ -36,8 +36,9 @@ func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
   var commandLineLength = path.utf8.count + 1
   for arg in args {
     #if os(Linux)
-      // Linux limits the length of each individual argument to MAX_ARG_STRLEN,
-      guard arg.utf8.count < MAX_ARG_STRLEN else {
+      // Linux limits the length of each individual argument to MAX_ARG_STRLEN.
+      // There is no available constant, so it is hardcoded here.
+      guard arg.utf8.count < 32 * 4096 else {
         return false
       }
     #endif

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -1,0 +1,53 @@
+//===------------ System.swift - Swift Driver System Utilities ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+#if os(macOS) || os(Linux)
+// Adapted from llvm::sys::commandLineFitsWithinSystemLimits.
+func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
+  let upperBound = sysconf(_SC_ARG_MAX)
+  guard upperBound != -1 else {
+    // The system reports no limit.
+    return true
+  }
+  // The lower bound for ARG_MAX on a POSIX system
+  let lowerBound = Int(_POSIX_ARG_MAX)
+  // This the same baseline used by xargs.
+  let baseline = 128 * 1024;
+
+  var effectiveArgMax = max(min(baseline, upperBound), lowerBound)
+  // Conservatively assume environment variables consume half the space.
+  effectiveArgMax /= 2
+
+  var commandLineLength = path.utf8.count + 1
+  for arg in args {
+    #if os(Linux)
+      // Linux limits the length of each individual argument to MAX_ARG_STRLEN,
+      guard arg.utf8.count < MAX_ARG_STRLEN else {
+        return false
+      }
+    #endif
+    commandLineLength += arg.utf8.count + 1
+  }
+  return commandLineLength < effectiveArgMax
+}
+#else
+func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
+  #warning("missing implementation for current platform")
+  return true
+}
+#endif

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -456,6 +456,7 @@ final class SwiftDriverTests: XCTestCase {
         @NotAFile
         -flag="quoted string with a \"quote\" inside" -another-flag
         """#
+        <<< "\nthis  line\thas        lots \t  of    whitespace"
       }
       
       try localFileSystem.writeFileContents(barPath) {
@@ -476,7 +477,7 @@ final class SwiftDriverTests: XCTestCase {
         $0 <<< "swift\n--driver-mode=swiftc\n-v\r\n//comment\n\"the end\""
       }
       let args = try Driver.expandResponseFiles(["@" + fooPath.pathString], diagnosticsEngine: diags)
-      XCTAssertEqual(args, ["Command1", "--kkc", "but", "this", "is", #"\\a"#, "command", #"swift"#, "rocks!" ,"compiler", "-Xlinker", "@loader_path", "mkdir", "Quoted Dir", "cd", "Unquoted Dir", "@NotAFile", #"-flag=quoted string with a "quote" inside"#, "-another-flag"])
+      XCTAssertEqual(args, ["Command1", "--kkc", "but", "this", "is", #"\\a"#, "command", #"swift"#, "rocks!" ,"compiler", "-Xlinker", "@loader_path", "mkdir", "Quoted Dir", "cd", "Unquoted Dir", "@NotAFile", #"-flag=quoted string with a "quote" inside"#, "-another-flag", "this", "line", "has", "lots", "of", "whitespace"])
       let escapingArgs = try Driver.expandResponseFiles(["@" + escapingPath.pathString], diagnosticsEngine: diags)
       XCTAssertEqual(escapingArgs, ["swift", "--driver-mode=swiftc", "-v","the end"])
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -453,7 +453,8 @@ final class SwiftDriverTests: XCTestCase {
         // this is another comment
         but this is \\\\\a command
         @\#(barPath.pathString)
-        @YouAren'tAFile
+        @NotAFile
+        -flag="quoted string with a \"quote\" inside" -another-flag
         """#
       }
       
@@ -466,18 +467,18 @@ final class SwiftDriverTests: XCTestCase {
         
         @loader_path
         mkdir "Quoted Dir"
-        cd Unquoted \\Dir
+        cd Unquoted\ Dir
         // Bye!
         """#
       }
       
       try localFileSystem.writeFileContents(escapingPath) {
-        $0 <<< "swift\n--driver-mode=swift\tc\n-v\r\n//comment\n\"the end\""
+        $0 <<< "swift\n--driver-mode=swiftc\n-v\r\n//comment\n\"the end\""
       }
       let args = try Driver.expandResponseFiles(["@" + fooPath.pathString], diagnosticsEngine: diags)
-      XCTAssertEqual(args, [#"Command1 --kkc"#, #"but this is \\a command"#, #"swift"#, #""rocks!""# ,#"compiler"#, #"-Xlinker"#, #"@loader_path"#, #"mkdir "Quoted Dir""#, #"cd Unquoted \Dir"#, #"@YouAren'tAFile"#])
+      XCTAssertEqual(args, ["Command1", "--kkc", "but", "this", "is", #"\\a"#, "command", #"swift"#, "rocks!" ,"compiler", "-Xlinker", "@loader_path", "mkdir", "Quoted Dir", "cd", "Unquoted Dir", "@NotAFile", #"-flag=quoted string with a "quote" inside"#, "-another-flag"])
       let escapingArgs = try Driver.expandResponseFiles(["@" + escapingPath.pathString], diagnosticsEngine: diags)
-      XCTAssertEqual(escapingArgs, ["swift", "--driver-mode=swiftc", "-v","\"the end\""])
+      XCTAssertEqual(escapingArgs, ["swift", "--driver-mode=swiftc", "-v","the end"])
     }
   }
   


### PR DESCRIPTION
Now, when a job is created, it can optionally indicate that it supports using a response file to pass its arguments. Then, `ArgsResolver` is responsible for checking the argument length and writing out a response file if needed. This ensures that if `ArgsResolver` lengthens the arguments, this is accounted for properly.

I'm fairly happy with this design, but there's one issue in how it interacts with LLBuild, which is why this is a WIP for now. A couple of the integration tests which pass 500k args run very slowly (~3-4 minutes each). It looks like most of the time is spent in JSONDecoder objc bridging (at least on macOS), which is used to serialize Jobs. This might need to be switched to a faster encoder/decoder.

This PR also makes a few changes to response file tokenization to more closely match the integrated driver. 

With this change, two response file integration tests still fail: one due to different sets of files being passed with `-primary-file`, and another because the c++ and swift drivers use a different tmp dir layout.