### PR TITLE
Gather more information from -print-target-info

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1601,7 +1601,9 @@ extension Driver {
     var info = try executor.execute(
         job: toolchain.printTargetInfoJob(
           target: explicitTarget, targetVariant: explicitTargetVariant,
-          sdkPath: sdkPath, resourceDirPath: resourceDirPath
+          sdkPath: sdkPath, resourceDirPath: resourceDirPath,
+          runtimeCompatibilityVersion:
+            parsedOptions.getLastArgument(.runtimeCompatibilityVersion)?.asSingle
         ),
         capturingJSONOutputAs: FrontendTargetInfo.self,
         forceResponseFiles: false,

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -331,7 +331,7 @@ public struct Driver {
       fileSystem: fileSystem,
       inputFiles: inputFiles,
       diagnosticEngine: diagnosticEngine,
-      actualSwiftVersion: try? toolchain.swiftCompilerVersion()
+      actualSwiftVersion: self.frontendTargetInfo.compilerVersion
     )
 
     // Local variable to alias the target triple, because self.targetTriple

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -31,11 +31,6 @@ struct SwiftVersion {
   }
 }
 
-extension SwiftVersion {
-  static let v5_0 = SwiftVersion(major: 5, minor: 0)
-  static let v5_1 = SwiftVersion(major: 5, minor: 1)
-}
-
 extension SwiftVersion: Comparable {
   static func < (lhs: SwiftVersion, rhs: SwiftVersion) -> Bool {
     (lhs.major, lhs.minor) < (rhs.major, rhs.minor)
@@ -68,6 +63,16 @@ extension SwiftVersion: Codable {
 
 /// Describes information about the target as provided by the Swift frontend.
 public struct FrontendTargetInfo: Codable {
+  struct CompatibilityLibrary: Codable {
+    enum Filter: String, Codable {
+      case all
+      case executable
+    }
+
+    let libraryName: String
+    let filter: Filter
+  }
+
   struct Target: Codable {
     /// The target triple
     let triple: Triple
@@ -81,6 +86,10 @@ public struct FrontendTargetInfo: Codable {
     /// The version of the Swift runtime that is present in the runtime
     /// environment of the target.
     var swiftRuntimeCompatibilityVersion: SwiftVersion?
+
+    /// The set of compatibility libraries that one needs to link against
+    /// for this particular target.
+    let compatibilityLibraries: [CompatibilityLibrary]
 
     /// Whether the Swift libraries need to be referenced in their system
     /// location (/usr/lib/swift) via rpath.
@@ -106,6 +115,7 @@ extension Toolchain {
                           targetVariant: Triple?,
                           sdkPath: VirtualPath? = nil,
                           resourceDirPath: VirtualPath? = nil,
+                          runtimeCompatibilityVersion: String? = nil,
                           requiresInPlaceExecution: Bool = false) throws -> Job {
     var commandLine: [Job.ArgTemplate] = [.flag("-frontend"),
                                           .flag("-print-target-info")]
@@ -126,6 +136,13 @@ extension Toolchain {
 
     if let resourceDirPath = resourceDirPath {
       commandLine += [.flag("-resource-dir"), .path(resourceDirPath)]
+    }
+
+    if let runtimeCompatibilityVersion = runtimeCompatibilityVersion {
+      commandLine += [
+        .flag("-runtime-compatibility-version"),
+        .flag(runtimeCompatibilityVersion)
+      ]
     }
 
     return Job(

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -95,6 +95,7 @@ public struct FrontendTargetInfo: Codable {
     let runtimeResourcePath: String
   }
 
+  var compilerVersion: String
   var target: Target
   var targetVariant: Target?
   let paths: Paths

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -144,20 +144,19 @@ extension DarwinToolchain {
       }
     }
 
-    if let compatibilityVersion = targetInfo.target.swiftRuntimeCompatibilityVersion {
-      if compatibilityVersion <= .v5_0 {
-        // Swift 5.0 compatibility library
-        addArgsForBackDeployLib("libswiftCompatibility50.a")
+    for compatibilityLib in targetInfo.target.compatibilityLibraries {
+      let shouldLink: Bool
+      switch compatibilityLib.filter {
+      case .all:
+        shouldLink = true
+        break
+
+      case .executable:
+        shouldLink = linkerOutputType == .executable
       }
 
-      if compatibilityVersion <= .v5_1 {
-        // Swift 5.1 compatibility library
-        addArgsForBackDeployLib("libswiftCompatibility51.a")
-      }
-
-      if linkerOutputType == .executable && compatibilityVersion <= .v5_0 {
-        // Swift 5.0 dynamic replacement compatibility library.
-        addArgsForBackDeployLib("libswiftCompatibilityDynamicReplacements.a")
+      if shouldLink {
+        addArgsForBackDeployLib("lib" + compatibilityLib.libraryName + ".a")
       }
     }
 

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -79,25 +79,9 @@ public final class DarwinToolchain: Toolchain {
     toolPaths[tool] = path
   }
 
-  /// SDK path.
-  public lazy var sdk: Result<AbsolutePath, Swift.Error> = Result {
-    let result = try executor.checkNonZeroExit(
-      args: "xcrun", "-sdk", "macosx", "--show-sdk-path",
-      environment: env
-    ).spm_chomp()
-    return AbsolutePath(result)
-  }
-
   /// Path to the StdLib inside the SDK.
   public func sdkStdlib(sdk: AbsolutePath) -> AbsolutePath {
     sdk.appending(RelativePath("usr/lib/swift"))
-  }
-
-  public var resourcesDirectory: Result<AbsolutePath, Swift.Error> {
-    // FIXME: This will need to take -resource-dir and target triple into account.
-    return Result {
-      try getToolPath(.swiftCompiler).appending(RelativePath("../../lib/swift/macosx"))
-    }
   }
 
   public func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String {
@@ -106,10 +90,6 @@ public final class DarwinToolchain: Toolchain {
     case .dynamicLibrary: return "lib\(moduleName).dylib"
     case .staticLibrary: return "lib\(moduleName).a"
     }
-  }
-
-  public var clangRT: Result<AbsolutePath, Error> {
-    resourcesDirectory.map { $0.appending(RelativePath("../clang/lib/darwin/libclang_rt.osx.a")) }
   }
 
   public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -108,14 +108,6 @@ public final class DarwinToolchain: Toolchain {
     }
   }
 
-  public var compatibility50: Result<AbsolutePath, Error> {
-    resourcesDirectory.map { $0.appending(component: "libswiftCompatibility50.a") }
-  }
-
-  public var compatibilityDynamicReplacements: Result<AbsolutePath, Error> {
-    resourcesDirectory.map { $0.appending(component: "libswiftCompatibilityDynamicReplacements.a") }
-  }
-
   public var clangRT: Result<AbsolutePath, Error> {
     resourcesDirectory.map { $0.appending(RelativePath("../clang/lib/darwin/libclang_rt.osx.a")) }
   }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -83,13 +83,6 @@ extension Toolchain {
     getEnvSearchPaths(pathString: env["PATH"], currentWorkingDirectory: fileSystem.currentWorkingDirectory)
   }
 
-  public func swiftCompilerVersion() throws -> String {
-    try executor.checkNonZeroExit(
-      args: getToolPath(.swiftCompiler).pathString, "-version",
-      environment: env
-    ).split(separator: "\n").first.map(String.init) ?? ""
-  }
-
   /// Returns the `executablePath`'s directory.
   public var executableDir: AbsolutePath {
     guard let path = Bundle.main.executablePath else {

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -53,6 +53,28 @@ class JobCollectingDelegate: JobExecutionDelegate {
 }
 
 extension DarwinToolchain {
+  /// macOS SDK path, for testing only.
+  var sdk: Result<AbsolutePath, Swift.Error> {
+    Result {
+      let result = try executor.checkNonZeroExit(
+        args: "xcrun", "-sdk", "macosx", "--show-sdk-path",
+        environment: env
+      ).spm_chomp()
+      return AbsolutePath(result)
+    }
+  }
+
+  /// macOS resource directory, for testing only.
+  var resourcesDirectory: Result<AbsolutePath, Swift.Error> {
+    return Result {
+      try getToolPath(.swiftCompiler).appending(RelativePath("../../lib/swift/macosx"))
+    }
+  }
+
+  var clangRT: Result<AbsolutePath, Error> {
+    resourcesDirectory.map { $0.appending(RelativePath("../clang/lib/darwin/libclang_rt.osx.a")) }
+  }
+
   var compatibility50: Result<AbsolutePath, Error> {
     resourcesDirectory.map { $0.appending(component: "libswiftCompatibility50.a") }
   }

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -52,6 +52,16 @@ class JobCollectingDelegate: JobExecutionDelegate {
   }
 }
 
+extension DarwinToolchain {
+  var compatibility50: Result<AbsolutePath, Error> {
+    resourcesDirectory.map { $0.appending(component: "libswiftCompatibility50.a") }
+  }
+
+  var compatibilityDynamicReplacements: Result<AbsolutePath, Error> {
+    resourcesDirectory.map { $0.appending(component: "libswiftCompatibilityDynamicReplacements.a") }
+  }
+}
+
 final class JobExecutorTests: XCTestCase {
   func testDarwinBasic() throws {
 #if os(macOS)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1617,19 +1617,6 @@ final class SwiftDriverTests: XCTestCase {
     _ = try driverWithEmptySDK.planBuild()
   }
 
-  func testToolchainUtilities() throws {
-    let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
-                                           processSet: ProcessSet(),
-                                           fileSystem: localFileSystem,
-                                           env: ProcessEnv.vars)
-    let darwinToolchain = DarwinToolchain(env: ProcessEnv.vars, executor: executor)
-    let darwinSwiftVersion = try darwinToolchain.swiftCompilerVersion()
-    let unixToolchain =  GenericUnixToolchain(env: ProcessEnv.vars, executor: executor)
-    let unixSwiftVersion = try unixToolchain.swiftCompilerVersion()
-    assertString(darwinSwiftVersion, contains: "Swift version ")
-    assertString(unixSwiftVersion, contains: "Swift version ")
-  }
-
   func testToolchainClangPath() throws {
     // Overriding the swift executable to a specific location breaks this.
     guard ProcessEnv.vars["SWIFT_DRIVER_SWIFT_EXEC"] == nil else {

--- a/Tests/SwiftDriverTests/XCTestManifests.swift
+++ b/Tests/SwiftDriverTests/XCTestManifests.swift
@@ -114,7 +114,6 @@ extension SwiftDriverTests {
         ("testTargetTriple", testTargetTriple),
         ("testTargetVariant", testTargetVariant),
         ("testToolchainClangPath", testToolchainClangPath),
-        ("testToolchainUtilities", testToolchainUtilities),
         ("testUsingResponseFiles", testUsingResponseFiles),
         ("testVerifyDebugInfo", testVerifyDebugInfo),
         ("testVersionRequest", testVersionRequest),


### PR DESCRIPTION
Adopt improvements to `-print-target-info` from https://github.com/apple/swift/pull/32758:
* Use the compiler version provided by `-print-target-info` rather than invoking a second time with `-version`
* Use the compatibility libraries provided by `-print-target-info` rather than hard-coding the known set.