### PR TITLE
Allow relative paths in output file map

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -247,13 +247,19 @@ public struct Driver {
     let inputFiles = try Self.collectInputFiles(&self.parsedOptions)
     self.inputFiles = inputFiles
 
+    let outputFileMap: OutputFileMap?
     // Initialize an empty output file map, which will be populated when we start creating jobs.
     if let outputFileMapArg = parsedOptions.getLastArgument(.outputFileMap)?.asSingle {
       let path = try AbsolutePath(validating: outputFileMapArg)
-      self.outputFileMap = try .load(file: path, diagnosticEngine: diagnosticEngine)
+      outputFileMap = try .load(file: path, diagnosticEngine: diagnosticEngine)
+    } else {
+      outputFileMap = nil
     }
-    else {
-      self.outputFileMap = nil
+
+    if let workingDirectory = self.workingDirectory {
+      self.outputFileMap = outputFileMap?.resolveRelativePaths(relativeTo: workingDirectory)
+    } else {
+      self.outputFileMap = outputFileMap
     }
 
     // Determine the compilation mode.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -453,6 +453,44 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testOutputFileMapResolving() throws {
+    // Create sample OutputFileMap:
+
+    let stringyEntries: [String: [FileType: String]] = [
+      "": [.swiftDeps: "foo.build/master.swiftdeps"],
+      "foo.swift" : [
+        .dependencies: "foo.build/foo.d",
+        .object: "foo.build/foo.swift.o",
+        .swiftModule: "foo.build/foo~partial.swiftmodule",
+        .swiftDeps: "foo.build/foo.swiftdeps"
+      ]
+    ]
+    let resolvedStringyEntries: [String: [FileType: String]] = [
+      "": [.swiftDeps: "/foo_root/foo.build/master.swiftdeps"],
+      "/foo_root/foo.swift" : [
+        .dependencies: "/foo_root/foo.build/foo.d",
+        .object: "/foo_root/foo.build/foo.swift.o",
+        .swiftModule: "/foo_root/foo.build/foo~partial.swiftmodule",
+        .swiftDeps: "/foo_root/foo.build/foo.swiftdeps"
+      ]
+    ]
+    func outputFileMapFromStringyEntries(
+      _ entries: [String: [FileType: String]]
+    ) throws -> OutputFileMap {
+      .init(entries: Dictionary(uniqueKeysWithValues: try entries.map { try (
+        VirtualPath(path: $0.key),
+        $0.value.mapValues(VirtualPath.init(path:))
+      )}))
+    }
+    let sampleOutputFileMap =
+      try outputFileMapFromStringyEntries(stringyEntries)
+    let resolvedOutputFileMap = sampleOutputFileMap
+      .resolveRelativePaths(relativeTo: .init("/foo_root"))
+    let expectedOutputFileMap =
+      try outputFileMapFromStringyEntries(resolvedStringyEntries)
+    XCTAssertEqual(expectedOutputFileMap, resolvedOutputFileMap)
+  }
+
   func testResponseFileExpansion() throws {
     try withTemporaryDirectory { path in
       let diags = DiagnosticsEngine()


### PR DESCRIPTION
This allows having relative paths on output file map json file. 
Also, I've made working directory to default to cwd if no `-working-directory` arg is supplied.
Also, there is small bug, if there is two identical inputs in output file map, driver would silently crash, as it uses `Dictionary(uniqueKeysWithValues:)` initializer, now it will choose last record (behaviour that usually seen in clang, for example), but is it better to have warning or error? There is some difficulty thought, as closure that handles duplicates doesn't have key as argument, so we need to find duplicates beforehand.

Also, it looks that there is a lot of dangling whitespaces, is it ok to remove them? May be e need some codestyle tool (swift-format?) that will make codestyle automated?

This is my first contribution to swift project, so any help would be very much appreciated :)