### PR TITLE
Treat -frontend and -modulewrap invocations as subcommands

### DIFF
--- a/Sources/SwiftOptions/DriverKind.swift
+++ b/Sources/SwiftOptions/DriverKind.swift
@@ -14,53 +14,15 @@
 public enum DriverKind: String {
   case interactive = "swift"
   case batch = "swiftc"
-  case moduleWrap = "swift-modulewrap"
-  case frontend = "swift-frontend"
-  case autolinkExtract = "swift-autolink-extract"
-
-  /// Returns true if driver kind is Swift compiler.
-  public var isSwiftCompiler: Bool {
-    return self == .interactive || self == .batch
-  }
 }
 
 extension DriverKind {
   public var usage: String {
-    usageArgs.joined(separator: " ")
-  }
-
-  public var usageArgs: [String] {
     switch self {
-    case .autolinkExtract:
-      return ["swift-autolink-extract"]
-
-    case .batch:
-      return ["swiftc"]
-
-    case .frontend:
-      return ["swift", "-frontend"]
-
     case .interactive:
-      return ["swift"]
-
-    case .moduleWrap:
-      return ["swift-modulewrap"]
-    }
-  }
-
-  public var title: String {
-    switch self {
-    case .autolinkExtract:
-      return "Swift Autolink Extract"
-
-    case .frontend:
-      return "Swift frontend"
-
-    case .batch, .interactive:
-      return "Swift compiler"
-
-    case .moduleWrap:
-      return "Swift Module Wrapper"
+      return "swift"
+    case .batch:
+      return "swiftc"
     }
   }
 
@@ -76,8 +38,6 @@ extension DriverKind {
              """
     case .batch:
       return "SEE ALSO: swift build, swift run, swift package, swift test"
-    default:
-      return nil
     }
   }
 }

--- a/Sources/SwiftOptions/Option.swift
+++ b/Sources/SwiftOptions/Option.swift
@@ -133,20 +133,10 @@ extension Option {
   /// Whether this option is accepted by a driver of the given kind.
   public func isAccepted(by driverKind: DriverKind) -> Bool {
     switch driverKind {
-    case .autolinkExtract:
-      return attributes.contains(.autolinkExtract)
-
     case .batch:
       return !attributes.contains(.noBatch)
-
-    case .frontend:
-      return attributes.contains(.frontend)
-
     case .interactive:
       return !attributes.contains(.noInteractive)
-
-    case .moduleWrap:
-      return attributes.contains(.moduleWrap)
     }
   }
 }

--- a/Sources/SwiftOptions/OptionTable.swift
+++ b/Sources/SwiftOptions/OptionTable.swift
@@ -28,7 +28,7 @@ extension OptionTable {
   /// Print help information to the terminal.
   public func printHelp(driverKind: DriverKind, includeHidden: Bool) {
     print("""
-      OVERVIEW: \(driverKind.title)
+      OVERVIEW: Swift compiler
 
       USAGE: \(driverKind.usage)
 

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -37,7 +37,7 @@ do {
     }
 
     // Execute the subcommand.
-    try exec(path: subcommandPath?.pathString ?? "", args: Array(arguments.dropFirst()))
+    try exec(path: subcommandPath?.pathString ?? "", args: arguments)
   }
 
   let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -42,6 +42,14 @@ final class SwiftDriverTests: XCTestCase {
     let driver6 = try Driver.invocationRunMode(forArgs: ["swift", "foo", "bar"])
     XCTAssertEqual(driver6.mode, .subcommand("swift-foo"))
     XCTAssertEqual(driver6.args, ["swift-foo", "bar"])
+
+    let driver7 = try Driver.invocationRunMode(forArgs: ["swift", "-frontend", "foo", "bar"])
+    XCTAssertEqual(driver7.mode, .subcommand("swift-frontend"))
+    XCTAssertEqual(driver7.args, ["swift-frontend", "foo", "bar"])
+
+    let driver8 = try Driver.invocationRunMode(forArgs: ["swift", "-modulewrap", "foo", "bar"])
+    XCTAssertEqual(driver8.mode, .subcommand("swift-frontend"))
+    XCTAssertEqual(driver8.args, ["swift-frontend", "-modulewrap", "foo", "bar"])
   }
 
   func testSubcommandsHandling() throws {
@@ -79,21 +87,10 @@ final class SwiftDriverTests: XCTestCase {
     try assertArgs("/path/to/swift", parseTo: .interactive, leaving: [])
     try assertArgs("swiftc", parseTo: .batch, leaving: [])
     try assertArgs(".build/debug/swiftc", parseTo: .batch, leaving: [])
-    try assertArgs("swiftc", "-frontend", parseTo: .frontend, leaving: [])
-    try assertArgs("swiftc", "-modulewrap", parseTo: .moduleWrap, leaving: [])
-    try assertArgs("/path/to/swiftc", "-modulewrap",
-                   parseTo: .moduleWrap, leaving: [])
-
     try assertArgs("swiftc", "--driver-mode=swift", parseTo: .interactive, leaving: [])
-    try assertArgs("swiftc", "--driver-mode=swift-autolink-extract", parseTo: .autolinkExtract, leaving: [])
-    try assertArgs("swift", "--driver-mode=swift-autolink-extract", parseTo: .autolinkExtract, leaving: [])
-
     try assertArgs("swift", "-zelda", parseTo: .interactive, leaving: ["-zelda"])
-    try assertArgs("/path/to/swiftc", "-modulewrap", "savannah",
-                   parseTo: .moduleWrap, leaving: ["savannah"])
     try assertArgs("swiftc", "--driver-mode=swift", "swiftc",
                    parseTo: .interactive, leaving: ["swiftc"])
-
     try assertArgsThrow("driver")
     try assertArgsThrow("swiftc", "--driver-mode=blah")
     try assertArgsThrow("swiftc", "--driver-mode=")
@@ -1619,7 +1616,8 @@ final class SwiftDriverTests: XCTestCase {
 
   func testToolchainClangPath() throws {
     // Overriding the swift executable to a specific location breaks this.
-    guard ProcessEnv.vars["SWIFT_DRIVER_SWIFT_EXEC"] == nil else {
+    guard ProcessEnv.vars["SWIFT_DRIVER_SWIFT_EXEC"] == nil,
+          ProcessEnv.vars["SWIFT_DRIVER_SWIFT_FRONTEND_EXEC"] == nil else {
       return
     }
     // TODO: remove this conditional check once DarwinToolchain does not requires xcrun to look for clang.


### PR DESCRIPTION
This eliminates the last case where the driver was launching processes directly. IMO it makes sense to treat these flags as subcommands since they're direct frontend tool invocations that don't involve any coordination by the driver. I also dropped references to swift-autolink-extract because it's now a direct symlink to swift-frontend alongside swift-symbolgraph-extract.