### PR TITLE
Support -embed-bitcode and -driver-print-bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The goal of the new Swift driver is to provide a drop-in replacement for the exi
   * [x] Immediate mode
 * Features
   * [x] Precompiled bridging headers
-  * [ ] Support embedding of bitcode
+  * [x] Support embedding of bitcode
   * [ ] Incremental compilation
   * [x] Parseable output, as used by SwiftPM
   * [x] Response files

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -1,0 +1,77 @@
+//===--------------- BackendJob.swift - Swift Backend Job -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension Driver {
+  /// Form a backend job.
+  mutating func backendJob(input: TypedVirtualPath,
+                           allOutputs: inout [TypedVirtualPath]) throws -> Job {
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    var inputs = [TypedVirtualPath]()
+    var outputs = [TypedVirtualPath]()
+
+    commandLine.appendFlag("-frontend")
+    addCompileModeOption(outputType: compilerOutputType, commandLine: &commandLine)
+
+    // Add input arguments.
+    commandLine.appendFlag(.primaryFile)
+    commandLine.appendPath(input.file)
+    inputs.append(input)
+
+    commandLine.appendFlag(.embedBitcode)
+
+    // -embed-bitcode only supports a restricted set of flags.
+    commandLine.appendFlag(.target)
+    commandLine.appendFlag(targetTriple.triple)
+
+    // Enable address top-byte ignored in the ARM64 backend.
+    if targetTriple.arch == .aarch64 {
+      commandLine.appendFlag(.Xllvm)
+      commandLine.appendFlag("-aarch64-use-tbi")
+    }
+
+    // Handle the CPU and its preferences.
+    try commandLine.appendLast(.targetCpu, from: &parsedOptions)
+
+    // Enable optimizations, but disable all LLVM-IR-level transformations.
+    try commandLine.appendLast(in: .O, from: &parsedOptions)
+    commandLine.appendFlag(.disableLlvmOptzns)
+
+    try commandLine.appendLast(.parseStdlib, from: &parsedOptions)
+
+    commandLine.appendFlag(.moduleName)
+    commandLine.appendFlag(moduleName)
+
+    // Add the output file argument if necessary.
+    if let compilerOutputType = compilerOutputType {
+      let output = computePrimaryOutput(for: input,
+                                        outputType: compilerOutputType,
+                                        isTopLevel: isTopLevelOutput(type: compilerOutputType))
+      commandLine.appendFlag(.o)
+      commandLine.appendPath(output.file)
+      outputs.append(output)
+    }
+
+    allOutputs += outputs
+
+    return Job(
+      kind: .backend,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      displayInputs: inputs,
+      inputs: inputs,
+      outputs: outputs,
+      supportsResponseFiles: true
+    )
+  }
+}

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -14,7 +14,7 @@ import SwiftOptions
 
 extension Driver {
   /// Add the appropriate compile mode option to the command line for a compile job.
-  private mutating func addCompileModeOption(outputType: FileType?, commandLine: inout [Job.ArgTemplate]) {
+  mutating func addCompileModeOption(outputType: FileType?, commandLine: inout [Job.ArgTemplate]) {
     if let compileOption = outputType?.frontendCompileOption {
       commandLine.appendFlag(compileOption)
     } else {
@@ -26,7 +26,7 @@ extension Driver {
     }
   }
 
-  fileprivate mutating func computePrimaryOutput(for input: TypedVirtualPath, outputType: FileType,
+  mutating func computePrimaryOutput(for input: TypedVirtualPath, outputType: FileType,
                                         isTopLevel: Bool) -> TypedVirtualPath {
     if let path = outputFileMap?.existingOutput(inputFile: input.file, outputType: outputType) {
       return TypedVirtualPath(file: path, type: outputType)
@@ -56,28 +56,31 @@ extension Driver {
     return TypedVirtualPath(file: .relative(.init(baseName.appendingFileTypeExtension(outputType))), type: outputType)
   }
 
-  /// Add the compiler inputs for a frontend compilation job, and return the
-  /// corresponding primary set of outputs.
-  mutating func addCompileInputs(primaryInputs: [TypedVirtualPath],
-                                 inputs: inout [TypedVirtualPath],
-                                 commandLine: inout [Job.ArgTemplate]) -> [TypedVirtualPath] {
-    // Is this compile job top-level
-    let isTopLevel: Bool
-
-    switch compilerOutputType {
+  /// Is this compile job top-level
+  func isTopLevelOutput(type: FileType?) -> Bool {
+    switch type {
     case .assembly, .sil, .raw_sil, .llvmIR, .ast:
-      isTopLevel = true
+      return true
     case .object:
-      isTopLevel = (linkerOutputType == nil)
+      return (linkerOutputType == nil)
     case .swiftModule:
-      isTopLevel = compilerMode.isSingleCompilation && moduleOutput?.isTopLevel ?? false
+      return compilerMode.isSingleCompilation && moduleOutput?.isTopLevel ?? false
     case .swift, .sib, .image, .dSYM, .dependencies, .autolink,
          .swiftDocumentation, .swiftInterface,
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
          .objcHeader, .swiftDeps, .remap, .importedModules, .tbd, .moduleTrace,
          .indexData, .optimizationRecord, .pcm, .pch, nil:
-      isTopLevel = false
+      return false
     }
+  }
+
+  /// Add the compiler inputs for a frontend compilation job, and return the
+  /// corresponding primary set of outputs.
+  mutating func addCompileInputs(primaryInputs: [TypedVirtualPath],
+                                 inputs: inout [TypedVirtualPath],
+                                 outputType: FileType?,
+                                 commandLine: inout [Job.ArgTemplate]) -> [TypedVirtualPath] {
+    let isTopLevel = isTopLevelOutput(type: outputType)
 
     // Collect the set of input files that are part of the Swift compilation.
     let swiftInputFiles: [TypedVirtualPath] = inputFiles.filter { $0.type.isPartOfSwiftCompilation }
@@ -104,16 +107,16 @@ extension Driver {
 
       // If there is a primary output or we are doing multithreaded compiles,
       // add an output for the input.
-      if let compilerOutputType = compilerOutputType,
-        isPrimary || (!usesPrimaryFileInputs && isMultithreaded && compilerOutputType.isAfterLLVM) {
+      if let outputType = outputType,
+        isPrimary || (!usesPrimaryFileInputs && isMultithreaded && outputType.isAfterLLVM) {
         primaryOutputs.append(computePrimaryOutput(for: input,
-                                                   outputType: compilerOutputType,
+                                                   outputType: outputType,
                                                    isTopLevel: isTopLevel))
       }
     }
 
     // When not using primary file inputs or multithreading, add a single output.
-    if let outputType = compilerOutputType,
+    if let outputType = outputType,
       !usesPrimaryFileInputs && !(isMultithreaded && outputType.isAfterLLVM) {
       primaryOutputs.append(computePrimaryOutput(
         for: TypedVirtualPath(file: try! VirtualPath(path: ""),
@@ -133,7 +136,10 @@ extension Driver {
 
     commandLine.appendFlag("-frontend")
     addCompileModeOption(outputType: outputType, commandLine: &commandLine)
-    let primaryOutputs = addCompileInputs(primaryInputs: primaryInputs, inputs: &inputs, commandLine: &commandLine)
+    let primaryOutputs = addCompileInputs(primaryInputs: primaryInputs,
+                                          inputs: &inputs,
+                                          outputType: outputType,
+                                          commandLine: &commandLine)
     outputs += primaryOutputs
     outputs += try addFrontendSupplementaryOutputArguments(commandLine: &commandLine, primaryInputs: primaryInputs)
 

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -16,6 +16,7 @@ import Foundation
 public struct Job: Codable, Equatable, Hashable {
   public enum Kind: String, Codable {
     case compile
+    case backend
     case mergeModule = "merge-module"
     case link
     case generateDSYM = "generate-dsym"

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -14,10 +14,9 @@ import TSCBasic
 extension Driver {
 
   /// Compute the output file for an image output.
-  private func outputFileForImage(inputs: [TypedVirtualPath]) -> VirtualPath {
-    // FIXME: The check for __bad__ here, is
-    if inputs.count == 1 && moduleName == "__bad__" && inputs.first!.file != .standardInput {
-      // FIXME: llvm::sys::path::stem(BaseInput);
+  private var outputFileForImage: VirtualPath {
+    if inputFiles.count == 1 && moduleNameIsFallback && inputFiles[0].file != .standardInput {
+      return .relative(RelativePath(inputFiles[0].file.basenameWithoutExt))
     }
 
     let outputName =
@@ -35,7 +34,7 @@ extension Driver {
     if let output = parsedOptions.getLastArgument(.o) {
       outputFile = try VirtualPath(path: output.asSingle)
     } else {
-      outputFile = outputFileForImage(inputs: inputs)
+      outputFile = outputFileForImage
     }
 
     // Defer to the toolchain for platform-specific linking
@@ -58,7 +57,7 @@ extension Driver {
       tool: .absolute(toolPath),
       commandLine: commandLine,
       inputs: inputs,
-      outputs: [.init(file: outputFile, type: .object)]
+      outputs: [.init(file: outputFile, type: .image)]
     )
   }
 }

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -80,6 +80,18 @@ public enum VirtualPath: Hashable {
     }
   }
 
+  /// Retrieve the basename of the path.
+  public var basename: String {
+    switch self {
+    case .absolute(let path):
+      return path.basename
+    case .relative(let path), .temporary(let path):
+      return path.basename
+    case .standardInput, .standardOutput:
+      return ""
+    }
+  }
+
   /// Retrieve the basename of the path without the extension.
   public var basenameWithoutExt: String {
     switch self {

--- a/Sources/SwiftOptions/ParsedOptions.swift
+++ b/Sources/SwiftOptions/ParsedOptions.swift
@@ -307,4 +307,13 @@ extension ParsedOptions {
   public mutating func getLast(in group: Option.Group) -> ParsedOption? {
     return groupIndex[group]?.last
   }
+
+  /// Remove argument from parsed options.
+  public mutating func eraseArgument(_ option: Option) {
+    parsedOptions.removeAll { $0.option == option }
+    optionIndex.removeValue(forKey: option.spelling)
+    if let group = option.group {
+      groupIndex[group]?.removeAll { $0.option == option }
+    }
+  }
 }


### PR DESCRIPTION
- The moduleNameIsFallback fix for the linker fixes `Driver/verify-debug-info.swift` (dysm at wrong name)
- embed-bitcode tests in `Driver/multi-threaded.swift` are fixed (Still some tests there "failing" because parsable output json is in different order)
- `Driver/embed-bitcode.swift` tests are fixed except one. Driver jobs are printed in different order.
```
// RUN: %target-swiftc_driver -embed-bitcode -Xcc -DDEBUG -Xllvm -fake-llvm-option -c -emit-module %s 2>&1 -### | %FileCheck %s -check-prefix=CHECK-MODULE
// CHECK-MODULE: -frontend
// CHECK-MODULE: -emit-bc
// CHECK-MODULE-DAG: -Xcc -DDEBUG
// CHECK-MODULE-DAG: -Xllvm -fake-llvm-option
// CHECK-MODULE-DAG: -emit-module-path
// CHECK-MODULE: -frontend
// CHECK-MODULE: -emit-module
// CHECK-MODULE: -frontend
// CHECK-MODULE: -c
// CHECK-MODULE-NOT: -Xcc
// CHECK-MODULE-NOT: -DDEBUG
// CHECK-MODULE-NOT: -fake-llvm-option
// CHECK-MODULE-NOT: -emit-module-path
```
In this case the merge module job gets printed before the backend job. For all other tests the merge module job is last. Not sure what is effecting the print order in c++ driver.