### PR TITLE
Update README to avoid recursive lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ ln -s /path/to/built/swift-driver $SOME_PATH/swift
 ln -s /path/to/built/swift-driver $SOME_PATH/swiftc
 ```
 
-Swift packages can be built with the new Swift driver by overriding `SWIFT_EXEC` to refer to the `swiftc` symbolic link created above, e.g.,
+Swift packages can be built with the new Swift driver by overriding `SWIFT_EXEC` to refer to the `swiftc` symbolic link created above and `SWIFT_DRIVER_SWIFT_EXEC` to refer to the original `swiftc`, e.g.,
 
 ```
-SWIFT_EXEC=$SOME_PATH/swiftc swift build
+SWIFT_EXEC=$SOME_PATH/swiftc SWIFT_DRIVER_SWIFT_EXEC=$TOOLCHAIN_PATH/bin/swiftc swift build
 ```
 
-Similarly, one can use the new Swift driver within Xcode by adding a custom build setting (usually at the project level) named `SWIFT_EXEC` that refers to `$SOME_PATH/swiftc`.
+Similarly, one can use the new Swift driver within Xcode by adding a custom build setting (usually at the project level) named `SWIFT_EXEC` that refers to `$SOME_PATH/swiftc` and adding `-driver-use-frontend-path $TOOLCHAIN_PATH/bin/swiftc` to `Other Swift Flags`.
 
 ## Building with CMake
 


### PR DESCRIPTION
This matches the workflow I've been using to avoid the issue where `swift-driver` keeps invoking itself instead of the frontend. Maybe there's a better way?