### PR TITLE
Search for the default SDK path only if triple is macOSX

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1320,8 +1320,8 @@ extension Driver {
     } else if let SDKROOT = env["SDKROOT"] {
       sdkPath = SDKROOT
     } else if compilerMode == .immediate || compilerMode == .repl {
-      // FIXME: ... is triple macOS ...
-      if true {
+      let triple = try? toolchain.hostTargetTriple()
+      if triple?.isMacOSX == true {
         // In immediate modes, use the SDK provided by xcrun.
         // This will prefer the SDK alongside the Swift found by "xcrun swift".
         // We don't do this in compilation modes because defaulting to the

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1055,7 +1055,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(job.commandLine.contains(.flag("-interpret")))
       XCTAssertTrue(job.commandLine.contains(.flag("-module-name")))
       XCTAssertTrue(job.commandLine.contains(.flag("foo")))
-
+      
+      if driver.targetTriple.isMacOSX {
+        XCTAssertTrue(job.commandLine.contains(.flag("-sdk")))
+      }
+      
       XCTAssertFalse(job.commandLine.contains(.flag("--")))
       XCTAssertTrue(job.extraEnvironment.keys.contains("\(driver.targetTriple.isDarwin ? "DYLD" : "LD")_LIBRARY_PATH"))
     }


### PR DESCRIPTION
Addresses a minor fixme on getting default SDK Path only if triple is macosx.

cc @aciidb0mb3r 