### PR TITLE
Extract debug info and module output properties from Driver.swift

### DIFF
--- a/Sources/SwiftDriver/Driver/DebugInfo.swift
+++ b/Sources/SwiftDriver/Driver/DebugInfo.swift
@@ -1,4 +1,4 @@
-//===--------------- main.swift - Swift Debug Information Kind ------------===//
+//===--------------- DebugInfo.swift - Swift Debug Information ------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -9,29 +9,44 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-/// Describes the format used for debug information.
-public enum DebugInfoFormat: String {
-  case dwarf
-  case codeView = "codeview"
-}
 
-public enum DebugInfoLevel {
-  /// Line tables only (no type information).
-  case lineTables
+/// The debug information produced by the driver.
+public struct DebugInfo {
 
-  /// Line tables with AST type references
-  case astTypes
+  /// Describes the format used for debug information.
+  public enum Format: String {
+    case dwarf
+    case codeView = "codeview"
+  }
 
-  /// Line tables with AST type references and DWARF types
-  case dwarfTypes
+  /// Describes the level of debug information.
+  public enum Level {
+    /// Line tables only (no type information).
+    case lineTables
 
-  public var requiresModule: Bool {
-    switch self {
-    case .lineTables:
-      return false
+    /// Line tables with AST type references
+    case astTypes
 
-    case .astTypes, .dwarfTypes:
-      return true
+    /// Line tables with AST type references and DWARF types
+    case dwarfTypes
+
+    public var requiresModule: Bool {
+      switch self {
+      case .lineTables:
+        return false
+
+      case .astTypes, .dwarfTypes:
+        return true
+      }
     }
   }
+
+  // The format of debug information.
+  public let format: Format
+
+  /// The level of debug information.
+  public let level: Level?
+
+  /// Whether 'dwarfdump' should be used to verify debug info.
+  public let shouldVerify: Bool
 }

--- a/Sources/SwiftDriver/Driver/ModuleOutputInfo.swift
+++ b/Sources/SwiftDriver/Driver/ModuleOutputInfo.swift
@@ -1,0 +1,51 @@
+//===--------------- ModuleOutputInfo.swift - Module output information ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The information about module output produced by the driver.
+public struct ModuleOutputInfo {
+
+  /// How should the Swift module output be handled?
+  public enum ModuleOutput: Equatable {
+    /// The Swift module is a top-level output.
+    case topLevel(VirtualPath)
+
+    /// The Swift module is an auxiliary output.
+    case auxiliary(VirtualPath)
+
+    public var outputPath: VirtualPath {
+      switch self {
+      case .topLevel(let path):
+        return path
+
+      case .auxiliary(let path):
+        return path
+      }
+    }
+
+    public var isTopLevel: Bool {
+      switch self {
+      case .topLevel: return true
+      default: return false
+      }
+    }
+  }
+
+  /// The form that the module output will take, e.g., top-level vs. auxiliary,
+  /// and the path at which the module should be emitted. `nil` if no module should be emitted.
+  public let output: ModuleOutput?
+
+  /// The name of the Swift module being built.
+  public let name: String
+
+  /// Whether `name` was picked by the driver instead of the user.
+  public let nameIsFallback: Bool
+}

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -28,7 +28,7 @@ public struct IncrementalCompilation {
        compilerMode: CompilerMode,
        outputFileMap: OutputFileMap?,
        compilerOutputType: FileType?,
-       moduleOutput: ModuleOutput?,
+       moduleOutput: ModuleOutputInfo.ModuleOutput?,
        fileSystem: FileSystem,
        inputFiles: [TypedVirtualPath],
        diagnosticEngine: DiagnosticsEngine,

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -22,14 +22,14 @@ extension Driver {
     }
 
     var commandLine = [Job.ArgTemplate]()
-    let output = VirtualPath.temporary(RelativePath("\(moduleName).autolink"))
+    let output = VirtualPath.temporary(RelativePath("\(moduleOutputInfo.name).autolink"))
 
     commandLine.append(contentsOf: inputs.map { .path($0.file) })
     commandLine.appendFlag(.o)
     commandLine.appendPath(output)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .autolinkExtract,
       tool: .absolute(try toolchain.getToolPath(.swiftAutolinkExtract)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -50,7 +50,7 @@ extension Driver {
     try commandLine.appendLast(.parseStdlib, from: &parsedOptions)
 
     commandLine.appendFlag(.moduleName)
-    commandLine.appendFlag(moduleName)
+    commandLine.appendFlag(moduleOutputInfo.name)
 
     // Add the output file argument if necessary.
     if let compilerOutputType = compilerOutputType {
@@ -65,7 +65,7 @@ extension Driver {
     allOutputs += outputs
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .backend,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -43,7 +43,7 @@ extension Driver {
 
     let baseName: String
     if !compilerMode.usesPrimaryFileInputs && numThreads == 0 {
-      baseName = moduleName
+      baseName = moduleOutputInfo.name
     } else {
       baseName = input.file.basenameWithoutExt
     }
@@ -64,7 +64,7 @@ extension Driver {
     case .object:
       return (linkerOutputType == nil)
     case .swiftModule:
-      return compilerMode.isSingleCompilation && moduleOutput?.isTopLevel ?? false
+      return compilerMode.isSingleCompilation && moduleOutputInfo.output?.isTopLevel ?? false
     case .swift, .sib, .image, .dSYM, .dependencies, .autolink,
          .swiftDocumentation, .swiftInterface,
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
@@ -201,11 +201,11 @@ extension Driver {
 
     // If we're creating emit module job, order the compile jobs after that.
     if shouldCreateEmitModuleJob {
-      inputs.append(TypedVirtualPath(file: moduleOutput!.outputPath, type: .swiftModule))
+      inputs.append(TypedVirtualPath(file: moduleOutputInfo.output!.outputPath, type: .swiftModule))
     }
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .compile,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -35,7 +35,7 @@ extension Driver {
       var path = dependenciesFilePath
       // FIXME: Hack to workaround the fact that SwiftPM/Xcode don't pass this path right now.
       if parsedOptions.getLastArgument(.emitDependenciesPath) == nil {
-        path = try moduleOutput!.outputPath.replacingExtension(with: .dependencies)
+        path = try moduleOutputInfo.output!.outputPath.replacingExtension(with: .dependencies)
       }
       addSupplementalOutput(path: path, flag: "-emit-dependencies-path", type: .dependencies)
     }
@@ -43,7 +43,7 @@ extension Driver {
 
   /// Form a job that emits a single module
   mutating func emitModuleJob() throws -> Job {
-    let moduleOutputPath = moduleOutput!.outputPath
+    let moduleOutputPath = moduleOutputInfo.output!.outputPath
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []
     var outputs: [TypedVirtualPath] = [
@@ -69,7 +69,7 @@ extension Driver {
     commandLine.appendPath(moduleOutputPath)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .emitModule,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,
@@ -82,6 +82,6 @@ extension Driver {
   var shouldCreateEmitModuleJob: Bool {
     return forceEmitModuleInSingleInvocation
       && compilerOutputType != .swiftModule
-      && moduleOutput != nil
+      && moduleOutputInfo.output != nil
   }
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -223,7 +223,7 @@ extension Driver {
 
     // Repl Jobs shouldn't include -module-name.
     if compilerMode != .repl {
-      commandLine.appendFlags("-module-name", moduleName)
+      commandLine.appendFlags("-module-name", moduleOutputInfo.name)
     }
   }
 
@@ -264,7 +264,7 @@ extension Driver {
       if !forceEmitModuleInSingleInvocation {
         addOutputOfType(
             outputType: .swiftModule,
-            finalOutputPath: moduleOutput?.outputPath,
+            finalOutputPath: moduleOutputInfo.output?.outputPath,
             input: input,
             flag: "-emit-module-path")
         addOutputOfType(

--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -23,7 +23,7 @@ extension Driver {
     commandLine.appendPath(outputPath)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .generateDSYM,
       tool: .absolute(try toolchain.getToolPath(.dsymutil)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -62,7 +62,7 @@ extension Driver {
     outputs.append(output)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .generatePCH,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -39,7 +39,7 @@ extension Driver {
     } else {
       output = .init(
         file: try VirtualPath(
-          path: moduleName.appendingFileTypeExtension(.pcm)),
+          path: moduleOutputInfo.name.appendingFileTypeExtension(.pcm)),
         type: .pcm)
     }
 
@@ -53,7 +53,7 @@ extension Driver {
     try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .generatePCM,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -41,7 +41,7 @@ extension Driver {
       targetTriple: self.targetTriple)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .interpret,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -15,12 +15,12 @@ extension Driver {
 
   /// Compute the output file for an image output.
   private var outputFileForImage: VirtualPath {
-    if inputFiles.count == 1 && moduleNameIsFallback && inputFiles[0].file != .standardInput {
+    if inputFiles.count == 1 && moduleOutputInfo.nameIsFallback && inputFiles[0].file != .standardInput {
       return .relative(RelativePath(inputFiles[0].file.basenameWithoutExt))
     }
 
     let outputName =
-      toolchain.makeLinkerOutputFilename(moduleName: moduleName,
+      toolchain.makeLinkerOutputFilename(moduleName: moduleOutputInfo.name,
                                          type: linkerOutputType!)
     return .relative(RelativePath(outputName))
   }
@@ -53,7 +53,7 @@ extension Driver {
 
     // TODO: some, but not all, linkers support response files.
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .link,
       tool: .absolute(toolPath),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -15,7 +15,7 @@ extension Driver {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []
     var outputs: [TypedVirtualPath] = [
-      TypedVirtualPath(file: moduleOutput!.outputPath, type: .swiftModule)
+      TypedVirtualPath(file: moduleOutputInfo.output!.outputPath, type: .swiftModule)
     ]
 
     commandLine.appendFlags("-frontend", "-merge-modules", "-emit-module")
@@ -47,10 +47,10 @@ extension Driver {
     try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs)
 
     commandLine.appendFlag(.o)
-    commandLine.appendPath(moduleOutput!.outputPath)
+    commandLine.appendPath(moduleOutputInfo.output!.outputPath)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .mergeModule,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -208,10 +208,10 @@ extension Driver {
     }
 
     // If we should generate a dSYM, do so.
-    if let linkJob = link, targetTriple.isDarwin, debugInfoLevel != nil {
+    if let linkJob = link, targetTriple.isDarwin, debugInfo.level != nil {
       let dsymJob = try generateDSYMJob(inputs: linkJob.outputs)
       jobs.append(dsymJob)
-      if shouldVerifyDebugInfo {
+      if debugInfo.shouldVerify {
         jobs.append(try verifyDebugInfoJob(inputs: dsymJob.outputs))
       }
     }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -168,7 +168,7 @@ extension Driver {
         }
 
       case .swiftModule, .swiftDocumentation:
-        if moduleOutput != nil && linkerOutputType == nil {
+        if moduleOutputInfo.output != nil && linkerOutputType == nil {
           // When generating a .swiftmodule as a top-level output (as opposed
           // to, for example, linking an image), treat .swiftmodule files as
           // inputs to a MergeModule action.
@@ -189,7 +189,7 @@ extension Driver {
     jobs.append(contentsOf: backendJobs)
 
     // Plan the merge-module job, if there are module inputs.
-    if moduleOutput != nil && !moduleInputs.isEmpty && compilerMode.usesPrimaryFileInputs {
+    if moduleOutputInfo.output != nil && !moduleInputs.isEmpty && compilerMode.usesPrimaryFileInputs {
       jobs.append(try mergeModuleJob(inputs: moduleInputs))
     }
 
@@ -240,7 +240,7 @@ extension Driver {
       try commandLine.appendLast(.sdk, from: &parsedOptions)
       try commandLine.appendLast(.resourceDir, from: &parsedOptions)
       return Job(
-        moduleName: moduleName,
+        moduleName: moduleOutputInfo.name,
         kind: .printTargetInfo,
         tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
         commandLine: commandLine,
@@ -251,7 +251,7 @@ extension Driver {
 
     if parsedOptions.hasArgument(.version) || parsedOptions.hasArgument(.version_) {
       return Job(
-        moduleName: moduleName,
+        moduleName: moduleOutputInfo.name,
         kind: .versionRequest,
         tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
         commandLine: [.flag("--version")],
@@ -266,7 +266,7 @@ extension Driver {
         commandLine.append(.flag("-show-hidden"))
       }
       return Job(
-        moduleName: moduleName,
+        moduleName: moduleOutputInfo.name,
         kind: .help,
         tool: .absolute(try toolchain.getToolPath(.swiftHelp)),
         commandLine: commandLine,

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -24,7 +24,7 @@ extension Driver {
     // Squash important frontend options into a single argument for LLDB.
     let lldbArg = "--repl=\(commandLine.joinedArguments)"
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .repl,
       tool: .absolute(try toolchain.getToolPath(.lldb)),
       commandLine: [Job.ArgTemplate.flag(lldbArg)],

--- a/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
@@ -21,7 +21,7 @@ extension Driver {
     commandLine.appendPath(input.file)
 
     return Job(
-      moduleName: moduleName,
+      moduleName: moduleOutputInfo.name,
       kind: .verifyDebugInfo,
       tool: .absolute(try toolchain.getToolPath(.dwarfdump)),
       commandLine: commandLine,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -347,37 +347,37 @@ final class SwiftDriverTests: XCTestCase {
 
   func testModuleSettings() throws {
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift") { driver in
-      XCTAssertNil(driver.moduleOutput)
-      XCTAssertEqual(driver.moduleName, "foo")
+      XCTAssertNil(driver.moduleOutputInfo.output)
+      XCTAssertEqual(driver.moduleOutputInfo.name, "foo")
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g") { driver in
-      XCTAssertEqual(driver.moduleOutput, ModuleOutput.auxiliary(VirtualPath.temporary(RelativePath("foo.swiftmodule"))))
-      XCTAssertEqual(driver.moduleName, "foo")
+      XCTAssertEqual(driver.moduleOutputInfo.output, .auxiliary(VirtualPath.temporary(RelativePath("foo.swiftmodule"))))
+      XCTAssertEqual(driver.moduleOutputInfo.name, "foo")
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-module-name", "wibble", "bar.swift", "-g") { driver in
-      XCTAssertEqual(driver.moduleOutput, ModuleOutput.auxiliary( VirtualPath.temporary(RelativePath("wibble.swiftmodule"))))
-      XCTAssertEqual(driver.moduleName, "wibble")
+      XCTAssertEqual(driver.moduleOutputInfo.output, .auxiliary( VirtualPath.temporary(RelativePath("wibble.swiftmodule"))))
+      XCTAssertEqual(driver.moduleOutputInfo.name, "wibble")
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "-emit-module", "foo.swift", "-module-name", "wibble", "bar.swift") { driver in
-      XCTAssertEqual(driver.moduleOutput, ModuleOutput.topLevel(try VirtualPath(path: "wibble.swiftmodule")))
-      XCTAssertEqual(driver.moduleName, "wibble")
+      XCTAssertEqual(driver.moduleOutputInfo.output, .topLevel(try VirtualPath(path: "wibble.swiftmodule")))
+      XCTAssertEqual(driver.moduleOutputInfo.name, "wibble")
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift") { driver in
-      XCTAssertNil(driver.moduleOutput)
-      XCTAssertEqual(driver.moduleName, "main")
+      XCTAssertNil(driver.moduleOutputInfo.output)
+      XCTAssertEqual(driver.moduleOutputInfo.name, "main")
     }
 
     try assertNoDriverDiagnostics(args: "swift", "-repl") { driver in
-      XCTAssertNil(driver.moduleOutput)
-      XCTAssertEqual(driver.moduleName, "REPL")
+      XCTAssertNil(driver.moduleOutputInfo.output)
+      XCTAssertEqual(driver.moduleOutputInfo.name, "REPL")
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-library", "-o", "libWibble.so") { driver in
-      XCTAssertEqual(driver.moduleName, "Wibble")
+      XCTAssertEqual(driver.moduleOutputInfo.name, "Wibble")
     }
 
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-library", "-o", "libWibble.so", "-module-name", "Swift") {
@@ -385,15 +385,15 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-module", "-emit-library", "-o", "some/dir/libFoo.so", "-module-name", "MyModule") { driver in
-      XCTAssertEqual(driver.moduleOutput, ModuleOutput.topLevel(try VirtualPath(path: "some/dir/MyModule.swiftmodule")))
+      XCTAssertEqual(driver.moduleOutputInfo.output, .topLevel(try VirtualPath(path: "some/dir/MyModule.swiftmodule")))
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-module", "-emit-library", "-o", "/", "-module-name", "MyModule") { driver in
-      XCTAssertEqual(driver.moduleOutput, ModuleOutput.topLevel(try VirtualPath(path: "/MyModule.swiftmodule")))
+      XCTAssertEqual(driver.moduleOutputInfo.output, .topLevel(try VirtualPath(path: "/MyModule.swiftmodule")))
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-module", "-emit-library", "-o", "../../some/other/dir/libFoo.so", "-module-name", "MyModule") { driver in
-      XCTAssertEqual(driver.moduleOutput, ModuleOutput.topLevel(try VirtualPath(path: "../../some/other/dir/MyModule.swiftmodule")))
+      XCTAssertEqual(driver.moduleOutputInfo.output, .topLevel(try VirtualPath(path: "../../some/other/dir/MyModule.swiftmodule")))
     }
   }
 
@@ -435,16 +435,16 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testModuleNaming() throws {
-    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift"]).moduleName, "foo")
-    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out"]).moduleName, "a")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift"]).moduleOutputInfo.name, "foo")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out"]).moduleOutputInfo.name, "a")
 
     // This is silly, but necesary for compatibility with the integrated driver.
-    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out.optimized"]).moduleName, "main")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out.optimized"]).moduleOutputInfo.name, "main")
 
-    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out.optimized", "-module-name", "bar"]).moduleName, "bar")
-    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "+++.out"]).moduleName, "main")
-    XCTAssertEqual(try Driver(args: ["swift"]).moduleName, "REPL")
-    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-emit-library", "-o", "libBaz.dylib"]).moduleName, "Baz")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "a.out.optimized", "-module-name", "bar"]).moduleOutputInfo.name, "bar")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "+++.out"]).moduleOutputInfo.name, "main")
+    XCTAssertEqual(try Driver(args: ["swift"]).moduleOutputInfo.name, "REPL")
+    XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-emit-library", "-o", "libBaz.dylib"]).moduleOutputInfo.name, "Baz")
   }
 
   func testOutputFileMapLoading() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -313,23 +313,23 @@ final class SwiftDriverTests: XCTestCase {
 
   func testDebugSettings() throws {
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module") { driver in
-      XCTAssertNil(driver.debugInfoLevel)
-      XCTAssertEqual(driver.debugInfoFormat, .dwarf)
+      XCTAssertNil(driver.debugInfo.level)
+      XCTAssertEqual(driver.debugInfo.format, .dwarf)
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g") { driver in
-      XCTAssertEqual(driver.debugInfoLevel, .astTypes)
-      XCTAssertEqual(driver.debugInfoFormat, .dwarf)
+      XCTAssertEqual(driver.debugInfo.level, .astTypes)
+      XCTAssertEqual(driver.debugInfo.format, .dwarf)
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "-g", "foo.swift", "-gline-tables-only") { driver in
-      XCTAssertEqual(driver.debugInfoLevel, .lineTables)
-      XCTAssertEqual(driver.debugInfoFormat, .dwarf)
+      XCTAssertEqual(driver.debugInfo.level, .lineTables)
+      XCTAssertEqual(driver.debugInfo.format, .dwarf)
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=codeview") { driver in
-      XCTAssertEqual(driver.debugInfoLevel, .astTypes)
-      XCTAssertEqual(driver.debugInfoFormat, .codeView)
+      XCTAssertEqual(driver.debugInfo.level, .astTypes)
+      XCTAssertEqual(driver.debugInfo.format, .codeView)
     }
 
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-debug-info-format=dwarf") {


### PR DESCRIPTION
I noticed that there were groups of properties in the driver that were returned as tuples and then assigned. It seemed natural to group these in structs. 