### PR TITLE
Add support for reading fine-grained source file dependency graphs

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(SwiftDriver
   "Incremental Compilation/IncrementalCompilation.swift"
   "Incremental Compilation/InputIInfoMap.swift"
   "Incremental Compilation/InputInfo.swift"
+  "Incremental Compilation/SourceFileDependencyGraph.swift"
 
   Jobs/AutolinkExtractJob.swift
   Jobs/CommandLineArguments.swift

--- a/Sources/SwiftDriver/Incremental Compilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/SourceFileDependencyGraph.swift
@@ -1,0 +1,113 @@
+//===------- SourceFileDependencyGraph.swift - Read swiftdeps files -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+@_implementationOnly import Yams
+
+public struct SourceFileDependencyGraph: Codable {
+  public static let sourceFileProvidesInterfaceSequenceNumber: Int = 0
+  public static let sourceFileProvidesImplementationSequenceNumber: Int = 1
+
+  private var allNodes: [Node]
+
+  public var sourceFileNodePair: (interface: Node, implementation: Node) {
+    (interface: allNodes[SourceFileDependencyGraph.sourceFileProvidesInterfaceSequenceNumber],
+     implementation: allNodes[SourceFileDependencyGraph.sourceFileProvidesImplementationSequenceNumber])
+  }
+
+  public func forEachNode(_ doIt: (Node)->Void) {
+    allNodes.forEach(doIt)
+  }
+
+  public func forEachDefDependedUpon(by node: Node, _ doIt: (Node)->Void) {
+    for sequenceNumber in node.defsIDependUpon {
+      doIt(allNodes[sequenceNumber])
+    }
+  }
+
+  public func forEachArc(_ doIt: (Node, Node)->Void) {
+    forEachNode { useNode in
+      forEachDefDependedUpon(by: useNode) { defNode in
+        doIt(defNode, useNode)
+      }
+    }
+  }
+
+  @discardableResult public func verify() -> Bool {
+    assert(Array(allNodes.indices) == allNodes.map { $0.sequenceNumber })
+    forEachNode {
+      $0.verify()
+    }
+    return true
+  }
+
+  public init(contents: String) throws {
+    let decoder = YAMLDecoder()
+    self = try decoder.decode(Self.self, from: contents)
+    assert(verify())
+  }
+}
+
+public enum DeclAspect: String, Codable {
+  case interface, implementation
+}
+
+public struct DependencyKey: Codable {
+  public enum Kind: String, Codable {
+    case topLevel
+    case nominal
+    case potentialMember
+    case member
+    case dynamicLookup
+    case externalDepend
+    case sourceFileProvide
+  }
+
+  public var kind: Kind
+  public var aspect: DeclAspect
+  public var context: String
+  public var name: String
+
+  public func verify() {
+    assert(kind != .externalDepend || aspect == .interface, "All external dependencies must be interfaces.")
+    switch kind {
+    case .topLevel, .dynamicLookup, .externalDepend, .sourceFileProvide:
+      assert(context.isEmpty && !name.isEmpty, "Must only have a name")
+    case .nominal, .potentialMember:
+      assert(!context.isEmpty && name.isEmpty, "Must only have a context")
+    case .member:
+      assert(!context.isEmpty && !name.isEmpty, "Must have both")
+    }
+  }
+}
+
+
+extension SourceFileDependencyGraph {
+  public struct Node: Codable {
+    public var key: DependencyKey
+    public var fingerprint: String?
+    public var sequenceNumber: Int
+    public var defsIDependUpon: [Int]
+    public var isProvides: Bool
+
+    public func verify() {
+      key.verify()
+
+      if key.kind == .sourceFileProvide {
+        switch key.aspect {
+        case .interface:
+          assert(sequenceNumber == SourceFileDependencyGraph.sourceFileProvidesInterfaceSequenceNumber)
+        case .implementation:
+          assert(sequenceNumber == SourceFileDependencyGraph.sourceFileProvidesImplementationSequenceNumber)
+        }
+      }
+    }
+  }
+}

--- a/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
@@ -1,0 +1,300 @@
+//===--- IncrementalCompilationInputs.swift - Test Inputs -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+enum Inputs {
+  static var inputInfoMap: String {
+    """
+        version: "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
+        options: "abbbfbcaf36b93e58efaadd8271ff142"
+        build_time: [1570318779, 32358000]
+        inputs:
+          "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift": !dirty [1570318778, 0]
+          "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift": [1570083660, 0]
+          "/Volumes/gazorp.swift": !private [0,0]
+    """
+  }
+  static var fineGrainedSourceFileDependencyGraph: String {
+    """
+    # Fine-grained v0
+    ---
+    allNodes:
+      - key:
+          kind:            sourceFileProvide
+          aspect:          interface
+          context:         ''
+          name:            '/Users/owenvoorhees/Desktop/hello.swiftdeps'
+        fingerprint:     85188db3503106210367dbcb7f5d1524
+        sequenceNumber:  0
+        defsIDependUpon: [ 30, 28, 24, 23, 27, 22, 21 ]
+        isProvides:      true
+      - key:
+          kind:            sourceFileProvide
+          aspect:          implementation
+          context:         ''
+          name:            '/Users/owenvoorhees/Desktop/hello.swiftdeps'
+        fingerprint:     85188db3503106210367dbcb7f5d1524
+        sequenceNumber:  1
+        defsIDependUpon: [ 26, 25, 31, 20, 19, 29, 18 ]
+        isProvides:      true
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            Foo
+        fingerprint:     8daabb8cdf69d8e8702b4788be12efd6
+        sequenceNumber:  2
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            topLevel
+          aspect:          implementation
+          context:         ''
+          name:            Foo
+        fingerprint:     8daabb8cdf69d8e8702b4788be12efd6
+        sequenceNumber:  3
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            a
+        sequenceNumber:  4
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            topLevel
+          aspect:          implementation
+          context:         ''
+          name:            a
+        sequenceNumber:  5
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            y
+        sequenceNumber:  6
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            topLevel
+          aspect:          implementation
+          context:         ''
+          name:            y
+        sequenceNumber:  7
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            nominal
+          aspect:          interface
+          context:         SS
+          name:            ''
+        sequenceNumber:  8
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            nominal
+          aspect:          implementation
+          context:         SS
+          name:            ''
+        sequenceNumber:  9
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            nominal
+          aspect:          interface
+          context:         5hello3FooV
+          name:            ''
+        fingerprint:     8daabb8cdf69d8e8702b4788be12efd6
+        sequenceNumber:  10
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            nominal
+          aspect:          implementation
+          context:         5hello3FooV
+          name:            ''
+        fingerprint:     8daabb8cdf69d8e8702b4788be12efd6
+        sequenceNumber:  11
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            potentialMember
+          aspect:          interface
+          context:         SS
+          name:            ''
+        sequenceNumber:  12
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            potentialMember
+          aspect:          implementation
+          context:         SS
+          name:            ''
+        sequenceNumber:  13
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            potentialMember
+          aspect:          interface
+          context:         5hello3FooV
+          name:            ''
+        fingerprint:     8daabb8cdf69d8e8702b4788be12efd6
+        sequenceNumber:  14
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            potentialMember
+          aspect:          implementation
+          context:         5hello3FooV
+          name:            ''
+        fingerprint:     8daabb8cdf69d8e8702b4788be12efd6
+        sequenceNumber:  15
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            member
+          aspect:          interface
+          context:         SS
+          name:            abc
+        sequenceNumber:  16
+        defsIDependUpon: [ 0 ]
+        isProvides:      true
+      - key:
+          kind:            member
+          aspect:          implementation
+          context:         SS
+          name:            abc
+        sequenceNumber:  17
+        defsIDependUpon: [  ]
+        isProvides:      true
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            StringLiteralType
+        sequenceNumber:  18
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            FloatLiteralType
+        sequenceNumber:  19
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            IntegerLiteralType
+        sequenceNumber:  20
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            String
+        sequenceNumber:  21
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            topLevel
+          aspect:          interface
+          context:         ''
+          name:            Int
+        sequenceNumber:  22
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            externalDepend
+          aspect:          interface
+          context:         ''
+          name:            '/Users/owenvoorhees/Documents/Development/swift-source/build/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/Swift.swiftmodule/x86_64-apple-macos.swiftmodule'
+        sequenceNumber:  23
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            externalDepend
+          aspect:          interface
+          context:         ''
+          name:            '/Users/owenvoorhees/Documents/Development/swift-source/build/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftmodule'
+        sequenceNumber:  24
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            nominal
+          aspect:          interface
+          context:         s35_ExpressibleByBuiltinIntegerLiteralP
+          name:            ''
+        sequenceNumber:  25
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            nominal
+          aspect:          interface
+          context:         s34_ExpressibleByBuiltinStringLiteralP
+          name:            ''
+        sequenceNumber:  26
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            member
+          aspect:          interface
+          context:         5hello3FooV
+          name:            init
+        sequenceNumber:  27
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            member
+          aspect:          interface
+          context:         SS
+          name:            Int
+        sequenceNumber:  28
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            member
+          aspect:          interface
+          context:         s35_ExpressibleByBuiltinIntegerLiteralP
+          name:            init
+        sequenceNumber:  29
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            member
+          aspect:          interface
+          context:         5hello3FooV
+          name:            baz
+        sequenceNumber:  30
+        defsIDependUpon: [  ]
+        isProvides:      false
+      - key:
+          kind:            member
+          aspect:          interface
+          context:         s34_ExpressibleByBuiltinStringLiteralP
+          name:            init
+        sequenceNumber:  31
+        defsIDependUpon: [  ]
+        isProvides:      false
+    ...
+
+    """
+  }
+}

--- a/Tests/SwiftDriverTests/XCTestManifests.swift
+++ b/Tests/SwiftDriverTests/XCTestManifests.swift
@@ -18,6 +18,7 @@ extension IncrementalCompilationTests {
     // to regenerate.
     static let __allTests__IncrementalCompilationTests = [
         ("testInputInfoMapReading", testInputInfoMapReading),
+        ("testReadSourceFileDependencyGraph", testReadSourceFileDependencyGraph),
     ]
 }
 
@@ -92,6 +93,7 @@ extension SwiftDriverTests {
         ("testMultithreading", testMultithreading),
         ("testMultithreadingDiagnostics", testMultithreadingDiagnostics),
         ("testOutputFileMapLoading", testOutputFileMapLoading),
+        ("testOutputFileMapRelativePathArg", testOutputFileMapRelativePathArg),
         ("testOutputFileMapResolving", testOutputFileMapResolving),
         ("testOutputFileMapStoring", testOutputFileMapStoring),
         ("testPCHGeneration", testPCHGeneration),
@@ -99,6 +101,7 @@ extension SwiftDriverTests {
         ("testPrimaryOutputKinds", testPrimaryOutputKinds),
         ("testPrimaryOutputKindsDiagnostics", testPrimaryOutputKindsDiagnostics),
         ("testPrintTargetInfo", testPrintTargetInfo),
+        ("testRecordedInputModificationDates", testRecordedInputModificationDates),
         ("testRegressions", testRegressions),
         ("testRepl", testRepl),
         ("testResponseFileExpansion", testResponseFileExpansion),
@@ -108,6 +111,7 @@ extension SwiftDriverTests {
         ("testStandardCompileJobs", testStandardCompileJobs),
         ("testSubcommandsHandling", testSubcommandsHandling),
         ("testTargetTriple", testTargetTriple),
+        ("testTargetVariant", testTargetVariant),
         ("testToolchainClangPath", testToolchainClangPath),
         ("testToolchainUtilities", testToolchainUtilities),
         ("testUsingResponseFiles", testUsingResponseFiles),


### PR DESCRIPTION
This just ports over the parts of the source file fine-grained dependency graph the driver cares about. I just called it `SourceFileDependencyGraph` because I assume we don't intend to support the older dependency system. I'm still learning how all this works in the C++ driver, so I'm open to feedback on the API and approach!