### PR TITLE
Propagate Explicit Module Build command arguments to compile jobs.

### DIFF
--- a/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
@@ -50,6 +50,25 @@ extension ModuleDependencyId: Codable {
         try container.encode(moduleName, forKey: .clang)
     }
   }
+
+  func getName() -> String {
+    switch self {
+      case .swift(let moduleName):
+        return moduleName
+      case .clang(let moduleName):
+        return moduleName
+    }
+  }
+
+  // Used in testing
+  init(name: String, kind: CodingKeys) {
+    switch kind {
+      case .swift:
+        self = .swift(name)
+      case .clang:
+        self = .clang(name)
+    }
+  }
 }
 
 /// Details specific to Swift modules.

--- a/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
@@ -50,25 +50,6 @@ extension ModuleDependencyId: Codable {
         try container.encode(moduleName, forKey: .clang)
     }
   }
-
-  func getName() -> String {
-    switch self {
-      case .swift(let moduleName):
-        return moduleName
-      case .clang(let moduleName):
-        return moduleName
-    }
-  }
-
-  // Used in testing
-  init(name: String, kind: CodingKeys) {
-    switch kind {
-      case .swift:
-        self = .swift(name)
-      case .clang:
-        self = .clang(name)
-    }
-  }
 }
 
 /// Details specific to Swift modules.

--- a/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
@@ -16,7 +16,8 @@ import Foundation
 extension Driver {
   /// For the current moduleDependencyGraph, plan the order and generate jobs
   /// for explicitly building all dependency modules.
-  mutating func planExplicitModuleDependenciesCompile(dependencyGraph: InterModuleDependencyGraph
+  mutating func planExplicitModuleDependenciesCompile(
+    dependencyGraph: InterModuleDependencyGraph
   ) throws -> [Job] {
     var jobs: [Job] = []
     for (id, moduleInfo) in dependencyGraph.modules {

--- a/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
@@ -145,7 +145,8 @@ extension Driver {
                                      inputs: inout [TypedVirtualPath],
                                      commandLine: inout [Job.ArgTemplate]) throws {
     // Prohibit the frontend from implicitly building textual modules into binary modules.
-    commandLine.appendFlags("-disable-implicit-swift-modules", "-disable-implicit-pcms")
+    commandLine.appendFlags("-disable-implicit-swift-modules", "-Xcc", "-Xclang", "-Xcc",
+                            "-fno-implicit-modules")
     for moduleId in moduleInfo.directDependencies {
       guard let dependencyInfo = dependencyGraph.modules[moduleId] else {
         throw Error.missingModuleDependency(moduleId.getName())

--- a/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
@@ -16,8 +16,8 @@ import Foundation
 extension Driver {
   /// For the current moduleDependencyGraph, plan the order and generate jobs
   /// for explicitly building all dependency modules.
-  mutating func planExplicitModuleDependenciesCompile(dependencyGraph: InterModuleDependencyGraph)
-  throws -> [Job] {
+  mutating func planExplicitModuleDependenciesCompile(dependencyGraph: InterModuleDependencyGraph
+  ) throws -> [Job] {
     var jobs: [Job] = []
     for (id, moduleInfo) in dependencyGraph.modules {
       // The generation of the main module file will be handled elsewhere in the driver.
@@ -45,8 +45,8 @@ extension Driver {
   /// For a given swift module dependency, generate a build job
   mutating private func genSwiftModuleDependencyBuildJob(moduleInfo: ModuleInfo,
                                                          moduleName: String,
-                                                         dependencyGraph: InterModuleDependencyGraph)
-  throws -> Job {
+                                                         dependencyGraph: InterModuleDependencyGraph
+  ) throws -> Job {
     guard case .swift(let swiftModuleDetails) = moduleInfo.details else {
       throw Error.malformedModuleDependency(moduleName, "no `details` object")
     }
@@ -91,8 +91,8 @@ extension Driver {
   /// For a given clang module dependency, generate a build job
   mutating private func genClangModuleDependencyBuildJob(moduleInfo: ModuleInfo,
                                                          moduleName: String,
-                                                         dependencyGraph: InterModuleDependencyGraph)
-  throws -> Job {
+                                                         dependencyGraph: InterModuleDependencyGraph
+  ) throws -> Job {
     // For clang modules, the Fast Dependency Scanner emits a list of source
     // files (with a .modulemap among them), and a list of compile command
     // options.
@@ -149,11 +149,11 @@ extension Driver {
                             "-fno-implicit-modules")
     for moduleId in moduleInfo.directDependencies {
       guard let dependencyInfo = dependencyGraph.modules[moduleId] else {
-        throw Error.missingModuleDependency(moduleId.getName())
+        throw Error.missingModuleDependency(moduleId.moduleName)
       }
-
-      try addModuleAsExplicitDependency(moduleInfo: dependencyInfo, commandLine: &commandLine,
-                                        inputs: &inputs)
+      try addModuleAsExplicitDependency(moduleInfo: dependencyInfo,
+                                        dependencyGraph: dependencyGraph,
+                                        commandLine: &commandLine, inputs: &inputs)
     }
   }
 }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -51,6 +51,7 @@ public struct Driver {
     case integratedReplRemoved
     case conflictingOptions(Option, Option)
     case malformedModuleDependency(String, String)
+    case missingModuleDependency(String)
     case dependencyScanningFailure(Int, String)
 
     public var description: String {
@@ -72,6 +73,8 @@ public struct Driver {
         return "conflicting options '\(one.spelling)' and '\(two.spelling)'"
       case .malformedModuleDependency(let moduleName, let errorDescription):
         return "Malformed Module Dependency: \(moduleName), \(errorDescription)"
+      case .missingModuleDependency(let moduleName):
+        return "Missing Module Dependency Info: \(moduleName)"
       case .dependencyScanningFailure(let code, let error):
         return "Module Dependency Scanner returned with non-zero exit status: \(code), \(error)"
       }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -51,6 +51,7 @@ public struct Driver {
     case integratedReplRemoved
     case conflictingOptions(Option, Option)
     case malformedModuleDependency(String, String)
+    case dependencyScanningFailure(Int, String)
 
     public var description: String {
       switch self {
@@ -71,6 +72,8 @@ public struct Driver {
         return "conflicting options '\(one.spelling)' and '\(two.spelling)'"
       case .malformedModuleDependency(let moduleName, let errorDescription):
         return "Malformed Module Dependency: \(moduleName), \(errorDescription)"
+      case .dependencyScanningFailure(let code, let error):
+        return "Module Dependency Scanner returned with non-zero exit status: \(code), \(error)"
       }
     }
   }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -50,6 +50,7 @@ public struct Driver {
     case subcommandPassedToDriver
     case integratedReplRemoved
     case conflictingOptions(Option, Option)
+    // Explicit Module Build Failures
     case malformedModuleDependency(String, String)
     case missingModuleDependency(String)
     case dependencyScanningFailure(Int, String)
@@ -71,6 +72,7 @@ public struct Driver {
         return "Compiler-internal integrated REPL has been removed; use the LLDB-enhanced REPL instead."
       case .conflictingOptions(let one, let two):
         return "conflicting options '\(one.spelling)' and '\(two.spelling)'"
+      // Explicit Module Build Failures
       case .malformedModuleDependency(let moduleName, let errorDescription):
         return "Malformed Module Dependency: \(moduleName), \(errorDescription)"
       case .missingModuleDependency(let moduleName):
@@ -205,6 +207,11 @@ public struct Driver {
   ///
   /// This will force the driver to first emit the module and then run compile jobs.
   public var forceEmitModuleInSingleInvocation: Bool = false
+
+  /// The module dependency graph, which is populated during the planning phase
+  /// only when all modules will be prebuilt and treated as explicit by the
+  /// various compilation jobs.
+  var interModuleDependencyGraph: InterModuleDependencyGraph? = nil
 
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in

--- a/Sources/SwiftDriver/Driver/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Driver/ModuleDependencyScanning.swift
@@ -23,6 +23,7 @@ extension Driver {
     let resolver = try ArgsResolver()
     let compilerPath = VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler))
     let tool = try resolver.resolve(.path(compilerPath))
+    var inputs: [TypedVirtualPath] = []
 
     // Aggregate the fast dependency scanner arguments
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
@@ -31,7 +32,9 @@ extension Driver {
     if parsedOptions.hasArgument(.parseStdlib) {
        commandLine.appendFlag(.disableObjcAttrRequiresFoundationModule)
     }
-    try addCommonFrontendOptions(commandLine: &commandLine)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
+                                 bridgingHeaderHandling: .precompiled,
+                                 moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
     // Pass on the input files

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -155,6 +155,10 @@ extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine)
     // FIXME: MSVC runtime flags
 
+    if parsedOptions.contains(.driverExplicitModuleBuild) {
+      try addExplicitModuleBuildArguments(commandLine: &commandLine, inputs: &inputs)
+    }
+
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
       commandLine.appendFlag(.parseAsLibrary)
     }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -152,16 +152,8 @@ extension Driver {
       commandLine.appendFlag(.disableObjcAttrRequiresFoundationModule)
     }
 
-    try addCommonFrontendOptions(commandLine: &commandLine)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
-
-    if parsedOptions.contains(.driverExplicitModuleBuild) {
-      guard let dependencyGraph = interModuleDependencyGraph else {
-        fatalError("Inter Module Dependency Graph does not exist in explicit module build mode.")
-      }
-      try addExplicitModuleBuildArguments(dependencyGraph: dependencyGraph,
-                                          commandLine: &commandLine, inputs: &inputs)
-    }
 
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
       commandLine.appendFlag(.parseAsLibrary)

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -156,7 +156,11 @@ extension Driver {
     // FIXME: MSVC runtime flags
 
     if parsedOptions.contains(.driverExplicitModuleBuild) {
-      try addExplicitModuleBuildArguments(commandLine: &commandLine, inputs: &inputs)
+      guard let dependencyGraph = interModuleDependencyGraph else {
+        fatalError("Inter Module Dependency Graph does not exist in explicit module build mode.")
+      }
+      try addExplicitModuleBuildArguments(dependencyGraph: dependencyGraph,
+                                          commandLine: &commandLine, inputs: &inputs)
     }
 
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -60,7 +60,7 @@ extension Driver {
       inputs.append(input)
     }
 
-    try addCommonFrontendOptions(commandLine: &commandLine)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: Add MSVC runtime library flags
 
     try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -35,10 +35,21 @@ extension Driver {
     /// Use the precompiled bridging header.
     case precompiled
   }
+  /// Whether the driver has already constructed a module dependency graph or is in the process
+  /// of doing so
+  enum ModuleDependencyGraphUse {
+    /// Even though the driver may be in ExplicitModuleBuild mode, the dependency graph has not yet
+    /// been constructed, omit processing module dependencies
+    case dependencyScan
+    /// If the driver is in Explicit Module Build mode, the dependency graph has been computed
+    case computed
+  }
   /// Add frontend options that are common to different frontend invocations.
   mutating func addCommonFrontendOptions(
     commandLine: inout [Job.ArgTemplate],
-    bridgingHeaderHandling: BridgingHeaderHandling = .precompiled
+    inputs: inout [TypedVirtualPath],
+    bridgingHeaderHandling: BridgingHeaderHandling = .precompiled,
+    moduleDependencyGraphUse: ModuleDependencyGraphUse = .computed
   ) throws {
     // Only pass -target to the REPL or immediate modes if it was explicitly
     // specified on the command line.
@@ -52,6 +63,18 @@ extension Driver {
         commandLine.appendFlag(.target)
         commandLine.appendFlag(targetTriple.triple)
       }
+    }
+
+    // If in ExplicitModuleBuild mode and the dependency graph has been computed, add module
+    // dependencies.
+    // May also be used for generation of the dependency graph itself in ExplicitModuleBuild mode.
+    if (parsedOptions.contains(.driverExplicitModuleBuild) &&
+          moduleDependencyGraphUse == .computed) {
+      guard let dependencyGraph = interModuleDependencyGraph else {
+        fatalError("Attempting to add Explicit Module job dependencies, but the Inter Module Dependency Graph does not exist.")
+      }
+      try addExplicitModuleBuildArguments(dependencyGraph: dependencyGraph,
+                                          commandLine: &commandLine, inputs: &inputs)
     }
 
     if let variant = parsedOptions.getLastArgument(.targetVariant)?.asSingle {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -321,8 +321,10 @@ extension Driver {
                                                type: .pcm)
         let clangModuleMapPath = TypedVirtualPath(file: try VirtualPath(path: clangDependencyDetails.moduleMapPath),
                                                   type: .pcm)
-        commandLine.appendFlag("-clang-module-file=\(clangModulePath.file.description)")
-        commandLine.appendFlag("-clang-module-map-file=\(clangModuleMapPath.file.description)")
+        commandLine.appendFlags("-Xcc", "-Xclang", "-Xcc",
+                                "-fmodule-map-file=\(clangModuleMapPath.file.description)")
+        commandLine.appendFlags("-Xcc", "-Xclang", "-Xcc",
+                                "-fmodule-file=\(clangModulePath.file.description)")
         inputs.append(clangModulePath)
         inputs.append(clangModuleMapPath)
     }
@@ -336,7 +338,8 @@ extension Driver {
       fatalError("Inter Module Dependency Graph does not exist in explicit module build mode.")
     }
     // Prohibit the frontend from implicitly building textual modules into binary modules.
-    commandLine.appendFlags("-disable-implicit-swift-modules", "-disable-implicit-pcms")
+    commandLine.appendFlags("-disable-implicit-swift-modules", "-Xcc", "-Xclang", "-Xcc",
+                            "-fno-implicit-modules")
 
     // Provide the frontend with a list of explicitly pre-built modules.
     for (moduleId, moduleInfo) in dependencyGraph.modules {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -329,8 +329,8 @@ extension Driver {
   }
 
   /// Adds the specified module as an explicit module dependency to given
-  /// inputs and comman line arguments of a compile job.
-  /// Also add transitive dependencies that arise from dependencies of this module.
+  /// inputs and command line arguments of a compile job.
+  /// Also adds transitive dependencies that arise from dependencies of this module.
   func addModuleAsExplicitDependency(moduleInfo: ModuleInfo,
                                      dependencyGraph: InterModuleDependencyGraph,
                                      commandLine: inout [Job.ArgTemplate],
@@ -339,7 +339,8 @@ extension Driver {
       case .swift:
         let swiftModulePath = TypedVirtualPath(file: try VirtualPath(path: moduleInfo.modulePath),
                                                type: .swiftModule)
-        commandLine.appendFlag("-swift-module-file=\(swiftModulePath.file.description)")
+        commandLine.appendFlags("-swift-module-file")
+        commandLine.appendPath(swiftModulePath.file)
         inputs.append(swiftModulePath)
       case .clang(let clangDependencyDetails):
         let clangModulePath = TypedVirtualPath(file: try VirtualPath(path: moduleInfo.modulePath),

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -23,7 +23,7 @@ extension Driver {
     commandLine.appendFlag("-frontend")
 
     try addCommonFrontendOptions(
-      commandLine: &commandLine, bridgingHeaderHandling: .parsed)
+      commandLine: &commandLine, inputs: &inputs, bridgingHeaderHandling: .parsed)
 
     try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
 

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -48,7 +48,7 @@ extension Driver {
     commandLine.appendPath(output.file)
 
     try addCommonFrontendOptions(
-      commandLine: &commandLine, bridgingHeaderHandling: .ignored)
+      commandLine: &commandLine, inputs: &inputs, bridgingHeaderHandling: .ignored)
 
     try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
 

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -27,7 +27,7 @@ extension Driver {
       commandLine.appendFlag(.disableObjcAttrRequiresFoundationModule)
     }
 
-    try addCommonFrontendOptions(commandLine: &commandLine)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
     try commandLine.appendLast(.parseSil, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -41,7 +41,7 @@ extension Driver {
     commandLine.appendFlag(.disableDiagnosticPasses)
     commandLine.appendFlag(.disableSilPerfOptzns)
 
-    try addCommonFrontendOptions(commandLine: &commandLine)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: Add MSVC runtime library flags
 
     try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs)

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -34,17 +34,6 @@ extension Driver {
   private mutating func planStandardCompile() throws -> [Job] {
     var jobs = [Job]()
 
-    // If we've been asked to prebuild module dependencies,
-    // for the time being, just print the jobs' compile commands.
-    if parsedOptions.contains(.driverPrintModuleDependenciesJobs) {
-      let modulePrebuildJobs = try generateExplicitModuleBuildJobs()
-      let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)
-      for job in modulePrebuildJobs {
-        try Self.printJob(job, resolver: try ArgsResolver(),
-                          forceResponseFiles: forceResponseFiles)
-      }
-    }
-
     // Keep track of the various outputs we care about from the jobs we build.
     var linkerInputs: [TypedVirtualPath] = []
     var moduleInputs: [TypedVirtualPath] = []
@@ -63,9 +52,24 @@ extension Driver {
       }
     }
 
-    // Precompile module dependencies, if asked.
-    if parsedOptions.contains(.driverExplicitModuleBuild) {
-      jobs.append(contentsOf: try generateExplicitModuleBuildJobs())
+    // If asked, add jobs to precompile module dependencies
+    if parsedOptions.contains(.driverExplicitModuleBuild) ||
+        parsedOptions.contains(.driverPrintModuleDependenciesJobs) {
+      let modulePrebuildJobs = try generateExplicitModuleBuildJobs()
+
+      if parsedOptions.contains(.driverExplicitModuleBuild) {
+        jobs.append(contentsOf: modulePrebuildJobs)
+      }
+
+      // If we've been asked to prebuild module dependencies,
+      // for the time being, just print the jobs' compile commands.
+      if parsedOptions.contains(.driverPrintModuleDependenciesJobs) {
+        let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)
+        for job in modulePrebuildJobs {
+          try Self.printJob(job, resolver: try ArgsResolver(),
+                            forceResponseFiles: forceResponseFiles)
+        }
+      }
     }
 
     // Precompile the bridging header if needed.
@@ -218,13 +222,11 @@ extension Driver {
   /// Prescan the source files to produce a module dependency graph and turn it into a set
   /// of jobs required to build all dependencies.
   public mutating func generateExplicitModuleBuildJobs() throws -> [Job] {
-    let moduleDependencyGraph = try computeModuleDependencyGraph()
-    if let dependencyGraph = moduleDependencyGraph {
-      let modulePrebuildJobs =
-            try planExplicitModuleDependenciesCompile(dependencyGraph: dependencyGraph)
-      return modulePrebuildJobs
+    interModuleDependencyGraph = try computeModuleDependencyGraph()
+    guard let dependencyGraph = interModuleDependencyGraph else {
+      fatalError("Attempting to perform Explicit Module Build job generation, but the Inter Module Dependency Graph does not exist.")
     }
-    return []
+    return try planExplicitModuleDependenciesCompile(dependencyGraph: dependencyGraph)
   }
 
   /// Create a job if needed for simple requests that can be immediately

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -63,6 +63,11 @@ extension Driver {
       }
     }
 
+    // Precompile module dependencies, if asked.
+    if parsedOptions.contains(.driverExplicitModuleBuild) {
+      jobs.append(contentsOf: try generateExplicitModuleBuildJobs())
+    }
+
     // Precompile the bridging header if needed.
     if let importedObjCHeader = importedObjCHeader,
       let bridgingPrecompiledHeader = bridgingPrecompiledHeader {

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -13,8 +13,9 @@
 extension Driver {
   mutating func replJob() throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    var inputs: [TypedVirtualPath] = []
 
-    try addCommonFrontendOptions(commandLine: &commandLine)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
     try commandLine.appendLast(.importObjcHeader, from: &parsedOptions)
@@ -27,7 +28,7 @@ extension Driver {
       kind: .repl,
       tool: .absolute(try toolchain.getToolPath(.lldb)),
       commandLine: [Job.ArgTemplate.flag(lldbArg)],
-      inputs: [],
+      inputs: inputs,
       outputs: [],
       requiresInPlaceExecution: true
     )

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -11,13 +11,13 @@
 //===----------------------------------------------------------------------===//
 extension Option {
   public static let driverPrintGraphviz: Option = Option("-driver-print-graphviz", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Write the job graph as a graphviz file", group: .internalDebug)
-  public static let driverPrebuildModuleDependencies: Option = Option("-driver-prebuild-module-dependencies", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
+  public static let driverExplicitModuleBuild: Option = Option("-experimental-explicit-module-build", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
   public static let driverPrintModuleDependenciesJobs: Option = Option("-driver-print-module-dependencies-jobs", .flag, attributes: [.helpHidden], helpText: "Print commands to explicitly build module dependencies")
 
   public static var extraOptions: [Option] {
     return [
       Option.driverPrintGraphviz,
-      Option.driverPrebuildModuleDependencies,
+      Option.driverExplicitModuleBuild,
       Option.driverPrintModuleDependenciesJobs
     ]
   }

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/A.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/A.h
@@ -1,0 +1,1 @@
+void funcA(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/B.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/B.h
@@ -1,0 +1,4 @@
+#include <A.h>
+
+void funcB(void);
+

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/B.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/B.h
@@ -1,4 +1,4 @@
-#include <A.h>
+#include "A.h"
 
 void funcB(void);
 

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/Bridging.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/Bridging.h
@@ -1,0 +1,3 @@
+#include "BridgingOther.h"
+
+int bridging_other(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/BridgingOther.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/BridgingOther.h
@@ -1,0 +1,3 @@
+#include "F.h"
+
+int bridging_other(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
@@ -1,0 +1,3 @@
+#include <B.h>
+
+void funcC(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
@@ -1,3 +1,3 @@
-#include <B.h>
+#include "B.h"
 
 void funcC(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/D.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/D.h
@@ -1,0 +1,1 @@
+void funcD(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/F.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/F.h
@@ -1,0 +1,1 @@
+void funcF(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
@@ -1,0 +1,1 @@
+void funcG(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/module.modulemap
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/module.modulemap
@@ -1,0 +1,29 @@
+module A {
+  header "A.h"
+  export *
+}
+
+module B {
+  header "B.h"
+  export *
+}
+
+module C {
+  header "C.h"
+  export *
+}
+
+module D {
+  header "D.h"
+  export *
+}
+
+module F {
+  header "F.h"
+  export *
+}
+
+module G {
+  header "G.h"
+  export *
+}

--- a/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
@@ -1,5 +1,6 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name A
+import Swift
 @_exported import A
 public func overlayFuncA() { }
 

--- a/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A
+@_exported import A
+public func overlayFuncA() { }
+

--- a/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name E
+import Swift
+public func funcE() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name F
+import Swift
+@_exported import F
+public func funcF() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
@@ -2,7 +2,7 @@
 // swift-module-flags: -module-name G -swift-version 5
 
 #if swift(>=5.0)
-
+import Swift
 @_exported import G
 public func overlayFuncG() { }
 

--- a/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name G -swift-version 5
+
+#if swift(>=5.0)
+
+@_exported import G
+public func overlayFuncG() { }
+
+#endif

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -62,7 +62,9 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
                            type: .swiftModule)
         XCTAssertTrue(job.inputs.contains(swiftDependencyModulePath))
         XCTAssertTrue(job.commandLine.contains(
-                        .flag(String("-swift-module-file=\(dependencyInfo.modulePath)"))))
+                        .flag(String("-swift-module-file"))))
+        XCTAssertTrue(
+          job.commandLine.contains(.path(try VirtualPath(path: dependencyInfo.modulePath))))
       case .clang(let clangDependencyDetails):
         let clangDependencyModulePath =
           TypedVirtualPath(file: try VirtualPath(path: dependencyInfo.modulePath),

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -47,7 +47,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
                                                      moduleDependencyGraph: InterModuleDependencyGraph)
 throws {
   XCTAssertTrue(job.commandLine.contains(.flag(String("-disable-implicit-swift-modules"))))
-  XCTAssertTrue(job.commandLine.contains(.flag(String("-disable-implicit-pcms"))))
+  XCTAssertTrue(job.commandLine.contains(.flag(String("-fno-implicit-modules"))))
   for dependencyId in moduleInfo.directDependencies {
     let dependencyInfo = moduleDependencyGraph.modules[dependencyId]!
     switch dependencyInfo.details {
@@ -68,9 +68,9 @@ throws {
         XCTAssertTrue(job.inputs.contains(clangDependencyModulePath))
         XCTAssertTrue(job.inputs.contains(clangDependencyModuleMapPath))
         XCTAssertTrue(job.commandLine.contains(
-                        .flag(String("-clang-module-file=\(dependencyInfo.modulePath)"))))
+                        .flag(String("-fmodule-file=\(dependencyInfo.modulePath)"))))
         XCTAssertTrue(job.commandLine.contains(
-                        .flag(String("-clang-module-map-file=\(clangDependencyDetails.moduleMapPath)"))))
+                        .flag(String("-fmodule-map-file=\(clangDependencyDetails.moduleMapPath)"))))
     }
   }
 }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -153,7 +153,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let jobs = try driver.planBuild()
       XCTAssertTrue(driver.parsedOptions.contains(.driverExplicitModuleBuild))
       let dependencyGraph = driver.interModuleDependencyGraph!
-      XCTAssertEqual(jobs.count, 12)
       for job in jobs {
         XCTAssertEqual(job.outputs.count, 1)
         switch (job.outputs[0].file) {


### PR DESCRIPTION
This PR adds the compile command argument interface for Explicit Module Builds, as specified in: https://github.com/apple/swift/pull/32125

- `-disable-implicit-swift-modules` and `-Xcc -Xclang -Xcc -fno-implicit-modules` are passed to all compile jobs to prevent the frontend from building any modules implicitly and diagnose if they have to.
- When building a module, the compile commands are passed paths to the module's direct dependencies with `-Xcc -Xclang -Xcc -fmodule-map-file=` and `-Xcc -Xclang -Xcc -fmodule-file=` and `-swift-module-file=`.
- Add `-experimental-explicit-module-build` option to request that the driver must attempt to perform a full explicit-module-build compile. 

For now, I include a test that verifies that the commands are generated as expected w.r.t. their dependencies. Once the frontend puzzle piece is landed, we should be close to getting a full end-to-end test. 

This PR subsumes #112. 