### PR TITLE
Move -num-threads tests to single function

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -268,17 +268,6 @@ final class SwiftDriverTests: XCTestCase {
   }
 
     func testMultithreading() throws {
-
-      XCTAssertEqual(try Driver(args: ["swiftc"]).numThreads, 0)
-
-      XCTAssertEqual(try Driver(args: ["swiftc", "-num-threads", "4"]).numThreads, 4)
-
-      XCTAssertEqual(try Driver(args: ["swiftc", "-num-threads", "0"]).numThreads, 0)
-
-      XCTAssertEqual(try Driver(args: ["swiftc", "-num-threads", "-1"]).numThreads, 0)
-
-      XCTAssertEqual(try Driver(args: ["swiftc", "-enable-batch-mode", "-num-threads", "4"]).numThreads, 0)
-
       XCTAssertNil(try Driver(args: ["swiftc"]).numParallelJobs)
 
       XCTAssertEqual(try Driver(args: ["swiftc", "-j", "4"]).numParallelJobs, 4)
@@ -291,15 +280,6 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     func testMultithreadingDiagnostics() throws {
-
-      try assertDriverDiagnostics(args: "swift", "-num-threads", "-1") {
-        $1.expect(.error("invalid value '-1' in '-num-threads'"))
-      }
-
-      try assertDriverDiagnostics(args: "swiftc", "-enable-batch-mode", "-num-threads", "4") {
-        $1.expect(.warning("ignoring -num-threads argument; cannot multithread batch mode"))
-      }
-
       try assertDriverDiagnostics(args: "swiftc", "-j", "0") {
         $1.expect(.error("invalid value '0' in '-j'"))
       }
@@ -1609,6 +1589,24 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
       XCTAssertTrue(job.commandLine.contains(.flag("-print-educational-notes")))
+    }
+  }
+
+  func testNumThreads() throws {
+    XCTAssertEqual(try Driver(args: ["swiftc"]).numThreads, 0)
+
+    XCTAssertEqual(try Driver(args: ["swiftc", "-num-threads", "4"]).numThreads, 4)
+
+    XCTAssertEqual(try Driver(args: ["swiftc", "-num-threads", "0"]).numThreads, 0)
+
+    try assertDriverDiagnostics(args: ["swift", "-num-threads", "-1"]) { driver, verify in
+      verify.expect(.error("invalid value '-1' in '-num-threads'"))
+      XCTAssertEqual(driver.numThreads, 0)
+    }
+
+    try assertDriverDiagnostics(args: "swiftc", "-enable-batch-mode", "-num-threads", "4") { driver, verify in
+      verify.expect(.warning("ignoring -num-threads argument; cannot multithread batch mode"))
+      XCTAssertEqual(driver.numThreads, 0)
     }
   }
 


### PR DESCRIPTION
This is just an organizational change to keep all the tests for
`-num-threads` behavior in one place.