### PR TITLE
RFC: New Job discovery mechanism

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -704,8 +704,8 @@ extension Driver {
                          recordedInputModificationDates: recordedInputModificationDates)
   }
 
-  public mutating func createToolExecutionDelegate() -> ToolExecutionDelegate {
-    var mode: ToolExecutionDelegate.Mode = .regular
+  public mutating func createToolExecutionDelegate() -> TextualOutputExecutionDelegate {
+    var mode: TextualOutputExecutionDelegate.Mode = .regular
 
     // FIXME: Old driver does _something_ if both are passed. Not sure if we want to support that.
     if parsedOptions.contains(.parseableOutput) {
@@ -714,7 +714,7 @@ extension Driver {
       mode = .verbose
     }
 
-    return ToolExecutionDelegate(mode: mode)
+    return TextualOutputExecutionDelegate(mode: mode)
   }
 
   private func printBindings(_ job: Job) {

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -72,8 +72,8 @@ public protocol JobExecutionDelegate {
   /// Called when a job starts executing.
   func jobStarted(job: Job, arguments: [String], pid: Int)
   
-  /// Called when a job finished.
-  func jobFinished(job: Job, result: ProcessResult, pid: Int)
+  /// Called when a job finished. May return newly discovered jobs.
+  func jobFinished(job: Job, result: ProcessResult, pid: Int) -> [Job]
 }
 
 public final class SwiftDriverExecutor: DriverExecutor {

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -43,13 +43,25 @@ class JobCollectingDelegate: JobExecutionDelegate {
   var started: [Job] = []
   var finished: [(Job, ProcessResult)] = []
 
-  func jobFinished(job: Job, result: ProcessResult, pid: Int) {
+  func jobFinished(job: Job, result: ProcessResult, pid: Int) -> [Job] {
     finished.append((job, result))
+    return []
   }
 
   func jobStarted(job: Job, arguments: [String], pid: Int) {
     started.append(job)
   }
+}
+
+class JobDiscoveryDelegate: JobExecutionDelegate {
+  func jobFinished(job: Job, result: ProcessResult, pid: Int) -> [Job] {
+    guard !job.moduleName.hasSuffix("-new") else { return [] }
+    var newJob = job
+    newJob.moduleName = job.moduleName + "-new"
+    return [newJob]
+  }
+
+  func jobStarted(job: Job, arguments: [String], pid: Int) {}
 }
 
 extension DarwinToolchain {
@@ -198,6 +210,30 @@ final class JobExecutorTests: XCTestCase {
       XCTAssertFalse(localFileSystem.exists(AbsolutePath(fooObject)), "expected foo.o to be removed from the temporary directory")
     }
 #endif
+  }
+
+  func testJobDiscovery() throws {
+    try withTemporaryDirectory { path in
+      let foo = path.appending(component: "foo.swift")
+      try localFileSystem.writeFileContents(foo) {
+        $0 <<< "let foo = 5"
+      }
+
+      let collector = JobCollectingDelegate()
+      let discoverer = JobDiscoveryDelegate()
+      let delegate = ForwardingExecutionDelegate(delegates: [collector, discoverer])
+      let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
+                                             processSet: ProcessSet(),
+                                             fileSystem: localFileSystem,
+                                             env: ProcessEnv.vars)
+      var driver = try Driver(args: ["swiftc", foo.pathString], executor: executor)
+      let jobs = try driver.planBuild()
+
+      try executor.execute(jobs: jobs, delegate: delegate)
+
+      XCTAssertEqual(collector.finished.count, 4)
+      XCTAssertEqual(collector.finished.filter { $0.0.moduleName.hasSuffix("-new") }.count, 2)
+    }
   }
 
   func testStubProcessProtocol() throws {


### PR DESCRIPTION
~This isn't complete yet, but I figured I'd post it now to get some feedback.~ It's intended to support job discovery based on the output of preceding jobs for use in explicit module/incremental builds.

1. An executor can now have > 1 JobExecutionDelegate. This allows, e.g. one for parseable output and one for incremental build computation
2. JobExecutionDelegate.jobFinished can now return newly discovered jobs

~The problem I'm running into now is creating new ExecuteJobRule keys for discovered jobs because jobs are no longer serialized as part of the key, they're referenced by index instead. Undoing that change would solve the problem but introduce a pretty big performance regression.~

Also, if we use this approach, we'll probably want planBuild to return a list of "mandatory execution delegates" in addition to the list of jobs. If a client like SwiftPM wants to merge those jobs into a larger build graph it'll require some additional record keeping to ensure the right delegates get notified about the status of jobs and have a chance to schedule new work.