### PR TITLE
Drop the executor default argument value in Driver's init

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -232,16 +232,13 @@ public struct Driver {
     env: [String: String] = ProcessEnv.vars,
     diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
     fileSystem: FileSystem = localFileSystem,
-    executor: DriverExecutor? = nil
+    executor: DriverExecutor
   ) throws {
     self.env = env
     self.fileSystem = fileSystem
 
     self.diagnosticEngine = diagnosticsEngine
-    self.executor = try executor ?? SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
-                                                        processSet: ProcessSet(),
-                                                        fileSystem: fileSystem,
-                                                        env: env)
+    self.executor = executor
 
     if case .subcommand = try Self.invocationRunMode(forArgs: args).mode {
       throw Error.subcommandPassedToDriver

--- a/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
+++ b/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
@@ -1,0 +1,34 @@
+//===-------- DriverExtensions.swift - Driver Testing Extensions ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDriver
+import TSCBasic
+
+extension Driver {
+  /// Initializer which creates an executor suitable for use in tests.
+  init(
+    args: [String],
+    env: [String: String] = ProcessEnv.vars,
+    diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
+    fileSystem: FileSystem = localFileSystem
+  ) throws {
+    let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
+                                       processSet: ProcessSet(),
+                                       fileSystem: fileSystem,
+                                       env: env)
+    try self.init(args: args,
+                  env: env,
+                  diagnosticsEngine: diagnosticsEngine,
+                  fileSystem: fileSystem,
+                  executor: executor)
+  }
+}


### PR DESCRIPTION
We shouldn't merge this until SPM stops relying on it (https://github.com/apple/swift-package-manager/pull/2798).