### PR TITLE
Replace "-" into "_" when figuring out SWIFT_DRIVER_*_EXEC names.

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -114,7 +114,10 @@ extension Toolchain {
 
   /// - Returns: String in the form of: `SWIFT_DRIVER_TOOLNAME_EXEC`
   private func envVarName(for toolName: String) -> String {
-    return "SWIFT_DRIVER_\(toolName.uppercased())_EXEC"
+    let lookupName = toolName
+      .replacingOccurrences(of: "-", with: "_")
+      .uppercased()
+    return "SWIFT_DRIVER_\(lookupName)_EXEC"
   }
 
   /// Use this property only for testing purposes, for example,
@@ -158,6 +161,6 @@ extension Toolchain {
   }
 }
 
-fileprivate enum ToolchainError: Swift.Error {
+public enum ToolchainError: Swift.Error {
   case unableToFind(tool: String)
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2371,6 +2371,13 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssert(plannedJobs[0].commandLine.contains(subsequence: [.flag("-vfsoverlay"), .path(.relative(RelativePath("overlay1.yaml"))), .flag("-vfsoverlay"), .path(.relative(RelativePath("overlay2.yaml"))), .flag("-vfsoverlay"), .path(.relative(RelativePath("overlay3.yaml")))]))
     }
   }
+
+  func testSwiftHelpOverride() throws {
+    var driver = try Driver(args: ["swiftc", "-help"], env: ["SWIFT_DRIVER_SWIFT_HELP_EXEC" : "/usr/bin/nonexistent-swift-help"])
+    let jobs = try driver.planBuild()
+    XCTAssert(jobs.count == 1)
+    XCTAssertEqual(jobs.first!.tool.name, "/usr/bin/nonexistent-swift-help")
+  }
 }
 
 func assertString(

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2373,7 +2373,12 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testSwiftHelpOverride() throws {
-    var driver = try Driver(args: ["swiftc", "-help"], env: ["SWIFT_DRIVER_SWIFT_HELP_EXEC" : "/usr/bin/nonexistent-swift-help"])
+    var driver = try Driver(
+      args: ["swiftc", "-help"],
+      env: [
+        "SWIFT_DRIVER_SWIFT_HELP_EXEC" : "/usr/bin/nonexistent-swift-help",
+        "SWIFT_DRIVER_CLANG_EXEC" : "/usr/bin/clang"
+      ])
     let jobs = try driver.planBuild()
     XCTAssert(jobs.count == 1)
     XCTAssertEqual(jobs.first!.tool.name, "/usr/bin/nonexistent-swift-help")

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2373,6 +2373,9 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testSwiftHelpOverride() throws {
+    // FIXME: On Linux, we might not have any Clang in the path. We need a
+    // better override.
+    #if os(macOS)
     var driver = try Driver(
       args: ["swiftc", "-help"],
       env: [
@@ -2382,6 +2385,7 @@ final class SwiftDriverTests: XCTestCase {
     let jobs = try driver.planBuild()
     XCTAssert(jobs.count == 1)
     XCTAssertEqual(jobs.first!.tool.name, "/usr/bin/nonexistent-swift-help")
+    #endif
   }
 }
 


### PR DESCRIPTION
Some of Swift-related executables (like swift-help) have hyphens in the
name, which does not translate well into an environment name for overriding
executables (e.g., `SWIFT_DRIVER_SWIFT-HELP_EXEC`). Replace hyphens
with underscores to make the names usable.