### PR TITLE
Set LC_ALL=en_US.UTF-8 when running integration tests with lit.py

### DIFF
--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -190,7 +190,8 @@ final class IntegrationTests: IntegrationTestCase {
       let extraEnv = [
         "SWIFT": swift.pathString,
         "SWIFTC": swiftc.pathString,
-        "SWIFT_DRIVER_SWIFT_EXEC": frontendFile.pathString
+        "SWIFT_DRIVER_SWIFT_EXEC": frontendFile.pathString,
+        "LC_ALL": "en_US.UTF-8"
       ]
 
       printCommand(args: args, extraEnv: extraEnv)


### PR DESCRIPTION
I needed to make this change to successfully run the `driver/` integration tests inside Xcode, otherwise they would hang because the encoding was defaulting to ascii. It might be ok to just set LC_CTYPES instead, but I'm really not sure which is better.