### PR TITLE
[Explicit Modules] Provide an API for querying whether a job is a main module job.

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -344,4 +344,13 @@ extension Driver {
     }
     try handler.resolveMainModuleDependencies(inputs: &inputs, commandLine: &commandLine)
   }
+
+  /// In Explicit Module Build mode, distinguish between main module jobs and intermediate dependency build jobs,
+  /// such as Swift modules built from .swiftmodule files and Clang PCMs.
+  public func isExplicitMainModuleJob(job: Job) -> Bool {
+    guard let handler = explicitModuleBuildHandler else {
+      fatalError("No handler in Explicit Module Build mode.")
+    }
+    return job.moduleName == handler.dependencyGraph.mainModuleName
+  }
 }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -43,7 +43,7 @@ public struct Job: Codable, Equatable, Hashable {
     case path(VirtualPath)
   }
 
-  /// The SWift module this job involves.
+  /// The Swift module this job involves.
   public var moduleName: String
 
   /// The tool to invoke.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -129,6 +129,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertEqual(modulePrebuildJobs.count, 4)
       for job in modulePrebuildJobs {
         XCTAssertEqual(job.outputs.count, 1)
+        XCTAssertFalse(driver.isExplicitMainModuleJob(job: job))
         switch (job.outputs[0].file) {
 
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgs)):
@@ -221,6 +222,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("SwiftShims"),
                                             moduleDependencyGraph: dependencyGraph)
           case .temporary(RelativePath("main.o")):
+            XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
             guard case .swift(let mainModuleSwiftDetails) = dependencyGraph.mainModule.details else {
               XCTFail("Main module does not have Swift details field")
               return
@@ -230,6 +232,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                                         moduleInfo: dependencyGraph.mainModule,
                                                         moduleDependencyGraph: dependencyGraph)
           case .relative(RelativePath("main")):
+            XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
             XCTAssertEqual(job.kind, .link)
           default:
             XCTFail("Unexpected module dependency build job output: \(job.outputs[0].file)")


### PR DESCRIPTION
This will be useful for SwiftPM (and other build systems) to distinguish intermediate dependency artifacts versus the main module build, in order to correctly pass in cross-target dependencies.