### PR TITLE
Allow linking an existing llbuild.framework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     /// The driver library.
     .target(
       name: "SwiftDriver",
-      dependencies: ["SwiftOptions", "SwiftToolsSupport-auto", "llbuildSwift", "Yams"]),
+      dependencies: ["SwiftOptions", "SwiftToolsSupport-auto", "Yams"]),
     .testTarget(
       name: "SwiftDriverTests",
       dependencies: ["SwiftDriver", "swift-driver"]),
@@ -56,16 +56,29 @@ let package = Package(
   cxxLanguageStandard: .cxx14
 )
 
+if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
+    if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+        package.dependencies += [
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("master")),
+        ]
+    } else {
+        // In Swift CI, use a local path to llbuild to interoperate with tools
+        // like `update-checkout`, which control the sources externally.
+        package.dependencies += [
+            .package(path: "../llbuild"),
+        ]
+    }
+    package.targets.first(where: { $0.name == "SwiftDriver" })!.dependencies += ["llbuildSwift"]
+}
+
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
-    .package(url: "https://github.com/apple/swift-llbuild.git", .branch("master")),
     .package(url: "https://github.com/jpsim/Yams.git", .branch("master")),
     ]
 } else {
     package.dependencies += [
         .package(path: "../swiftpm/swift-tools-support-core"),
         .package(path: "../yams"),
-        .package(path: "../llbuild"),
     ]
 }

--- a/Sources/SwiftDriver/Execution/llbuild.swift
+++ b/Sources/SwiftDriver/Execution/llbuild.swift
@@ -12,7 +12,13 @@
 
 // FIXME: This is directly copied from SwiftPM, consider moving this to llbuild.
 
+// We either export the llbuildSwift shared library or the llbuild framework.
+#if canImport(llbuildSwift)
 @_exported import llbuildSwift
+@_exported import llbuild
+#else
+@_exported import llbuild
+#endif
 
 import Foundation
 


### PR DESCRIPTION
This introduces a new environment variable `SWIFT_DRIVER_LLBUILD_FWK` which can be set to opt out of having a dependency on llbuild in the manifest. This allows linking with an existing llbuild.framework instead of building it, similar to SwiftPM's `SWIFTPM_LLBUILD_FWK` option.