### PR TITLE
Forward -print-target-info to the frontend, begin refactoring planning for simple driver invocations

### DIFF
--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -27,6 +27,8 @@ public struct Job: Codable, Equatable {
     case interpret
     case repl
     case verifyDebugInfo = "verify-debug-info"
+    case printTargetInfo = "print-target-info"
+    case versionRequest = "version-request"
   }
 
   public enum ArgTemplate: Equatable {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -196,7 +196,7 @@ extension Driver {
 
   /// Plan a build by producing a set of jobs to complete the build.
   public mutating func planBuild() throws -> [Job] {
-    // Handle invocations which can be trivially forwarded to the frontend.
+
     if let job = try immediateForwardingJob() {
       return [job]
     }

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -41,8 +41,9 @@ do {
   }
 
   var driver = try Driver(args: arguments, diagnosticsEngine: diagnosticsEngine)
+  let jobs = try driver.planBuild()
   let resolver = try ArgsResolver()
-  try driver.run(resolver: resolver, processSet: processSet)
+  try driver.run(jobs: jobs, resolver: resolver, processSet: processSet)
 
   if driver.diagnosticEngine.hasErrors {
     exit(EXIT_FAILURE)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1203,6 +1203,29 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertNoThrow(try driver2.toolchain.getToolPath(.dsymutil))
   }
 
+  func testVersionRequest() throws {
+    for arg in ["-version", "--version"] {
+      var driver = try Driver(args: ["swift"] + [arg])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertTrue(plannedJobs.count == 1)
+      let job = plannedJobs[0]
+      XCTAssertEqual(job.kind, .versionRequest)
+      XCTAssertEqual(job.commandLine, [.flag("--version")])
+    }
+  }
+
+  func testPrintTargetInfo() throws {
+    var driver = try Driver(args: ["swift", "-print-target-info", "-target", "arm64-apple-ios12.0", "-sdk", "bar", "-resource-dir", "baz"])
+    let plannedJobs = try driver.planBuild()
+    XCTAssertTrue(plannedJobs.count == 1)
+    let job = plannedJobs[0]
+    XCTAssertEqual(job.kind, .printTargetInfo)
+    XCTAssertTrue(job.commandLine.contains(.flag("-print-target-info")))
+    XCTAssertTrue(job.commandLine.contains(.flag("-target")))
+    XCTAssertTrue(job.commandLine.contains(.flag("-sdk")))
+    XCTAssertTrue(job.commandLine.contains(.flag("-resource-dir")))
+  }
+
   func testPCHGeneration() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-typecheck", "-import-objc-header", "TestInputHeader.h", "foo.swift"])


### PR DESCRIPTION
The `-print-target-info` implementation itself is pretty straightforward. The refactor is a little more interesting, I pulled the `planBuild` call out of `Driver.run`. Now, all clients are expected to call `planBuild` for a list of jobs they can hand off to `Driver.run` or schedule themselves. I also pulled `-version` and `-print-target-info` handling out of `run` and into the build planning stage. This gives clients more control over executing them in case they want to do something like capture the output. It's not yet clear if we want to do something similar for printing help or forwarding to `swift-indent`/`swift-autolink-extract`, I've left that logic alone for now.