### PR TITLE
Print commands required to explicitly build module dependencies.

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -7,12 +7,16 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(SwiftDriver
+  "Dependency Scanning/ModuleDependencyBuildGeneration.swift"
+  "Dependency Scanning/InterModuleDependencyGraph.swift"
+
   Driver/CompilerMode.swift
   Driver/DebugInfo.swift
   Driver/Driver.swift
   Driver/LinkKind.swift
   Driver/OutputFileMap.swift
   Driver/ToolExecutionDelegate.swift
+  Driver/ModuleDependencyScanning.swift
 
   Execution/JobExecutor.swift
   Execution/ParsableOutput.swift

--- a/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
@@ -1,0 +1,145 @@
+//===--------------- ModuleDependencyGraph.swift --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+
+enum ModuleDependencyId: Hashable {
+  case swift(String)
+  case clang(String)
+
+  var moduleName: String {
+    switch self {
+      case .swift(let name): return name
+      case .clang(let name): return name
+    }
+  }
+}
+
+extension ModuleDependencyId: Codable {
+  enum CodingKeys: CodingKey {
+    case swift
+    case clang
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    do {
+      let moduleName =  try container.decode(String.self, forKey: .swift)
+      self = .swift(moduleName)
+    } catch {
+      let moduleName =  try container.decode(String.self, forKey: .clang)
+      self = .clang(moduleName)
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+      case .swift(let moduleName):
+        try container.encode(moduleName, forKey: .swift)
+      case .clang(let moduleName):
+        try container.encode(moduleName, forKey: .clang)
+    }
+  }
+}
+
+/// Details specific to Swift modules.
+struct SwiftModuleDetails: Codable {
+  /// The module interface from which this module was built, if any.
+  var moduleInterfacePath: String?
+
+  /// The bridging header, if any.
+  var bridgingHeaderPath: String?
+
+  /// The source files referenced by the bridging header.
+  var bridgingSourceFiles: [String]? = []
+
+  /// Options to the compile command
+  var commandLine: [String]? = []
+}
+
+/// Details specific to Clang modules.
+struct ClangModuleDetails: Codable {
+  /// The path to the module map used to build this module.
+  var moduleMapPath: String
+
+  /// clang-generated context hash
+  var contextHash: String?
+
+  /// Options to the compile command
+  var commandLine: [String]? = []
+}
+
+struct ModuleInfo: Codable {
+  /// The path for the module.
+  var modulePath: String
+
+  /// The source files used to build this module.
+  var sourceFiles: [String] = []
+
+  /// The set of direct module dependencies of this module.
+  var directDependencies: [ModuleDependencyId] = []
+
+  /// Specific details of a particular kind of module.
+  var details: Details
+
+  /// Specific details of a particular kind of module.
+  enum Details {
+    /// Swift modules may be built from a module interface, and may have
+    /// a bridging header.
+    case swift(SwiftModuleDetails)
+
+    /// Clang modules are built from a module map file.
+    case clang(ClangModuleDetails)
+  }
+}
+
+extension ModuleInfo.Details: Codable {
+  enum CodingKeys: CodingKey {
+    case swift
+    case clang
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    do {
+      let details = try container.decode(SwiftModuleDetails.self, forKey: .swift)
+      self = .swift(details)
+    } catch {
+      let details = try container.decode(ClangModuleDetails.self, forKey: .clang)
+      self = .clang(details)
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+      case .swift(let details):
+        try container.encode(details, forKey: .swift)
+      case .clang(let details):
+        try container.encode(details, forKey: .clang)
+    }
+  }
+}
+
+/// Describes the complete set of dependencies for a Swift module, including
+/// all of the Swift and C modules and source files it depends on.
+struct InterModuleDependencyGraph: Codable {
+  /// The name of the main module.
+  var mainModuleName: String
+
+  /// The complete set of modules discovered
+  var modules: [ModuleDependencyId: ModuleInfo] = [:]
+
+  /// Information about the main module.
+  var mainModule: ModuleInfo { modules[.swift(mainModuleName)]! }
+}

--- a/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
@@ -1,0 +1,109 @@
+//===--------------- ModuleDependencyBuildGeneration.swift ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+import TSCUtility
+import Foundation
+
+extension Driver {
+  /// For the current moduleDependencyGraph, plan the order and generate jobs
+  /// for explicitly building all dependency modules.
+  mutating func planExplicitModuleDependenciesCompile(dependencyGraph: InterModuleDependencyGraph)
+  throws -> [Job] {
+    var jobs: [Job] = []
+    for (id, moduleInfo) in dependencyGraph.modules {
+      // The generation of the main module file will be handled elsewhere in the driver.
+      if (id.moduleName == dependencyGraph.mainModuleName) {
+        continue
+      }
+      switch id {
+        case .swift(let moduleName):
+          let swiftModuleBuildJob = try genSwiftModuleDependencyBuildJob(moduleInfo: moduleInfo,
+                                                                         moduleName: moduleName)
+          jobs.append(swiftModuleBuildJob)
+        case .clang(let moduleName):
+          let clangModuleBuildJob = try genClangModuleDependencyBuildJob(moduleInfo: moduleInfo,
+                                                                         moduleName: moduleName)
+          jobs.append(clangModuleBuildJob)
+
+      }
+    }
+    return jobs
+  }
+
+  /// For a given swift module dependency, generate a build job
+  mutating private func genSwiftModuleDependencyBuildJob(moduleInfo: ModuleInfo,
+                                                         moduleName: String) throws -> Job {
+    // FIXIT: Needs more error handling
+    guard case .swift(let swiftModuleDetails) = moduleInfo.details else {
+      throw Error.malformedModuleDependency(moduleName, "no `details` object")
+    }
+
+    var inputs: [TypedVirtualPath] = []
+    var outputs: [TypedVirtualPath] = [
+      TypedVirtualPath(file: try VirtualPath(path: moduleInfo.modulePath), type: .swiftModule)
+    ]
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    commandLine.appendFlag("-frontend")
+
+    // Build the .swiftinterfaces file using a list of command line options specified in the
+    // `details` field.
+    guard let moduleInterfacePath = swiftModuleDetails.moduleInterfacePath else {
+      throw Error.malformedModuleDependency(moduleName, "no `moduleInterfacePath` object")
+    }
+    inputs.append(TypedVirtualPath(file: try VirtualPath(path: moduleInterfacePath),
+                                   type: .swiftInterface))
+    try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs)
+    swiftModuleDetails.commandLine?.forEach { commandLine.appendFlag($0) }
+
+    return Job(
+      kind: .emitModule,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      inputs: inputs,
+      outputs: outputs
+    )
+  }
+
+  /// For a given clang module dependency, generate a build job
+  mutating private func genClangModuleDependencyBuildJob(moduleInfo: ModuleInfo,
+                                                         moduleName: String) throws -> Job {
+    // For clang modules, the Fast Dependency Scanner emits a list of source
+    // files (with a .modulemap among them), and a list of compile command
+    // options.
+    // FIXIT: Needs more error handling
+    guard case .clang(let clangModuleDetails) = moduleInfo.details else {
+      throw Error.malformedModuleDependency(moduleName, "no `details` object")
+    }
+    var inputs: [TypedVirtualPath] = []
+    var outputs: [TypedVirtualPath] = [
+      TypedVirtualPath(file: try VirtualPath(path: moduleInfo.modulePath), type: .pcm)
+    ]
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    commandLine.appendFlag("-frontend")
+    commandLine.appendFlags("-emit-pcm", "-module-name", moduleName)
+
+    // The only required input is the .modulemap for this module.
+    commandLine.append(Job.ArgTemplate.path(try VirtualPath(path: clangModuleDetails.moduleMapPath)))
+    inputs.append(TypedVirtualPath(file: try VirtualPath(path: clangModuleDetails.moduleMapPath),
+                                   type: .clangModuleMap))
+    try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs)
+    clangModuleDetails.commandLine?.forEach { commandLine.appendFlags("-Xcc", $0) }
+
+    return Job(
+      kind: .generatePCM,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      inputs: inputs,
+      outputs: outputs
+    )
+  }
+}

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -50,6 +50,7 @@ public struct Driver {
     case subcommandPassedToDriver
     case integratedReplRemoved
     case conflictingOptions(Option, Option)
+    case malformedModuleDependency(String, String)
 
     public var description: String {
       switch self {
@@ -68,6 +69,8 @@ public struct Driver {
         return "Compiler-internal integrated REPL has been removed; use the LLDB-enhanced REPL instead."
       case .conflictingOptions(let one, let two):
         return "conflicting options '\(one.spelling)' and '\(two.spelling)'"
+      case .malformedModuleDependency(let moduleName, let errorDescription):
+        return "Malformed Module Dependency: \(moduleName), \(errorDescription)"
       }
     }
   }

--- a/Sources/SwiftDriver/Driver/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Driver/ModuleDependencyScanning.swift
@@ -1,0 +1,50 @@
+//===--------------- ModuleDependencyScanning.swift -----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import TSCBasic
+
+extension Driver {
+  /// Precompute the dependencies for a given Swift compilation, producing a
+  /// complete dependency graph including all Swift and C module files and
+  /// source files.
+  // TODO: Instead of directly invoking the frontend,
+  // treat this as any other `Job`.
+  mutating func computeModuleDependencyGraph() throws
+      -> InterModuleDependencyGraph? {
+    // Grab the swift compiler
+    let resolver = try ArgsResolver()
+    let compilerPath = VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler))
+    let tool = try resolver.resolve(.path(compilerPath))
+
+    // Aggregate the fast dependency scanner arguments
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    commandLine.appendFlag("-frontend")
+    commandLine.appendFlag("-scan-dependencies")
+    if parsedOptions.hasArgument(.parseStdlib) {
+       commandLine.appendFlag(.disableObjcAttrRequiresFoundationModule)
+    }
+    try addCommonFrontendOptions(commandLine: &commandLine)
+    // FIXME: MSVC runtime flags
+
+    // Pass on the input files
+    commandLine.append(contentsOf: inputFiles.map { .path($0.file)})
+
+    // Execute dependency scanner and decode its output
+    let arguments = [tool] + (try commandLine.map { try resolver.resolve($0) })
+    let scanProcess = try Process.launchProcess(arguments: arguments, env: env)
+    let result = try scanProcess.waitUntilExit()
+    guard let outputData = try? Data(result.utf8Output().utf8) else {
+      return nil
+    }
+    return try JSONDecoder().decode(InterModuleDependencyGraph.self, from: outputData)
+  }
+}

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -69,7 +69,7 @@ extension Driver {
          .swiftDocumentation, .swiftInterface,
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
          .objcHeader, .swiftDeps, .remap, .importedModules, .tbd, .moduleTrace,
-         .indexData, .optimizationRecord, .pcm, .pch, nil:
+         .indexData, .optimizationRecord, .pcm, .pch, .clangModuleMap, nil:
       return false
     }
   }
@@ -253,7 +253,7 @@ extension FileType {
 
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
-         .optimizationRecord, .swiftInterface, .swiftSourceInfoFile:
+         .optimizationRecord, .swiftInterface, .swiftSourceInfoFile, .clangModuleMap:
       fatalError("Output type can never be a primary output")
     }
   }

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -110,6 +110,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
 
   /// Clang precompiled header
   case pch
+
+  /// Clang Module Map
+  case clangModuleMap = "modulemap"
 }
 
 extension FileType: CustomStringConvertible {
@@ -117,7 +120,7 @@ extension FileType: CustomStringConvertible {
     switch self {
     case .swift, .sil, .sib, .image, .object, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile, .assembly,
-         .remap, .tbd, .pcm, .pch:
+         .remap, .tbd, .pcm, .pch, .clangModuleMap:
       return rawValue
 
     case .ast:
@@ -173,7 +176,7 @@ extension FileType {
          .importedModules, .indexData, .remap, .dSYM, .autolink, .dependencies,
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
          .swiftDeps, .moduleTrace, .tbd, .optimizationRecord, .swiftInterface,
-         .swiftSourceInfoFile, .jsonDependencies:
+         .swiftSourceInfoFile, .jsonDependencies, .clangModuleMap:
       return false
     }
   }
@@ -216,6 +219,8 @@ extension FileType {
       return "swiftinterface"
     case .swiftSourceInfoFile:
       return "swiftsourceinfo"
+    case .clangModuleMap:
+      return "modulemap"
     case .assembly:
       return "assembly"
     case .remap:
@@ -261,7 +266,7 @@ extension FileType {
     switch self {
     case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
-         .optimizationRecord, .swiftInterface, .jsonDependencies:
+         .optimizationRecord, .swiftInterface, .jsonDependencies, .clangModuleMap:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -279,7 +284,8 @@ extension FileType {
     case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile,
          .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap, .importedModules,
-         .tbd, .moduleTrace, .indexData, .optimizationRecord, .pcm, .pch, .jsonDependencies:
+         .tbd, .moduleTrace, .indexData, .optimizationRecord, .pcm, .pch, .jsonDependencies,
+         .clangModuleMap:
       return false
     }
   }

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -11,10 +11,14 @@
 //===----------------------------------------------------------------------===//
 extension Option {
   public static let driverPrintGraphviz: Option = Option("-driver-print-graphviz", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Write the job graph as a graphviz file", group: .internalDebug)
+  public static let driverPrebuildModuleDependencies: Option = Option("-driver-prebuild-module-dependencies", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
+  public static let driverPrintModuleDependenciesJobs: Option = Option("-driver-print-module-dependencies-jobs", .flag, attributes: [.helpHidden], helpText: "Print commands to explicitly build module dependencies")
 
   public static var extraOptions: [Option] {
     return [
-      Option.driverPrintGraphviz
+      Option.driverPrintGraphviz,
+      Option.driverPrebuildModuleDependencies,
+      Option.driverPrintModuleDependenciesJobs
     ]
   }
 }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1,0 +1,57 @@
+//===------- ExplicitModuleBuildTests.swift - Swift Driver Tests ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@testable import SwiftDriver
+import TSCBasic
+import XCTest
+
+/// Test that for the given JSON module dependency graph, valid jobs are generated
+final class ExplicitModuleBuildTests: XCTestCase {
+  func testModuleDependencyBuildCommandGeneration() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-driver-print-module-dependencies-jobs", "test.swift"])
+      let moduleDependencyGraph =
+            try JSONDecoder().decode(
+              InterModuleDependencyGraph.self,
+              from: ModuleDependenciesInputs.fastDependencyScannerOutput.data(using: .utf8)!)
+      let modulePrebuildJobs =
+            try driver.planExplicitModuleDependenciesCompile(dependencyGraph: moduleDependencyGraph)
+      XCTAssertEqual(modulePrebuildJobs.count, 4)
+      for job in modulePrebuildJobs {
+        XCTAssertEqual(job.outputs.count, 1)
+        switch (job.outputs[0].file) {
+          case .relative(RelativePath("SwiftShims.pcm")):
+            XCTAssertEqual(job.kind, .generatePCM)
+            XCTAssertEqual(job.inputs.count, 1)
+            XCTAssertTrue(job.inputs[0].file.absolutePath!.pathString.contains("swift/shims/module.modulemap"))
+          case .relative(RelativePath("c_simd.pcm")):
+            XCTAssertEqual(job.kind, .generatePCM)
+            XCTAssertEqual(job.inputs.count, 1)
+            XCTAssertTrue(job.inputs[0].file.absolutePath!.pathString.contains("clang-importer-sdk/usr/include/module.map"))
+          case .relative(RelativePath("Swift.swiftmodule")):
+            XCTAssertEqual(job.kind, .emitModule)
+            XCTAssertEqual(job.inputs.count, 1)
+            XCTAssertTrue(job.inputs[0].file.absolutePath!.pathString.contains("Swift.swiftmodule/x86_64-apple-macos.swiftinterface"))
+          case .relative(RelativePath("SwiftOnoneSupport.swiftmodule")):
+            XCTAssertEqual(job.kind, .emitModule)
+            XCTAssertEqual(job.inputs.count, 1)
+            XCTAssertTrue(job.inputs[0].file.absolutePath!.pathString.contains("SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface"))
+          default:
+            XCTFail("Unexpected module dependency build job output")
+        }
+      }
+    }
+  }
+
+
+}

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -1,0 +1,223 @@
+//===--- ExplicitModuleDependencyBuildInputs.swift - Test Inputs ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+enum ModuleDependenciesInputs {
+  static var fastDependencyScannerOutput: String {
+    """
+    {
+      "mainModuleName": "test",
+      "modules": [
+        {
+          "swift": "test"
+        },
+        {
+          "modulePath": "test.swiftmodule",
+          "sourceFiles": [
+            "test.swift"
+          ],
+          "directDependencies": [
+            {
+              "clang": "c_simd"
+            },
+            {
+              "swift": "Swift"
+            },
+            {
+              "swift": "SwiftOnoneSupport"
+            }
+          ],
+          "details": {
+            "swift": {
+            }
+          }
+        },
+        {
+          "clang": "c_simd"
+        },
+        {
+          "modulePath": "c_simd.pcm",
+          "sourceFiles": [
+            "/Volumes/clang-importer-sdk/usr/include/module.map",
+            "/Volumes/clang-importer-sdk/usr/include/simd.h"
+          ],
+          "directDependencies": [
+          ],
+          "details": {
+            "clang": {
+              "moduleMapPath": "/Volumes/clang-importer-sdk/usr/include/module.map",
+              "contextHash": "2QEMRLNY63H2N",
+              "commandLine": [
+                "-remove-preceeding-explicit-module-build-incompatible-options",
+                "-fno-implicit-modules",
+                "-emit-module",
+                "-fmodule-name=c_simd"
+              ]
+            }
+          }
+        },
+        {
+          "swift": "Swift"
+        },
+        {
+          "modulePath": "Swift.swiftmodule",
+          "sourceFiles": [
+          ],
+          "directDependencies": [
+            {
+              "clang": "SwiftShims"
+            }
+          ],
+          "details": {
+            "swift": {
+              "moduleInterfacePath": "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/Swift.swiftmodule/x86_64-apple-macos.swiftinterface",
+              "contextHash": "2WMED1WFU2S4M",
+              "commandLine": [
+                "-compile-module-from-interface",
+                "-target",
+                "x86_64-apple-macosx10.15",
+                "-sdk",
+                "/Volumes/clang-importer-sdk",
+                "-resource-dir",
+                "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift",
+                "-suppress-warnings",
+                "-disable-objc-attr-requires-foundation-module",
+                "-module-cache-path",
+                "/var/folders/7b/chq5yqgn7fz8zhmw8tkz53d80000gn/C/org.llvm.clang.ac/ModuleCache",
+                "-prebuilt-module-cache-path",
+                "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/prebuilt-modules",
+                "-track-system-dependencies",
+                "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/Swift.swiftmodule/x86_64-apple-macos.swiftinterface",
+                "-module-name",
+                "Swift",
+                "-o",
+                "/var/folders/7b/chq5yqgn7fz8zhmw8tkz53d80000gn/C/org.llvm.clang.ac/ModuleCache/Swift-2WMED1WFU2S4M.swiftmodule",
+                "-disable-objc-attr-requires-foundation-module",
+                "-target",
+                "x86_64-apple-macosx10.9",
+                "-enable-objc-interop",
+                "-enable-library-evolution",
+                "-module-link-name",
+                "swiftCore",
+                "-parse-stdlib",
+                "-swift-version",
+                "5",
+                "-O",
+                "-enforce-exclusivity=unchecked",
+                "-module-name",
+                "Swift"
+              ]
+            }
+          }
+        },
+        {
+          "swift": "SwiftOnoneSupport"
+        },
+        {
+          "modulePath": "SwiftOnoneSupport.swiftmodule",
+          "sourceFiles": [
+          ],
+          "directDependencies": [
+            {
+              "swift": "Swift"
+            }
+          ],
+          "details": {
+            "swift": {
+              "moduleInterfacePath": "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface",
+              "contextHash": "1PC0P8MX6CFZA",
+              "commandLine": [
+                "-compile-module-from-interface",
+                "-target",
+                "x86_64-apple-macosx10.15",
+                "-sdk",
+                "/Volumes/clang-importer-sdk",
+                "-resource-dir",
+                "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift",
+                "-suppress-warnings",
+                "-disable-objc-attr-requires-foundation-module",
+                "-module-cache-path",
+                "/var/folders/7b/chq5yqgn7fz8zhmw8tkz53d80000gn/C/org.llvm.clang.ac/ModuleCache",
+                "-prebuilt-module-cache-path",
+                "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/prebuilt-modules",
+                "-track-system-dependencies",
+                "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface",
+                "-module-name",
+                "SwiftOnoneSupport",
+                "-o",
+                "/var/folders/7b/chq5yqgn7fz8zhmw8tkz53d80000gn/C/org.llvm.clang.ac/ModuleCache/SwiftOnoneSupport-1PC0P8MX6CFZA.swiftmodule",
+                "-disable-objc-attr-requires-foundation-module",
+                "-target",
+                "x86_64-apple-macosx10.9",
+                "-enable-objc-interop",
+                "-enable-library-evolution",
+                "-module-link-name",
+                "swiftSwiftOnoneSupport",
+                "-parse-stdlib",
+                "-swift-version",
+                "5",
+                "-O",
+                "-enforce-exclusivity=unchecked",
+                "-module-name",
+                "SwiftOnoneSupport"
+              ]
+            }
+          }
+        },
+        {
+          "clang": "SwiftShims"
+        },
+        {
+          "modulePath": "SwiftShims.pcm",
+          "sourceFiles": [
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/Random.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/module.modulemap",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/SwiftStdint.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/CoreFoundationShims.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/SwiftStdbool.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/RefCount.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/SwiftStddef.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/Visibility.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/RuntimeShims.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/Target.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/System.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/UnicodeShims.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/AssertionReporting.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/HeapObject.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/KeyPath.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/RuntimeStubs.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/ThreadLocalStorage.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/FoundationShims.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/GlobalObjects.h",
+            "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/LibcShims.h"
+          ],
+          "directDependencies": [
+          ],
+          "details": {
+            "clang": {
+              "moduleMapPath": "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/shims/module.modulemap",
+              "contextHash": "2QEMRLNY63H2N",
+              "commandLine": [
+                "-remove-preceeding-explicit-module-build-incompatible-options",
+                "-fno-implicit-modules",
+                "-emit-module",
+                "-fmodule-name=SwiftShims"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """
+  }
+}


### PR DESCRIPTION
This PR resurrects #47 and builds on top of it.

Adds new flag `-driver-print-module-dependencies-jobs` to instruct the driver to scan for dependencies and generate build jobs for each dependent Swift or C module.

At present, this WIP does the following:
- Invoke the Swift frontend Fast Dependency Scanner to prescan for dependencies.
- Construct a ModuleDependencyGraph from the dependency scanner's JSON output.
- Generate and print build jobs for each dependent module.

Next Steps:
- Actually have the driver schedule and execute the dependent module build jobs ahead of time, eliminating the need to re-build those modules when it tries to import them.

I am new to writing Swift so I encourage reviewers to nit-pick with extreme prejudice. 