### PR TITLE
[Explicit Modules] Use @_spi for types exposed only for testing

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -191,7 +191,7 @@ public struct Driver {
   /// Handler for constructing module build jobs using Explicit Module Builds.
   /// Constructed during the planning phase only when all modules will be prebuilt and treated
   /// as explicit by the various compilation jobs.
-  public var explicitModuleBuildHandler: ExplicitModuleBuildHandler? = nil
+  @_spi(Testing) public var explicitModuleBuildHandler: ExplicitModuleBuildHandler? = nil
 
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -16,9 +16,8 @@ import Foundation
 /// In Explicit Module Build mode, this handler is responsible for generating and providing
 /// build jobs for all module dependencies and providing compile command options
 /// that specify said explicit module dependencies.
-public struct ExplicitModuleBuildHandler {
+@_spi(Testing) public struct ExplicitModuleBuildHandler {
   /// The module dependency graph.
-  /// FIXME: The dependency graph is public for the sake of unit tests only.
   public var dependencyGraph: InterModuleDependencyGraph
 
   /// Cache Clang modules for which a build job has already been constructed with a given
@@ -26,7 +25,7 @@ public struct ExplicitModuleBuildHandler {
   private var clangTargetModuleBuildCache = ClangModuleBuildJobCache()
 
   /// Cache Swift modules for which a build job has already been constructed.
-  private var swiftModuleBuildCache: [ModuleDependencyId: Job] = [:]
+  @_spi(Testing) public var swiftModuleBuildCache: [ModuleDependencyId: Job] = [:]
 
   /// The toolchain to be used for frontend job generation.
   private let toolchain: Toolchain

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 
-public enum ModuleDependencyId: Hashable {
+@_spi(Testing) public enum ModuleDependencyId: Hashable {
   case swift(String)
   case clang(String)
 
@@ -53,7 +53,7 @@ extension ModuleDependencyId: Codable {
 }
 
 /// Details specific to Swift modules.
-public struct SwiftModuleDetails: Codable {
+@_spi(Testing) public struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
   public var moduleInterfacePath: String?
 
@@ -76,7 +76,7 @@ public struct SwiftModuleDetails: Codable {
 }
 
 /// Details specific to Clang modules.
-public struct ClangModuleDetails: Codable {
+@_spi(Testing) public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
   public var moduleMapPath: String
 
@@ -87,7 +87,7 @@ public struct ClangModuleDetails: Codable {
   public var commandLine: [String]? = []
 }
 
-public struct ModuleInfo: Codable {
+@_spi(Testing) public struct ModuleInfo: Codable {
   /// The path for the module.
   public var modulePath: String
 
@@ -141,7 +141,7 @@ extension ModuleInfo.Details: Codable {
 
 /// Describes the complete set of dependencies for a Swift module, including
 /// all of the Swift and C modules and source files it depends on.
-public struct InterModuleDependencyGraph: Codable {
+@_spi(Testing) public struct InterModuleDependencyGraph: Codable {
   /// The name of the main module.
   public var mainModuleName: String
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import SwiftDriver
+@_spi(Testing) import SwiftDriver
 import TSCBasic
 import XCTest
 


### PR DESCRIPTION
These types are only public for testing, so use @_spi to hide them.