### PR TITLE
Port to Android

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -535,7 +535,7 @@ extension Driver {
   ///
   /// - Parameter content: response file's content to be tokenized.
   private static func tokenizeResponseFile(_ content: String) -> [String] {
-    #if !os(macOS) && !os(Linux)
+    #if !os(macOS) && !os(Linux) && !os(Android)
       #warning("Response file tokenization unimplemented for platform; behavior may be incorrect")
     #endif
     return content.split { $0 == "\n" || $0 == "\r\n" }

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -93,7 +93,7 @@ public struct OutputFileMap: Equatable {
   ) throws {
     let encoder = JSONEncoder()
 
-  #if os(Linux)
+  #if os(Linux) || os(Android)
     encoder.outputFormatting = [.prettyPrinted]
   #else
     if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -12,11 +12,11 @@
 
 #if os(macOS)
 import Darwin
-#elseif os(Linux)
+#elseif canImport(Glibc)
 import Glibc
 #endif
 
-#if os(macOS) || os(Linux)
+#if os(macOS) || os(Linux) || os(Android)
 // Adapted from llvm::sys::commandLineFitsWithinSystemLimits.
 func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
   let upperBound = sysconf(Int32(_SC_ARG_MAX))
@@ -35,7 +35,7 @@ func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
 
   var commandLineLength = path.utf8.count + 1
   for arg in args {
-    #if os(Linux)
+    #if os(Linux) || os(Android)
       // Linux limits the length of each individual argument to MAX_ARG_STRLEN.
       // There is no available constant, so it is hardcoded here.
       guard arg.utf8.count < 32 * 4096 else {


### PR DESCRIPTION
Tested with Swift master natively on Android, also had to add the `swiftc` path below to my `PATH` for the tests to find it. Most tests pass with the following commands (the `_GNU_SOURCE` flag has to do with [building TSC on Android](https://github.com/apple/swift-package-manager/pull/2417#pullrequestreview-321705438)):
```
SWIFTCI_USE_LOCAL_DEPS=1 ../build/Ninja-Release/toolchain-android-aarch64/usr/bin/swift build -j 9 -Xswiftc -Xcc -Xswiftc -U_GNU_SOURCE
SWIFTCI_USE_LOCAL_DEPS=1 ../build/Ninja-Release/toolchain-android-aarch64/usr/bin/swift test -j 9 -Xswiftc -Xcc -Xswiftc -U_GNU_SOURCE
```