### PR TITLE
Remove @testable import from explicit module builds test

### DIFF
--- a/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/InterModuleDependencyGraph.swift
@@ -12,11 +12,11 @@
 import Foundation
 
 
-enum ModuleDependencyId: Hashable {
+public enum ModuleDependencyId: Hashable {
   case swift(String)
   case clang(String)
 
-  var moduleName: String {
+  public var moduleName: String {
     switch self {
       case .swift(let name): return name
       case .clang(let name): return name
@@ -30,7 +30,7 @@ extension ModuleDependencyId: Codable {
     case clang
   }
 
-  init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     do {
       let moduleName =  try container.decode(String.self, forKey: .swift)
@@ -41,7 +41,7 @@ extension ModuleDependencyId: Codable {
     }
   }
 
-  func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     switch self {
       case .swift(let moduleName):
@@ -53,47 +53,47 @@ extension ModuleDependencyId: Codable {
 }
 
 /// Details specific to Swift modules.
-struct SwiftModuleDetails: Codable {
+public struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
-  var moduleInterfacePath: String?
+  public var moduleInterfacePath: String?
 
   /// The bridging header, if any.
-  var bridgingHeaderPath: String?
+  public var bridgingHeaderPath: String?
 
   /// The source files referenced by the bridging header.
-  var bridgingSourceFiles: [String]? = []
+  public var bridgingSourceFiles: [String]? = []
 
   /// Options to the compile command
-  var commandLine: [String]? = []
+  public var commandLine: [String]? = []
 }
 
 /// Details specific to Clang modules.
-struct ClangModuleDetails: Codable {
+public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
-  var moduleMapPath: String
+  public var moduleMapPath: String
 
   /// clang-generated context hash
-  var contextHash: String?
+  public var contextHash: String?
 
   /// Options to the compile command
-  var commandLine: [String]? = []
+  public var commandLine: [String]? = []
 }
 
-struct ModuleInfo: Codable {
+public struct ModuleInfo: Codable {
   /// The path for the module.
-  var modulePath: String
+  public var modulePath: String
 
   /// The source files used to build this module.
-  var sourceFiles: [String] = []
+  public var sourceFiles: [String] = []
 
   /// The set of direct module dependencies of this module.
-  var directDependencies: [ModuleDependencyId] = []
+  public var directDependencies: [ModuleDependencyId] = []
 
   /// Specific details of a particular kind of module.
-  var details: Details
+  public var details: Details
 
   /// Specific details of a particular kind of module.
-  enum Details {
+  public enum Details {
     /// Swift modules may be built from a module interface, and may have
     /// a bridging header.
     case swift(SwiftModuleDetails)
@@ -109,7 +109,7 @@ extension ModuleInfo.Details: Codable {
     case clang
   }
 
-  init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     do {
       let details = try container.decode(SwiftModuleDetails.self, forKey: .swift)
@@ -120,7 +120,7 @@ extension ModuleInfo.Details: Codable {
     }
   }
 
-  func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     switch self {
       case .swift(let details):
@@ -133,13 +133,13 @@ extension ModuleInfo.Details: Codable {
 
 /// Describes the complete set of dependencies for a Swift module, including
 /// all of the Swift and C modules and source files it depends on.
-struct InterModuleDependencyGraph: Codable {
+public struct InterModuleDependencyGraph: Codable {
   /// The name of the main module.
-  var mainModuleName: String
+  public var mainModuleName: String
 
   /// The complete set of modules discovered
-  var modules: [ModuleDependencyId: ModuleInfo] = [:]
+  public var modules: [ModuleDependencyId: ModuleInfo] = [:]
 
   /// Information about the main module.
-  var mainModule: ModuleInfo { modules[.swift(mainModuleName)]! }
+  public var mainModule: ModuleInfo { modules[.swift(mainModuleName)]! }
 }

--- a/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
+++ b/Sources/SwiftDriver/Dependency Scanning/ModuleDependencyBuildGeneration.swift
@@ -16,7 +16,7 @@ import Foundation
 extension Driver {
   /// For the current moduleDependencyGraph, plan the order and generate jobs
   /// for explicitly building all dependency modules.
-  mutating func planExplicitModuleDependenciesCompile(
+  public mutating func planExplicitModuleDependenciesCompile(
     dependencyGraph: InterModuleDependencyGraph
   ) throws -> [Job] {
     var jobs: [Job] = []

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -211,7 +211,7 @@ public struct Driver {
   /// The module dependency graph, which is populated during the planning phase
   /// only when all modules will be prebuilt and treated as explicit by the
   /// various compilation jobs.
-  var interModuleDependencyGraph: InterModuleDependencyGraph? = nil
+  public var interModuleDependencyGraph: InterModuleDependencyGraph? = nil
 
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -11,20 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-@testable import SwiftDriver
+import SwiftDriver
 import TSCBasic
 import XCTest
 
 /// Check that an explicit module build job contains expected inputs and options
 private func checkExplicitModuleBuildJob(job: Job,
-                                         moduleName: String,
-                                         moduleKind: ModuleDependencyId.CodingKeys,
+                                         moduleId: ModuleDependencyId,
                                          moduleDependencyGraph: InterModuleDependencyGraph) throws {
-  var moduleId : ModuleDependencyId
-  switch moduleKind {
-    case .swift: moduleId = .swift(moduleName)
-    case .clang: moduleId = .clang(moduleName)
-  }
   let moduleInfo = moduleDependencyGraph.modules[moduleId]!
   switch moduleInfo.details {
     case .swift(let swiftModuleDetails):
@@ -107,20 +101,16 @@ final class ExplicitModuleBuildTests: XCTestCase {
         XCTAssertEqual(job.outputs.count, 1)
         switch (job.outputs[0].file) {
           case .relative(RelativePath("SwiftShims.pcm")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "SwiftShims",
-                                            moduleKind: ModuleDependencyId.CodingKeys.clang,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("SwiftShims"),
                                             moduleDependencyGraph: moduleDependencyGraph)
           case .relative(RelativePath("c_simd.pcm")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "c_simd",
-                                            moduleKind: ModuleDependencyId.CodingKeys.clang,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("c_simd"),
                                             moduleDependencyGraph: moduleDependencyGraph)
           case .relative(RelativePath("Swift.swiftmodule")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "Swift",
-                                            moduleKind: ModuleDependencyId.CodingKeys.swift,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .swift("Swift"),
                                             moduleDependencyGraph: moduleDependencyGraph)
           case .relative(RelativePath("SwiftOnoneSupport.swiftmodule")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "SwiftOnoneSupport",
-                                            moduleKind: ModuleDependencyId.CodingKeys.swift,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .swift("SwiftOnoneSupport"),
                                             moduleDependencyGraph: moduleDependencyGraph)
           default:
             XCTFail("Unexpected module dependency build job output")
@@ -151,50 +141,39 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-experimental-explicit-module-build",
                                      main.pathString])
       let jobs = try driver.planBuild()
-      XCTAssertTrue(driver.parsedOptions.contains(.driverExplicitModuleBuild))
       let dependencyGraph = driver.interModuleDependencyGraph!
       for job in jobs {
         XCTAssertEqual(job.outputs.count, 1)
         switch (job.outputs[0].file) {
           case .relative(RelativePath("A.swiftmodule")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "A",
-                                            moduleKind: ModuleDependencyId.CodingKeys.swift,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .swift("A"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("E.swiftmodule")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "E",
-                                            moduleKind: ModuleDependencyId.CodingKeys.swift,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .swift("E"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("G.swiftmodule")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "G",
-                                            moduleKind: ModuleDependencyId.CodingKeys.swift,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .swift("G"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("A.pcm")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "A",
-                                            moduleKind: ModuleDependencyId.CodingKeys.clang,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("A"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("B.pcm")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "B",
-                                            moduleKind: ModuleDependencyId.CodingKeys.clang,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("B"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("C.pcm")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "C",
-                                            moduleKind: ModuleDependencyId.CodingKeys.clang,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("C"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("G.pcm")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "G",
-                                            moduleKind: ModuleDependencyId.CodingKeys.clang,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("G"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("Swift.swiftmodule")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "Swift",
-                                            moduleKind: ModuleDependencyId.CodingKeys.swift,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .swift("Swift"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("SwiftOnoneSupport.swiftmodule")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "SwiftOnoneSupport",
-                                            moduleKind: ModuleDependencyId.CodingKeys.swift,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .swift("SwiftOnoneSupport"),
                                             moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("SwiftShims.pcm")):
-            try checkExplicitModuleBuildJob(job: job, moduleName: "SwiftShims",
-                                            moduleKind: ModuleDependencyId.CodingKeys.clang,
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("SwiftShims"),
                                             moduleDependencyGraph: dependencyGraph)
           case .temporary(RelativePath("main.o")):
             try checkExplicitModuleBuildJobDependencies(job: job,


### PR DESCRIPTION
`@testable` may make eventual toolchain integration more difficult (because we'd have to build once for testing and again for integrating), so remove it from the one place it's currently used. This requires making the module dependency graph structures public, which IMO is an ok tradeoff.