### PR TITLE
Change -num-threads to only multithread for values > 1

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -91,7 +91,7 @@ extension Driver {
     assert(!usesPrimaryFileInputs || !primaryInputs.isEmpty)
     let primaryInputFiles = usesPrimaryFileInputs ? Set(primaryInputs) : Set()
 
-    let isMultithreaded = numThreads > 0
+    let isMultithreaded = numThreads > 1
 
     // Add each of the input files.
     // FIXME: Use/create input file lists and primary input file lists.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1058,6 +1058,30 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[1].kind, .link)
     }
 
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-whole-module-optimization", "foo.swift", "bar.swift", "wibble.swift", "-num-threads", "0", "-c", "-o", "foo.o",
+      ])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      XCTAssertEqual(plannedJobs[0].outputs.count, 1)
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, VirtualPath.relative(RelativePath("foo.o")))
+      XCTAssert(!plannedJobs[0].commandLine.contains(.flag("-primary-file")))
+    }
+
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-whole-module-optimization", "foo.swift", "bar.swift", "wibble.swift", "-num-threads", "1", "-c", "-o", "foo.o",
+      ])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      XCTAssertEqual(plannedJobs[0].outputs.count, 1)
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, VirtualPath.relative(RelativePath("foo.o")))
+      XCTAssert(!plannedJobs[0].commandLine.contains(.flag("-primary-file")))
+    }
+
     // emit-module
     do {
       var driver = try Driver(args: ["swiftc", "-module-name=ThisModule", "-wmo", "-num-threads", "4", "main.swift", "multi-threaded.swift", "-emit-module", "-o", "test.swiftmodule"])


### PR DESCRIPTION
Previously the 0 value of num-threads was the only one that meant don't
use single threading. Now 1 is treated the same way.