### PR TITLE
[Job] Add some convenient APIs for SwiftPM

### DIFF
--- a/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
@@ -65,6 +65,7 @@ extension Driver {
     swiftModuleDetails.commandLine?.forEach { commandLine.appendFlag($0) }
 
     return Job(
+      moduleName: moduleName,
       kind: .emitModule,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,
@@ -99,6 +100,7 @@ extension Driver {
     clangModuleDetails.commandLine?.forEach { commandLine.appendFlags("-Xcc", $0) }
 
     return Job(
+      moduleName: moduleName,
       kind: .generatePCM,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -29,6 +29,7 @@ extension Driver {
     commandLine.appendPath(output)
 
     return Job(
+      moduleName: moduleName,
       kind: .autolinkExtract,
       tool: .absolute(try toolchain.getToolPath(.swiftAutolinkExtract)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -65,6 +65,7 @@ extension Driver {
     allOutputs += outputs
 
     return Job(
+      moduleName: moduleName,
       kind: .backend,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -205,6 +205,7 @@ extension Driver {
     }
 
     return Job(
+      moduleName: moduleName,
       kind: .compile,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -69,6 +69,7 @@ extension Driver {
     commandLine.appendPath(moduleOutputPath)
 
     return Job(
+      moduleName: moduleName,
       kind: .emitModule,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -23,6 +23,7 @@ extension Driver {
     commandLine.appendPath(outputPath)
 
     return Job(
+      moduleName: moduleName,
       kind: .generateDSYM,
       tool: .absolute(try toolchain.getToolPath(.dsymutil)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -62,6 +62,7 @@ extension Driver {
     outputs.append(output)
 
     return Job(
+      moduleName: moduleName,
       kind: .generatePCH,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -53,6 +53,7 @@ extension Driver {
     try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
 
     return Job(
+      moduleName: moduleName,
       kind: .generatePCM,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -41,6 +41,7 @@ extension Driver {
       targetTriple: self.targetTriple)
 
     return Job(
+      moduleName: moduleName,
       kind: .interpret,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -115,6 +115,21 @@ extension Job {
   }
 }
 
+extension Job.Kind {
+  /// Whether this job kind uses the Swift frontend.
+  public var isSwiftFrontend: Bool {
+    switch self {
+    case .backend, .compile, .mergeModule, .emitModule, .generatePCH,
+        .generatePCM, .interpret, .repl, .printTargetInfo,
+        .versionRequest:
+        return true
+
+    case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo:
+        return false
+    }
+
+  }
+}
 // MARK: - Job.ArgTemplate + Codable
 
 extension Job.ArgTemplate: Codable {

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -42,6 +42,9 @@ public struct Job: Codable, Equatable, Hashable {
     case path(VirtualPath)
   }
 
+  /// The SWift module this job involves.
+  public var moduleName: String
+
   /// The tool to invoke.
   public var tool: VirtualPath
 
@@ -70,6 +73,7 @@ public struct Job: Codable, Equatable, Hashable {
   public var kind: Kind
 
   public init(
+    moduleName: String,
     kind: Kind,
     tool: VirtualPath,
     commandLine: [ArgTemplate],
@@ -80,6 +84,7 @@ public struct Job: Codable, Equatable, Hashable {
     requiresInPlaceExecution: Bool = false,
     supportsResponseFiles: Bool = false
   ) {
+    self.moduleName = moduleName
     self.kind = kind
     self.tool = tool
     self.commandLine = commandLine
@@ -111,6 +116,58 @@ extension Job {
         try fileSystem.getFileInfo(absolutePath).modTime != recordedModificationTime {
         throw InputError.inputUnexpectedlyModified(input)
       }
+    }
+  }
+}
+
+extension Job : CustomStringConvertible {
+  public var description: String {
+    let moduleName = "hello"
+    switch kind {
+    case .compile:
+        return "Compiling \(moduleName) \(displayInputs.first?.file.name ?? "")"
+
+    case .mergeModule:
+        return "Merging module \(moduleName)"
+
+    case .link:
+        return "Linking \(moduleName)"
+
+    case .generateDSYM:
+        return "Generating dSYM for module \(moduleName)"
+
+    case .autolinkExtract:
+        return "Extracting autolink information for module \(moduleName)"
+
+    case .emitModule:
+        return "Emitting module for \(moduleName)"
+
+    case .generatePCH:
+        return "Compiling bridging header \(displayInputs.first!.file.name)"
+
+    case .generatePCM:
+        return "Compiling Clang module \(displayInputs.first!.file.name)"
+
+    case .interpret:
+        return "Interpreting \(displayInputs.first!.file.name)"
+
+    case .repl:
+        return "Executing Swift REPL"
+
+    case .verifyDebugInfo:
+        return "Verifying debug information for module \(moduleName)"
+
+    case .printTargetInfo:
+        return "Gathering target information for module \(moduleName)"
+
+    case .versionRequest:
+        return "Getting Swift version information"
+
+    case .help:
+        return "Swift help"
+
+    case .backend:
+      return "Embedding bitcode for \(moduleName)"
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -167,7 +167,7 @@ extension Job : CustomStringConvertible {
         return "Swift help"
 
     case .backend:
-      return "Embedding bitcode for \(moduleName)"
+      return "Embedding bitcode for \(moduleName) \(displayInputs.first?.file.name ?? "")"
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -53,6 +53,7 @@ extension Driver {
 
     // TODO: some, but not all, linkers support response files.
     return Job(
+      moduleName: moduleName,
       kind: .link,
       tool: .absolute(toolPath),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -50,6 +50,7 @@ extension Driver {
     commandLine.appendPath(moduleOutput!.outputPath)
 
     return Job(
+      moduleName: moduleName,
       kind: .mergeModule,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -226,21 +226,25 @@ extension Driver {
       try commandLine.appendLast(.targetVariant, from: &parsedOptions)
       try commandLine.appendLast(.sdk, from: &parsedOptions)
       try commandLine.appendLast(.resourceDir, from: &parsedOptions)
-      return Job(kind: .printTargetInfo,
-                 tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
-                 commandLine: commandLine,
-                 inputs: [],
-                 outputs: [],
-                 requiresInPlaceExecution: true)
+      return Job(
+        moduleName: moduleName,
+        kind: .printTargetInfo,
+        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        commandLine: commandLine,
+        inputs: [],
+        outputs: [],
+        requiresInPlaceExecution: true)
     }
 
     if parsedOptions.hasArgument(.version) || parsedOptions.hasArgument(.version_) {
-      return Job(kind: .versionRequest,
-                 tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
-                 commandLine: [.flag("--version")],
-                 inputs: [],
-                 outputs: [],
-                 requiresInPlaceExecution: true)
+      return Job(
+        moduleName: moduleName,
+        kind: .versionRequest,
+        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        commandLine: [.flag("--version")],
+        inputs: [],
+        outputs: [],
+        requiresInPlaceExecution: true)
     }
 
     if parsedOptions.contains(.help) || parsedOptions.contains(.helpHidden) {
@@ -248,12 +252,14 @@ extension Driver {
       if parsedOptions.contains(.helpHidden) {
         commandLine.append(.flag("-show-hidden"))
       }
-      return Job(kind: .help,
-                 tool: .absolute(try toolchain.getToolPath(.swiftHelp)),
-                 commandLine: commandLine,
-                 inputs: [],
-                 outputs: [],
-                 requiresInPlaceExecution: true)
+      return Job(
+        moduleName: moduleName,
+        kind: .help,
+        tool: .absolute(try toolchain.getToolPath(.swiftHelp)),
+        commandLine: commandLine,
+        inputs: [],
+        outputs: [],
+        requiresInPlaceExecution: true)
     }
 
     return nil

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -23,6 +23,7 @@ extension Driver {
     // Squash important frontend options into a single argument for LLDB.
     let lldbArg = "--repl=\(commandLine.joinedArguments)"
     return Job(
+      moduleName: moduleName,
       kind: .repl,
       tool: .absolute(try toolchain.getToolPath(.lldb)),
       commandLine: [Job.ArgTemplate.flag(lldbArg)],

--- a/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
@@ -21,6 +21,7 @@ extension Driver {
     commandLine.appendPath(input.file)
 
     return Job(
+      moduleName: moduleName,
       kind: .verifyDebugInfo,
       tool: .absolute(try toolchain.getToolPath(.dwarfdump)),
       commandLine: commandLine,

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -81,6 +81,7 @@ final class JobExecutorTests: XCTestCase {
       ]
 
       let compileFoo = Job(
+        moduleName: "main",
         kind: .compile,
         tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
         commandLine: [
@@ -104,6 +105,7 @@ final class JobExecutorTests: XCTestCase {
       )
 
       let compileMain = Job(
+        moduleName: "main",
         kind: .compile,
         tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
         commandLine: [
@@ -127,6 +129,7 @@ final class JobExecutorTests: XCTestCase {
       )
 
       let link = Job(
+        moduleName: "main",
         kind: .link,
         tool: .absolute(try toolchain.getToolPath(.dynamicLinker)),
         commandLine: [
@@ -167,6 +170,7 @@ final class JobExecutorTests: XCTestCase {
 
   func testStubProcessProtocol() throws {
     let job = Job(
+      moduleName: "main",
       kind: .compile,
       tool: .absolute(AbsolutePath("/usr/bin/swift")),
       commandLine: [.flag("something")],


### PR DESCRIPTION
Add two APIs for `Job` that are helpful in SwiftPM:
* `Job.Kind.isSwiftFrontend`: whether the job is executing the Swift frontend
* `Job.description`: simple description of what the job is doing