### PR TITLE
Driver performance improvements (profile test/Driver/response-file.swift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ on the command line:
 ```
 $ SWIFT_DRIVER_ENABLE_INTEGRATION_TESTS=1 \
   SWIFT_DRIVER_LIT_DIR=/path/to/build/Ninja-ReleaseAssert/swift-.../test-... \
-  swift test --parallel
+  swift test -c release --parallel
 ```
 
 #### Preparing a Linux docker for debug

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -508,18 +508,21 @@ extension Driver {
         continue
       } else if char.isWhitespace && !quoted {
         // This is unquoted, unescaped whitespace, start a new token.
-        tokens.append(token)
-        token = ""
+        if !token.isEmpty {
+          tokens.append(token)
+          token = ""
+        }
         continue
       }
 
       token.append(char)
     }
     // Add the final token
-    tokens.append(token)
+    if !token.isEmpty {
+      tokens.append(token)
+    }
 
-    // Filter any empty tokens that might be parsed if there's excessive whitespace.
-    return tokens.filter { !$0.isEmpty }
+    return tokens
   }
 
   /// Tokenize each line of the response file, omitting empty lines.

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -241,7 +241,7 @@ public struct Driver {
       throw Error.subcommandPassedToDriver
     }
 
-    var args = try Self.expandResponseFiles(args, fileSystem: fileSystem, diagnosticsEngine: self.diagnosticEngine)[...]
+    var args = try Self.expandResponseFiles(args, fileSystem: fileSystem, diagnosticsEngine: self.diagnosticEngine)
 
     self.driverKind = try Self.determineDriverKind(args: &args)
     self.optionTable = OptionTable()
@@ -581,7 +581,7 @@ extension Driver {
   /// Determine the driver kind based on the command-line arguments, consuming the arguments
   /// conveying this information.
   public static func determineDriverKind(
-    args: inout ArraySlice<String>
+    args: inout [String]
   ) throws -> DriverKind {
     // Get the basename of the driver executable.
     let execRelPath = args.removeFirst()

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -58,21 +58,21 @@ final class SwiftDriverTests: XCTestCase {
     func assertArgs(
       _ args: String...,
       parseTo driverKind: DriverKind,
-      leaving remainingArgs: ArraySlice<String>,
+      leaving remainingArgs: [String],
       file: StaticString = #file, line: UInt = #line
     ) throws {
-      var slice = args[...]
-      let result = try Driver.determineDriverKind(args: &slice)
+      var args = args
+      let result = try Driver.determineDriverKind(args: &args)
 
       XCTAssertEqual(result, driverKind, file: file, line: line)
-      XCTAssertEqual(slice, remainingArgs, file: file, line: line)
+      XCTAssertEqual(args, remainingArgs, file: file, line: line)
     }
     func assertArgsThrow(
       _ args: String...,
       file: StaticString = #file, line: UInt = #line
     ) throws {
-      var slice = args[...]
-      XCTAssertThrowsError(try Driver.determineDriverKind(args: &slice))
+      var args = args
+      XCTAssertThrowsError(try Driver.determineDriverKind(args: &args))
     }
 
     try assertArgs("swift", parseTo: .interactive, leaving: [])


### PR DESCRIPTION
Big change is:
> Remove job from build keys. Saves encoding and decoding the jobs
> 
> The runtime of the following (in release build) went from 2.27 minutes to 2.29 seconds (notice the change in units!!!)
> // RUN: %{python} -c 'for i in range(500001): print("-DTEST5_" + str(i))' > %t.5.resp
> // RUN: not %target-swiftc_driver %s @%t.5.resp -Xfrontend -debug-crash-immediately 2>&1