### PR TITLE
Sketch out model for capturing JSON output from jobs

### DIFF
--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -31,6 +31,7 @@ public struct Job: Codable, Equatable, Hashable {
     case verifyDebugInfo = "verify-debug-info"
     case printTargetInfo = "print-target-info"
     case versionRequest = "version-request"
+    case scanDependencies = "scan-dependencies"
     case help
   }
 
@@ -168,6 +169,9 @@ extension Job : CustomStringConvertible {
 
     case .backend:
       return "Embedding bitcode for \(moduleName) \(displayInputs.first?.file.name ?? "")"
+
+    case .scanDependencies:
+      return "Scanning dependencies for module \(moduleName)"
     }
   }
 }
@@ -178,7 +182,7 @@ extension Job.Kind {
     switch self {
     case .backend, .compile, .mergeModule, .emitModule, .generatePCH,
         .generatePCM, .interpret, .repl, .printTargetInfo,
-        .versionRequest:
+        .versionRequest, .scanDependencies:
         return true
 
     case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo:
@@ -194,7 +198,7 @@ extension Job.Kind {
     case .backend, .mergeModule, .emitModule, .generatePCH,
          .generatePCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
-         .help, .link, .verifyDebugInfo:
+         .help, .link, .verifyDebugInfo, .scanDependencies:
       return false
     }
   }


### PR DESCRIPTION
This is an attempt to generalize the dependency scanning operation so we can model it as a `Job`. There's no real benefit at the moment, but I'd like to reuse this pattern to capture `-print-target-info` output for the reasons mentioned in https://github.com/apple/swift-driver/pull/129#pullrequestreview-432926884. I think it could also make delegating the job's execution to a library client easier if that's something we'd eventually like to do.