### PR TITLE
Use swift-frontend as the Swift frontend executable.

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -43,7 +43,7 @@ public final class DarwinToolchain: Toolchain {
   private func lookupToolPath(_ tool: Tool) throws -> AbsolutePath {
     switch tool {
     case .swiftCompiler:
-      return try lookup(executable: "swift")
+      return try lookup(executable: "swift-frontend")
 
     case .dynamicLinker:
       return try lookup(executable: "ld")

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -49,7 +49,7 @@ public final class GenericUnixToolchain: Toolchain {
   private func lookupToolPath(_ tool: Tool) throws -> AbsolutePath {
     switch tool {
     case .swiftCompiler:
-      return try lookup(executable: "swift")
+      return try lookup(executable: "swift-frontend")
     case .staticLinker:
       return try lookup(executable: "ar")
     case .dynamicLinker:

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -140,6 +140,9 @@ extension Toolchain {
       return path
     } else if let path = lookupExecutablePath(filename: executable, searchPaths: searchPaths) {
       return path
+    } else if executable == "swift-frontend" {
+      // Temporary shim: fall back to looking for "swift" before failing.
+      return try lookup(executable: "swift")
     } else if fallbackToExecutableDefaultPath {
       return AbsolutePath("/usr/bin/" + executable)
     } else {


### PR DESCRIPTION
Look for the swift-frontend executable for the Swift frontend, rather
than the "swift" executable. If there is no swift-frontend, fall back
to "swift".

The Swift compiler recently changed to make the primary (non-symlink)
executable "swift-frontend", although it contains both the driver and
the frontend logic. In this new scheme, "swift" and "swiftc" are
symlinks to swift-frontend (to use the existing C++ driver), but can
be replaced with symlinks to "swift-driver" to use this new driver.
This allows a much simpler drop-in replacement strategy.