### PR TITLE
Make swift driver friendlier to relative paths

### DIFF
--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -68,7 +68,7 @@ public struct OutputFileMap: Equatable {
 
   /// Load the output file map at the given path.
   public static func load(
-    file: AbsolutePath,
+    file: VirtualPath,
     diagnosticEngine: DiagnosticsEngine
   ) throws -> OutputFileMap {
     // Load and decode the file.

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -16,7 +16,7 @@ import Foundation
 public struct IncrementalCompilation {
   public let showIncrementalBuildDecisions: Bool
   public let enableIncrementalBuild: Bool
-  public let buildRecordPath: AbsolutePath?
+  public let buildRecordPath: VirtualPath?
   public let outputBuildRecordForModuleOnlyBuild: Bool
   public let argsHash: String
   public let lastBuildTime: Date
@@ -118,14 +118,14 @@ public struct IncrementalCompilation {
     outputFileMap: OutputFileMap?,
     compilerOutputType: FileType?,
     diagnosticEngine: DiagnosticsEngine?
-  ) -> AbsolutePath? {
+  ) -> VirtualPath? {
     // FIXME: This should work without an output file map. We should have
     // another way to specify a build record and where to put intermediates.
     guard let ofm = outputFileMap else {
       diagnosticEngine.map { $0.emit(.warning_incremental_requires_output_file_map) }
       return nil
     }
-    guard let partialBuildRecordPath = ofm.existingOutputForSingleInput(outputType: .swiftDeps)?.absolutePath
+    guard let partialBuildRecordPath = ofm.existingOutputForSingleInput(outputType: .swiftDeps)
       else {
         diagnosticEngine.map { $0.emit(.warning_incremental_requires_build_record_entry) }
         return nil
@@ -134,7 +134,7 @@ public struct IncrementalCompilation {
     // '~moduleonly'. So that module-only mode doesn't mess up build-record
     // file for full compilation.
     return compilerOutputType == .swiftModule
-      ? AbsolutePath(partialBuildRecordPath.pathString + "~moduleonly")
+      ? partialBuildRecordPath.appendingToBaseName("~moduleonly")
       : partialBuildRecordPath
   }
 

--- a/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
@@ -130,7 +130,7 @@ public extension InputInfoMap {
     argsHash: String,
     lastBuildTime: Date,
     inputFiles: [TypedVirtualPath],
-    buildRecordPath: AbsolutePath,
+    buildRecordPath: VirtualPath,
     showIncrementalBuildDecisions: Bool,
     diagnosticEngine: DiagnosticsEngine
   ) -> Self? {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -207,6 +207,28 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(driver4.inputFiles, [ TypedVirtualPath(file: .standardInput, type: .swift )])
   }
 
+  func testRecordedInputModificationDates() throws {
+    try withTemporaryDirectory { path in
+      guard let cwd = localFileSystem
+        .currentWorkingDirectory else { fatalError() }
+      let main = path.appending(component: "main.swift")
+      let util = path.appending(component: "util.swift")
+      let utilRelative = util.relative(to: cwd)
+      try localFileSystem.writeFileContents(main) { $0 <<< "print(hi)" }
+      try localFileSystem.writeFileContents(util) { $0 <<< "let hi = \"hi\"" }
+
+      let mainMDate = try localFileSystem.getFileInfo(main).modTime
+      let utilMDate = try localFileSystem.getFileInfo(util).modTime
+      let driver = try Driver(args: [
+        "swiftc", main.pathString, utilRelative.pathString,
+      ])
+      XCTAssertEqual(driver.recordedInputModificationDates, [
+        .init(file: .absolute(main), type: .swift) : mainMDate,
+        .init(file: .relative(utilRelative), type: .swift) : utilMDate,
+      ])
+    }
+  }
+
   func testPrimaryOutputKinds() throws {
     let driver1 = try Driver(args: ["swiftc", "foo.swift", "-emit-module"])
     XCTAssertEqual(driver1.compilerOutputType, .swiftModule)
@@ -453,7 +475,7 @@ final class SwiftDriverTests: XCTestCase {
     try withTemporaryFile { file in
       try assertNoDiagnostics { diags in
         try localFileSystem.writeFileContents(file.path) { $0 <<< contents }
-        let outputFileMap = try OutputFileMap.load(file: file.path, diagnosticEngine: diags)
+        let outputFileMap = try OutputFileMap.load(file: .absolute(file.path), diagnosticEngine: diags)
 
         let object = try outputFileMap.getOutput(inputFile: .init(path: "/tmp/foo/Sources/foo/foo.swift"), outputType: .object)
         XCTAssertEqual(object.name, "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.o")
@@ -489,7 +511,7 @@ final class SwiftDriverTests: XCTestCase {
       try sampleOutputFileMap.store(file: file.path, diagnosticEngine: DiagnosticsEngine())
       let contentsForDebugging = try localFileSystem.readFileContents(file.path).cString
       _ = contentsForDebugging
-      let recoveredOutputFileMap = try OutputFileMap.load(file: file.path, diagnosticEngine: DiagnosticsEngine())
+      let recoveredOutputFileMap = try OutputFileMap.load(file: .absolute(file.path), diagnosticEngine: DiagnosticsEngine())
       XCTAssertEqual(sampleOutputFileMap, recoveredOutputFileMap)
     }
   }
@@ -530,6 +552,38 @@ final class SwiftDriverTests: XCTestCase {
     let expectedOutputFileMap =
       try outputFileMapFromStringyEntries(resolvedStringyEntries)
     XCTAssertEqual(expectedOutputFileMap, resolvedOutputFileMap)
+  }
+
+  func testOutputFileMapRelativePathArg() throws {
+    try withTemporaryDirectory { path in
+      guard let cwd = localFileSystem
+        .currentWorkingDirectory else { fatalError() }
+      let outputFileMap = path.appending(component: "outputFileMap.json")
+      try localFileSystem.writeFileContents(outputFileMap) {
+        $0 <<< """
+        {
+          "": {
+            "swift-dependencies": "build/master.swiftdeps"
+          },
+          "main.swift": {
+            "object": "build/main.o",
+            "dependencies": "build/main.o.d"
+          },
+          "util.swift": {
+            "object": "build/util.o",
+            "dependencies": "build/util.o.d"
+          }
+        }
+        """
+      }
+      let outputFileMapRelative = outputFileMap.relative(to: cwd).pathString
+      // FIXME: Needs a better way to check that outputFileMap correctly loaded
+      XCTAssertNoThrow(try Driver(args: [
+        "swiftc",
+        "--output-file-map", outputFileMapRelative,
+        "main.swift", "util.swift",
+      ]))
+    }
   }
 
   func testResponseFileExpansion() throws {


### PR DESCRIPTION
Add handling for relative paths in output file map path,
resonse file paths, recorded input modification dates.