### PR TITLE
[Build Script Helper] Fix frontend executable search environment variable.

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -108,7 +108,7 @@ def handle_invocation(swift_exec, args):
   if args.action == 'build':
     swiftpm('build', swift_exec, swiftpm_args, env)
   elif args.action == 'test':
-    env['SWIFT_DRIVER_SWIFT_EXEC'] = '%sc' % (swift_exec)
+    env['SWIFT_DRIVER_SWIFT_FRONTEND_EXEC'] = '%sc' % (swift_exec)
     test_args = swiftpm_args
     if should_test_parallel():
       test_args += ['--parallel']


### PR DESCRIPTION
This reflects the new `swift-frontend` executable the driver will look for.
Gearing up for: https://github.com/apple/swift/pull/32851 
