### PR TITLE
Move forwarding to non-compiler driver kinds into the planning stage

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -558,10 +558,6 @@ extension Driver {
     executorDelegate: JobExecutorDelegate? = nil,
     processSet: ProcessSet? = nil
   ) throws {
-    // We just need to invoke the corresponding tool if the kind isn't Swift compiler.
-    guard driverKind.isSwiftCompiler else {
-      return try exec(path: toolchain.getToolPath(.swiftCompiler).pathString, args: driverKind.usageArgs + parsedOptions.commandLine)
-    }
 
     if parsedOptions.contains(.help) || parsedOptions.contains(.helpHidden) {
       optionTable.printHelp(driverKind: driverKind, includeHidden: parsedOptions.contains(.helpHidden))

--- a/Sources/SwiftDriver/Driver/DriverKind.swift
+++ b/Sources/SwiftDriver/Driver/DriverKind.swift
@@ -27,28 +27,28 @@ public enum DriverKind {
 
 extension DriverKind {
   public var usage: String {
-    usageArgs.joined(separator: " ")
+    usageArgs.joinedArguments
   }
 
-  public var usageArgs: [String] {
+  public var usageArgs: [Job.ArgTemplate] {
     switch self {
     case .autolinkExtract:
-      return ["swift-autolink-extract"]
+      return [.flag("swift-autolink-extract")]
 
     case .batch:
-      return ["swiftc"]
+      return [.flag("swiftc")]
 
     case .frontend:
-      return ["swift", "-frontend"]
+      return [.flag("swift"), .flag("-frontend")]
 
     case .indent:
-      return ["swift-indent"]
+      return [.flag("swift-indent")]
 
     case .interactive:
-      return ["swift"]
+      return [.flag("swift")]
 
     case .moduleWrap:
-      return ["swift-modulewrap"]
+      return [.flag("swift-modulewrap")]
     }
   }
 

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -29,6 +29,9 @@ public struct Job: Codable, Equatable {
     case verifyDebugInfo = "verify-debug-info"
     case printTargetInfo = "print-target-info"
     case versionRequest = "version-request"
+
+    // A generic job which forwards a command line to another tool.
+    case forwarding
   }
 
   public enum ArgTemplate: Equatable {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -168,6 +168,20 @@ extension Driver {
   /// Create a job if needed for simple requests that can be immediately
   /// forwarded to the frontend.
   public mutating func immediateForwardingJob() throws -> Job? {
+
+    // We just need to invoke the corresponding tool if the kind isn't Swift compiler.
+    if !driverKind.isSwiftCompiler {
+      var commandLine: [Job.ArgTemplate] = driverKind.usageArgs
+      try commandLine.append(contentsOf: parsedOptions.allArguments())
+      return Job(kind: .forwarding,
+                 tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+                 commandLine: commandLine,
+                 displayInputs: [],
+                 inputs: [],
+                 outputs: [],
+                 requiresInPlaceExecution: true)
+    }
+
     if parsedOptions.hasArgument(.printTargetInfo) {
       var commandLine: [Job.ArgTemplate] = [.flag("-frontend"),
                                             .flag("-print-target-info")]

--- a/Sources/SwiftDriver/Options/ParsedOptions.swift
+++ b/Sources/SwiftDriver/Options/ParsedOptions.swift
@@ -184,6 +184,14 @@ extension ParsedOptions {
     return result
   }
 
+  /// Return all options and mark them as consumed.
+  public mutating func allArguments() -> [ParsedOption] {
+    for option in parsedOptions {
+      consumed[option.index] = true
+    }
+    return parsedOptions
+  }
+
   public mutating func arguments(for options: Option...) -> [ParsedOption] {
     return options.flatMap { lookup($0) }
   }


### PR DESCRIPTION
This is a continuation of https://github.com/apple/swift-driver/pull/58 which moves forwarding into jobs created during build planning.
