### PR TITLE
Add -jit-build mode

### DIFF
--- a/Sources/SwiftDriver/Driver/CompilerMode.swift
+++ b/Sources/SwiftDriver/Driver/CompilerMode.swift
@@ -29,6 +29,10 @@ public enum CompilerMode: Equatable {
 
   /// Compile a Clang module (.pcm).
   case compilePCM
+
+  /// A compilation that emits a stub JIT executable which connects to a
+  /// Swift frontend process for lazy compilation.
+  case jitCompile
 }
 
 /// Information about batch mode, which is used to determine how to form
@@ -43,7 +47,7 @@ extension CompilerMode {
   /// Whether this compilation mode uses -primary-file to specify its inputs.
   public var usesPrimaryFileInputs: Bool {
     switch self {
-    case .immediate, .repl, .singleCompile, .compilePCM:
+    case .immediate, .repl, .singleCompile, .compilePCM, .jitCompile:
       return false
 
     case .standardCompile, .batchCompile:
@@ -54,7 +58,7 @@ extension CompilerMode {
   /// Whether this compilation mode compiles the whole target in one job.
   public var isSingleCompilation: Bool {
     switch self {
-    case .immediate, .repl, .standardCompile, .batchCompile:
+    case .immediate, .repl, .standardCompile, .batchCompile, .jitCompile:
       return false
 
     case .singleCompile, .compilePCM:
@@ -66,7 +70,7 @@ extension CompilerMode {
   // headers.
   public var supportsBridgingPCH: Bool {
     switch self {
-    case .batchCompile, .singleCompile, .standardCompile, .compilePCM:
+    case .batchCompile, .singleCompile, .standardCompile, .compilePCM, .jitCompile:
       return true
     case .immediate, .repl:
       return false
@@ -89,6 +93,8 @@ extension CompilerMode: CustomStringConvertible {
         return "immediate compilation"
       case .compilePCM:
         return "compile Clang module (.pcm)"
+      case .jitCompile:
+        return "JIT compilation"
       }
   }
 }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -786,6 +786,9 @@ extension Driver {
       case .emitPcm:
         return .compilePCM
 
+      case .jitBuild:
+        return .jitCompile
+
       default:
         // Output flag doesn't determine the compiler mode.
         break
@@ -966,6 +969,10 @@ extension Driver {
 
       case .scanDependencies:
         compilerOutputType = .jsonDependencies
+
+      case .jitBuild:
+        compilerOutputType = nil
+        linkerOutputType = .executable
 
       default:
         fatalError("unhandled output mode option \(outputOption)")

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilation.swift
@@ -157,7 +157,7 @@ fileprivate extension CompilerMode {
   var supportsIncrementalCompilation: Bool {
     switch self {
     case .standardCompile, .immediate, .repl, .batchCompile: return true
-    case .singleCompile, .compilePCM: return false
+    case .singleCompile, .compilePCM, .jitCompile: return false
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/CommandInvocation.swift
+++ b/Sources/SwiftDriver/Jobs/CommandInvocation.swift
@@ -1,0 +1,33 @@
+//===--- CommandInvocation.swift - A command line invocation --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Represents a command to invoke along with its arguments.
+public struct CommandInvocation {
+  public enum ArgTemplate: Equatable, Hashable {
+    /// Represents a command-line flag that is substitued as-is.
+    case flag(String)
+
+    /// Represents a virtual path on disk.
+    case path(VirtualPath)
+  }
+
+  /// The command to invoke.
+  public var command: VirtualPath
+
+  /// The arguments to pass to the command.
+  public var args: [ArgTemplate]
+
+  public init(_ command: VirtualPath, args: [ArgTemplate]) {
+    self.command = command
+    self.args = args
+  }
+}

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -15,6 +15,8 @@ import SwiftOptions
 /// Utilities for manipulating a list of command line arguments, including
 /// constructing one from a set of ParsedOptions.
 extension Array where Element == Job.ArgTemplate {
+  // TODO: Move these onto CommandInvocation.
+
   /// Append a fixed flag to the command line arguments.
   ///
   /// When possible, use the more semantic forms `appendFlag` or

--- a/Sources/SwiftDriver/Jobs/FilesystemJobs.swift
+++ b/Sources/SwiftDriver/Jobs/FilesystemJobs.swift
@@ -1,0 +1,40 @@
+//===--------------- FilesystemJobs.swift - Generic Filesystem Jobs -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Driver {
+  /// Create a symbolic link.
+  func symlinkJob(from input: TypedVirtualPath, to output: VirtualPath) throws -> Job {
+    let invocation = try toolchain.getSymlinkInvocation(from: input.file, to: output)
+    return Job(
+      moduleName: moduleOutputInfo.name,
+      kind: .symlink,
+      tool: invocation.command,
+      commandLine: invocation.args,
+      displayInputs: [input],
+      inputs: [input],
+      outputs: [.init(file: output, type: input.type)]
+    )
+  }
+
+  /// Create a directory.
+  func mkdirJob(for path: VirtualPath) throws -> Job {
+    let invocation = try toolchain.getMkdirInvocation(for: path)
+    return Job(
+      moduleName: moduleOutputInfo.name,
+      kind: .mkdir,
+      tool: invocation.command,
+      commandLine: invocation.args,
+      inputs: [],
+      outputs: []
+    )
+  }
+}

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -54,7 +54,7 @@ extension Driver {
     // Only pass -target to the REPL or immediate modes if it was explicitly
     // specified on the command line.
     switch compilerMode {
-    case .standardCompile, .singleCompile, .batchCompile, .compilePCM:
+    case .standardCompile, .singleCompile, .batchCompile, .compilePCM, .jitCompile:
       commandLine.appendFlag(.target)
       commandLine.appendFlag(targetTriple.triple)
 

--- a/Sources/SwiftDriver/Jobs/JITBuildJob.swift
+++ b/Sources/SwiftDriver/Jobs/JITBuildJob.swift
@@ -1,0 +1,66 @@
+//===--------------- JITBuildJob.swift - Swift JIT Build Job --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCBasic
+
+extension Driver {
+  /// A frontend job that will provide JIT code for an executable.
+  mutating func frontendJITBuildJob() throws -> Job {
+    var commandLine = swiftCompilerPrefixArgs.map(Job.ArgTemplate.flag)
+    commandLine.appendFlag("-frontend")
+    commandLine.appendFlag("-jit-build")
+
+    // Add the frontend inputs. Note we don't output anything – the stub
+    // executable output will be created separately.
+    var inputs: [TypedVirtualPath] = []
+    _ = addCompileInputs(primaryInputs: [], inputs: &inputs, outputType: nil,
+                         commandLine: &commandLine)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
+
+    return Job(
+      moduleName: moduleOutputInfo.name,
+      kind: .frontendJITBuild,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      inputs: inputs,
+      outputs: []
+    )
+  }
+
+  /// Retrieve the jobs needed to generate a stub executable with a frontend
+  /// process registered to JIT code for it.
+  public mutating func generateJITCompileJobs() throws -> [Job] {
+    // Ask the toolchain for the jit stub executable.
+    let rawStubPath = try toolchain.getToolPath(.jitStub)
+    let stubPath = TypedVirtualPath(file: .absolute(rawStubPath), type: .image)
+
+    // Compute the output path for the stub executable, using the same logic
+    // as the linker job.
+    let stubOutputPath = try getOutputFileForImage()
+
+    var jobs = [Job]()
+
+    // First create a symlink to the stub executable at the output path.
+    jobs.append(try symlinkJob(from: stubPath, to: stubOutputPath))
+
+    // Then add a .xojit directory adjacent to the output.
+    let outputDir = stubOutputPath.dirname
+    let stubName = stubOutputPath.basename
+    let xojitOutputPath = outputDir.appending(component: ".\(stubName).xojit")
+    jobs.append(try mkdirJob(for: xojitOutputPath))
+
+    // Finally invoke the frontend, which will register itself as a JIT
+    // provider.
+    jobs.append(try frontendJITBuildJob())
+    return jobs
+  }
+}

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -33,6 +33,7 @@ public struct Job: Codable, Equatable, Hashable {
     case versionRequest = "version-request"
     case scanDependencies = "scan-dependencies"
     case help
+    case frontendJITBuild = "frontend-jit-build"
 
     case symlink
     case mkdir
@@ -171,6 +172,9 @@ extension Job : CustomStringConvertible {
     case .scanDependencies:
       return "Scanning dependencies for module \(moduleName)"
 
+    case .frontendJITBuild:
+      return "Registering the Frontend for a JIT build"
+
     case .symlink:
       return "Creating symlink to \(displayInputs[0].file.name)"
 
@@ -186,7 +190,7 @@ extension Job.Kind {
     switch self {
     case .backend, .compile, .mergeModule, .emitModule, .generatePCH,
         .generatePCM, .interpret, .repl, .printTargetInfo,
-        .versionRequest, .scanDependencies:
+        .versionRequest, .scanDependencies, .frontendJITBuild:
         return true
 
     case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo,
@@ -204,7 +208,7 @@ extension Job.Kind {
          .generatePCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
          .help, .link, .verifyDebugInfo, .scanDependencies,
-         .symlink, .mkdir:
+         .frontendJITBuild, .symlink, .mkdir:
       return false
     }
   }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -35,13 +35,7 @@ public struct Job: Codable, Equatable, Hashable {
     case help
   }
 
-  public enum ArgTemplate: Equatable, Hashable {
-    /// Represents a command-line flag that is substitued as-is.
-    case flag(String)
-
-    /// Represents a virtual path on disk.
-    case path(VirtualPath)
-  }
+  public typealias ArgTemplate = CommandInvocation.ArgTemplate
 
   /// The Swift module this job involves.
   public var moduleName: String
@@ -49,6 +43,8 @@ public struct Job: Codable, Equatable, Hashable {
   /// The tool to invoke.
   public var tool: VirtualPath
 
+  // TODO: Store a CommandInvocation.
+  
   /// The command-line arguments of the job.
   public var commandLine: [ArgTemplate]
 

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -33,6 +33,9 @@ public struct Job: Codable, Equatable, Hashable {
     case versionRequest = "version-request"
     case scanDependencies = "scan-dependencies"
     case help
+
+    case symlink
+    case mkdir
   }
 
   public typealias ArgTemplate = CommandInvocation.ArgTemplate
@@ -167,6 +170,12 @@ extension Job : CustomStringConvertible {
 
     case .scanDependencies:
       return "Scanning dependencies for module \(moduleName)"
+
+    case .symlink:
+      return "Creating symlink to \(displayInputs[0].file.name)"
+
+    case .mkdir:
+      return "Creating directory"
     }
   }
 }
@@ -180,7 +189,8 @@ extension Job.Kind {
         .versionRequest, .scanDependencies:
         return true
 
-    case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo:
+    case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo,
+         .symlink, .mkdir:
         return false
     }
   }
@@ -193,7 +203,8 @@ extension Job.Kind {
     case .backend, .mergeModule, .emitModule, .generatePCH,
          .generatePCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
-         .help, .link, .verifyDebugInfo, .scanDependencies:
+         .help, .link, .verifyDebugInfo, .scanDependencies,
+         .symlink, .mkdir:
       return false
     }
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -117,6 +117,10 @@ extension Driver {
 
     case .standardCompile:
       partitions = nil
+
+    case .jitCompile:
+      jobs += try generateJITCompileJobs()
+      partitions = nil
     }
 
     for input in inputFiles {
@@ -297,7 +301,7 @@ extension Driver {
     case .immediate:
       return [try interpretJob(inputs: inputFiles)]
 
-    case .standardCompile, .batchCompile, .singleCompile:
+    case .standardCompile, .batchCompile, .singleCompile, .jitCompile:
       return try planStandardCompile()
 
     case .compilePCM:

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -155,4 +155,16 @@ public final class DarwinToolchain: Toolchain {
     \(isShared ? "_dynamic.dylib" : ".a")
     """
   }
+
+  public func getSymlinkInvocation(
+    from input: VirtualPath, to output: VirtualPath
+  ) throws -> CommandInvocation {
+    CommandInvocation(.absolute(try lookup(executable: "ln")),
+                      args: [.flag("-s"), .path(input), .path(output)])
+  }
+
+  public func getMkdirInvocation(for path: VirtualPath) throws -> CommandInvocation {
+    CommandInvocation(.absolute(try lookup(executable: "mkdir")),
+                      args: [.path(path)])
+  }
 }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -72,6 +72,8 @@ public final class DarwinToolchain: Toolchain {
       return try lookup(executable: "dwarfdump")
     case .swiftHelp:
       return try lookup(executable: "swift-help")
+    case .jitStub:
+      return try lookup(executable: "jit-stub")
     }
   }
 

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -71,6 +71,8 @@ public final class GenericUnixToolchain: Toolchain {
       return try lookup(executable: "dwarfdump")
     case .swiftHelp:
       return try lookup(executable: "swift-help")
+    case .jitStub:
+      return try lookup(executable: "jit-stub")
     }
   }
 

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -91,4 +91,16 @@ public final class GenericUnixToolchain: Toolchain {
   ) throws -> String {
     return "libclang_rt.\(sanitizer.libraryName)-\(targetTriple.archName).a"
   }
+
+  public func getSymlinkInvocation(
+    from input: VirtualPath, to output: VirtualPath
+  ) throws -> CommandInvocation {
+    CommandInvocation(.absolute(try lookup(executable: "ln")),
+                      args: [.flag("-s"), .path(input), .path(output)])
+  }
+
+  public func getMkdirInvocation(for path: VirtualPath) throws -> CommandInvocation {
+    CommandInvocation(.absolute(try lookup(executable: "mkdir")),
+                      args: [.path(path)])
+  }
 }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -23,6 +23,7 @@ public enum Tool {
   case lldb
   case dwarfdump
   case swiftHelp
+  case jitStub
 }
 
 /// Describes a toolchain, which includes information about compilers, linkers

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -76,6 +76,14 @@ public protocol Toolchain {
     parsedOptions: inout ParsedOptions,
     sdkPath: String?,
     targetTriple: Triple) throws -> [String: String]
+
+  /// Returns an invocation of the platform's symlink command.
+  func getSymlinkInvocation(
+    from input: VirtualPath, to output: VirtualPath
+  ) throws -> CommandInvocation
+
+  /// Returns an invocation of the platform's mkdir command.
+  func getMkdirInvocation(for path: VirtualPath) throws -> CommandInvocation
 }
 
 extension Toolchain {

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -99,6 +99,21 @@ public enum VirtualPath: Hashable {
     }
   }
 
+  /// Retrieve the directory component of the path.
+  public var dirname: VirtualPath {
+    switch self {
+    case .absolute(let path):
+      return .absolute(AbsolutePath(path.dirname))
+    case .relative(let path):
+      return .relative(RelativePath(path.dirname))
+    case .temporary(let path):
+      return .temporary(RelativePath(path.dirname))
+    case .standardInput, .standardOutput:
+      assertionFailure("Can't get directory of stdin/stdout")
+      return self
+    }
+  }
+
   /// Returns the virtual path with an additional literal component appended.
   ///
   /// This should not be used with `.standardInput` or `.standardOutput`.

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -291,6 +291,7 @@ extension Option {
   public static let interpret: Option = Option("-interpret", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Immediate mode", group: .modes)
   public static let I: Option = Option("-I", .joinedOrSeparate, attributes: [.frontend, .argumentIsPath], helpText: "Add directory to the import search path")
   public static let i: Option = Option("-i", .flag, group: .modes)
+  public static let jitBuild: Option = Option("-jit-build", .flag, attributes: [.helpHidden, .noInteractive], helpText: "JIT compilation mode", group: .modes)
   public static let j: Option = Option("-j", .joinedOrSeparate, attributes: [.doesNotAffectIncrementalBuild], metaVar: "<n>", helpText: "Number of commands to execute in parallel")
   public static let LEQ: Option = Option("-L=", .joined, alias: Option.L, attributes: [.frontend, .doesNotAffectIncrementalBuild, .argumentIsPath])
   public static let lazyAstscopes: Option = Option("-lazy-astscopes", .flag, attributes: [.frontend, .noDriver], helpText: "Build ASTScopes lazily")
@@ -763,6 +764,7 @@ extension Option {
       Option.interpret,
       Option.I,
       Option.i,
+      Option.jitBuild,
       Option.j,
       Option.LEQ,
       Option.lazyAstscopes,


### PR DESCRIPTION
This new compilation mode emits a (symlink to a) stub executable and invokes the frontend with `-jit-build`, which will eventually allow it to register itself as a provider that can JIT code for the executable.