### PR TITLE
Add an end-to-end test for the option to print compile jobs for module dependencies

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -51,6 +51,7 @@ public struct Driver {
     case integratedReplRemoved
     case conflictingOptions(Option, Option)
     case malformedModuleDependency(String, String)
+    case dependencyScanningFailure(Int, String)
 
     public var description: String {
       switch self {
@@ -71,6 +72,8 @@ public struct Driver {
         return "conflicting options '\(one.spelling)' and '\(two.spelling)'"
       case .malformedModuleDependency(let moduleName, let errorDescription):
         return "Malformed Module Dependency: \(moduleName), \(errorDescription)"
+      case .dependencyScanningFailure(let code, let error):
+        return "Module Dependency Scanner returned with non-zero exit status: \(code), \(error)"
       }
     }
   }

--- a/Sources/SwiftDriver/Driver/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Driver/ModuleDependencyScanning.swift
@@ -42,6 +42,17 @@ extension Driver {
     let arguments = [tool] + (try commandLine.map { try resolver.resolve($0) })
     let scanProcess = try Process.launchProcess(arguments: arguments, env: env)
     let result = try scanProcess.waitUntilExit()
+    // Error on dependency scanning failure
+    if (result.exitStatus != .terminated(code: 0)) {
+      var returnCode = 0
+      switch result.exitStatus {
+        case .terminated(let code):
+          returnCode = Int(code)
+        case .signalled(let signal):
+          returnCode = Int(signal)
+      }
+      throw Error.dependencyScanningFailure(returnCode, try result.utf8stderrOutput())
+    }
     guard let outputData = try? Data(result.utf8Output().utf8) else {
       return nil
     }

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/A.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/A.h
@@ -1,0 +1,1 @@
+void funcA(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/B.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/B.h
@@ -1,0 +1,4 @@
+#include <A.h>
+
+void funcB(void);
+

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/Bridging.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/Bridging.h
@@ -1,0 +1,3 @@
+#include "BridgingOther.h"
+
+int bridging_other(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/BridgingOther.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/BridgingOther.h
@@ -1,0 +1,3 @@
+#include "F.h"
+
+int bridging_other(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
@@ -1,0 +1,3 @@
+#include <B.h>
+
+void funcC(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/D.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/D.h
@@ -1,0 +1,1 @@
+void funcD(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/F.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/F.h
@@ -1,0 +1,1 @@
+void funcF(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
@@ -1,0 +1,1 @@
+void funcG(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/module.modulemap
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/module.modulemap
@@ -1,0 +1,29 @@
+module A {
+  header "A.h"
+  export *
+}
+
+module B {
+  header "B.h"
+  export *
+}
+
+module C {
+  header "C.h"
+  export *
+}
+
+module D {
+  header "D.h"
+  export *
+}
+
+module F {
+  header "F.h"
+  export *
+}
+
+module G {
+  header "G.h"
+  export *
+}

--- a/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A
+@_exported import A
+public func overlayFuncA() { }
+

--- a/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name E
+import Swift
+public func funcE() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name F
+import Swift
+@_exported import F
+public func funcF() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name G -swift-version 5
+
+#if swift(>=5.0)
+
+@_exported import G
+public func overlayFuncG() { }
+
+#endif


### PR DESCRIPTION
As discovered by invoking the fast dependency scanner from within the driver.