### PR TITLE
Significantly improve prefix trie performance and memory usage

### DIFF
--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -37,9 +37,9 @@ extension OptionTable {
   /// Throws an error if the command line contains any errors.
   public func parse(_ arguments: [String],
                     for driverKind: DriverKind) throws -> ParsedOptions {
-    var trie = PrefixTrie<String.UTF8View, Option>()
+    var trie = PrefixTrie<Option>()
     for opt in options {
-      trie[opt.spelling.utf8] = opt
+      trie[opt.spelling] = opt
     }
 
     var parsedOptions = ParsedOptions()
@@ -71,7 +71,7 @@ extension OptionTable {
       // match -- if the option is a `.flag`, we'll explicitly check to see if
       // there's an unmatched suffix at the end, and pop an error. Otherwise,
       // we'll treat the unmatched suffix as the argument to the option.
-      guard let option = trie[argument.utf8] else {
+      guard let option = trie[argument] else {
         throw OptionParseError.unknownOption(
           index: index - 1, argument: argument)
       }

--- a/Sources/SwiftOptions/PrefixTrie.swift
+++ b/Sources/SwiftOptions/PrefixTrie.swift
@@ -14,16 +14,32 @@
 /// It's a tree structure where each node in the tree corresponds to another
 /// element in the prefix of whatever you're looking for.
 ///
-/// For example, the strings 'Hello' and 'Help' would look like this:
+/// For example, if you entered these strings:
+///
+/// "Help", "Helper", "Helping", "Helicopters", "Helicoptering"
+///
+/// The resulting trie would look like this:
 ///
 /// ```
-///                      ┌───┐  ┌───┐
-///                 ┌───▶│ l │─▶│ o │
-/// ┌───┐  ┌───┐  ┌───┐  └───┘  └───┘
-/// │ H │─▶│ e │─▶│ l │
-/// └───┘  └───┘  └───┘  ┌───┐
-///                 └───▶│ p │
-///                      └───┘
+///                      ┌───┐
+///              ┌──────▶│ s │
+///              │       └───┘
+///         ┌─────────┐
+///    ┌───▶│ icopter │
+///    │    └─────────┘
+///    │         │       ┌───┐
+///    │         └──────▶│ing│
+/// ┌─────┐              └───┘
+/// │ Hel │
+/// └─────┘              ┌────┐
+///    │      ┌─────────▶│ er │
+///    │      │          └────┘
+///    │    ┌───┐
+///    └───▶│ p │
+///         └───┘
+///           │          ┌─────┐
+///           └─────────▶│ ing │
+///                      └─────┘
 /// ```
 ///
 /// Traversing this trie is O(min(n, m)) with `n` representing the length of the
@@ -32,114 +48,365 @@
 ///
 /// Inserting into the trie is also O(n) with the length of the key being
 /// inserted.
-public struct PrefixTrie<Key: Collection, Value> where Key.Element: Hashable {
-  internal class Node {
-    var value: Value?
-    var next = [Key.Element: Node]()
+public struct PrefixTrie<Payload> {
+  final class Node {
+    /// The result of querying the trie for a given string. This represents the
+    /// kind and length of the match.
+    enum QueryResult: Equatable {
+      /// The exact string queried was found in the trie.
+      case same
 
-    init(value: Value?) {
-      self.value = value
+      /// The query string is a prefix of the nodes in the trie; there are still
+      /// unconsumed characters in the matching node's label.
+      case stringIsPrefix
+
+      /// The label of the queried node is a prefix of the string; there are
+      /// still characters left in the query string that have yet to be
+      /// matched.
+      case labelIsPrefix
+
+      /// The strings do not match at all.
+      case dontMatch
+
+      /// There's a common part of the string, but neither the label nor the
+      /// query string were matched entirely.
+      case haveCommonPart(Int)
+    }
+
+    /// The string corresponding to this hop in the trie.
+    var label: Substring
+
+    /// The data associated with this node, if any. If this is `nil`, the node
+    /// is an intermediate node (or its data has been explicitly erased).
+    var data: Payload?
+
+    /// The children of this node. This array is always in sorted order by
+    /// the node's `id`.
+    var children = [Node]()
+
+    /// Each node is identified in the child list by the first character in its
+    /// label.
+    var id: Character {
+      label.first!
+    }
+
+    /// Creates a new `Node` with the given label and data.
+    init(label: Substring, data: Payload?) {
+      self.label = label
+      self.data = data
+    }
+
+    /// Adds the provided child to the children list, maintaining the list's
+    /// sort.
+    func addChild(_ node: Node) {
+      if children.isEmpty {
+        children.append(node)
+      } else {
+        let index = children.lowerBound(of: node) {
+          $0.id < $1.id
+        }
+        children.insert(node, at: index)
+      }
+    }
+
+    /// Replaces the existing child for that `id` with the provided child.
+    func updateChild(_ node: Node) {
+      let index = children.lowerBound(of: node) {
+        $0.id < $1.id
+      }
+      children[index] = node
+    }
+
+    /// Searches through the trie for the given string, returning the kind of
+    /// match made.
+    func query<S: StringProtocol>(_ s: S) -> QueryResult {
+      let stringCount = s.count
+      let labelCount = label.count
+
+      // Find the length of common part.
+      let leastCount = min(stringCount, labelCount)
+
+      var index = s.startIndex
+      var otherIndex = label.startIndex
+      var length = 0
+      while length < leastCount && s[index] == label[otherIndex] {
+        s.formIndex(after: &index)
+        label.formIndex(after: &otherIndex)
+        length += 1
+      }
+
+      // One is prefix of another, find who is who
+      if length == leastCount {
+        if stringCount == labelCount {
+          return .same
+        } else if length == stringCount {
+          return .stringIsPrefix
+        } else {
+          return .labelIsPrefix
+        }
+      } else if length == 0 {
+          return .dontMatch
+      } else {
+        // The query string and the label have a common part, return its length.
+        return .haveCommonPart(length)
+      }
+    }
+
+    /// Splits the receiver into two nodes at the provided index. Doing this
+    /// will turn the receiver into an intermediate node, and transfer its
+    /// children to the new node.
+    ///
+    /// For example, if the current branch is:
+    ///
+    /// ```
+    /// "Hel" -> "per" -> "s"
+    /// ```
+    ///
+    /// then calling `"per".split(at: 1)` will turn the branch into:
+    ///
+    /// ```
+    /// "Hel" -> "p" -> "er" -> "s"
+    /// ```
+    func split(at rawIndex: Int) {
+      assert((1..<label.count).contains(rawIndex),
+             "Trying to split outside the bounds of the label")
+
+      let index = label.index(label.startIndex, offsetBy: rawIndex)
+      let firstPart = label[..<index]
+      let secondPart = label[index...]
+
+      let new = Node(label: secondPart, data: data)
+      new.children = children
+      label = firstPart
+      data = nil
+      children = []
+      addChild(new)
+    }
+
+    /// Searches the array for the given `id` and returns the node with that
+    /// `id`, if present.
+    func findChild(for id: Character) -> Node? {
+      if children.isEmpty { return nil }
+
+      let index = children.lowerBound(of: id) { $0.id < $1 }
+      guard index < children.endIndex else { return nil }
+      let node = children[index]
+      guard node.id == id else { return nil }
+      return node
     }
   }
 
-  /// Creates a prefix trie with nothing inside.
+  /// The root of the hierarchy, intentionally empty. This label is never
+  /// queried.
+  var root = Node(label: "", data: nil)
+
+  /// Creates a new, empty prefix trie.
   public init() {}
 
-  // Start with an empty node at the root, to make traversal easy
-  var root = Node(value: nil)
-
-  /// Finds the value associated with the longest prefix that matches the
-  /// provided key.
-  /// For example, for a trie that has `["Help", "Hello", "Helping"]` inside,
-  /// Searching for `"Helper"` gives you the value associated with `"Help"`,
-  /// while searching for `"Helping a friend"` gives you `"Helping"`.
-  public subscript(key: Key) -> Value? {
+  /// Searches the trie for the given query string and either returns the best
+  /// matching entry or stores the provided payload into the trie.
+  public subscript(_ query: String) -> Payload? {
     get {
-      var bestMatch: Value?
       var current = root
-      for elt in key {
-        guard let next = current.next[elt] else { break }
-        current = next
-        if let value = current.value {
-          bestMatch = value
+      var bestMatch: Payload?
+      var string = query[...]
+
+      while true {
+        let id = string.first!
+        guard let existing = current.findChild(for: id) else {
+          return bestMatch
+        }
+
+        switch existing.query(string) {
+        case .same:
+          // If we've found an exact match, return it directly.
+          return existing.data
+        case .labelIsPrefix:
+          // If we have more of our query to consume, keep going down this path.
+          string = string.dropFirst(existing.label.count)
+          current = existing
+          if let data = existing.data {
+            // If there's data associated with this node, though, keep track of
+            // it. We may end up with a later match that doesn't have associated
+            // data.
+            bestMatch = data
+          }
+        case .dontMatch:
+          fatalError("Impossible because we found a child with id \(id)")
+        default:
+          // If we've consumed the whole query string, return the best match
+          // now.
+          return bestMatch
         }
       }
-      return bestMatch
     }
+
     set {
-      var index = key.startIndex
       var current = root
-      // Keep track of which nodes we've visited along the way,
-      // so we can walk back up this if we need to prune dead branches.
-      // Note: This is only used (and is only appended to) if the new
-      //       value being stored is `nil`.
-      var traversed: [(parent: Node, step: Key.Element)] = []
+      var string = query[...]
 
-      // Traverse as much of the prefix as we can, keeping track of the index
-      // we ended on
-      while index < key.endIndex, let next = current.next[key[index]] {
-        if newValue == nil {
-            traversed.append((current, key[index]))
+      while true {
+        let id = string.first!
+
+        guard let existing = current.findChild(for: id) else {
+          current.addChild(Node(label: string, data: newValue))
+          return
         }
 
-        key.formIndex(after: &index)
-        current = next
-      }
+        switch existing.query(string) {
+        case .same:
+          // If we've matched an entry exactly, just update its value in place.
+          existing.data = newValue
+          return
+        case .stringIsPrefix:
+          // In this case, the string we're matching is a prefix of an existing
+          // string in the trie. e.g. we're trying to add "-debug-constraints"
+          // when we already have "-debug-constraints-on-line" and
+          // "-debug-constraints-attempt"
 
-      // We're matching a prefix of an existing key in the trie
-      if index == key.endIndex {
-        // Update the value in the trie with the new value
-        current.value = newValue
-        // remove dead nodes if the current child is a leaf
-        if newValue == nil && current.next.keys.count == 0 {
-          self.pruneEmptyBranchesIfNeeded(traversed)
+          // So far we have:
+          //   "debug-" : <A>
+          //     -> "constraints-" : <B>
+          //       -> "on-line" : <C>
+          //       -> "attempt" : <D>
+          //
+          // We need to end up with:
+          //   "debug-" : <A>
+          //     -> "constraints" : <B>
+          //       -> "-"         : <E>
+          //         -> "on-line" : <C>
+          //         -> "attempt" : <D>
+          //
+          // In this example, we need to take the '-' from the end of B and
+          // split it into its own node, and then add the existing children as a child
+          // of that node.
+          //
+
+          // First, strip off the leading text of "constraints"
+          let remaining = existing.label.dropFirst(string.count)
+
+          // Create a new node for this, and give it the existing node's
+          // children.
+          let new = Node(label: remaining, data: existing.data)
+          new.children = existing.children
+
+          // Reset 'existing' to the common prefix, and set its data
+          // accordingly.
+          existing.label = string
+          existing.data = newValue
+
+          // Now remove all of 'existing's children, and replace it with this
+          // hop.
+          existing.children = [new]
+          return
+        case .dontMatch:
+          fatalError("Impossible because we found a child with id \(id)")
+        case .labelIsPrefix:
+          // If we've matched an entry along the way, remove it from the
+          // beginning of our query and continue down this path.
+          string = string.dropFirst(existing.label.count)
+          current = existing
+        case .haveCommonPart(let length):
+          // If the existing node has some in common with our node, we need
+          // to split the existing node at the common point, then add the
+          // remaining characters as a child of that node.
+          existing.split(at: length)
+          let new = Node(label: string.dropFirst(length), data: newValue)
+          existing.addChild(new)
+          return
         }
-        return
-      }
-
-      // If the value we're adding is `nil` just return and don't create the trie
-      guard newValue != nil else {
-        return
-      }
-
-      while index < key.endIndex {
-        // Fill out the remaining nodes with nils, until we get to the last
-        // element
-        let step = key[index]
-
-        key.formIndex(after: &index)
-        let new = Node(value: index == key.endIndex ? newValue : nil)
-        current.next[step] = new
-        current = new
       }
     }
   }
 
-
-  /// Given a list of nodes starting from a root node to any other node along a branch,
-  /// prune the branch of any dead nodes along the way.
-  private func pruneEmptyBranchesIfNeeded(_ traversed: [(parent: Node, step: Key.Element)]) {
-    for (parent, step) in traversed.reversed() {
-      // find the first parent with a value or more than one child.
-      // If we traversed up to the root then chop everything regarless.
-      if parent.value != nil || parent.next.keys.count > 1 || parent === traversed.first!.parent {
-        parent.next[step] = nil
-        break
-      }
-    }
-  }
-
-  /// Returns the number of nodes in the trie
   public var nodeCount: Int {
+    var count = 1
+    var queue = [root]
+    while !queue.isEmpty {
+      let node = queue.popLast()!
+      queue += node.children
+      count += node.children.count
+    }
+    return count
+  }
 
-      var count = 0
+  public func printDOT() {
+    let writer = Node.DOTWriter(node: root)
+    writer.writeDOT()
+  }
+}
 
-      var nodes = [self.root]
-      while let currentNode = nodes.popLast() {
-          nodes.append(contentsOf: currentNode.next.values)
-          count += currentNode.next.keys.count
+// MARK: - DOT generation for nodes (for debugging)
+
+extension PrefixTrie.Node {
+  class DOTWriter {
+    let node: PrefixTrie.Node
+    init(node: PrefixTrie.Node) {
+      self.node = node
+    }
+    var labelCounter = [Substring: Int]()
+    var nodeIDs = [ObjectIdentifier: String]()
+
+    func id(for node: PrefixTrie.Node) -> String {
+      if let id = nodeIDs[ObjectIdentifier(node)] {
+        return id
       }
 
-      return count
+      let count = labelCounter[node.label, default: 0]
+      labelCounter[node.label] = count + 1
+
+      let id: String
+      if count == 0 {
+        id = String(node.label)
+      } else {
+        id = "\(node.label)_\(count)"
+      }
+      nodeIDs[ObjectIdentifier(node)] = id
+      return id
+    }
+
+    func writeDOT() {
+      print("digraph Trie {")
+      var queue = [node]
+      while !queue.isEmpty {
+        let node = queue.popLast()!
+        var str = #"  "\#(id(for: node))" [label="\#(node.label)""#
+        if node.data != nil {
+          str += ", style=bold"
+        }
+        str += "]"
+        print(str)
+        for child in node.children {
+          print(#"  "\#(id(for: node))" -> "\#(id(for: child))""#)
+          queue.insert(child, at: 0)
+        }
+      }
+      print("}")
+    }
+  }
+}
+
+extension Array {
+  /// A naïve implementation of `std::lower_bound` for Array.
+  /// Returns the index before the first element in the list that is ordered
+  /// after the given `value`, as determined by the provided predicate.
+  func lowerBound<T>(of value: T, isOrderedBefore: (Element, T) -> Bool) -> Int {
+    var count = self.count
+    var index = startIndex
+    var first = startIndex
+    var step = 0
+    while count > 0 {
+      index = first
+      step = count / 2
+      index += step
+      if isOrderedBefore(self[index], value) {
+        index += 1
+        first = index
+        count -= step + 1
+      } else {
+        count = step
+      }
+    }
+    return first
   }
 }

--- a/Tests/SwiftOptionsTests/PrefixTrieTests.swift
+++ b/Tests/SwiftOptionsTests/PrefixTrieTests.swift
@@ -3,17 +3,17 @@ import SwiftOptions
 
 final class PrefixTrieTests: XCTestCase {
   func testSimpleTrie() {
-    var trie = PrefixTrie<String, Int>()
+    var trie = PrefixTrie<Int>()
 
     trie["1234"] = nil
-    XCTAssertEqual(trie.nodeCount, 0)
+    XCTAssertEqual(trie.nodeCount, 2)
 
     trie["a"] = 0
     trie["b"] = 1
     trie["abcd"] = 2
     trie["abc"] = 3
 
-    XCTAssertEqual(trie.nodeCount, 5)
+    XCTAssertEqual(trie.nodeCount, 6)
 
     XCTAssertEqual(trie["a"], 0)
     XCTAssertEqual(trie["ab"], 0)
@@ -25,7 +25,7 @@ final class PrefixTrieTests: XCTestCase {
   }
 
   func testManyMatchingPrefixes() {
-    var trie = PrefixTrie<String, Int>()
+    var trie = PrefixTrie<Int>()
     trie["an"] = 0
     trie["ant"] = 1
     trie["anteater"] = 2
@@ -44,7 +44,7 @@ final class PrefixTrieTests: XCTestCase {
 
   func testUpdating() {
 
-    var trie = PrefixTrie<String, Int>()
+    var trie = PrefixTrie<Int>()
     trie["garbage"] = 0
     XCTAssertEqual(trie["garbage"], 0)
 
@@ -53,34 +53,23 @@ final class PrefixTrieTests: XCTestCase {
 
     trie["garbage"] = nil
     XCTAssertNil(trie["garbage"])
-    XCTAssertEqual(trie.nodeCount, 0)
+    XCTAssertEqual(trie.nodeCount, 2)
+    // Removing a node leaves the entry in the trie
 
     trie["12345"] = 12345 // 5 nodes
     trie["12367"] = 12367 // 3 common nodes, 2 new nodes
-    XCTAssertEqual(trie.nodeCount, 7)
+    XCTAssertEqual(trie.nodeCount, 5)
     trie["123890"] = 123890 // 3 common nodes, 3 new nodes
-    XCTAssertEqual(trie.nodeCount, 10)
+    XCTAssertEqual(trie.nodeCount, 6)
     trie["123890"] = nil
-    XCTAssertEqual(trie.nodeCount, 7)
+    XCTAssertEqual(trie.nodeCount, 6)
     XCTAssertNil(trie["123890"])
-    trie["abc"] = 979899 // 3 new nodes, 0 common nodes
-    XCTAssertEqual(trie.nodeCount, 10)
+    trie["abc"] = 979899 // 1 new node, 0 common nodes
+    XCTAssertEqual(trie.nodeCount, 7)
     // existing prefix that cannot be deleted since
     // 12345 & 12367 exist
     trie["123"] = nil
-    XCTAssertEqual(trie.nodeCount, 10)
+    XCTAssertEqual(trie.nodeCount, 7)
 
-  }
-
-  func testCollectionMatching() {
-    var trie = PrefixTrie<[Int], Int>()
-    trie[[1, 2, 3]] = 0
-    trie[[1, 2]] = 1
-    trie[[0, 1, 2]] = 2
-
-    XCTAssertEqual(trie[[1, 2]], 1)
-    XCTAssertEqual(trie[[1, 2, 3, 4]], 0)
-    XCTAssertNil(trie[[0, 1]])
-    XCTAssertEqual(trie[[0, 1, 2]], 2)
   }
 }

--- a/Tests/SwiftOptionsTests/XCTestManifests.swift
+++ b/Tests/SwiftOptionsTests/XCTestManifests.swift
@@ -6,7 +6,6 @@ extension PrefixTrieTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__PrefixTrieTests = [
-        ("testCollectionMatching", testCollectionMatching),
         ("testManyMatchingPrefixes", testManyMatchingPrefixes),
         ("testSimpleTrie", testSimpleTrie),
         ("testUpdating", testUpdating),


### PR DESCRIPTION
The previous prefix trie made a new `Node` for each character along the
input string. In addition to being wasteful, this would introduce many
more hops to match a given string.

Instead, store common `Substring`s in the `Node`s, and use a sorted
array/binary search through children to avoid extra time spend hashing
and storing in hashed collections.

Doing this reduces the number of nodes in the trie for the driver's
options by an order of magnitude -- from 6601 nodes to 660.

(This is actually a port of LLVM's Trie, but cleaned up and made more
idiomatic in Swift)