### PR TITLE
[Darwin] Miscellaneous toolchain cleanups and modernizations

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -48,22 +48,14 @@ public final class DarwinToolchain: Toolchain {
     switch tool {
     case .swiftCompiler:
       return try lookup(executable: "swift-frontend")
-
     case .dynamicLinker:
       return try lookup(executable: "ld")
-
     case .staticLinker:
       return try lookup(executable: "libtool")
-
     case .dsymutil:
       return try lookup(executable: "dsymutil")
-
     case .clang:
-      let result = try executor.checkNonZeroExit(
-        args: "xcrun", "-toolchain", "default", "-f", "clang",
-        environment: env
-      ).spm_chomp()
-      return AbsolutePath(result)
+      return try lookup(executable: "clang")
     case .swiftAutolinkExtract:
       return try lookup(executable: "swift-autolink-extract")
     case .lldb:

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -112,7 +112,7 @@ public enum DarwinPlatform: Hashable {
     case .iOS(.simulator):
       return "iossim"
     case .iOS(.catalyst):
-        return "osx"
+      return "osx"
     case .tvOS(.device):
       return "tvos"
     case .tvOS(.simulator):
@@ -128,9 +128,7 @@ public enum DarwinPlatform: Hashable {
 extension Triple {
   /// If this is a Darwin device platform, should it be inferred to be a device simulator?
   public var _isSimulatorEnvironment: Bool {
-    // FIXME: transitional, this should eventually stop testing arch, and
-    // switch to only checking the -environment field.
-    return environment == .simulator || arch == .x86 || arch == .x86_64
+    return environment == .simulator
   }
 
   /// Returns the OS version equivalent for the given platform, converting and

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -1634,7 +1634,7 @@ extension Triple {
 // MARK: - Catalyst
 
 extension Triple {
-  var isMacCatalyst: Bool {
+  @_spi(Testing) public var isMacCatalyst: Bool {
     return self.isiOS && !self.isTvOS && environment == .macabi
   }
 

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 
-import SwiftDriver
+@_spi(Testing) import SwiftDriver
 
 final class TripleTests: XCTestCase {
   func testBasics() throws {
@@ -910,7 +910,7 @@ final class TripleTests: XCTestCase {
     XCTAssertEqual(V?.minor, 3)
     XCTAssertEqual(V?.micro, 0)
     XCTAssertTrue(T._isSimulatorEnvironment)
-//    XCTAssertFalse(T.isMacCatalystEnvironment)
+    XCTAssertFalse(T.isMacCatalyst)
 
     T = Triple("x86_64-apple-ios13.0-macabi")
     XCTAssertTrue(T.os?.isiOS)
@@ -919,8 +919,17 @@ final class TripleTests: XCTestCase {
     XCTAssertEqual(V?.minor, 0)
     XCTAssertEqual(V?.micro, 0)
     XCTAssertEqual(T.environment, .macabi)
-//    XCTAssertTrue(T.isMacCatalystEnvironment)
-//    XCTAssertFalse(T._isSimulatorEnvironment)
+    XCTAssertTrue(T.isMacCatalyst)
+    XCTAssertFalse(T._isSimulatorEnvironment)
+
+    T = Triple("x86_64-apple-ios12.0")
+    XCTAssertTrue(T.os?.isiOS)
+    V = T._iOSVersion
+    XCTAssertEqual(V?.major, 12)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+    XCTAssertFalse(T._isSimulatorEnvironment)
+    XCTAssertFalse(T.isMacCatalyst)
   }
 
   func testFileFormat() {
@@ -1124,7 +1133,7 @@ final class TripleTests: XCTestCase {
 
     let tvOS1 = Triple("x86_64-apple-tvos13.0-simulator")
     let tvOS2 = Triple("powerpc-apple-tvos50.0") // FIXME: should test with ARM
-    let tvOS3 = Triple("x86_64-apple-tvos60.0")
+    let tvOS3 = Triple("x86_64-apple-tvos60.0-simulator")
 
     assertDarwinPlatformCorrect(tvOS1,
                                 case: tvOS,
@@ -1150,7 +1159,7 @@ final class TripleTests: XCTestCase {
 
     let watchOS1 = Triple("x86_64-apple-watchos6.0-simulator")
     let watchOS2 = Triple("powerpc-apple-watchos50.0") // FIXME: should test with ARM
-    let watchOS3 = Triple("x86_64-apple-watchos60.0")
+    let watchOS3 = Triple("x86_64-apple-watchos60.0-simulator")
 
     assertDarwinPlatformCorrect(watchOS1,
                                 case: watchOS,


### PR DESCRIPTION
A couple of minor changes on top of https://github.com/apple/swift-driver/pull/165:
* Sink some macOS-specific APIs down into tests; I kept thinking they needed generalization, but really they needed not to be APIs at all
* Lookup "clang" via the normal approach, rather than only using the one from the Xcode default toolchain
* Stop inferring simulator-ness based on architecture.