### PR TITLE
[Explicit Modules] Handle compiledModulePaths output by the dependency scanner

### DIFF
--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -57,6 +57,9 @@ public struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
   public var moduleInterfacePath: String?
 
+  /// The path to the already-compiled module.
+  public var compiledModulePath: String?
+
   /// The bridging header, if any.
   public var bridgingHeaderPath: String?
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -58,7 +58,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
   for dependencyId in moduleInfo.directDependencies {
     let dependencyInfo = moduleDependencyGraph.modules[dependencyId]!
     switch dependencyInfo.details {
-      case .swift:
+      case .swift(let swiftDetails):
         // Load the dependency JSON and verify this dependency was encoded correctly
         let explicitDepsFlag =
           SwiftDriver.Job.ArgTemplate.flag(String("-explicit-swift-module-map-file"))
@@ -75,7 +75,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
                                                       from: Data(contents.contents))
         let dependencyArtifacts =
           dependencyInfoList.first(where:{ $0.moduleName == dependencyId.moduleName })
-        XCTAssertEqual(dependencyArtifacts!.modulePath, dependencyInfo.modulePath)
+        XCTAssertEqual(dependencyArtifacts!.modulePath, swiftDetails.compiledModulePath ?? dependencyInfo.modulePath)
       case .clang(let clangDependencyDetails):
         let clangDependencyModulePathString =
           try ExplicitModuleBuildHandler.targetEncodedClangModuleFilePath(


### PR DESCRIPTION
As of https://github.com/apple/swift/pull/32633 when the scanner finds an up-to-date, already-compiled module next to the interface or cached, it reports a compiledModulePath in lieu of the usual dependency info. Instead of trying to generate a job, we should use this path directly.

I think this should fix the recent CI failures