### PR TITLE
Diagnose when inputs are modified during the build

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 import TSCBasic
 import TSCUtility
+import Foundation
 
 /// How should the Swift module output be handled?
 public enum ModuleOutput: Equatable {
@@ -78,6 +79,9 @@ public struct Driver {
 
   /// The set of input files
   public let inputFiles: [TypedVirtualPath]
+
+  /// The last time each input file was modified, recorded at the start of the build.
+  public let recordedInputModificationDates: [TypedVirtualPath: Date]
 
   /// The mapping from input files to output files for each kind.
   internal let outputFileMap: OutputFileMap?
@@ -246,6 +250,14 @@ public struct Driver {
     // Classify and collect all of the input files.
     let inputFiles = try Self.collectInputFiles(&self.parsedOptions)
     self.inputFiles = inputFiles
+    self.recordedInputModificationDates = .init(uniqueKeysWithValues:
+      Set(inputFiles).compactMap {
+        if case .absolute(let absolutePath) = $0.file,
+          let modTime = try? localFileSystem.getFileInfo(absolutePath).modTime {
+          return ($0, modTime)
+        }
+        return nil
+    })
 
     // Initialize an empty output file map, which will be populated when we start creating jobs.
     if let outputFileMapArg = parsedOptions.getLastArgument(.outputFileMap)?.asSingle {
@@ -618,7 +630,8 @@ extension Driver {
         executorDelegate: executorDelegate,
         numParallelJobs: numParallelJobs,
         processSet: processSet,
-        forceResponseFiles: forceResponseFiles
+        forceResponseFiles: forceResponseFiles,
+        recordedInputModificationDates: recordedInputModificationDates
     )
     try jobExecutor.execute(env: env)
   }
@@ -643,6 +656,8 @@ extension Driver {
     for (envVar, value) in job.extraEnvironment {
       try ProcessEnv.setVar(envVar, value: value)
     }
+
+    try job.verifyInputsNotModified(since: self.recordedInputModificationDates)
 
     return try exec(path: arguments[0], args: arguments)
   }

--- a/Sources/SwiftDriver/Execution/JobExecutor.swift
+++ b/Sources/SwiftDriver/Execution/JobExecutor.swift
@@ -138,6 +138,9 @@ public final class JobExecutor {
     /// If true, always use response files to pass command line arguments.
     let forceResponseFiles: Bool
 
+    /// The last time each input file was modified, recorded at the start of the build.
+    public let recordedInputModificationDates: [TypedVirtualPath: Date]
+
     init(
       argsResolver: ArgsResolver,
       env: [String: String],
@@ -145,7 +148,8 @@ public final class JobExecutor {
       executorDelegate: JobExecutorDelegate,
       jobQueue: OperationQueue,
       processSet: ProcessSet?,
-      forceResponseFiles: Bool
+      forceResponseFiles: Bool,
+      recordedInputModificationDates: [TypedVirtualPath: Date]
     ) {
       self.producerMap = producerMap
       self.argsResolver = argsResolver
@@ -154,6 +158,7 @@ public final class JobExecutor {
       self.jobQueue = jobQueue
       self.processSet = processSet
       self.forceResponseFiles = forceResponseFiles
+      self.recordedInputModificationDates = recordedInputModificationDates
     }
   }
 
@@ -175,13 +180,17 @@ public final class JobExecutor {
   /// If true, always use response files to pass command line arguments.
   let forceResponseFiles: Bool
 
+  /// The last time each input file was modified, recorded at the start of the build.
+  public let recordedInputModificationDates: [TypedVirtualPath: Date]
+
   public init(
     jobs: [Job],
     resolver: ArgsResolver,
     executorDelegate: JobExecutorDelegate,
     numParallelJobs: Int? = nil,
     processSet: ProcessSet? = nil,
-    forceResponseFiles: Bool = false
+    forceResponseFiles: Bool = false,
+    recordedInputModificationDates: [TypedVirtualPath: Date] = [:]
   ) {
     self.jobs = jobs
     self.argsResolver = resolver
@@ -189,6 +198,7 @@ public final class JobExecutor {
     self.numParallelJobs = numParallelJobs ?? 1
     self.processSet = processSet
     self.forceResponseFiles = forceResponseFiles
+    self.recordedInputModificationDates = recordedInputModificationDates
   }
 
   /// Execute all jobs.
@@ -227,7 +237,8 @@ public final class JobExecutor {
       executorDelegate: executorDelegate,
       jobQueue: jobQueue,
       processSet: processSet,
-      forceResponseFiles: forceResponseFiles
+      forceResponseFiles: forceResponseFiles,
+      recordedInputModificationDates: recordedInputModificationDates
     )
   }
 }
@@ -381,6 +392,8 @@ class ExecuteJobRule: LLBuildRule {
     do {
       let arguments: [String] = try resolver.resolveArgumentList(for: job,
                                                                  forceResponseFiles: context.forceResponseFiles)
+
+      try job.verifyInputsNotModified(since: context.recordedInputModificationDates)
 
       let process = try context.executorDelegate.launchProcess(
         for: job, arguments: arguments, env: env

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
+import Foundation
 
 /// A job represents an individual subprocess that should be invoked during compilation.
 public struct Job: Codable, Equatable, Hashable {
@@ -86,6 +87,29 @@ public struct Job: Codable, Equatable, Hashable {
     self.extraEnvironment = extraEnvironment
     self.requiresInPlaceExecution = requiresInPlaceExecution
     self.supportsResponseFiles = supportsResponseFiles
+  }
+}
+
+extension Job {
+  public enum InputError: Error, Equatable, DiagnosticData {
+    case inputUnexpectedlyModified(TypedVirtualPath)
+
+    public var description: String {
+      switch self {
+      case .inputUnexpectedlyModified(let input):
+        return "input file '\(input.file.name)' was modified during the build"
+      }
+    }
+  }
+
+  public func verifyInputsNotModified(since recordedInputModificationDates: [TypedVirtualPath: Date]) throws {
+    for input in inputs {
+      if case .absolute(let absolutePath) = input.file,
+        let recordedModificationTime = recordedInputModificationDates[input],
+        try localFileSystem.getFileInfo(absolutePath).modTime != recordedModificationTime {
+        throw InputError.inputUnexpectedlyModified(input)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The condition is checked in both cases, but only single-job build plans emit a diagnostic right now, I left a fixme in the multi-job test. For that, I need to decide if the `JobExecutor` should propagate errors through the build graph, or if the `Context`should just include a `DiagnosticEngine`.