### PR TITLE
Add support for building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+cmake_minimum_required(VERSION 3.15.1)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+
+project(SwiftDriver LANGUAGES Swift)
+
+set(SWIFT_VERSION 5)
+set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})
+if(CMAKE_VERSION VERSION_LESS 3.16)
+    add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-swift-version$<SEMICOLON>${SWIFT_VERSION}>)
+    set(CMAKE_LINK_LIBRARY_FLAG "-l")
+endif()
+
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+if(CMAKE_VERSION VERSION_LESS 3.16 AND CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+else()
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+endif()
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+option(BUILD_SHARED_LIBS "Build shared libraryes by default" YES)
+
+find_package(TSC CONFIG REQUIRED)
+
+find_package(LLBuild CONFIG)
+if(NOT LLBuild_FOUND)
+  find_package(LLBuild REQUIRED)
+endif()
+
+find_package(dispatch QUIET)
+find_package(Foundation QUIET)
+find_package(Yams CONFIG REQUIRED)
+
+add_subdirectory(Sources)

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": "master",
-          "revision": "fbc979b7feb4c32e2aa1087f958d826d3cf8472f",
+          "revision": "b2537bc463f5622e1d30be81fe4e4ef841d1a718",
           "version": null
         }
       }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `swift-driver` project is a new implementation of the Swift compiler driver 
 
 ## Getting Started
 
-Use the Swift package manager to build `swift-driver`:
+The preferred way to build `swift-driver` is to use the Swift package manager:
 
 ```
 $ swift build
@@ -31,6 +31,26 @@ SWIFT_EXEC=$SOME_PATH/swiftc swift build
 ```
 
 Similarly, one can use the new Swift driver within Xcode by adding a custom build setting (usually at the project level) named `SWIFT_EXEC` that refers to `$SOME_PATH/swiftc`.
+
+## Building with CMake
+
+`swift-driver` can also be built with CMake, which is suggested for
+environments where the Swift Package Manager is not yet
+available. Doing so requires several dependencies to be built first,
+all with CMake:
+
+* (Non-Apple platforms only) [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation)
+* [llbuild](https://github.com/apple/swift-llbuild) configure CMake with `-DLLBUILD_SUPPORT_BINDINGS="Swift"` when building
+  ```
+  cmake -B <llbuild-build-dir> -G Ninja <llbuild-source-dir> -DLLBUILD_SUPPORT_BINDINGS="Swift"
+  ```
+* [Yams](https://github.com/jpsim/Yams)
+
+Once those dependencies have built, build `swift-driver` itself:
+```
+cmake -B <swift-driver-build-dir> -G Ninja <swift-driver-source-dir> -DTSC_DIR=<swift-tools-support-core-build-dir>/cmake/modules -DLLBuild_DIR=<llbuild-build-dir>/cmake/modules -DYams_DIR=<yamls-build-dir>/cmake/modules
+cmake --build <swift-driver-build-dir>
+```
 
 ## Developing `swift-driver`
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_subdirectory(SwiftOptions)
+add_subdirectory(SwiftDriver)
+add_subdirectory(swift-driver)
+add_subdirectory(swift-help)

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -1,0 +1,70 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SwiftDriver
+  Driver/CompilerMode.swift
+  Driver/DebugInfo.swift
+  Driver/Driver.swift
+  Driver/LinkKind.swift
+  Driver/OutputFileMap.swift
+  Driver/ToolExecutionDelegate.swift
+
+  Execution/JobExecutor.swift
+  Execution/ParsableOutput.swift
+  Execution/ProcessProtocol.swift
+  Execution/llbuild.swift
+
+  "Incremental Compilation/IncrementalCompilation.swift"
+  "Incremental Compilation/InputIInfoMap.swift"
+  "Incremental Compilation/InputInfo.swift"
+
+  Jobs/AutolinkExtractJob.swift
+  Jobs/CommandLineArguments.swift
+  Jobs/CompileJob.swift
+  Jobs/DarwinToolchain+LinkerSupport.swift
+  Jobs/EmitModuleJob.swift
+  Jobs/FrontendJobHelpers.swift
+  Jobs/GenerateDSYMJob.swift
+  Jobs/GeneratePCHJob.swift
+  Jobs/GeneratePCMJob.swift
+  Jobs/GenericUnixToolchain+LinkerSupport.swift
+  Jobs/InterpretJob.swift
+  Jobs/Job.swift
+  Jobs/LinkJob.swift
+  Jobs/MergeModuleJob.swift
+  Jobs/Planning.swift
+  Jobs/ReplJob.swift
+  Jobs/Toolchain+InterpreterSupport.swift
+  Jobs/Toolchain+LinkerSupport.swift
+  Jobs/VerifyDebugInfoJob.swift
+
+  Toolchains/DarwinToolchain.swift
+  Toolchains/GenericUnixToolchain.swift
+  Toolchains/Toolchain.swift
+
+  Utilities/DOTJobGraphSerializer.swift
+  Utilities/DateAdditions.swift
+  Utilities/Diagnostics.swift
+  Utilities/FileType.swift
+  Utilities/PredictableRandomNumberGenerator.swift
+  Utilities/RelativePathAdditions.swift
+  Utilities/Sanitizer.swift
+  Utilities/StringAdditions.swift
+  Utilities/System.swift
+  Utilities/Triple+Platforms.swift
+  Utilities/Triple.swift
+  Utilities/TypedVirtualPath.swift
+  Utilities/VirtualPath.swift)
+
+target_link_libraries(SwiftDriver PUBLIC
+  TSCBasic
+  SwiftOptions
+  LLBuild
+  llbuildSwift
+  CYaml
+  Yams)

--- a/Sources/SwiftOptions/CMakeLists.txt
+++ b/Sources/SwiftOptions/CMakeLists.txt
@@ -1,0 +1,23 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SwiftOptions
+  DriverKind.swift
+  Option.swift
+  OptionTable.swift
+  ParsedOptions.swift
+  ExtraOptions.swift
+  OptionParsing.swift
+  Options.swift
+  PrefixTrie.swift)
+target_link_libraries(SwiftOptions PUBLIC
+  TSCBasic)
+
+# NOTE: workaround for CMake not setting up include flags yet
+set_target_properties(SwiftOptions PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/swift-driver/CMakeLists.txt
+++ b/Sources/swift-driver/CMakeLists.txt
@@ -1,0 +1,14 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_executable(swift-driver
+  main.swift)
+target_link_libraries(swift-driver PUBLIC
+  SwiftDriver)
+
+

--- a/Sources/swift-help/CMakeLists.txt
+++ b/Sources/swift-help/CMakeLists.txt
@@ -1,0 +1,13 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_executable(swift-help
+  main.swift)
+target_link_libraries(swift-help PUBLIC
+  SwiftOptions)
+

--- a/cmake/modules/FindLLBuild.cmake
+++ b/cmake/modules/FindLLBuild.cmake
@@ -1,0 +1,58 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+if(TARGET llbuildSwift)
+  return()
+endif()
+
+include(CMakeFindFrameworks)
+cmake_find_frameworks(llbuild)
+if(llbuild_FRAMEWORKS)
+  if(NOT TARGET llbuildSwift)
+    add_library(llbuildSwift UNKNOWN IMPORTED)
+    set_target_properties(llbuildSwift PROPERTIES
+      FRAMEWORK TRUE
+      INTERFACE_COMPILE_OPTIONS -F${llbuild_FRAMEWORKS}
+      IMPORTED_LOCATION ${llbuild_FRAMEWORKS}/llbuild.framework/llbuild)
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LLBuild
+    REQUIRED_VARS llbuild_FRAMEWORKS)
+else()
+  find_library(libllbuild_LIBRARIES libllbuild)
+  find_file(libllbuild_INCLUDE_DIRS llbuild/llbuild.h)
+
+  find_library(llbuildSwift_LIBRARIES llbuildSwift)
+  find_file(llbuildSwift_INCLUDE_DIRS llbuildSwift.swiftmodule)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LLBuild REQUIRED_VARS
+    libllbuild_LIBRARIES
+    libllbuild_INCLUDE_DIRS
+    llbuildSwift_LIBRARIES
+    llbuildSwift_INCLUDE_DIRS)
+
+  if(NOT TARGET libllbuild)
+    add_library(libllbuild UNKNOWN IMPORTED)
+    get_filename_component(libllbuild_INCLUDE_DIRS
+      ${libllbuild_INCLUDE_DIRS} DIRECTORY)
+    set_target_properties(libllbuild PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${libllbuild_INCLUDE_DIRS}
+      IMPORTED_LOCATION ${libllbuild_LIBRARIES})
+  endif()
+  if(NOT TARGET llbuildSwift)
+    add_library(llbuildSwift UNKNOWN IMPORTED)
+    get_filename_component(llbuildSwift_INCLUDE_DIRS
+      ${llbuildSwift_INCLUDE_DIRS} DIRECTORY)
+    set_target_properties(llbuildSwift PROPERTIES
+      INTERFACE_LINK_LIBRARIES libllbuild
+      INTERFACE_INCLUDE_DIRECTORIES ${llbuildSwift_INCLUDE_DIRS}
+      IMPORTED_LOCATION ${llbuildSwift_LIBRARIES})
+  endif()
+endif()


### PR DESCRIPTION
The Swift driver is intended to be built fairly early in overall toolchain construction. Introduce a CMake build system that aligns with the CMake build for SwiftPM and other tools that need to be bootstrapped in this manner.