### PR TITLE
[Explicit Module Builds] Emit a JSON file that specifies details of explicit Swift module dependencies

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(SwiftDriver
   "Explicit Module Builds/ExplicitModuleBuildHandler.swift"   
   "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
-  "Explicit Module Builds/SwiftModuleArtifacts.swift"
+  "Explicit Module Builds/ModuleArtifacts.swift"
 
   Driver/CompilerMode.swift
   Driver/DebugInfo.swift

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(SwiftDriver
   "Explicit Module Builds/ExplicitModuleBuildHandler.swift"   
   "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
+  "Explicit Module Builds/SwiftModuleArtifacts.swift"
 
   Driver/CompilerMode.swift
   Driver/DebugInfo.swift

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -1,4 +1,4 @@
-//===--------------- ModuleDependencyGraph.swift --------------------------===//
+//===--------------- InterModuleDependencyGraph.swift ---------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleArtifacts.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleArtifacts.swift
@@ -33,3 +33,22 @@ public struct SwiftModuleArtifactInfo: Codable {
     self.sourceInfoPath = sourceInfoPath
   }
 }
+
+/// Describes a given Clang module's pre-built module artifacts:
+/// - Clang Module (name)
+/// - Clang Module (PCM) Path
+/// - Clang Module Map Path
+public struct ClangModuleArtifactInfo {
+  /// The module's name
+  public let moduleName: String
+  /// The path for the module's .pcm file
+  public let modulePath: String
+  /// The path for this module's .modulemap file
+  public let moduleMapPath: String
+
+  init(name: String, modulePath: String, moduleMapPath: String) {
+    self.moduleName = name
+    self.modulePath = modulePath
+    self.moduleMapPath = moduleMapPath
+  }
+}

--- a/Sources/SwiftDriver/Explicit Module Builds/SwiftModuleArtifacts.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/SwiftModuleArtifacts.swift
@@ -1,0 +1,35 @@
+//===--------------- SwiftModuleArtifacts.swift ---------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+/// Describes a given Swift module's pre-built module artifacts:
+/// - Swift Module (name)
+/// - Swift Module Path
+/// - Swift Doc Path
+/// - Swift Source Info Path
+public struct SwiftModuleArtifactInfo: Codable {
+  /// The module's name
+  public let moduleName: String
+  /// The path for the module's .swiftmodule file
+  public let modulePath: String
+  /// The path for the module's .swiftdoc file
+  public let docPath: String?
+  /// The path for the module's .swiftsourceinfo file
+  public let sourceInfoPath: String?
+
+  init(name: String, modulePath: String, docPath: String? = nil, sourceInfoPath: String? = nil) {
+    self.moduleName = name
+    self.modulePath = modulePath
+    self.docPath = docPath
+    self.sourceInfoPath = sourceInfoPath
+  }
+}

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -69,7 +69,9 @@ extension Driver {
          .swiftDocumentation, .swiftInterface,
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
          .objcHeader, .swiftDeps, .remap, .importedModules, .tbd, .moduleTrace,
-         .indexData, .optimizationRecord, .pcm, .pch, .clangModuleMap, .jsonTargetInfo, nil:
+
+         .indexData, .optimizationRecord, .pcm, .pch, .clangModuleMap,
+         .jsonTargetInfo, .jsonSwiftArtifacts, nil:
       return false
     }
   }
@@ -256,7 +258,8 @@ extension FileType {
 
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
-         .optimizationRecord, .swiftInterface, .swiftSourceInfoFile, .clangModuleMap:
+         .optimizationRecord, .swiftInterface, .swiftSourceInfoFile, .clangModuleMap,
+         .jsonSwiftArtifacts:
       fatalError("Output type can never be a primary output")
     }
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -232,7 +232,8 @@ extension Driver {
                                 recordedInputModificationDates: recordedInputModificationDates)
 
     explicitModuleBuildHandler = try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
-                                                                toolchain: toolchain)
+                                                                toolchain: toolchain,
+                                                                fileSystem: fileSystem)
     return try explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
   }
 

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -93,6 +93,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// JSON-based -print-target-info output
   case jsonTargetInfo = "targetInfo.json"
 
+  /// JSON-based binary Swift module artifact description
+  case jsonSwiftArtifacts = "artifacts.json"
+
   /// Module trace file.
   ///
   /// Module traces are used by Apple's internal build infrastructure. Apple
@@ -153,6 +156,9 @@ extension FileType: CustomStringConvertible {
     case .jsonTargetInfo:
       return "json-target-info"
 
+    case .jsonSwiftArtifacts:
+      return "json-module-artifacts"
+
     case .importedModules:
       return "imported-modules"
 
@@ -182,7 +188,8 @@ extension FileType {
          .importedModules, .indexData, .remap, .dSYM, .autolink, .dependencies,
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
          .swiftDeps, .moduleTrace, .tbd, .optimizationRecord, .swiftInterface,
-         .swiftSourceInfoFile, .jsonDependencies, .clangModuleMap, .jsonTargetInfo:
+         .swiftSourceInfoFile, .jsonDependencies, .clangModuleMap, .jsonTargetInfo,
+         .jsonSwiftArtifacts:
       return false
     }
   }
@@ -255,6 +262,8 @@ extension FileType {
       return "json-dependencies"
     case .jsonTargetInfo:
       return "json-target-info"
+    case .jsonSwiftArtifacts:
+      return "json-module-artifacts"
     case .importedModules:
       return "imported-modules"
     case .moduleTrace:
@@ -274,7 +283,8 @@ extension FileType {
     switch self {
     case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
-         .optimizationRecord, .swiftInterface, .jsonDependencies, .clangModuleMap, .jsonTargetInfo:
+         .optimizationRecord, .swiftInterface, .jsonDependencies, .clangModuleMap, .jsonTargetInfo,
+         .jsonSwiftArtifacts:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -293,7 +303,7 @@ extension FileType {
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile,
          .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap, .importedModules,
          .tbd, .moduleTrace, .indexData, .optimizationRecord, .pcm, .pch, .jsonDependencies,
-         .clangModuleMap, .jsonTargetInfo:
+         .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts:
       return false
     }
   }


### PR DESCRIPTION
This PR implements the interface expected by the frontend, as built by @nkcsgexi in:
https://github.com/apple/swift/pull/32355
https://github.com/apple/swift/pull/32450 

Swift module's explicit Swift module dependencies are now encoded in a JSON file, passed with `-explicit-swift-module-map-file`. The key benefit is that now the frontend doesn't need to deserialize the .swiftmodule file just to collect the module's name.

Resolves rdar://problem/64533451