### PR TITLE
Add missing output file map error

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -52,6 +52,7 @@ do {
   exit(EXIT_FAILURE)
 } catch let diagnosticData as DiagnosticData {
   diagnosticsEngine.emit(.error(diagnosticData))
+  exit(EXIT_FAILURE)
 } catch {
   print("error: \(error)")
   exit(EXIT_FAILURE)


### PR DESCRIPTION
- Add an error message matching the c++ driver for missing/malformed output file maps
- add a missing exit(EXIT_FAILURE) to main.swift (pretty sure it's my fault that was missing)

Fixes: Driver/warnings_control and Driver/missing-ofm