### PR TITLE
Use the frontend's -print-target-info more often

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -196,8 +196,7 @@ extension DarwinToolchain {
     outputFile: VirtualPath,
     sdkPath: String?,
     sanitizers: Set<Sanitizer>,
-    targetTriple: Triple,
-    targetVariantTriple: Triple?
+    targetInfo: FrontendTargetInfo
   ) throws -> AbsolutePath {
 
     // FIXME: If we used Clang as a linker instead of going straight to ld,
@@ -209,6 +208,7 @@ extension DarwinToolchain {
     //
     // Note: Normally we'd just add this unconditionally, but it's valid to build
     // Swift and use it as a linker without building compiler_rt.
+    let targetTriple = targetInfo.target.triple
     let darwinPlatformSuffix =
         targetTriple.darwinPlatform!.with(.device)!.libraryNameSuffix
     let compilerRTPath =
@@ -258,7 +258,7 @@ extension DarwinToolchain {
         to: &commandLine,
         parsedOptions: &parsedOptions,
         sdkPath: sdkPath,
-        targetTriple: targetTriple,
+        targetInfo: targetInfo,
         linkerOutputType: linkerOutputType,
         fileSystem: fileSystem
       )
@@ -280,6 +280,7 @@ extension DarwinToolchain {
       parsedOptions: &parsedOptions,
       targetTriple: targetTriple
     )
+    let targetVariantTriple = targetInfo.targetVariant?.triple
     addDeploymentTargetArgs(
       to: &commandLine,
       targetTriple: targetTriple,

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -51,9 +51,9 @@ extension GenericUnixToolchain {
     outputFile: VirtualPath,
     sdkPath: String?,
     sanitizers: Set<Sanitizer>,
-    targetTriple: Triple,
-    targetVariantTriple: Triple?
+    targetInfo: FrontendTargetInfo
   ) throws -> AbsolutePath {
+    let targetTriple = targetInfo.target.triple
     switch linkerOutputType {
     case .dynamicLibrary:
       // Same options as an executable, just with '-shared'

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -47,8 +47,7 @@ extension Driver {
       outputFile: outputFile,
       sdkPath: sdkPath,
       sanitizers: enabledSanitizers,
-      targetTriple: targetTriple,
-      targetVariantTriple: targetVariantTriple
+      targetInfo: frontendTargetInfo
     )
 
     // TODO: some, but not all, linkers support response files.

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -51,7 +51,7 @@ extension SwiftVersion: Codable {
 }
 
 /// Describes information about the target as provided by the Swift frontend.
-struct FrontendTargetInfo: Codable {
+public struct FrontendTargetInfo: Codable {
   struct Target: Codable {
     /// The target triple
     let triple: Triple
@@ -64,7 +64,7 @@ struct FrontendTargetInfo: Codable {
 
     /// The version of the Swift runtime that is present in the runtime
     /// environment of the target.
-    let swiftRuntimeCompatibilityVersion: SwiftVersion?
+    var swiftRuntimeCompatibilityVersion: SwiftVersion?
 
     /// Whether the Swift libraries need to be referenced in their system
     /// location (/usr/lib/swift) via rpath .
@@ -77,8 +77,9 @@ struct FrontendTargetInfo: Codable {
     let runtimeResourcePath: String
   }
 
-  let target: Target
-  let targetVariant: Target?
+  var target: Target
+  var targetVariant: Target?
+  let paths: Paths
 }
 
 extension Toolchain {

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -67,7 +67,7 @@ public struct FrontendTargetInfo: Codable {
     var swiftRuntimeCompatibilityVersion: SwiftVersion?
 
     /// Whether the Swift libraries need to be referenced in their system
-    /// location (/usr/lib/swift) via rpath .
+    /// location (/usr/lib/swift) via rpath.
     let librariesRequireRPath: Bool
   }
 

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -10,6 +10,32 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Describes information about the target as provided by the Swift frontend.
+struct FrontendTargetInfo: Codable {
+  struct Target: Codable {
+    /// The target triple
+    let triple: Triple
+
+    /// The target triple without any version information.
+    let unversionedTriple: Triple
+
+    /// The triple used for module names.
+    let moduleTriple: Triple
+
+    /// Whether the Swift libraries need to be referenced in their system
+    /// location (/usr/lib/swift) via rpath .
+    let librariesRequireRPath: Bool
+  }
+
+  struct Paths: Codable {
+    let runtimeLibraryPaths: [String]
+    let runtimeLibraryImportPaths: [String]
+    let runtimeResourcePath: String
+  }
+
+  let target: Target
+  let targetVariant: Target?
+}
 
 extension Toolchain {
   func printTargetInfoJob(target: Triple?,

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -121,82 +121,26 @@ extension Toolchain {
 // MARK: - Common argument routines
 
 extension DarwinToolchain {
-  func getSwiftRuntimeCompatibilityVersion(for targetTriple: Triple) -> (Int, Int)? {
-    // FIXME: Add arm64e to Triple.swift
-    if targetTriple.archName == "arm64e" {
-      return (5, 3)
-    }
-
-    if targetTriple.isMacOSX {
-      let macOSVersion = targetTriple.version(for: .macOS)
-      switch (macOSVersion.major, macOSVersion.minor, macOSVersion.micro) {
-      case (10, ...14, _):
-        return (5, 0)
-      case (10, ...15, ...3):
-        return (5, 1)
-      case (10, ...15, _):
-        return (5, 2)
-      default:
-        break
-      }
-    } else if targetTriple.isiOS { // includes tvOS
-      let iOSVersion = targetTriple.version(for: .iOS(.device))
-      switch (iOSVersion.major, iOSVersion.minor, iOSVersion.micro) {
-      case (...12, _, _):
-        return (5, 0)
-      case (13, ...3, _):
-        return (5, 1)
-      case (13, _, _):
-        return (5, 2)
-      default:
-        break
-      }
-    } else if targetTriple.isWatchOS {
-      let watchOSVersion = targetTriple.version(for: .watchOS(.device))
-      switch (watchOSVersion.major, watchOSVersion.minor, watchOSVersion.micro) {
-      case (...5, _, _):
-        return (5, 0)
-      case (6, ...1, _):
-        return (5, 1)
-      case (6, _, _):
-        return (5, 2)
-      default:
-        break
-      }
-    }
-    return nil
-  }
-
   func addArgsToLinkStdlib(
     to commandLine: inout [Job.ArgTemplate],
     parsedOptions: inout ParsedOptions,
     sdkPath: String?,
-    targetTriple: Triple,
+    targetInfo: FrontendTargetInfo,
     linkerOutputType: LinkOutputType,
     fileSystem: FileSystem
   ) throws {
+    let targetTriple = targetInfo.target.triple
+
     // Link compatibility libraries, if we're deploying back to OSes that
     // have an older Swift runtime.
-    var runtimeCompatibilityVersion: (Int, Int)? = nil
+    let runtimeCompatibilityVersion: (Int, Int)? =
+          targetInfo.target.swiftRuntimeCompatibilityVersion.map {
+            ($0.major, $0.minor)
+          }
+
     let resourceDirPath = try computeResourceDirPath(for: targetTriple,
                                                      parsedOptions: &parsedOptions,
                                                      isShared: true)
-    if let version = parsedOptions.getLastArgument(.runtimeCompatibilityVersion)?.asSingle {
-      switch version {
-      case "5.0":
-        runtimeCompatibilityVersion = (5, 0)
-      case "5.1":
-        runtimeCompatibilityVersion = (5, 1)
-      case "none":
-        runtimeCompatibilityVersion = nil
-      default:
-        // TODO: diagnose unknown runtime compatibility version?
-        break
-      }
-    } else if linkerOutputType == .executable {
-      runtimeCompatibilityVersion = getSwiftRuntimeCompatibilityVersion(for: targetTriple)
-    }
-
     func addArgsForBackDeployLib(_ libName: String) {
       let backDeployLibPath = resourceDirPath.appending(component: libName)
       if fileSystem.exists(backDeployLibPath) {

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -181,7 +181,7 @@ extension DarwinToolchain {
 
     let rpaths = StdlibRpathRule(
       parsedOptions: &parsedOptions,
-      targetTriple: targetTriple
+      targetInfo: targetInfo
     )
     for path in rpaths.paths(runtimeLibraryPaths: runtimePaths) {
       commandLine.appendFlag("-rpath")
@@ -203,8 +203,8 @@ extension DarwinToolchain {
     /// Do not add any rpaths at all.
     case none
 
-    /// Determines the appropriate rule for the
-    init(parsedOptions: inout ParsedOptions, targetTriple: Triple) {
+    /// Determines the appropriate rule for the given set of options.
+    init(parsedOptions: inout ParsedOptions, targetInfo: FrontendTargetInfo) {
       if parsedOptions.hasFlag(
         positive: .toolchainStdlibRpath,
         negative: .noToolchainStdlibRpath,
@@ -219,7 +219,7 @@ extension DarwinToolchain {
         // stdlibs will be able to link to the stdlib bundled in that toolchain.
         self = .toolchain
       }
-      else if targetTriple.supports(.swiftInTheOS) ||
+      else if !targetInfo.target.librariesRequireRPath ||
         parsedOptions.hasArgument(.noStdlibRpath) {
         // If targeting an OS with Swift in /usr/lib/swift, the LC_ID_DYLIB
         // install_name the stdlib will be an absolute path like

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -25,33 +25,6 @@ public enum Tool {
   case swiftHelp
 }
 
-/// Describes information about the target as provided by the Swift frontend.
-struct FrontendTargetInfo: Codable {
-  struct Target: Codable {
-    /// The target triple
-    let triple: Triple
-
-    /// The target triple without any version information.
-    let unversionedTriple: Triple
-
-    /// The triple used for module names.
-    let moduleTriple: Triple
-
-    /// Whether the Swift libraries need to be referenced in their system
-    /// location (/usr/lib/swift) via rpath .
-    let librariesRequireRPath: Bool
-  }
-
-  struct Paths: Codable {
-    let runtimeLibraryPaths: [String]
-    let runtimeLibraryImportPaths: [String]
-    let runtimeResourcePath: String
-  }
-
-  let target: Target
-  let targetVariant: Target?
-}
-
 /// Describes a toolchain, which includes information about compilers, linkers
 /// and other tools required to build Swift code.
 public protocol Toolchain {

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -118,21 +118,6 @@ extension Toolchain {
     ).split(separator: "\n").first.map(String.init) ?? ""
   }
 
-  /// Retrieve information about the target from
-  func getFrontendTargetInfo(target: Triple?, targetVariant: Triple?) throws -> FrontendTargetInfo {
-    // Print information for the given target.
-    return try executor.execute(job: printTargetInfoJob(target: target, targetVariant: targetVariant),
-                                capturingJSONOutputAs: FrontendTargetInfo.self,
-                                forceResponseFiles: false,
-                                recordedInputModificationDates: [:])
-  }
-
-  /// Returns the target triple string for the current host.
-  public func hostTargetTriple() throws -> Triple {
-    return try getFrontendTargetInfo(target: nil, targetVariant: nil)
-      .target.triple
-  }
-
   /// Returns the `executablePath`'s directory.
   public var executableDir: AbsolutePath {
     guard let path = Bundle.main.executablePath else {

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -62,8 +62,7 @@ public protocol Toolchain {
     outputFile: VirtualPath,
     sdkPath: String?,
     sanitizers: Set<Sanitizer>,
-    targetTriple: Triple,
-    targetVariantTriple: Triple?
+    targetInfo: FrontendTargetInfo
   ) throws -> AbsolutePath
 
   func runtimeLibraryName(

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -321,17 +321,6 @@ extension Triple {
 }
 
 extension Triple.FeatureAvailability {
-  /// A Swift runtime is guaranteed to be available at `/usr/lib/swift` in triples
-  /// supporting this feature. More specifically, there is no need to include a
-  /// `/usr/lib/swift` rpath if this feature is supported.
-  static let swiftInTheOS = Self(
-    // macOS 10.14.4 contains a copy of Swift, but the linker will still use an
-    // rpath-based install name until 10.15.
-    macOS: Triple.Version(10, 15, 0),
-    iOS: Triple.Version(12, 2, 0),
-    watchOS: Triple.Version(5, 2, 0)
-  )
-
   /// Linking `libarclite` is unnecessary for triples supporting this feature.
   static let compatibleObjCRuntime = Self(
     macOS: Triple.Version(10, 11, 0),

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1417,10 +1417,12 @@ final class SwiftDriverTests: XCTestCase {
               "Default triple \(driver1.targetTriple) contains \(expectedDefaultContents)")
 
     let driver2 = try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-watchos12", "foo.swift", "-module-name", "Foo"])
-    XCTAssertEqual(driver2.targetTriple.triple, "x86_64-apple-watchos12")
+    XCTAssertEqual(
+      driver2.targetTriple.triple, "x86_64-apple-watchos12-simulator")
 
     let driver3 = try Driver(args: ["swiftc", "-c", "-target", "x86_64-watchos12", "foo.swift", "-module-name", "Foo"])
-    XCTAssertEqual(driver3.targetTriple.triple, "x86_64-unknown-watchos12")
+    XCTAssertEqual(
+      driver3.targetTriple.triple, "x86_64-unknown-watchos12-simulator")
   }
 
   func testTargetVariant() throws {


### PR DESCRIPTION
The Swift frontend provides a wealth of information about target triples, runtime compatibility, paths, and so on via its `-print-target-info`. Query `-print-target-info` and use it for several things:
* Canonicalizing target triples
* Determining the version of the Swift runtime that's guaranteed to be available for a given target triple
* Determining when to link against the OS-provided Swift standard library via rpaths.