### PR TITLE
Parallelize task build

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "master",
-          "revision": "cb4877c57af9c515f4801e096e06f9e07946dac6",
+          "revision": "0816cf594c2e4d890d1f188271da667f99763fa9",
           "version": null
         }
       },

--- a/Sources/SwiftDriver/Execution/JobExecutor.swift
+++ b/Sources/SwiftDriver/Execution/JobExecutor.swift
@@ -375,10 +375,12 @@ class ExecuteJobRule: LLBuildRule {
       return engine.taskIsComplete(DriverBuildValue.jobExecution(success: false))
     }
 
-    engine.taskIsComplete(self.executeJob(engine))
+    context.jobQueue.addOperation {
+      self.executeJob(engine)
+    }
   }
 
-  private func executeJob(_ engine: LLTaskBuildEngine) -> DriverBuildValue {
+  private func executeJob(_ engine: LLTaskBuildEngine) {
     let context = self.context
     let resolver = context.argsResolver
     let job = key.job
@@ -430,7 +432,7 @@ class ExecuteJobRule: LLBuildRule {
       value = .jobExecution(success: false)
     }
 
-    return value
+    engine.taskIsComplete(value)
   }
 }
 


### PR DESCRIPTION
Revert the change to avoid calling LLBuild's `taskIsComplete` from a thread, which should improve the parallelism in the build.