### PR TITLE
Add BackendJob.swift to cmake build

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(SwiftDriver
   "Incremental Compilation/SourceFileDependencyGraph.swift"
 
   Jobs/AutolinkExtractJob.swift
+  Jobs/BackendJob.swift
   Jobs/CommandLineArguments.swift
   Jobs/CompileJob.swift
   Jobs/DarwinToolchain+LinkerSupport.swift


### PR DESCRIPTION
https://github.com/apple/swift-driver/pull/101 added this file, but it wasn't added to the CMake build which I think is causing SwiftPM to fail on CI.