### PR TITLE
Validate Darwin deployment targets and target variants

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -309,7 +309,9 @@ public struct Driver {
 
     try Self.validateWarningControlArgs(&parsedOptions)
     Self.validateCoverageArgs(&parsedOptions, diagnosticsEngine: diagnosticEngine)
-    try toolchain.validateArgs(&parsedOptions, targetTriple: self.frontendTargetInfo.target.triple)
+    try toolchain.validateArgs(&parsedOptions,
+                               targetTriple: self.frontendTargetInfo.target.triple,
+                               targetVariantTriple: self.frontendTargetInfo.targetVariant?.triple)
 
     // Compute debug information output.
     self.debugInfo = Self.computeDebugInfo(&parsedOptions, diagnosticsEngine: diagnosticEngine)

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -309,6 +309,7 @@ public struct Driver {
 
     try Self.validateWarningControlArgs(&parsedOptions)
     Self.validateCoverageArgs(&parsedOptions, diagnosticsEngine: diagnosticEngine)
+    try toolchain.validateArgs(&parsedOptions, targetTriple: self.frontendTargetInfo.target.triple)
 
     // Compute debug information output.
     self.debugInfo = Self.computeDebugInfo(&parsedOptions, diagnosticsEngine: diagnosticEngine)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
+import SwiftOptions
 
 /// Toolchain for Darwin-based platforms, such as macOS and iOS.
 ///
@@ -118,5 +119,55 @@ public final class DarwinToolchain: Toolchain {
     \(targetTriple.darwinPlatform!.libraryNameSuffix)\
     \(isShared ? "_dynamic.dylib" : ".a")
     """
+  }
+
+  enum ToolchainValidationError: Error, DiagnosticData {
+    case osVersionBelowMinimumDeploymentTarget(String)
+    case iOSVersionAboveMaximumDeploymentTarget(Int)
+
+    var description: String {
+      switch self {
+      case .osVersionBelowMinimumDeploymentTarget(let target):
+        return "Swift requires a minimum deployment target of \(target)"
+      case .iOSVersionAboveMaximumDeploymentTarget(let version):
+        return "iOS \(version) does not support 32-bit programs"
+      }
+    }
+  }
+
+  public func validateArgs(_ parsedOptions: inout ParsedOptions,
+                           targetTriple: Triple) throws {
+    // TODO: Validating arclite library path when link-objc-runtime.
+
+    // Validating apple platforms deployment targets.
+    try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple)
+
+    // TODO: Validating darwin unsupported -static-stdlib argument.
+    // TODO: If a C++ standard library is specified, it has to be libc++.
+  }
+
+  func validateDeploymentTarget(_ parsedOptions: inout ParsedOptions,
+                                targetTriple: Triple) throws {
+    // Check minimum supported OS versions.
+    if targetTriple.isMacOSX,
+       targetTriple.version(for: .macOS) < Triple.Version(10, 9, 0) {
+      throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget("OS X 10.9")
+    }
+    // tvOS triples are also iOS, so check it first.
+    else if targetTriple.isTvOS,
+            targetTriple.version(for: .tvOS(.device)) < Triple.Version(9, 0, 0) {
+      throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget("tvOS 9.0")
+    } else if targetTriple.isiOS {
+      if targetTriple.version(for: .iOS(.device)) < Triple.Version(7, 0, 0) {
+        throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget("iOS 7")
+      }
+      if targetTriple.arch?.is32Bit == true,
+         targetTriple.version(for: .iOS(.device)) >= Triple.Version(11, 0, 0) {
+        throw ToolchainValidationError.iOSVersionAboveMaximumDeploymentTarget(targetTriple.version(for: .iOS(.device)).major)
+      }
+    } else if targetTriple.isWatchOS,
+              targetTriple.version(for: .watchOS(.device)) < Triple.Version(2, 0, 0) {
+      throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget("watchOS 2.0")
+    }
   }
 }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -55,7 +55,8 @@ public protocol Toolchain {
 
   /// Perform platform-specific argument validation.
   func validateArgs(_ parsedOptions: inout ParsedOptions,
-                    targetTriple: Triple) throws
+                    targetTriple: Triple,
+                    targetVariantTriple: Triple?) throws
 
   /// Adds platform-specific linker flags to the provided command line
   func addPlatformSpecificLinkerArgs(
@@ -153,7 +154,8 @@ extension Toolchain {
   }
 
   public func validateArgs(_ parsedOptions: inout ParsedOptions,
-                           targetTriple: Triple) {}
+                           targetTriple: Triple,
+                           targetVariantTriple: Triple?) {}
 }
 
 public enum ToolchainError: Swift.Error {

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -53,6 +53,10 @@ public protocol Toolchain {
   /// Constructs a proper output file name for a linker product.
   func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String
 
+  /// Perform platform-specific argument validation.
+  func validateArgs(_ parsedOptions: inout ParsedOptions,
+                    targetTriple: Triple) throws
+
   /// Adds platform-specific linker flags to the provided command line
   func addPlatformSpecificLinkerArgs(
     to commandLine: inout [Job.ArgTemplate],
@@ -147,6 +151,9 @@ extension Toolchain {
     ).spm_chomp()
     return AbsolutePath(path)
   }
+
+  public func validateArgs(_ parsedOptions: inout ParsedOptions,
+                           targetTriple: Triple) {}
 }
 
 public enum ToolchainError: Swift.Error {

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -112,7 +112,7 @@ final class IntegrationTests: IntegrationTestCase {
   // they will fail.
 
   func testLitDriverTests() throws {
-    try runLitTests(suite: "test", "Driver", "macabi-environment.swift")
+    try runLitTests(suite: "test", "Driver")
   }
 
   func testLitDriverValidationTests() throws {

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -112,7 +112,7 @@ final class IntegrationTests: IntegrationTestCase {
   // they will fail.
 
   func testLitDriverTests() throws {
-    try runLitTests(suite: "test", "Driver")
+    try runLitTests(suite: "test", "Driver", "macabi-environment.swift")
   }
 
   func testLitDriverValidationTests() throws {


### PR DESCRIPTION
This fixes Driver/os-deployment.swift and slightly improves Driver/macabi-environment.swift. There's some remaining Darwin-specific argument validation left to be implemented, which I'll create a starter bug for