### PR TITLE
Use the Swift frontend to determine the host target triple.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -30,6 +30,7 @@ public struct Driver {
     case missingPCMArguments(String)
     case missingModuleDependency(String)
     case dependencyScanningFailure(Int, String)
+    case malformedSwiftTargetInfo(String)
 
     public var description: String {
       switch self {
@@ -59,6 +60,8 @@ public struct Driver {
         return "Module Dependency Scanner returned with non-zero exit status: \(code), \(error)"
       case .unableToLoadOutputFileMap(let path):
         return "unable to load output file map '\(path)': no such file or directory"
+      case .malformedSwiftTargetInfo(let string):
+        return "malformed swift -print-target-info result: '\(string)'"
       }
     }
   }

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -176,6 +176,17 @@ public struct Triple {
   }
 }
 
+extension Triple: Codable {
+  public init(from decoder: Decoder) throws {
+    self.init(try decoder.singleValueContainer().decode(String.self))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(triple)
+  }
+}
+
 // MARK: - Triple component parsing
 
 fileprivate protocol TripleComponent {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1582,19 +1582,19 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(output,
     """
     digraph Jobs {
-      "compile (swift)" [style=bold];
+      "compile (swiftc)" [style=bold];
       "test.swift" [fontsize=12];
-      "test.swift" -> "compile (swift)" [color=blue];
+      "test.swift" -> "compile (swiftc)" [color=blue];
       "test.o" [fontsize=12];
-      "compile (swift)" -> "test.o" [color=green];
+      "compile (swiftc)" -> "test.o" [color=green];
       "test.swiftmodule" [fontsize=12];
-      "compile (swift)" -> "test.swiftmodule" [color=green];
+      "compile (swiftc)" -> "test.swiftmodule" [color=green];
       "test.swiftdoc" [fontsize=12];
-      "compile (swift)" -> "test.swiftdoc" [color=green];
-      "mergeModule (swift)" [style=bold];
-      "test.swiftmodule" -> "mergeModule (swift)" [color=blue];
-      "mergeModule (swift)" -> "test.swiftmodule" [color=green];
-      "mergeModule (swift)" -> "test.swiftdoc" [color=green];
+      "compile (swiftc)" -> "test.swiftdoc" [color=green];
+      "mergeModule (swiftc)" [style=bold];
+      "test.swiftmodule" -> "mergeModule (swiftc)" [color=blue];
+      "mergeModule (swiftc)" -> "test.swiftmodule" [color=green];
+      "mergeModule (swiftc)" -> "test.swiftdoc" [color=green];
       "link (\(dynamicLinker))" [style=bold];
       "test.o" -> "link (\(dynamicLinker))" [color=blue];
       "test" [fontsize=12];

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1406,7 +1406,7 @@ final class SwiftDriverTests: XCTestCase {
 
     let expectedDefaultContents: String
     #if os(macOS)
-    expectedDefaultContents = "x86_64-apple-darwin"
+    expectedDefaultContents = "x86_64-apple-"
     #elseif os(Linux)
     expectedDefaultContents = "-unknown-linux"
     #else
@@ -1582,19 +1582,19 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(output,
     """
     digraph Jobs {
-      "compile (swiftc)" [style=bold];
+      "compile (swift)" [style=bold];
       "test.swift" [fontsize=12];
-      "test.swift" -> "compile (swiftc)" [color=blue];
+      "test.swift" -> "compile (swift)" [color=blue];
       "test.o" [fontsize=12];
-      "compile (swiftc)" -> "test.o" [color=green];
+      "compile (swift)" -> "test.o" [color=green];
       "test.swiftmodule" [fontsize=12];
-      "compile (swiftc)" -> "test.swiftmodule" [color=green];
+      "compile (swift)" -> "test.swiftmodule" [color=green];
       "test.swiftdoc" [fontsize=12];
-      "compile (swiftc)" -> "test.swiftdoc" [color=green];
-      "mergeModule (swiftc)" [style=bold];
-      "test.swiftmodule" -> "mergeModule (swiftc)" [color=blue];
-      "mergeModule (swiftc)" -> "test.swiftmodule" [color=green];
-      "mergeModule (swiftc)" -> "test.swiftdoc" [color=green];
+      "compile (swift)" -> "test.swiftdoc" [color=green];
+      "mergeModule (swift)" [style=bold];
+      "test.swiftmodule" -> "mergeModule (swift)" [color=blue];
+      "mergeModule (swift)" -> "test.swiftmodule" [color=green];
+      "mergeModule (swift)" -> "test.swiftdoc" [color=green];
       "link (\(dynamicLinker))" [style=bold];
       "test.o" -> "link (\(dynamicLinker))" [color=blue];
       "test" [fontsize=12];
@@ -2375,17 +2375,12 @@ final class SwiftDriverTests: XCTestCase {
   func testSwiftHelpOverride() throws {
     // FIXME: On Linux, we might not have any Clang in the path. We need a
     // better override.
-    #if os(macOS)
-    var driver = try Driver(
-      args: ["swiftc", "-help"],
-      env: [
-        "SWIFT_DRIVER_SWIFT_HELP_EXEC" : "/usr/bin/nonexistent-swift-help",
-        "SWIFT_DRIVER_CLANG_EXEC" : "/usr/bin/clang"
-      ])
+    var env = ProcessEnv.vars
+    env["SWIFT_DRIVER_SWIFT_HELP_EXEC"] = "/usr/bin/nonexistent-swift-help"
+    var driver = try Driver(args: ["swiftc", "-help"], env: env)
     let jobs = try driver.planBuild()
     XCTAssert(jobs.count == 1)
     XCTAssertEqual(jobs.first!.tool.name, "/usr/bin/nonexistent-swift-help")
-    #endif
   }
 }
 


### PR DESCRIPTION
Introduce a utility function to invoke the Swift frontend with
its `-print-target-info` option and parse the resulting JSON, which
provides information about the target of the compile that will be
useful to the driver.

For now, use this to retrieve the host target triple when no triple
was supplied. This is more consistent than going through Clang to
retrieve this information, and we'll be using more of this info soon.