### PR TITLE
Support invoking the Fast Dependency Scanner: `-scan-dependencies`

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -963,6 +963,9 @@ extension Driver {
       case .interpret:
         compilerOutputType = nil
 
+      case .scanDependencies:
+        compilerOutputType = .jsonDependencies
+
       default:
         fatalError("unhandled output mode option \(outputOption)")
       }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -65,7 +65,7 @@ extension Driver {
     let isTopLevel: Bool
 
     switch compilerOutputType {
-    case .assembly, .sil, .raw_sil, .llvmIR, .ast:
+    case .assembly, .sil, .raw_sil, .llvmIR, .ast, .jsonDependencies:
       isTopLevel = true
     case .object:
       isTopLevel = (linkerOutputType == nil)
@@ -242,6 +242,8 @@ extension FileType {
       return .typecheck
     case .remap:
       return .updateCode
+    case .jsonDependencies:
+      return .scanDependencies
 
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -139,6 +139,7 @@ extension Driver {
     try commandLine.appendLast(.disableParserLookup, from: &parsedOptions)
     try commandLine.appendLast(.sanitizeRecoverEQ, from: &parsedOptions)
     try commandLine.appendLast(.enableFineGrainedDependencies, from: &parsedOptions)
+    try commandLine.appendLast(.scanDependencies, from: &parsedOptions)
     try commandLine.appendLast(.fineGrainedDependencyIncludeIntrafile, from: &parsedOptions)
     try commandLine.appendLast(.enableExperimentalConcisePoundFile, from: &parsedOptions)
     try commandLine.appendLast(.printEducationalNotes, from: &parsedOptions)

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -87,6 +87,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// Text-based dylib (TBD) file.
   case tbd
 
+  /// JSON-based Module Dependency Scanner output
+  case jsonDependencies = "dependencies.json"
+
   /// Module trace file.
   ///
   /// Module traces are used by Apple's internal build infrastructure. Apple
@@ -138,6 +141,9 @@ extension FileType: CustomStringConvertible {
     case .swiftDeps:
       return "swift-dependencies"
 
+    case .jsonDependencies:
+      return "json-dependencies"
+
     case .importedModules:
       return "imported-modules"
 
@@ -166,7 +172,8 @@ extension FileType {
     case .object, .pch, .ast, .llvmIR, .llvmBitcode, .assembly, .swiftModule,
          .importedModules, .indexData, .remap, .dSYM, .autolink, .dependencies,
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
-         .swiftDeps, .moduleTrace, .tbd, .optimizationRecord, .swiftInterface, .swiftSourceInfoFile:
+         .swiftDeps, .moduleTrace, .tbd, .optimizationRecord, .swiftInterface,
+         .swiftSourceInfoFile, .jsonDependencies:
       return false
     }
   }
@@ -233,6 +240,8 @@ extension FileType {
       return "objc-header"
     case .swiftDeps:
       return "swift-dependencies"
+    case .jsonDependencies:
+      return "json-dependencies"
     case .importedModules:
       return "imported-modules"
     case .moduleTrace:
@@ -252,7 +261,7 @@ extension FileType {
     switch self {
     case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
-         .optimizationRecord, .swiftInterface:
+         .optimizationRecord, .swiftInterface, .jsonDependencies:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -270,7 +279,7 @@ extension FileType {
     case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile,
          .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap, .importedModules,
-         .tbd, .moduleTrace, .indexData, .optimizationRecord, .pcm, .pch:
+         .tbd, .moduleTrace, .indexData, .optimizationRecord, .pcm, .pch, .jsonDependencies:
       return false
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1613,6 +1613,30 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testScanDependenciesOption() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-scan-dependencies", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      let job = plannedJobs[0]
+      XCTAssertTrue(job.commandLine.contains(.flag("-scan-dependencies")))
+    }
+
+    // Test .d output
+    do {
+      var driver = try Driver(args: ["swiftc", "-scan-dependencies",
+                                     "-emit-dependencies", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      let job = plannedJobs[0]
+      print("")
+      print(job.commandLine)
+      XCTAssertTrue(job.commandLine.contains(.flag("-scan-dependencies")))
+      XCTAssertTrue(job.commandLine.contains(.flag("-emit-dependencies-path")))
+      XCTAssertTrue(job.commandLine.contains(.path(.temporary(RelativePath("foo.d")))))
+    }
+  }
+
   func testPCHGeneration() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-typecheck", "-import-objc-header", "TestInputHeader.h", "foo.swift"])


### PR DESCRIPTION
Add support for the additional compiler mode added in: #28515. 