### PR TITLE
Fix tests to match behaviour when when using specific Swift toolchain.

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1507,6 +1507,10 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testToolchainClangPath() {
+    // Overriding the swift executable to a specific location breaks this.
+    guard ProcessEnv.vars["SWIFT_DRIVER_SWIFT_EXEC"] == nil else {
+      return
+    }
     // TODO: remove this conditional check once DarwinToolchain does not requires xcrun to look for clang.
     var toolchain: Toolchain
     #if os(macOS)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1470,19 +1470,19 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(output,
     """
     digraph Jobs {
-      "compile (swift)" [style=bold];
+      "compile (swiftc)" [style=bold];
       "test.swift" [fontsize=12];
-      "test.swift" -> "compile (swift)" [color=blue];
+      "test.swift" -> "compile (swiftc)" [color=blue];
       "test.o" [fontsize=12];
-      "compile (swift)" -> "test.o" [color=green];
+      "compile (swiftc)" -> "test.o" [color=green];
       "test.swiftmodule" [fontsize=12];
-      "compile (swift)" -> "test.swiftmodule" [color=green];
+      "compile (swiftc)" -> "test.swiftmodule" [color=green];
       "test.swiftdoc" [fontsize=12];
-      "compile (swift)" -> "test.swiftdoc" [color=green];
-      "mergeModule (swift)" [style=bold];
-      "test.swiftmodule" -> "mergeModule (swift)" [color=blue];
-      "mergeModule (swift)" -> "test.swiftmodule" [color=green];
-      "mergeModule (swift)" -> "test.swiftdoc" [color=green];
+      "compile (swiftc)" -> "test.swiftdoc" [color=green];
+      "mergeModule (swiftc)" [style=bold];
+      "test.swiftmodule" -> "mergeModule (swiftc)" [color=blue];
+      "mergeModule (swiftc)" -> "test.swiftmodule" [color=green];
+      "mergeModule (swiftc)" -> "test.swiftdoc" [color=green];
       "link (\(dynamicLinker))" [style=bold];
       "test.o" -> "link (\(dynamicLinker))" [color=blue];
       "test" [fontsize=12];


### PR DESCRIPTION
Having just switched CI to point to a specific (latest master snapshot) swift toolchain, instead of using the system toolchain (discussed in #113 ), a couple of test adjustments were required to get the test suite to pass:

- `testDOTFileEmission` to match latest toolchain's compiler executable name as `swiftc` vs `swift`. 
- `testToolchainClangPath` to skip the checking if the user overloaded swift executable path. 

