### PR TITLE
5.2 Compatibility updates to reflect the toolchain symlink removals

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -610,8 +610,6 @@ extension Driver {
       return .batch
     case "swift-autolink-extract":
       return .autolinkExtract
-    case "swift-indent":
-      return .indent
     default:
       throw Error.invalidDriverName(driverName)
     }

--- a/Sources/SwiftOptions/DriverKind.swift
+++ b/Sources/SwiftOptions/DriverKind.swift
@@ -17,7 +17,6 @@ public enum DriverKind: String {
   case moduleWrap = "swift-modulewrap"
   case frontend = "swift-frontend"
   case autolinkExtract = "swift-autolink-extract"
-  case indent = "swift-indent"
 
   /// Returns true if driver kind is Swift compiler.
   public var isSwiftCompiler: Bool {
@@ -41,9 +40,6 @@ extension DriverKind {
     case .frontend:
       return ["swift", "-frontend"]
 
-    case .indent:
-      return ["swift-indent"]
-
     case .interactive:
       return ["swift"]
 
@@ -59,9 +55,6 @@ extension DriverKind {
 
     case .frontend:
       return "Swift frontend"
-
-    case .indent:
-      return "Swift Format Tool"
 
     case .batch, .interactive:
       return "Swift compiler"

--- a/Sources/SwiftOptions/Option.swift
+++ b/Sources/SwiftOptions/Option.swift
@@ -142,9 +142,6 @@ extension Option {
     case .frontend:
       return attributes.contains(.frontend)
 
-    case .indent:
-      return attributes.contains(.indent)
-
     case .interactive:
       return !attributes.contains(.noInteractive)
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -86,7 +86,6 @@ final class SwiftDriverTests: XCTestCase {
 
     try assertArgs("swiftc", "--driver-mode=swift", parseTo: .interactive, leaving: [])
     try assertArgs("swiftc", "--driver-mode=swift-autolink-extract", parseTo: .autolinkExtract, leaving: [])
-    try assertArgs("swiftc", "--driver-mode=swift-indent", parseTo: .indent, leaving: [])
     try assertArgs("swift", "--driver-mode=swift-autolink-extract", parseTo: .autolinkExtract, leaving: [])
 
     try assertArgs("swift", "-zelda", parseTo: .interactive, leaving: ["-zelda"])


### PR DESCRIPTION
`swift-indent` hasn't been included in toolchains for a while now, so remove all references to it.

`swift-autolink-extract` was removed from macOS toolchains fairly recently, so #if-out the linux linker tests that rely on it on macOS.