### PR TITLE
Add support for remaining optimization record options

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -69,9 +69,8 @@ extension Driver {
          .swiftDocumentation, .swiftInterface,
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
          .objcHeader, .swiftDeps, .remap, .importedModules, .tbd, .moduleTrace,
-
-         .indexData, .optimizationRecord, .pcm, .pch, .clangModuleMap,
-         .jsonTargetInfo, .jsonSwiftArtifacts, nil:
+         .indexData, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
+         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, nil:
       return false
     }
   }
@@ -143,6 +142,16 @@ extension Driver {
                                           outputType: outputType,
                                           commandLine: &commandLine)
     outputs += primaryOutputs
+
+    // FIXME: optimization record arguments are added before supplementary outputs
+    // for compatibility with the integrated driver's test suite. We should adjust the tests
+    // so we can organize this better.
+    // -save-optimization-record and -save-optimization-record= have different meanings.
+    // In this case, we specifically want to pass the EQ variant to the frontend
+    // to control the output type of optimization remarks (YAML or bitstream).
+    try commandLine.appendLast(.saveOptimizationRecordEQ, from: &parsedOptions)
+    try commandLine.appendLast(.saveOptimizationRecordPasses, from: &parsedOptions)
+
     outputs += try addFrontendSupplementaryOutputArguments(commandLine: &commandLine, primaryInputs: primaryInputs)
 
     // Forward migrator flags.
@@ -258,8 +267,8 @@ extension FileType {
 
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
-         .optimizationRecord, .swiftInterface, .swiftSourceInfoFile, .clangModuleMap,
-         .jsonSwiftArtifacts:
+         .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
+         .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts:
       fatalError("Output type can never be a primary output")
     }
   }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -290,7 +290,7 @@ extension Driver {
       }
 
       addOutputOfType(
-          outputType: .optimizationRecord,
+          outputType: .yamlOptimizationRecord,
           finalOutputPath: optimizationRecordPath,
           input: input,
           flag: "-save-optimization-record-path")

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -109,7 +109,10 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   case indexData
 
   /// Optimization record.
-  case optimizationRecord = "opt.yaml"
+  case yamlOptimizationRecord = "opt.yaml"
+
+  /// Bitstream optimization record.
+  case bitstreamOptimizationRecord = "opt.bitstream"
 
   /// Clang compiler module file
   case pcm
@@ -168,8 +171,11 @@ extension FileType: CustomStringConvertible {
     case .indexData:
       return "index-data"
 
-    case .optimizationRecord:
-      return "opt-record"
+    case .yamlOptimizationRecord:
+      return "yaml-opt-record"
+
+    case .bitstreamOptimizationRecord:
+      return "bitstream-opt-record"
 
     case .diagnostics:
       return "diagnostics"
@@ -187,7 +193,7 @@ extension FileType {
     case .object, .pch, .ast, .llvmIR, .llvmBitcode, .assembly, .swiftModule,
          .importedModules, .indexData, .remap, .dSYM, .autolink, .dependencies,
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
-         .swiftDeps, .moduleTrace, .tbd, .optimizationRecord, .swiftInterface,
+         .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
          .swiftSourceInfoFile, .jsonDependencies, .clangModuleMap, .jsonTargetInfo,
          .jsonSwiftArtifacts:
       return false
@@ -270,8 +276,10 @@ extension FileType {
       return "module-trace"
     case .indexData:
       return "index-data"
-    case .optimizationRecord:
-      return "opt-record"
+    case .yamlOptimizationRecord:
+      return "yaml-opt-record"
+    case .bitstreamOptimizationRecord:
+      return "bitstream-opt-record"
     case .diagnostics:
       return "diagnostics"
     }
@@ -283,12 +291,12 @@ extension FileType {
     switch self {
     case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
-         .optimizationRecord, .swiftInterface, .jsonDependencies, .clangModuleMap, .jsonTargetInfo,
+         .yamlOptimizationRecord, .swiftInterface, .jsonDependencies, .clangModuleMap, .jsonTargetInfo,
          .jsonSwiftArtifacts:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
-         .pcm, .swiftDeps, .remap, .indexData:
+         .pcm, .swiftDeps, .remap, .indexData, .bitstreamOptimizationRecord:
       return false
     }
   }
@@ -302,8 +310,8 @@ extension FileType {
     case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile,
          .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap, .importedModules,
-         .tbd, .moduleTrace, .indexData, .optimizationRecord, .pcm, .pch, .jsonDependencies,
-         .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts:
+         .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
+         .pcm, .pch, .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts:
       return false
     }
   }

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -99,6 +99,21 @@ public enum VirtualPath: Hashable {
     }
   }
 
+  /// Retrieve the path to the parent directory.
+  public var parentDirectory: VirtualPath {
+    switch self {
+    case .absolute(let path):
+      return .absolute(path.parentDirectory)
+    case .relative(let path):
+      return .relative(RelativePath(path.dirname))
+    case .temporary(let path):
+      return .temporary(RelativePath(path.dirname))
+    case .standardInput, .standardOutput:
+      assertionFailure("Can't get directory of stdin/stdout")
+      return self
+    }
+  }
+
   /// Returns the virtual path with an additional literal component appended.
   ///
   /// This should not be used with `.standardInput` or `.standardOutput`.


### PR DESCRIPTION
- -save-optimization-record= is distinct from -save-optimization-record and has some unusual behavior to support different record types
- -save-optimization-record-passes just needs to be added to compile jobs

This change fixes Driver/opt-record.swift and Driver/opt-record-options.swift