### PR TITLE
Fix tests to match behaviour expected with newest toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ ln -s /path/to/built/swift-driver $SOME_PATH/swift
 ln -s /path/to/built/swift-driver $SOME_PATH/swiftc
 ```
 
-Swift packages can be built with the new Swift driver by overriding `SWIFT_EXEC` to refer to the `swiftc` symbolic link created above and `SWIFT_DRIVER_SWIFT_EXEC` to refer to the original `swiftc`, e.g.,
+Swift packages can be built with the new Swift driver by overriding `SWIFT_EXEC` to refer to the `swiftc` symbolic link created above and `SWIFT_DRIVER_SWIFT_FRONTEND_EXEC` to refer to the original `swift-frontend`, e.g.,
 
 ```
-SWIFT_EXEC=$SOME_PATH/swiftc SWIFT_DRIVER_SWIFT_EXEC=$TOOLCHAIN_PATH/bin/swiftc swift build
+SWIFT_EXEC=$SOME_PATH/swiftc SWIFT_DRIVER_SWIFT_FRONTEND_EXEC=$TOOLCHAIN_PATH/bin/swift-frontend swift build
 ```
 
 Similarly, one can use the new Swift driver within Xcode by adding a custom build setting (usually at the project level) named `SWIFT_EXEC` that refers to `$SOME_PATH/swiftc` and adding `-driver-use-frontend-path $TOOLCHAIN_DIR/usr/bin/swiftc` to `Other Swift Flags`.

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -192,7 +192,7 @@ final class JobExecutorTests: XCTestCase {
 
   func testSwiftDriverExecOverride() throws {
     var env = ProcessEnv.vars
-    let envVarName = "SWIFT_DRIVER_SWIFT_EXEC"
+    let envVarName = "SWIFT_DRIVER_SWIFT_FRONTEND_EXEC"
     let dummyPath = "/some/garbage/path/fnord"
     let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
                                            processSet: ProcessSet(),
@@ -202,7 +202,7 @@ final class JobExecutorTests: XCTestCase {
     // DarwinToolchain
     env.removeValue(forKey: envVarName)
     let normalSwiftPath = try DarwinToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
-    XCTAssertEqual(normalSwiftPath.basenameWithoutExt, "swift")
+    XCTAssertEqual(normalSwiftPath.basenameWithoutExt, "swift-frontend")
 
     env[envVarName] = dummyPath
     let overriddenSwiftPath = try DarwinToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
@@ -211,7 +211,7 @@ final class JobExecutorTests: XCTestCase {
     // GenericUnixToolchain
     env.removeValue(forKey: envVarName)
     let unixSwiftPath = try GenericUnixToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
-    XCTAssertEqual(unixSwiftPath.basenameWithoutExt, "swift")
+    XCTAssertEqual(unixSwiftPath.basenameWithoutExt, "swift-frontend")
 
     env[envVarName] = dummyPath
     let unixOverriddenSwiftPath = try GenericUnixToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1584,19 +1584,19 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(output,
     """
     digraph Jobs {
-      "compile (swiftc)" [style=bold];
+      "compile (swift-frontend)" [style=bold];
       "test.swift" [fontsize=12];
-      "test.swift" -> "compile (swiftc)" [color=blue];
+      "test.swift" -> "compile (swift-frontend)" [color=blue];
       "test.o" [fontsize=12];
-      "compile (swiftc)" -> "test.o" [color=green];
+      "compile (swift-frontend)" -> "test.o" [color=green];
       "test.swiftmodule" [fontsize=12];
-      "compile (swiftc)" -> "test.swiftmodule" [color=green];
+      "compile (swift-frontend)" -> "test.swiftmodule" [color=green];
       "test.swiftdoc" [fontsize=12];
-      "compile (swiftc)" -> "test.swiftdoc" [color=green];
-      "mergeModule (swiftc)" [style=bold];
-      "test.swiftmodule" -> "mergeModule (swiftc)" [color=blue];
-      "mergeModule (swiftc)" -> "test.swiftmodule" [color=green];
-      "mergeModule (swiftc)" -> "test.swiftdoc" [color=green];
+      "compile (swift-frontend)" -> "test.swiftdoc" [color=green];
+      "mergeModule (swift-frontend)" [style=bold];
+      "test.swiftmodule" -> "mergeModule (swift-frontend)" [color=blue];
+      "mergeModule (swift-frontend)" -> "test.swiftmodule" [color=green];
+      "mergeModule (swift-frontend)" -> "test.swiftdoc" [color=green];
       "link (\(dynamicLinker))" [style=bold];
       "test.o" -> "link (\(dynamicLinker))" [color=blue];
       "test" [fontsize=12];


### PR DESCRIPTION
Newest toolchains contain the swift --> swift-frontend rename so a couple of tests needed fixing up.