### PR TITLE
Thread a filesystem throughout the Swift driver.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -77,6 +77,9 @@ public struct Driver {
   /// it should be identical to the real environment.
   public let env: [String: String]
 
+  /// The file system which we should interact with.
+  public let fileSystem: FileSystem
+
   /// Diagnostic engine for emitting warnings, errors, etc.
   public let diagnosticEngine: DiagnosticsEngine
 
@@ -226,9 +229,11 @@ public struct Driver {
   public init(
     args: [String],
     env: [String: String] = ProcessEnv.vars,
-    diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
+    diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
+    fileSystem: FileSystem = localFileSystem
   ) throws {
     self.env = env
+    self.fileSystem = fileSystem
 
     self.diagnosticEngine = diagnosticsEngine
 
@@ -236,7 +241,7 @@ public struct Driver {
       throw Error.subcommandPassedToDriver
     }
 
-    var args = try Self.expandResponseFiles(args, diagnosticsEngine: self.diagnosticEngine)[...]
+    var args = try Self.expandResponseFiles(args, fileSystem: fileSystem, diagnosticsEngine: self.diagnosticEngine)[...]
 
     self.driverKind = try Self.determineDriverKind(args: &args)
     self.optionTable = OptionTable()
@@ -246,7 +251,7 @@ public struct Driver {
       .map {
         Triple($0, normalizing: true)
       }
-    (self.toolchain, self.targetTriple) = try Self.computeToolchain(explicitTarget, diagnosticsEngine: diagnosticEngine, env: env)
+    (self.toolchain, self.targetTriple) = try Self.computeToolchain(explicitTarget, diagnosticsEngine: diagnosticEngine, env: env, fileSystem: fileSystem)
     self.targetVariantTriple = self.parsedOptions.getLastArgument(.targetVariant).map { Triple($0.asSingle, normalizing: true) }
 
     // Find the Swift compiler executable.
@@ -266,7 +271,7 @@ public struct Driver {
 
     // Compute the working directory.
     workingDirectory = try parsedOptions.getLastArgument(.workingDirectory).map { workingDirectoryArg in
-      let cwd = localFileSystem.currentWorkingDirectory
+      let cwd = fileSystem.currentWorkingDirectory
       return try cwd.map{ AbsolutePath(workingDirectoryArg.asSingle, relativeTo: $0) } ?? AbsolutePath(validating: workingDirectoryArg.asSingle)
     }
 
@@ -280,7 +285,7 @@ public struct Driver {
     self.inputFiles = inputFiles
     self.recordedInputModificationDates = .init(uniqueKeysWithValues:
       Set(inputFiles).compactMap {
-        guard let modTime = try? localFileSystem
+        guard let modTime = try? fileSystem
           .getFileInfo($0.file).modTime else { return nil }
         return ($0, modTime)
     })
@@ -289,7 +294,7 @@ public struct Driver {
     // Initialize an empty output file map, which will be populated when we start creating jobs.
     if let outputFileMapArg = parsedOptions.getLastArgument(.outputFileMap)?.asSingle {
       let path = try VirtualPath(path: outputFileMapArg)
-      outputFileMap = try .load(file: path, diagnosticEngine: diagnosticEngine)
+        outputFileMap = try .load(fileSystem: fileSystem, file: path, diagnosticEngine: diagnosticEngine)
     } else {
       outputFileMap = nil
     }
@@ -327,13 +332,14 @@ public struct Driver {
       compilerMode: compilerMode,
       outputFileMap: self.outputFileMap,
       compilerOutputType: self.compilerOutputType,
-      moduleOutput: self.moduleOutput,
+        moduleOutput: self.moduleOutput,
+      fileSystem: fileSystem,
       inputFiles: inputFiles,
       diagnosticEngine: diagnosticEngine,
       actualSwiftVersion: try? toolchain.swiftCompilerVersion()
     )
 
-    self.sdkPath = Self.computeSDKPath(&parsedOptions, compilerMode: compilerMode, toolchain: toolchain, diagnosticsEngine: diagnosticEngine, env: env)
+    self.sdkPath = Self.computeSDKPath(&parsedOptions, compilerMode: compilerMode, toolchain: toolchain, fileSystem: fileSystem, diagnosticsEngine: diagnosticEngine, env: env)
 
     self.importedObjCHeader = try Self.computeImportedObjCHeader(&parsedOptions, compilerMode: compilerMode, diagnosticEngine: diagnosticEngine)
     self.bridgingPrecompiledHeader = try Self.computeBridgingPrecompiledHeader(&parsedOptions,
@@ -531,6 +537,7 @@ extension Driver {
   /// - Parameter visitedResponseFiles: Set containing visited response files to detect recursive parsing.
   private static func expandResponseFiles(
     _ args: [String],
+    fileSystem: FileSystem,
     diagnosticsEngine: DiagnosticsEngine,
     visitedResponseFiles: inout Set<AbsolutePath>
   ) throws -> [String] {
@@ -548,9 +555,9 @@ extension Driver {
           visitedResponseFiles.remove(responseFile)
         }
 
-        let contents = try localFileSystem.readFileContents(responseFile).cString
+        let contents = try fileSystem.readFileContents(responseFile).cString
         let lines = tokenizeResponseFile(contents)
-        result.append(contentsOf: try expandResponseFiles(lines, diagnosticsEngine: diagnosticsEngine, visitedResponseFiles: &visitedResponseFiles))
+        result.append(contentsOf: try expandResponseFiles(lines, fileSystem: fileSystem, diagnosticsEngine: diagnosticsEngine, visitedResponseFiles: &visitedResponseFiles))
       } else {
         result.append(arg)
       }
@@ -562,10 +569,11 @@ extension Driver {
   /// Expand response files in the input arguments and return a new argument list.
   public static func expandResponseFiles(
     _ args: [String],
+    fileSystem: FileSystem,
     diagnosticsEngine: DiagnosticsEngine
   ) throws -> [String] {
     var visitedResponseFiles = Set<AbsolutePath>()
-    return try expandResponseFiles(args, diagnosticsEngine: diagnosticsEngine, visitedResponseFiles: &visitedResponseFiles)
+    return try expandResponseFiles(args, fileSystem: fileSystem, diagnosticsEngine: diagnosticsEngine, visitedResponseFiles: &visitedResponseFiles)
   }
 }
 
@@ -573,13 +581,11 @@ extension Driver {
   /// Determine the driver kind based on the command-line arguments, consuming the arguments
   /// conveying this information.
   public static func determineDriverKind(
-    args: inout ArraySlice<String>,
-    cwd: AbsolutePath? = localFileSystem.currentWorkingDirectory
+    args: inout ArraySlice<String>
   ) throws -> DriverKind {
     // Get the basename of the driver executable.
     let execRelPath = args.removeFirst()
-    let execPath = try cwd.map{ AbsolutePath(execRelPath, relativeTo: $0) } ?? AbsolutePath(validating: execRelPath)
-    var driverName = execPath.basename
+    var driverName = try VirtualPath(path: execRelPath).basenameWithoutExt
 
     // Determine driver kind based on the first argument.
     let driverModeOption = "--driver-mode="
@@ -670,7 +676,7 @@ extension Driver {
         forceResponseFiles: forceResponseFiles,
         recordedInputModificationDates: recordedInputModificationDates
     )
-    try jobExecutor.execute(env: env)
+    try jobExecutor.execute(env: env, fileSystem: fileSystem)
   }
 
   public mutating func createToolExecutionDelegate() -> ToolExecutionDelegate {
@@ -694,7 +700,7 @@ extension Driver {
       try ProcessEnv.setVar(envVar, value: value)
     }
 
-    try job.verifyInputsNotModified(since: self.recordedInputModificationDates)
+    try job.verifyInputsNotModified(since: self.recordedInputModificationDates, fileSystem: fileSystem)
 
     return try exec(path: arguments[0], args: arguments)
   }
@@ -1357,6 +1363,7 @@ extension Driver {
     _ parsedOptions: inout ParsedOptions,
     compilerMode: CompilerMode,
     toolchain: Toolchain,
+    fileSystem: FileSystem,
     diagnosticsEngine: DiagnosticsEngine,
     env: [String: String]
   ) -> String? {
@@ -1392,14 +1399,14 @@ extension Driver {
       // FIXME: TSC should provide a better utility for this.
       if let absPath = try? AbsolutePath(validating: sdkPath) {
         path = absPath
-      } else if let cwd = localFileSystem.currentWorkingDirectory {
+      } else if let cwd = fileSystem.currentWorkingDirectory {
         path = AbsolutePath(sdkPath, relativeTo: cwd)
       } else {
         diagnosticsEngine.emit(.warning_no_such_sdk(sdkPath))
         return sdkPath
       }
 
-      if !localFileSystem.exists(path) {
+      if !fileSystem.exists(path) {
         diagnosticsEngine.emit(.warning_no_such_sdk(sdkPath))
       }
       // .. else check if SDK is too old (we need target triple to diagnose that).
@@ -1505,11 +1512,12 @@ extension Driver {
   static func computeToolchain(
     _ explicitTarget: Triple?,
     diagnosticsEngine: DiagnosticsEngine,
-    env: [String: String]
+    env: [String: String],
+    fileSystem: FileSystem
   ) throws -> (Toolchain, Triple) {
     let toolchainType = try explicitTarget?.toolchainType(diagnosticsEngine) ??
           defaultToolchainType
-    let toolchain = toolchainType.init(env: env)
+    let toolchain = toolchainType.init(env: env, fileSystem: fileSystem)
     return (toolchain, try explicitTarget ?? toolchain.hostTargetTriple())
   }
 }

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -12,6 +12,8 @@
 import TSCBasic
 import Foundation
 
+public typealias FileSystem = TSCBasic.FileSystem
+
 /// Mapping of input file paths to specific output files.
 public struct OutputFileMap: Equatable {
   /// The known mapping from input file to specific output files.
@@ -68,11 +70,12 @@ public struct OutputFileMap: Equatable {
 
   /// Load the output file map at the given path.
   public static func load(
+    fileSystem: FileSystem,
     file: VirtualPath,
     diagnosticEngine: DiagnosticsEngine
   ) throws -> OutputFileMap {
     // Load and decode the file.
-    let contents = try localFileSystem.readFileContents(file)
+    let contents = try fileSystem.readFileContents(file)
     let result = try JSONDecoder().decode(OutputFileMapJSON.self, from: Data(contents.contents))
 
     // Convert the loaded entries into virual output file map.
@@ -84,6 +87,7 @@ public struct OutputFileMap: Equatable {
 
   /// Store the output file map at the given path.
   public func store(
+    fileSystem: FileSystem,
     file: AbsolutePath,
     diagnosticEngine: DiagnosticsEngine
   ) throws {
@@ -98,7 +102,7 @@ public struct OutputFileMap: Equatable {
   #endif
 
     let contents = try encoder.encode(OutputFileMapJSON.fromVirtualOutputFileMap(entries).entries)
-    try localFileSystem.writeFileContents(file, bytes: ByteString(contents))
+    try fileSystem.writeFileContents(file, bytes: ByteString(contents))
   }
 }
 

--- a/Sources/SwiftDriver/Execution/llbuild.swift
+++ b/Sources/SwiftDriver/Execution/llbuild.swift
@@ -106,9 +106,11 @@ public final class LLBuildEngine {
 public class LLTaskBuildEngine {
 
     let engine: TaskBuildEngine
+    let fileSystem: FileSystem
 
-    init(_ engine: TaskBuildEngine) {
+    init(_ engine: TaskBuildEngine, fileSystem: FileSystem) {
         self.engine = engine
+        self.fileSystem = fileSystem
     }
 
     public func taskNeedsInput<T: LLBuildKey>(_ key: T, inputID: Int) {
@@ -132,7 +134,10 @@ open class LLBuildRule: Rule, Task {
         fatalError("subclass responsibility")
     }
 
-    public init() {
+    let fileSystem: FileSystem
+
+    public init(fileSystem: FileSystem) {
+      self.fileSystem = fileSystem
     }
 
     public func createTask() -> Task {
@@ -140,15 +145,15 @@ open class LLBuildRule: Rule, Task {
     }
 
     public func start(_ engine: TaskBuildEngine) {
-        self.start(LLTaskBuildEngine(engine))
+        self.start(LLTaskBuildEngine(engine, fileSystem: fileSystem))
     }
 
     public func provideValue(_ engine: TaskBuildEngine, inputID: Int, value: Value) {
-        self.provideValue(LLTaskBuildEngine(engine), inputID: inputID, value: value)
+        self.provideValue(LLTaskBuildEngine(engine, fileSystem: fileSystem), inputID: inputID, value: value)
     }
 
     public func inputsAvailable(_ engine: TaskBuildEngine) {
-        self.inputsAvailable(LLTaskBuildEngine(engine))
+        self.inputsAvailable(LLTaskBuildEngine(engine, fileSystem: fileSystem))
     }
 
     // MARK:-

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -29,6 +29,7 @@ public struct IncrementalCompilation {
        outputFileMap: OutputFileMap?,
        compilerOutputType: FileType?,
        moduleOutput: ModuleOutput?,
+       fileSystem: FileSystem,
        inputFiles: [TypedVirtualPath],
        diagnosticEngine: DiagnosticsEngine,
        actualSwiftVersion: String?
@@ -63,6 +64,7 @@ public struct IncrementalCompilation {
       let outOfDateMap = InputInfoMap.populateOutOfDateMap(
         argsHash: argsHash,
         lastBuildTime: lastBuildTime,
+        fileSystem: fileSystem,
         inputFiles: inputFiles,
         buildRecordPath: buRP,
         showIncrementalBuildDecisions: showIncrementalBuildDecisions,

--- a/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputIInfoMap.swift
@@ -129,6 +129,7 @@ public extension InputInfoMap {
   static func populateOutOfDateMap(
     argsHash: String,
     lastBuildTime: Date,
+    fileSystem: FileSystem,
     inputFiles: [TypedVirtualPath],
     buildRecordPath: VirtualPath,
     showIncrementalBuildDecisions: Bool,
@@ -136,7 +137,7 @@ public extension InputInfoMap {
   ) -> Self? {
     let contents: String
     do {
-      contents = try localFileSystem.readFileContents(buildRecordPath).cString
+      contents = try fileSystem.readFileContents(buildRecordPath).cString
       return try Self(contents: contents)
     }
     catch {

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -19,7 +19,7 @@ extension DarwinToolchain {
       .parentDirectory // 'bin'
       .appending(components: "lib", "arc")
 
-    if localFileSystem.exists(path) { return path }
+    if fileSystem.exists(path) { return path }
 
     // If we don't have a 'lib/arc/' directory, find the "arclite" library
     // relative to the Clang in the active Xcode.
@@ -216,7 +216,7 @@ extension DarwinToolchain {
         for: targetTriple,
         parsedOptions: &parsedOptions)
       .appending(component: "libclang_rt.\(darwinPlatformSuffix).a")
-    if localFileSystem.exists(compilerRTPath) {
+    if fileSystem.exists(compilerRTPath) {
       commandLine.append(.path(.absolute(compilerRTPath)))
     }
 

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -207,7 +207,7 @@ extension GenericUnixToolchain {
       }
 
       if let linkFile = linkFilePath {
-        guard localFileSystem.isFile(linkFile) else {
+        guard fileSystem.isFile(linkFile) else {
           fatalError("\(linkFile.pathString) not found")
         }
         commandLine.appendFlag("@\(linkFile.pathString)")

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -103,11 +103,11 @@ extension Job {
     }
   }
 
-  public func verifyInputsNotModified(since recordedInputModificationDates: [TypedVirtualPath: Date]) throws {
+  public func verifyInputsNotModified(since recordedInputModificationDates: [TypedVirtualPath: Date], fileSystem: FileSystem) throws {
     for input in inputs {
       if case .absolute(let absolutePath) = input.file,
         let recordedModificationTime = recordedInputModificationDates[input],
-        try localFileSystem.getFileInfo(absolutePath).modTime != recordedModificationTime {
+        try fileSystem.getFileInfo(absolutePath).modTime != recordedModificationTime {
         throw InputError.inputUnexpectedlyModified(input)
       }
     }

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -113,7 +113,7 @@ extension Toolchain {
       for: targetTriple,
       parsedOptions: &parsedOptions
     ).appending(component: runtimeName)
-    return localFileSystem.exists(path)
+    return fileSystem.exists(path)
   }
 }
 

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -20,8 +20,12 @@ public final class DarwinToolchain: Toolchain {
   /// Doubles as path cache and point for overriding normal lookup
   private var toolPaths = [Tool: AbsolutePath]()
 
-  public init(env: [String: String]) {
+  /// The file system to use for any file operations.
+  public let fileSystem: FileSystem
+
+  public init(env: [String: String], fileSystem: FileSystem = localFileSystem) {
     self.env = env
+    self.fileSystem = fileSystem
   }
 
   /// Retrieve the absolute path for a given tool.

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -15,11 +15,15 @@ import TSCBasic
 public final class GenericUnixToolchain: Toolchain {
   public let env: [String: String]
 
+  /// The file system to use for queries.
+  public let fileSystem: FileSystem
+
   /// Doubles as path cache and point for overriding normal lookup
   private var toolPaths = [Tool: AbsolutePath]()
 
-  public init(env: [String: String]) {
+  public init(env: [String: String], fileSystem: FileSystem = localFileSystem) {
     self.env = env
+    self.fileSystem = fileSystem
   }
 
   public func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String {

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -28,9 +28,11 @@ public enum Tool {
 /// Describes a toolchain, which includes information about compilers, linkers
 /// and other tools required to build Swift code.
 public protocol Toolchain {
-  init(env: [String: String])
+  init(env: [String: String], fileSystem: FileSystem)
 
   var env: [String: String] { get }
+
+  var fileSystem: FileSystem { get }
 
   var searchPaths: [AbsolutePath] { get }
 
@@ -77,7 +79,7 @@ public protocol Toolchain {
 
 extension Toolchain {
   public var searchPaths: [AbsolutePath] {
-    getEnvSearchPaths(pathString: env["PATH"], currentWorkingDirectory: localFileSystem.currentWorkingDirectory)
+    getEnvSearchPaths(pathString: env["PATH"], currentWorkingDirectory: fileSystem.currentWorkingDirectory)
   }
 
   public func swiftCompilerVersion() throws -> String {

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -42,7 +42,7 @@ do {
 
   var driver = try Driver(args: arguments, diagnosticsEngine: diagnosticsEngine)
   let jobs = try driver.planBuild()
-  let resolver = try ArgsResolver()
+  let resolver = try ArgsResolver(fileSystem: driver.fileSystem)
   try driver.run(jobs: jobs, resolver: resolver, processSet: processSet)
 
   if driver.diagnosticEngine.hasErrors {

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -151,7 +151,7 @@ final class JobExecutorTests: XCTestCase {
 
       let delegate = JobCollectingDelegate()
       let executor = JobExecutor(jobs: [compileFoo, compileMain, link], resolver: resolver, executorDelegate: delegate)
-      try executor.execute(env: toolchain.env)
+      try executor.execute(env: toolchain.env, fileSystem: localFileSystem)
 
       let output = try TSCBasic.Process.checkNonZeroExit(args: exec.pathString)
       XCTAssertEqual(output, "5\n")
@@ -180,7 +180,7 @@ final class JobExecutorTests: XCTestCase {
       jobs: [job], resolver: try ArgsResolver(),
       executorDelegate: delegate
     )
-    try executor.execute(env: ProcessEnv.vars)
+    try executor.execute(env: ProcessEnv.vars, fileSystem: localFileSystem)
 
     XCTAssertEqual(try delegate.finished[0].1.utf8Output(), "test")
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -466,7 +466,7 @@ final class SwiftDriverTests: XCTestCase {
     try withTemporaryFile { file in
       try assertNoDiagnostics { diags in
         try localFileSystem.writeFileContents(file.path) { $0 <<< contents }
-        let outputFileMap = try OutputFileMap.load(file: .absolute(file.path), diagnosticEngine: diags)
+        let outputFileMap = try OutputFileMap.load(fileSystem: localFileSystem, file: .absolute(file.path), diagnosticEngine: diags)
 
         let object = try outputFileMap.getOutput(inputFile: .init(path: "/tmp/foo/Sources/foo/foo.swift"), outputType: .object)
         XCTAssertEqual(object.name, "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.o")
@@ -499,10 +499,10 @@ final class SwiftDriverTests: XCTestCase {
     let sampleOutputFileMap = OutputFileMap(entries: pathyEntries)
 
     try withTemporaryFile { file in
-      try sampleOutputFileMap.store(file: file.path, diagnosticEngine: DiagnosticsEngine())
+      try sampleOutputFileMap.store(fileSystem: localFileSystem, file: file.path, diagnosticEngine: DiagnosticsEngine())
       let contentsForDebugging = try localFileSystem.readFileContents(file.path).cString
       _ = contentsForDebugging
-      let recoveredOutputFileMap = try OutputFileMap.load(file: .absolute(file.path), diagnosticEngine: DiagnosticsEngine())
+      let recoveredOutputFileMap = try OutputFileMap.load(fileSystem: localFileSystem, file: .absolute(file.path), diagnosticEngine: DiagnosticsEngine())
       XCTAssertEqual(sampleOutputFileMap, recoveredOutputFileMap)
     }
   }
@@ -588,7 +588,7 @@ final class SwiftDriverTests: XCTestCase {
       try localFileSystem.writeFileContents(barPath) {
         $0 <<< "from\nbar\n@\(fooPath.pathString)"
       }
-      let args = try Driver.expandResponseFiles(["swift", "compiler", "-Xlinker", "@loader_path", "@" + fooPath.pathString, "something"], diagnosticsEngine: diags)
+      let args = try Driver.expandResponseFiles(["swift", "compiler", "-Xlinker", "@loader_path", "@" + fooPath.pathString, "something"], fileSystem: localFileSystem, diagnosticsEngine: diags)
       XCTAssertEqual(args, ["swift", "compiler", "-Xlinker", "@loader_path", "hello", "bye", "bye to you", "from", "bar", "something"])
       XCTAssertEqual(diags.diagnostics.count, 1)
       XCTAssert(diags.diagnostics.first!.description.contains("is recursively expanded"))
@@ -633,9 +633,9 @@ final class SwiftDriverTests: XCTestCase {
       try localFileSystem.writeFileContents(escapingPath) {
         $0 <<< "swift\n--driver-mode=swiftc\n-v\r\n//comment\n\"the end\""
       }
-      let args = try Driver.expandResponseFiles(["@" + fooPath.pathString], diagnosticsEngine: diags)
+      let args = try Driver.expandResponseFiles(["@" + fooPath.pathString], fileSystem: localFileSystem, diagnosticsEngine: diags)
       XCTAssertEqual(args, ["Command1", "--kkc", "but", "this", "is", #"\\a"#, "command", #"swift"#, "rocks!" ,"compiler", "-Xlinker", "@loader_path", "mkdir", "Quoted Dir", "cd", "Unquoted Dir", "@NotAFile", #"-flag=quoted string with a "quote" inside"#, "-another-flag", "this", "line", "has", "lots", "of", "whitespace"])
-      let escapingArgs = try Driver.expandResponseFiles(["@" + escapingPath.pathString], diagnosticsEngine: diags)
+      let escapingArgs = try Driver.expandResponseFiles(["@" + escapingPath.pathString], fileSystem: localFileSystem, diagnosticsEngine: diags)
       XCTAssertEqual(escapingArgs, ["swift", "--driver-mode=swiftc", "-v","the end"])
     }
   }


### PR DESCRIPTION
The Swift driver library should never directly access the local file
system. Thread a file system parameter through the SwiftDriver library
so clients can provide an alternative file system if they want.