### PR TITLE
Fix -debug-prefix-map handling

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1079,6 +1079,14 @@ extension Driver {
   private static func computeDebugInfo(_ parsedOptions: inout ParsedOptions, diagnosticsEngine: DiagnosticsEngine) -> DebugInfo {
     var shouldVerify = parsedOptions.hasArgument(.verifyDebugInfo)
 
+    for debugPrefixMap in parsedOptions.arguments(for: .debugPrefixMap) {
+      let value = debugPrefixMap.argument.asSingle
+      let parts = value.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+      if parts.count != 2 {
+        diagnosticsEngine.emit(.error_opt_invalid_mapping(option: debugPrefixMap.option, value: value))
+      }
+    }
+
     // Determine the debug level.
     let level: DebugInfo.Level?
     if let levelOption = parsedOptions.getLast(in: .g), levelOption.option != .gnone {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -168,7 +168,7 @@ extension Driver {
     try commandLine.appendLast(.printEducationalNotes, from: &parsedOptions)
     try commandLine.appendAll(.D, from: &parsedOptions)
     try commandLine.appendAll(.sanitizeEQ, from: &parsedOptions)
-    try commandLine.appendAllArguments(.debugPrefixMap, from: &parsedOptions)
+    try commandLine.appendAll(.debugPrefixMap, from: &parsedOptions)
     try commandLine.appendAllArguments(.Xfrontend, from: &parsedOptions)
 
     if let workingDirectory = workingDirectory {

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -24,6 +24,10 @@ extension Diagnostic.Message {
     .error("option '\(option.spelling)' is missing a required argument (\(requiredArg.spelling))")
   }
 
+  static func error_opt_invalid_mapping(option: Option, value: String) -> Diagnostic.Message {
+    .error("values for '\(option.spelling)' must be in the format original=remapped not '\(value)'")
+  }
+
   static func error_invalid_arg_value(arg: Option, value: String) -> Diagnostic.Message {
     .error("invalid value '\(value)' in '\(arg.spelling)'")
   }


### PR DESCRIPTION
Previously only the values were passed through not the options as well.
This also adds the validation from Driver.cpp that they are correctly
formatted.