### PR TITLE
Make module naming consistent with the integrated driver when the output filename has 2+ extensions

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1147,12 +1147,12 @@ extension Driver {
   private static func baseNameWithoutExtension(_ path: String, hasExtension: inout Bool) -> String {
     if let absolute = try? AbsolutePath(validating: path) {
       hasExtension = absolute.extension != nil
-      return absolute.basenameWithoutAllExts
+      return absolute.basenameWithoutExt
     }
 
     if let relative = try? RelativePath(validating: path) {
       hasExtension = relative.extension != nil
-      return relative.basenameWithoutAllExts
+      return relative.basenameWithoutExt
     }
 
     hasExtension = false

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -394,6 +394,19 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertTrue(plannedJobs3[0].commandLine.contains(.flag("-parse-as-library")))
   }
 
+  func testModuleNaming() throws {
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift"]).moduleName, "foo")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out"]).moduleName, "a")
+
+    // This is silly, but necesary for compatibility with the integrated driver.
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out.optimized"]).moduleName, "main")
+
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out.optimized", "-module-name", "bar"]).moduleName, "bar")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "+++.out"]).moduleName, "main")
+    XCTAssertEqual(try Driver(args: ["swift"]).moduleName, "REPL")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-emit-library", "-o", "libBaz.dylib"]).moduleName, "Baz")
+  }
+
   func testOutputFileMapLoading() throws {
     let contents = """
     {


### PR DESCRIPTION
This caused a surprising number of tests to fail which wrote something like `-o a.out.optimized`. The C++ driver uses `llvm::sys::path::stem` to remove extensions, which would result in `a.out`, which is an invalid module name, so the fallback of `main` would be used. `swift-driver` used to remove both extensions, and would name the module `a`. This behavior is clearly better, but I think it's too late to change considering how many tests broke...