### PR TITLE
More accurate computation of compile job output paths

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -605,7 +605,7 @@ extension Driver {
       return
     }
 
-    if jobs.contains(where: { $0.requiresInPlaceExecution }) {
+    if jobs.contains(where: { $0.requiresInPlaceExecution }) || jobs.count == 1 {
       assert(jobs.count == 1, "Cannot execute in place for multi-job build plans")
       return try executeJobInPlace(jobs[0], resolver: resolver, forceResponseFiles: forceResponseFiles)
     }

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -246,3 +246,18 @@ extension FileType {
     }
   }
 }
+
+extension FileType {
+  var isTextual: Bool {
+    switch self {
+    case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
+         .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
+         .optimizationRecord, .swiftInterface:
+      return true
+    case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
+         .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
+         .pcm, .swiftDeps, .remap, .indexData:
+      return false
+    }
+  }
+}

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -227,6 +227,34 @@ final class SwiftDriverTests: XCTestCase {
       }
   }
 
+  func testBaseOutputPaths() throws {
+    // Test the combination of -c and -o includes the base output path.
+    do {
+      var driver = try Driver(args: ["swiftc", "-c", "foo.swift", "-o", "/some/output/path/bar.o"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(.path(try VirtualPath(path: "/some/output/path/bar.o"))))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-sil", "foo.swift", "-o", "/some/output/path/bar.sil"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(.path(try VirtualPath(path: "/some/output/path/bar.sil"))))
+    }
+
+    do {
+      // If no output is specified, verify we print to stdout for textual formats.
+      var driver = try Driver(args: ["swiftc", "-emit-assembly", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(.path(.standardOutput)))
+    }
+  }
+
     func testMultithreading() throws {
 
       XCTAssertEqual(try Driver(args: ["swiftc"]).numThreads, 0)


### PR DESCRIPTION
With this change, we're down to 6 interpreter and 3 stdlib lit tests still failing. I'm not all that happy with this solution, it feels kind of fragile. I haven't come up with anything better though so I thought I'd put this up in case anyone had a better solution in mind.