### PR TITLE
Diagnose inputs modified during the build for multi-job plans

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -671,6 +671,7 @@ extension Driver {
     let jobExecutor = JobExecutor(
         jobs: jobs, resolver: resolver,
         executorDelegate: executorDelegate,
+        diagnosticsEngine: diagnosticEngine,
         numParallelJobs: numParallelJobs,
         processSet: processSet,
         forceResponseFiles: forceResponseFiles,


### PR DESCRIPTION
The JobExecutor's context now holds a diagnostic engine which can be used to emit errors encountered when running jobs. 