### PR TITLE
Add -sanitize=scudo support

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1201,6 +1201,19 @@ extension Driver {
       )
     }
 
+    // Scudo can only be run with ubsan.
+    if set.contains(.scudo) {
+      let allowedSanitizers: Set<Sanitizer> = [.scudo, .undefinedBehavior]
+      for forbiddenSanitizer in set.subtracting(allowedSanitizers) {
+        diagnosticEngine.emit(
+          .error_argument_not_allowed_with(
+            arg: "-sanitize=scudo",
+            other: "-sanitize=\(forbiddenSanitizer.rawValue)"
+          )
+        )
+      }
+    }
+
     return set
   }
 

--- a/Sources/SwiftDriver/Utilities/Sanitizer.swift
+++ b/Sources/SwiftDriver/Utilities/Sanitizer.swift
@@ -27,6 +27,9 @@ public enum Sanitizer: String, Hashable {
   ///         it's distributed exactly the same as the sanitizers.
   case fuzzer
 
+  /// Scudo hardened allocator
+  case scudo
+
   /// The name inside the `compiler_rt` library path (e.g. libclang_rt.{name}.a)
   var libraryName: String {
     switch self {
@@ -34,6 +37,7 @@ public enum Sanitizer: String, Hashable {
     case .thread: return "tsan"
     case .undefinedBehavior: return "ubsan"
     case .fuzzer: return "fuzzer"
+    case .scudo: return "scudo"
     }
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1101,6 +1101,27 @@ final class SwiftDriverTests: XCTestCase {
       let linkCmd = linkJob.commandLine
       XCTAssertTrue(linkCmd.contains(.flag("-fsanitize=address,undefined")))
     }
+
+    do {
+      // linux scudo hardened allocator
+      var driver = try Driver(
+        args: commonArgs + [
+          "-target", "x86_64-unknown-linux",
+          "-sanitize=scudo"
+        ]
+      )
+      let plannedJobs = try driver.planBuild()
+
+      XCTAssertEqual(plannedJobs.count, 4)
+
+      let compileJob = plannedJobs[0]
+      let compileCmd = compileJob.commandLine
+      XCTAssertTrue(compileCmd.contains(.flag("-sanitize=scudo")))
+
+      let linkJob = plannedJobs[3]
+      let linkCmd = linkJob.commandLine
+      XCTAssertTrue(linkCmd.contains(.flag("-fsanitize=scudo")))
+    }
     #endif
   #endif
   }


### PR DESCRIPTION
This is enough to get all of sanitize_scudo.swift passing except for the Windows test cases, and one that relies on the sanitizer ordering. Rather than fix the ordering here, I'm going to change the integrated driver to match swift-driver.