### PR TITLE
Improve handling of multithreaded builds

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -651,7 +651,9 @@ extension Driver {
       return
     }
 
-    if jobs.contains(where: { $0.requiresInPlaceExecution }) || jobs.count == 1 {
+    if jobs.contains(where: { $0.requiresInPlaceExecution })
+      // Only one job and no cleanup required
+      || (jobs.count == 1 && !parsedOptions.hasArgument(.parseableOutput)) {
       assert(jobs.count == 1, "Cannot execute in place for multi-job build plans")
       return try executeJobInPlace(jobs[0], resolver: resolver, forceResponseFiles: forceResponseFiles)
     }
@@ -907,7 +909,7 @@ extension Driver {
       case .emitObject, .c:
         compilerOutputType = .object
 
-      case .emitAssembly:
+      case .emitAssembly, .S:
         compilerOutputType = .assembly
 
       case .emitSil:

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -90,8 +90,8 @@ public struct ToolExecutionDelegate: JobExecutorDelegate {
     // FIXME: Do we need to do error handling here? Can this even fail?
     guard let json = try? message.toJSON() else { return }
 
-    stdoutStream <<< json.count <<< "\n"
-    stdoutStream <<< String(data: json, encoding: .utf8)! <<< "\n"
-    stdoutStream.flush()
+    stderrStream <<< json.count <<< "\n"
+    stderrStream <<< String(data: json, encoding: .utf8)! <<< "\n"
+    stderrStream.flush()
   }
 }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -70,8 +70,7 @@ extension Driver {
     case .object:
       isTopLevel = (linkerOutputType == nil)
     case .swiftModule:
-      // The user has requested a module, so treat it as a top-level output
-      isTopLevel = parsedOptions.hasArgument(.emitModule, .emitModulePath)
+      isTopLevel = compilerMode.isSingleCompilation && moduleOutput?.isTopLevel ?? false
     case .swift, .sib, .image, .dSYM, .dependencies, .autolink,
          .swiftDocumentation, .swiftInterface,
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -69,8 +69,11 @@ extension Driver {
       isTopLevel = true
     case .object:
       isTopLevel = (linkerOutputType == nil)
+    case .swiftModule:
+      // The user has requested a module, so treat it as a top-level output
+      isTopLevel = parsedOptions.hasArgument(.emitModule, .emitModulePath)
     case .swift, .sib, .image, .dSYM, .dependencies, .autolink,
-         .swiftModule, .swiftDocumentation, .swiftInterface,
+         .swiftDocumentation, .swiftInterface,
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
          .objcHeader, .swiftDeps, .remap, .importedModules, .tbd, .moduleTrace,
          .indexData, .optimizationRecord, .pcm, .pch, nil:
@@ -86,6 +89,8 @@ extension Driver {
     assert(!usesPrimaryFileInputs || !primaryInputs.isEmpty)
     let primaryInputFiles = usesPrimaryFileInputs ? Set(primaryInputs) : Set()
 
+    let isMultithreaded = numThreads > 0
+
     // Add each of the input files.
     // FIXME: Use/create input file lists and primary input file lists.
     var primaryOutputs: [TypedVirtualPath] = []
@@ -100,8 +105,8 @@ extension Driver {
 
       // If there is a primary output or we are doing multithreaded compiles,
       // add an output for the input.
-      if isPrimary || numThreads > 0,
-          let compilerOutputType = compilerOutputType {
+      if let compilerOutputType = compilerOutputType,
+        isPrimary || (isMultithreaded && compilerOutputType.isAfterLLVM) {
         primaryOutputs.append(computePrimaryOutput(for: input,
                                                    outputType: compilerOutputType,
                                                    isTopLevel: isTopLevel))
@@ -109,8 +114,8 @@ extension Driver {
     }
 
     // When not using primary file inputs or multithreading, add a single output.
-    if !usesPrimaryFileInputs && numThreads == 0,
-        let outputType = compilerOutputType {
+    if let outputType = compilerOutputType,
+      !usesPrimaryFileInputs && !(isMultithreaded && outputType.isAfterLLVM) {
       primaryOutputs.append(computePrimaryOutput(
         for: TypedVirtualPath(file: try! VirtualPath(path: ""),
                               type: swiftInputFiles[0].type),

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -105,7 +105,7 @@ extension Driver {
       // If there is a primary output or we are doing multithreaded compiles,
       // add an output for the input.
       if let compilerOutputType = compilerOutputType,
-        isPrimary || (isMultithreaded && compilerOutputType.isAfterLLVM) {
+        isPrimary || (!usesPrimaryFileInputs && isMultithreaded && compilerOutputType.isAfterLLVM) {
         primaryOutputs.append(computePrimaryOutput(for: input,
                                                    outputType: compilerOutputType,
                                                    isTopLevel: isTopLevel))

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -260,4 +260,18 @@ extension FileType {
       return false
     }
   }
+
+  /// Returns true if the type is produced in the compiler after the LLVM passes.
+  /// For those types the compiler produces multiple output files in multi-threaded compilation.
+  var isAfterLLVM: Bool {
+    switch self {
+    case .assembly, .llvmIR, .llvmBitcode, .object:
+      return true
+    case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .autolink,
+         .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile,
+         .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap, .importedModules,
+         .tbd, .moduleTrace, .indexData, .optimizationRecord, .pcm, .pch:
+      return false
+    }
+  }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1110,13 +1110,13 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertEqual(plannedJobs[0].outputs.count, 3)
-      XCTAssertEqual(plannedJobs[0].outputs[0].file, .relative(RelativePath("foo.swiftmodule")))
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, .temporary(RelativePath("foo.swiftmodule")))
       XCTAssertEqual(plannedJobs[0].outputs[1].file, .temporary(RelativePath("foo.swiftdoc")))
       XCTAssertEqual(plannedJobs[0].outputs[2].file, .temporary(RelativePath("foo.d")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-import-objc-header")))
 
       XCTAssertEqual(plannedJobs[1].outputs.count, 3)
-      XCTAssertEqual(plannedJobs[1].outputs[0].file, .relative(RelativePath("bar.swiftmodule")))
+      XCTAssertEqual(plannedJobs[1].outputs[0].file, .temporary(RelativePath("bar.swiftmodule")))
       XCTAssertEqual(plannedJobs[1].outputs[1].file, .temporary(RelativePath("bar.swiftdoc")))
       XCTAssertEqual(plannedJobs[1].outputs[2].file, .temporary(RelativePath("bar.d")))
       XCTAssert(plannedJobs[1].commandLine.contains(.flag("-import-objc-header")))
@@ -1160,6 +1160,18 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[2].outputs[1].file, .relative(RelativePath("Test.swiftdoc")))
     }
 
+    do {
+      // -o specified
+      var driver = try Driver(args: ["swiftc", "-emit-module", "-o", "/tmp/test.swiftmodule", "input.swift"])
+      let plannedJobs = try driver.planBuild()
+
+      XCTAssertEqual(plannedJobs.count, 2)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, .temporary(RelativePath("input.swiftmodule")))
+      XCTAssertEqual(plannedJobs[1].kind, .mergeModule)
+      XCTAssertEqual(plannedJobs[1].inputs[0].file, .temporary(RelativePath("input.swiftmodule")))
+      XCTAssertEqual(plannedJobs[1].outputs[0].file, .absolute(AbsolutePath("/tmp/test.swiftmodule")))
+    }
   }
 
   func testRepl() throws {


### PR DESCRIPTION
Fixes most of the issues with test `Driver/multi-threaded.swift`.

Future improvements required for all tests to pass:
1. Spacing of parseable-output json is different than c++ driver (use a regex in the test to allow optional space)
2. Support embed bitcode (I might look at this next)