### PR TITLE
Remove support for the integrated repl

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -42,12 +42,13 @@ public enum ModuleOutput: Equatable {
 
 /// The Swift driver.
 public struct Driver {
-  public enum Error: Swift.Error, DiagnosticData {
+  public enum Error: Swift.Error, Equatable, DiagnosticData {
     case invalidDriverName(String)
     case invalidInput(String)
     case noJobsPassedToDriverFromEmptyInputFileList
     case relativeFrontendPath(String)
     case subcommandPassedToDriver
+    case integratedReplRemoved
 
     public var description: String {
       switch self {
@@ -62,6 +63,8 @@ public struct Driver {
         return "relative frontend path: \(path)"
       case .subcommandPassedToDriver:
         return "subcommand passed to driver"
+      case .integratedReplRemoved:
+        return "Compiler-internal integrated REPL has been removed; use the LLDB-enhanced REPL instead."
       }
     }
   }
@@ -295,7 +298,7 @@ public struct Driver {
     }
 
     // Determine the compilation mode.
-    self.compilerMode = Self.computeCompilerMode(&parsedOptions, driverKind: driverKind, diagnosticsEngine: diagnosticEngine)
+    self.compilerMode = try Self.computeCompilerMode(&parsedOptions, driverKind: driverKind, diagnosticsEngine: diagnosticEngine)
 
     // Figure out the primary outputs from the driver.
     (self.compilerOutputType, self.linkerOutputType) = Self.determinePrimaryOutputs(&parsedOptions, driverKind: driverKind, diagnosticsEngine: diagnosticEngine)
@@ -759,15 +762,18 @@ extension Driver {
     _ parsedOptions: inout ParsedOptions,
     driverKind: DriverKind,
     diagnosticsEngine: DiagnosticsEngine
-  ) -> CompilerMode {
+  ) throws -> CompilerMode {
     // Some output flags affect the compiler mode.
     if let outputOption = parsedOptions.getLast(in: .modes) {
       switch outputOption.option {
       case .emitPch, .emitImportedModules:
         return .singleCompile
 
-      case .repl, .deprecatedIntegratedRepl, .lldbRepl:
+      case .repl, .lldbRepl:
         return .repl
+
+      case .deprecatedIntegratedRepl:
+        throw Error.integratedReplRemoved
 
       case .emitPcm:
         return .compilePCM

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -196,7 +196,7 @@ extension Driver {
       }
     }
 
-    // Repl Jobs may include -module-name depending on the selected REPL (LLDB or integrated).
+    // Repl Jobs shouldn't include -module-name.
     if compilerMode != .repl {
       commandLine.appendFlags("-module-name", moduleName)
     }

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -20,33 +20,15 @@ extension Driver {
     try commandLine.appendLast(.importObjcHeader, from: &parsedOptions)
     try commandLine.appendAll(.l, .framework, .L, from: &parsedOptions)
 
-    // Look for -lldb-repl or -deprecated-integrated-repl to determine which
-    // REPL to use. If neither is provided, prefer LLDB if it can be found.
-    if parsedOptions.hasFlag(positive: .lldbRepl,
-                             negative: .deprecatedIntegratedRepl,
-                             default: (try? toolchain.getToolPath(.lldb)) != nil) {
-      // Squash important frontend options into a single argument for LLDB.
-      let lldbArg = "--repl=\(commandLine.joinedArguments)"
-      return Job(
-        kind: .repl,
-        tool: .absolute(try toolchain.getToolPath(.lldb)),
-        commandLine: [Job.ArgTemplate.flag(lldbArg)],
-        inputs: [],
-        outputs: [],
-        requiresInPlaceExecution: true
-      )
-    } else {
-      // Invoke the integrated REPL, which is part of the frontend.
-      commandLine = [.flag("-frontend"), .flag("-repl")] + commandLine
-      commandLine.appendFlags("-module-name", moduleName)
-      return Job(
-        kind: .repl,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
-        commandLine: commandLine,
-        inputs: [],
-        outputs: [],
-        requiresInPlaceExecution: true
-      )
-    }
+    // Squash important frontend options into a single argument for LLDB.
+    let lldbArg = "--repl=\(commandLine.joinedArguments)"
+    return Job(
+      kind: .repl,
+      tool: .absolute(try toolchain.getToolPath(.lldb)),
+      commandLine: [Job.ArgTemplate.flag(lldbArg)],
+      inputs: [],
+      outputs: [],
+      requiresInPlaceExecution: true
+    )
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1190,16 +1190,9 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      var driver = try Driver(args: ["swift", "-deprecated-integrated-repl"])
-      let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 1)
-      let replJob = plannedJobs.first!
-      XCTAssertTrue(replJob.tool.name.contains("swift"))
-      XCTAssertTrue(replJob.requiresInPlaceExecution)
-      XCTAssertTrue(replJob.commandLine.count >= 2)
-      XCTAssertEqual(replJob.commandLine[0], .flag("-frontend"))
-      XCTAssertEqual(replJob.commandLine[1], .flag("-repl"))
-      XCTAssert(replJob.commandLine.contains(.flag("-module-name")))
+      XCTAssertThrowsError(try Driver(args: ["swift", "-deprecated-integrated-repl"])) {
+        XCTAssertEqual($0 as? Driver.Error, Driver.Error.integratedReplRemoved)
+      }
     }
 
     do {


### PR DESCRIPTION
Now that it's been removed from the C++ driver, there's no reason to keep it around here.