### PR TITLE
Don't use a bridging pch in immediate mode

### DIFF
--- a/Sources/SwiftDriver/Driver/CompilerMode.swift
+++ b/Sources/SwiftDriver/Driver/CompilerMode.swift
@@ -61,6 +61,17 @@ extension CompilerMode {
       return true
     }
   }
+
+  // Whether this compilation mode supports the use of bridging pre-compiled
+  // headers.
+  public var supportsBridgingPCH: Bool {
+    switch self {
+    case .batchCompile, .singleCompile, .standardCompile, .compilePCM:
+      return true
+    case .immediate, .repl:
+      return false
+    }
+  }
 }
 
 extension CompilerMode: CustomStringConvertible {

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -291,6 +291,7 @@ public struct Driver {
 
     self.importedObjCHeader = try Self.computeImportedObjCHeader(&parsedOptions, compilerMode: compilerMode, diagnosticEngine: diagnosticEngine)
     self.bridgingPrecompiledHeader = try Self.computeBridgingPrecompiledHeader(&parsedOptions,
+                                                                               compilerMode: compilerMode,
                                                                                importedObjCHeader: importedObjCHeader,
                                                                                outputFileMap: outputFileMap)
 
@@ -1384,9 +1385,11 @@ extension Driver {
 
   /// Compute the path of the generated bridging PCH for the Objective-C header.
   static func computeBridgingPrecompiledHeader(_ parsedOptions: inout ParsedOptions,
+                                               compilerMode: CompilerMode,
                                                importedObjCHeader: VirtualPath?,
                                                outputFileMap: OutputFileMap?) throws -> VirtualPath? {
-    guard let input = importedObjCHeader,
+    guard compilerMode.supportsBridgingPCH,
+      let input = importedObjCHeader,
       parsedOptions.hasFlag(positive: .enableBridgingPch, negative: .disableBridgingPch, default: true) else {
         return nil
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1540,6 +1540,16 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[1].inputs.count, 1)
       XCTAssertEqual(plannedJobs[1].inputs[0].file, try VirtualPath(path: "foo.swift"))
     }
+
+    // Immediate mode doesn't generate a pch
+    do {
+      var driver = try Driver(args: ["swift", "-import-objc-header", "TestInputHeader.h", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .interpret)
+      XCTAssert(plannedJobs[0].commandLine.contains(.flag("-import-objc-header")))
+      XCTAssert(plannedJobs[0].commandLine.contains(.path(.relative(RelativePath("TestInputHeader.h")))))
+    }
   }
 
   func testPCMGeneration() throws {


### PR DESCRIPTION
This is consistent with the c++ driver and fixes `Interpreter/availability_host_os.swift`