### PR TITLE
Remove the localFileSystem default argument from ArgsResolver

### DIFF
--- a/Sources/SwiftDriver/Execution/JobExecutor.swift
+++ b/Sources/SwiftDriver/Execution/JobExecutor.swift
@@ -26,7 +26,7 @@ public struct ArgsResolver {
   /// Path to the directory that will contain the temporary files.
   private let temporaryDirectory: AbsolutePath
 
-  public init(fileSystem: FileSystem = localFileSystem) throws {
+  public init(fileSystem: FileSystem) throws {
     self.pathMapping = [:]
     self.fileSystem = fileSystem
     self.temporaryDirectory = try withTemporaryDirectory(removeTreeOnDeinit: false) { path in

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
@@ -20,7 +20,7 @@ extension Driver {
   /// source files.
   mutating func computeModuleDependencyGraph() throws -> InterModuleDependencyGraph? {
     // Grab the swift compiler
-    let resolver = try ArgsResolver()
+    let resolver = try ArgsResolver(fileSystem: self.fileSystem)
     let compilerPath = VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler))
     let tool = try resolver.resolve(.path(compilerPath))
     var inputs: [TypedVirtualPath] = []

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -66,7 +66,7 @@ extension Driver {
       if parsedOptions.contains(.driverPrintModuleDependenciesJobs) {
         let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)
         for job in modulePrebuildJobs {
-          try Self.printJob(job, resolver: try ArgsResolver(),
+          try Self.printJob(job, resolver: try ArgsResolver(fileSystem: self.fileSystem),
                             forceResponseFiles: forceResponseFiles)
         }
       }

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -73,7 +73,7 @@ final class JobExecutorTests: XCTestCase {
 
       let exec = path.appending(component: "main")
 
-      var resolver = try ArgsResolver()
+      var resolver = try ArgsResolver(fileSystem: localFileSystem)
       resolver.pathMapping = [
         .relative(RelativePath("foo.swift")): foo,
         .relative(RelativePath("main.swift")): main,
@@ -181,7 +181,7 @@ final class JobExecutorTests: XCTestCase {
     let delegate = JobCollectingDelegate()
     delegate.useStubProcess = true
     let executor = JobExecutor(
-      jobs: [job], resolver: try ArgsResolver(),
+      jobs: [job], resolver: try ArgsResolver(fileSystem: localFileSystem),
       executorDelegate: delegate,
       diagnosticsEngine: DiagnosticsEngine()
     )
@@ -224,7 +224,7 @@ final class JobExecutorTests: XCTestCase {
       var driver = try Driver(args: ["swift", main.pathString])
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs.count == 1 && jobs[0].requiresInPlaceExecution)
-      let resolver = try ArgsResolver()
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
 
       // Change the file
       try localFileSystem.writeFileContents(main) {
@@ -255,7 +255,7 @@ final class JobExecutorTests: XCTestCase {
       try assertDriverDiagnostics(args: ["swiftc", main.pathString, other.pathString]) {driver, verifier in
         let jobs = try driver.planBuild()
         XCTAssertTrue(jobs.count > 1)
-        let resolver = try ArgsResolver()
+        let resolver = try ArgsResolver(fileSystem: localFileSystem)
 
         // Change the file
         try localFileSystem.writeFileContents(other) {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -655,7 +655,7 @@ final class SwiftDriverTests: XCTestCase {
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs.count == 1 && jobs[0].kind == .interpret)
       let interpretJob = jobs[0]
-      let resolver = try ArgsResolver()
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob, forceResponseFiles: false)
       XCTAssertTrue(resolvedArgs.count == 2)
       XCTAssertEqual(resolvedArgs[1].first, "@")
@@ -671,7 +671,7 @@ final class SwiftDriverTests: XCTestCase {
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs.count == 1 && jobs[0].kind == .interpret)
       let interpretJob = jobs[0]
-      let resolver = try ArgsResolver()
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob, forceResponseFiles: true)
       XCTAssertTrue(resolvedArgs.count == 2)
       XCTAssertEqual(resolvedArgs[1].first, "@")
@@ -686,7 +686,7 @@ final class SwiftDriverTests: XCTestCase {
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs.count == 1 && jobs[0].kind == .interpret)
       let interpretJob = jobs[0]
-      let resolver = try ArgsResolver()
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob, forceResponseFiles: false)
       XCTAssertFalse(resolvedArgs.map { $0.hasPrefix("@") }.reduce(false){ $0 || $1 })
     }


### PR DESCRIPTION
I noticed the default argument was accidentally being used in a couple places and IMO it's not obvious the resolver holds a FileSystem, so this change drops it and passes the localFileSystem explicitly in tests.