### PR TITLE
Delegate job printing to the DriverExecutor since it involves argument resolution

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -647,10 +647,7 @@ extension Driver {
     // If we're only supposed to print the jobs, do so now.
     if parsedOptions.contains(.driverPrintJobs) {
       for job in jobs {
-        // FIXME: We shouldn't be constructing an ArgsResolver here.
-        try Self.printJob(job,
-                          resolver: try ArgsResolver(fileSystem: fileSystem),
-                          forceResponseFiles: forceResponseFiles)
+        print(try executor.description(of: job, forceResponseFiles: forceResponseFiles))
       }
       return
     }
@@ -704,24 +701,6 @@ extension Driver {
     }
 
     return ToolExecutionDelegate(mode: mode)
-  }
-
-  public static func printJob(_ job: Job, resolver: ArgsResolver, forceResponseFiles: Bool) throws {
-    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, forceResponseFiles: forceResponseFiles)
-    var result = args.joined(separator: " ")
-
-    if usedResponseFile {
-      // Print the response file arguments as a comment.
-      result += " # \(job.commandLine.joinedArguments)"
-    }
-
-    if !job.extraEnvironment.isEmpty {
-      result += " #"
-      for (envVar, val) in job.extraEnvironment {
-        result += " \(envVar)=\(val)"
-      }
-    }
-    print(result)
   }
 
   private func printBindings(_ job: Job) {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -66,8 +66,7 @@ extension Driver {
       if parsedOptions.contains(.driverPrintModuleDependenciesJobs) {
         let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)
         for job in modulePrebuildJobs {
-          try Self.printJob(job, resolver: try ArgsResolver(fileSystem: self.fileSystem),
-                            forceResponseFiles: forceResponseFiles)
+          print(try executor.description(of: job, forceResponseFiles: forceResponseFiles))
         }
       }
     }


### PR DESCRIPTION
This gets rid of the last two ArgsResolvers outside of the executor