### PR TITLE
[Explicit Module Builds] Support explicit module builds with external dependencies.

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -8,7 +8,8 @@
 
 add_library(SwiftDriver
   "Explicit Module Builds/ClangModuleBuildJobCache.swift"
-  "Explicit Module Builds/ExplicitModuleBuildHandler.swift"   
+  "Explicit Module Builds/ExplicitModuleBuildHandler.swift"
+  "Explicit Module Builds/PlaceholderDependencyResolution.swift"
   "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
   "Explicit Module Builds/ModuleArtifacts.swift"

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -193,6 +193,11 @@ public struct Driver {
   /// as explicit by the various compilation jobs.
   @_spi(Testing) public var explicitModuleBuildHandler: ExplicitModuleBuildHandler? = nil
 
+  /// A collection describing external dependencies for the current main module that may be invisible to
+  /// the driver itself, but visible to its clients (e.g. build systems like SwiftPM). Along with the external dependenceis'
+  /// module dependency graphs.
+  internal var externalDependencyArtifactMap: ExternalDependencyArtifactMap? = nil
+
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in
     let stream = stderrStream
@@ -226,13 +231,16 @@ public struct Driver {
   /// - Parameter diagnosticsHandler: A callback executed when a diagnostic is
   ///   emitted. The default argument prints diagnostics to stderr.
   /// - Parameter executor: Used by the driver to execute jobs. The default argument
-  /// is present to streamline testing, it shouldn't be used in production.
+  ///   is present to streamline testing, it shouldn't be used in production.
+  /// - Parameter externalModuleDependencies: A collection of external modules that the main module
+  ///   of the current compilation depends on. Explicit Module Build use only.
   public init(
     args: [String],
     env: [String: String] = ProcessEnv.vars,
     diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
     fileSystem: FileSystem = localFileSystem,
-    executor: DriverExecutor
+    executor: DriverExecutor,
+    externalModuleDependencies: ExternalDependencyArtifactMap? = nil
   ) throws {
     self.env = env
     self.fileSystem = fileSystem
@@ -240,9 +248,12 @@ public struct Driver {
     self.diagnosticEngine = diagnosticsEngine
     self.executor = executor
 
+    self.externalDependencyArtifactMap = externalModuleDependencies
+
     if case .subcommand = try Self.invocationRunMode(forArgs: args).mode {
       throw Error.subcommandPassedToDriver
     }
+
 
     var args = try Self.expandResponseFiles(args, fileSystem: fileSystem, diagnosticsEngine: self.diagnosticEngine)
 

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -30,6 +30,7 @@ public struct Driver {
     case missingPCMArguments(String)
     case missingModuleDependency(String)
     case dependencyScanningFailure(Int, String)
+    case missingExternalDependency(String)
 
     public var description: String {
       switch self {
@@ -59,6 +60,8 @@ public struct Driver {
         return "Module Dependency Scanner returned with non-zero exit status: \(code), \(error)"
       case .unableToLoadOutputFileMap(let path):
         return "unable to load output file map '\(path)': no such file or directory"
+      case .missingExternalDependency(let moduleName):
+        return "Missing External dependency info for module: \(moduleName)"
       }
     }
   }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -194,7 +194,7 @@ public struct Driver {
   @_spi(Testing) public var explicitModuleBuildHandler: ExplicitModuleBuildHandler? = nil
 
   /// A collection describing external dependencies for the current main module that may be invisible to
-  /// the driver itself, but visible to its clients (e.g. build systems like SwiftPM). Along with the external dependenceis'
+  /// the driver itself, but visible to its clients (e.g. build systems like SwiftPM). Along with the external dependencies'
   /// module dependency graphs.
   internal var externalDependencyArtifactMap: ExternalDependencyArtifactMap? = nil
 

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -129,7 +129,7 @@ public typealias ExternalDependencyArtifactMap =
     var mainModuleCommandLine: [Job.ArgTemplate] = []
     try resolveMainModuleDependencies(inputs: &mainModuleInputs,
                                       commandLine: &mainModuleCommandLine)
-
+    
     return Array(swiftModuleBuildCache.values) + clangTargetModuleBuildCache.allJobs
   }
 

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -13,9 +13,13 @@ import TSCBasic
 import TSCUtility
 import Foundation
 
+public typealias ExternalDependencyArtifactMap =
+    [ModuleDependencyId: (AbsolutePath, InterModuleDependencyGraph)]
+
 /// In Explicit Module Build mode, this handler is responsible for generating and providing
 /// build jobs for all module dependencies and providing compile command options
 /// that specify said explicit module dependencies.
+
 @_spi(Testing) public struct ExplicitModuleBuildHandler {
   /// The module dependency graph.
   public var dependencyGraph: InterModuleDependencyGraph
@@ -30,6 +34,9 @@ import Foundation
   /// The toolchain to be used for frontend job generation.
   private let toolchain: Toolchain
 
+  /// A collection of external dependency modules, and their binary module file paths and dependency graph.
+  private let externalDependencyArtifactMap: ExternalDependencyArtifactMap
+
   /// The file system which we should interact with.
   /// FIXME: Our end goal is to not have any direct filesystem manipulation in here, but  that's dependent on getting the
   /// dependency scanner/dependency job generation  moved into a Job.
@@ -42,9 +49,11 @@ import Foundation
   private let temporaryDirectory: AbsolutePath
 
   public init(dependencyGraph: InterModuleDependencyGraph, toolchain: Toolchain,
-              fileSystem: FileSystem) throws {
+              fileSystem: FileSystem,
+              externalDependencyArtifactMap: ExternalDependencyArtifactMap) throws {
     self.dependencyGraph = dependencyGraph
     self.toolchain = toolchain
+    self.externalDependencyArtifactMap = externalDependencyArtifactMap
     self.fileSystem = fileSystem
     self.temporaryDirectory = try determineTempDirectory()
   }
@@ -457,4 +466,10 @@ private extension InterModuleDependencyGraph {
   }
 }
 
-
+// To keep the ExplicitModuleBuildHandler an implementation detail, provide an API
+// to access the dependency graph
+extension Driver {
+  public var interModuleDependencyGraph: InterModuleDependencyGraph? {
+    return explicitModuleBuildHandler?.dependencyGraph
+  }
+}

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -17,7 +17,7 @@ public enum ModuleDependencyId: Hashable {
   case swiftPlaceholder(String)
   case clang(String)
 
-  var moduleName: String {
+  public var moduleName: String {
     switch self {
     case .swift(let name): return name
     case .swiftPlaceholder(let name): return name
@@ -77,8 +77,9 @@ public struct SwiftModuleDetails: Codable {
   /// The paths of potentially ready-to-use compiled modules for the interface.
   public var compiledModuleCandidates: [String]?
 
-  /// The path to the already-compiled module.
-  public var compiledModulePath: String?
+  /// The path to the already-compiled module that must be used instead of
+  /// generating a job to build this module.
+  public var explicitCompiledModulePath: String?
 
   /// The bridging header, if any.
   public var bridgingHeaderPath: String?
@@ -92,7 +93,7 @@ public struct SwiftModuleDetails: Codable {
   /// To build a PCM to be used by this Swift module, we need to append these
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
-  var extraPcmArgs: [String]?
+  public var extraPcmArgs: [String]?
 }
 
 /// Details specific to Swift external modules.

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 
-@_spi(Testing) public enum ModuleDependencyId: Hashable {
+public enum ModuleDependencyId: Hashable {
   case swift(String)
   case clang(String)
 
@@ -53,7 +53,7 @@ extension ModuleDependencyId: Codable {
 }
 
 /// Details specific to Swift modules.
-@_spi(Testing) public struct SwiftModuleDetails: Codable {
+public struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
   public var moduleInterfacePath: String?
 
@@ -79,7 +79,7 @@ extension ModuleDependencyId: Codable {
 }
 
 /// Details specific to Clang modules.
-@_spi(Testing) public struct ClangModuleDetails: Codable {
+public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
   public var moduleMapPath: String
 
@@ -90,7 +90,7 @@ extension ModuleDependencyId: Codable {
   public var commandLine: [String]? = []
 }
 
-@_spi(Testing) public struct ModuleInfo: Codable {
+public struct ModuleInfo: Codable {
   /// The path for the module.
   public var modulePath: String
 
@@ -144,7 +144,7 @@ extension ModuleInfo.Details: Codable {
 
 /// Describes the complete set of dependencies for a Swift module, including
 /// all of the Swift and C modules and source files it depends on.
-@_spi(Testing) public struct InterModuleDependencyGraph: Codable {
+public struct InterModuleDependencyGraph: Codable {
   /// The name of the main module.
   public var mainModuleName: String
 

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -72,31 +72,31 @@ public struct BridgingHeader: Codable {
 /// Details specific to Swift modules.
 public struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
-  public var moduleInterfacePath: String?
+  @_spi(Testing) public var moduleInterfacePath: String?
 
   /// The paths of potentially ready-to-use compiled modules for the interface.
-  public var compiledModuleCandidates: [String]?
+  @_spi(Testing) public var compiledModuleCandidates: [String]?
 
   /// The path to the already-compiled module that must be used instead of
   /// generating a job to build this module. In standard compilation, the dependency scanner
   /// may discover compiled module candidates to be used instead of re-compiling from interface.
   /// In contrast, this explicitCompiledModulePath is only to be used for precompiled modules
   /// external dependencies in Explicit Module Build mode
-  public var explicitCompiledModulePath: String?
+  @_spi(Testing) public var explicitCompiledModulePath: String?
 
   /// The bridging header, if any.
-  public var bridgingHeaderPath: String?
+  var bridgingHeaderPath: String?
 
   /// The source files referenced by the bridging header.
-  public var bridgingSourceFiles: [String]? = []
+  var bridgingSourceFiles: [String]? = []
 
   /// Options to the compile command
-  public var commandLine: [String]? = []
+  var commandLine: [String]? = []
 
   /// To build a PCM to be used by this Swift module, we need to append these
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
-  public var extraPcmArgs: [String]?
+  @_spi(Testing) public var extraPcmArgs: [String]?
 }
 
 /// Details specific to Swift external modules.
@@ -111,13 +111,13 @@ public struct swiftPlaceholderModuleDetails: Codable {
 /// Details specific to Clang modules.
 public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
-  public var moduleMapPath: String
+  @_spi(Testing) public var moduleMapPath: String
 
   /// clang-generated context hash
-  public var contextHash: String?
+  var contextHash: String?
 
   /// Options to the compile command
-  public var commandLine: [String]? = []
+  var commandLine: [String]? = []
 }
 
 public struct ModuleInfo: Codable {

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -78,7 +78,10 @@ public struct SwiftModuleDetails: Codable {
   public var compiledModuleCandidates: [String]?
 
   /// The path to the already-compiled module that must be used instead of
-  /// generating a job to build this module.
+  /// generating a job to build this module. In standard compilation, the dependency scanner
+  /// may discover compiled module candidates to be used instead of re-compiling from interface.
+  /// In contrast, this explicitCompiledModulePath is only to be used for precompiled modules
+  /// external dependencies in Explicit Module Build mode
   public var explicitCompiledModulePath: String?
 
   /// The bridging header, if any.

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -14,12 +14,14 @@ import Foundation
 
 public enum ModuleDependencyId: Hashable {
   case swift(String)
+  case swiftPlaceholder(String)
   case clang(String)
 
-  public var moduleName: String {
+  var moduleName: String {
     switch self {
-      case .swift(let name): return name
-      case .clang(let name): return name
+    case .swift(let name): return name
+    case .swiftPlaceholder(let name): return name
+    case .clang(let name): return name
     }
   }
 }
@@ -27,6 +29,7 @@ public enum ModuleDependencyId: Hashable {
 extension ModuleDependencyId: Codable {
   enum CodingKeys: CodingKey {
     case swift
+    case swiftPlaceholder
     case clang
   }
 
@@ -36,8 +39,13 @@ extension ModuleDependencyId: Codable {
       let moduleName =  try container.decode(String.self, forKey: .swift)
       self = .swift(moduleName)
     } catch {
-      let moduleName =  try container.decode(String.self, forKey: .clang)
-      self = .clang(moduleName)
+      do {
+        let moduleName =  try container.decode(String.self, forKey: .swiftPlaceholder)
+        self = .swiftPlaceholder(moduleName)
+      } catch {
+        let moduleName =  try container.decode(String.self, forKey: .clang)
+        self = .clang(moduleName)
+      }
     }
   }
 
@@ -46,10 +54,19 @@ extension ModuleDependencyId: Codable {
     switch self {
       case .swift(let moduleName):
         try container.encode(moduleName, forKey: .swift)
+      case .swiftPlaceholder(let moduleName):
+        try container.encode(moduleName, forKey: .swift)
       case .clang(let moduleName):
         try container.encode(moduleName, forKey: .clang)
     }
   }
+}
+
+/// Bridging header
+public struct BridgingHeader: Codable {
+  var path: String
+  var sourceFiles: [String]
+  var moduleDependencies: [String]
 }
 
 /// Details specific to Swift modules.
@@ -75,7 +92,16 @@ public struct SwiftModuleDetails: Codable {
   /// To build a PCM to be used by this Swift module, we need to append these
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
-  public var extraPcmArgs: [String]? = []
+  var extraPcmArgs: [String]?
+}
+
+/// Details specific to Swift external modules.
+public struct swiftPlaceholderModuleDetails: Codable {
+  /// The path to the .swiftModuleDoc file.
+  var moduleDocPath: String?
+
+  /// The path to the .swiftSourceInfo file.
+  var moduleSourceInfoPath: String?
 }
 
 /// Details specific to Clang modules.
@@ -95,10 +121,10 @@ public struct ModuleInfo: Codable {
   public var modulePath: String
 
   /// The source files used to build this module.
-  public var sourceFiles: [String] = []
+  public var sourceFiles: [String]? = []
 
   /// The set of direct module dependencies of this module.
-  public var directDependencies: [ModuleDependencyId] = []
+  public var directDependencies: [ModuleDependencyId]? = []
 
   /// Specific details of a particular kind of module.
   public var details: Details
@@ -109,6 +135,10 @@ public struct ModuleInfo: Codable {
     /// a bridging header.
     case swift(SwiftModuleDetails)
 
+    /// Swift external modules carry additional details that specify their
+    /// module doc path and source info paths.
+    case swiftPlaceholder(swiftPlaceholderModuleDetails)
+
     /// Clang modules are built from a module map file.
     case clang(ClangModuleDetails)
   }
@@ -117,6 +147,7 @@ public struct ModuleInfo: Codable {
 extension ModuleInfo.Details: Codable {
   enum CodingKeys: CodingKey {
     case swift
+    case swiftPlaceholder
     case clang
   }
 
@@ -126,8 +157,13 @@ extension ModuleInfo.Details: Codable {
       let details = try container.decode(SwiftModuleDetails.self, forKey: .swift)
       self = .swift(details)
     } catch {
-      let details = try container.decode(ClangModuleDetails.self, forKey: .clang)
-      self = .clang(details)
+      do {
+        let details = try container.decode(swiftPlaceholderModuleDetails.self, forKey: .swiftPlaceholder)
+        self = .swiftPlaceholder(details)
+      } catch {
+        let details = try container.decode(ClangModuleDetails.self, forKey: .clang)
+        self = .clang(details)
+      }
     }
   }
 
@@ -136,6 +172,8 @@ extension ModuleInfo.Details: Codable {
     switch self {
       case .swift(let details):
         try container.encode(details, forKey: .swift)
+      case .swiftPlaceholder(let details):
+        try container.encode(details, forKey: .swiftPlaceholder)
       case .clang(let details):
         try container.encode(details, forKey: .clang)
     }

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
@@ -54,7 +54,7 @@ extension Driver {
                supportsResponseFiles: true)
   }
 
-  /// Serialize a map of placeholder
+  /// Serialize a map of placeholder (external) dependencies for the dependency scanner.
   func serializeExternalDependencyArtifacts(externalDependencyArtifactMap: ExternalDependencyArtifactMap)
   throws -> AbsolutePath {
     let temporaryDirectory = try determineTempDirectory()

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
@@ -31,6 +31,15 @@ extension Driver {
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
+    // Pass in external dependencies to be treated as placeholder dependencies by the scanner
+    if let externalDependencyArtifactMap = externalDependencyArtifactMap {
+      let dependencyPlaceholderMapFile =
+        try serializeExternalDependencyArtifacts(externalDependencyArtifactMap:
+                                                  externalDependencyArtifactMap)
+      commandLine.appendFlag("-placeholder-dependency-module-map-file")
+      commandLine.appendPath(dependencyPlaceholderMapFile)
+    }
+
     // Pass on the input files
     commandLine.append(contentsOf: inputFiles.map { .path($0.file)})
 
@@ -43,5 +52,25 @@ extension Driver {
                inputs: inputs,
                outputs: [TypedVirtualPath(file: .standardOutput, type: .jsonDependencies)],
                supportsResponseFiles: true)
+  }
+
+  /// Serialize a map of placeholder
+  func serializeExternalDependencyArtifacts(externalDependencyArtifactMap: ExternalDependencyArtifactMap)
+  throws -> AbsolutePath {
+    let temporaryDirectory = try determineTempDirectory()
+    let placeholderMapFilePath =
+      temporaryDirectory.appending(component: "\(moduleOutputInfo.name)-placeholder-modules.json")
+
+    var placeholderArtifacts: [SwiftModuleArtifactInfo] = []
+    for (moduleId, dependencyInfo) in externalDependencyArtifactMap {
+      placeholderArtifacts.append(
+          SwiftModuleArtifactInfo(name: moduleId.moduleName,
+                                  modulePath: dependencyInfo.0.description))
+    }
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted]
+    let contents = try encoder.encode(placeholderArtifacts)
+    try fileSystem.writeFileContents(placeholderMapFilePath, bytes: ByteString(contents))
+    return placeholderMapFilePath
   }
 }

--- a/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
@@ -1,0 +1,164 @@
+//===--------------- PlaceholderDependencyResolution.swift ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+import TSCUtility
+import Foundation
+
+extension ExplicitModuleBuildHandler {
+  // Building a Swift module in Explicit Module Build mode requires passing all of its module
+  // dependencies as explicit arguments to the build command.
+  //
+  // When the driver's clients (build systems) are planning a build that involves multiple
+  // Swift modules, planning for each individual module may take place before its dependencies
+  // have been built. This means that the dependency scanning action will not be able to
+  // discover such modules. In such cases, the clients must provide the driver with information
+  // about such external dependencies, including the path to where their compiled .swiftmodule
+  // will be located, once built, and a full inter-module dependency graph for each such dependence.
+  //
+  // The driver will pass down the information about such external dependencies to the scanning
+  // action, which will generate `placeholder` swift modules for them in the resulting dependency
+  // graph. The driver will then use the complete dependency graph provided by
+  // the client for each external dependency and use it to "resolve" the dependency's "placeholder"
+  // module.
+  //
+  // Consider an example SwiftPM package with two targets: target B, and target A, where A
+  // depends on B:
+  // SwiftPM will process targets in a topological order and “bubble-up” each target’s
+  // inter-module dependency graph to its dependees. First, SwiftPM will process B, and be
+  // able to plan its full build because it does not have any target dependencies. Then the
+  // driver is tasked with planning a build for A. SwiftPM will pass as input to the driver
+  // the module dependency graph of its target’s dependencies, in this case, just the
+  // dependency graph of B. The scanning action for module A will contain a placeholder module B,
+  // which the driver will then resolve using B's full dependency graph provided by the client.
+
+  /// Resolve all placeholder dependencies using external dependency information provided by the client
+  mutating public func resolvePlaceholderDependencies() throws {
+    let placeholderModules = dependencyGraph.modules.keys.filter {
+      if case .swiftPlaceholder(_) = $0 {
+        return true
+      }
+      return false
+    }
+
+    // Resolve all placeholder modules
+    for moduleId in placeholderModules {
+      guard let (placeholderModulePath, placeholderDependencyGraph) =
+              externalDependencyArtifactMap[moduleId] else {
+        throw Driver.Error.missingExternalDependency(moduleId.moduleName)
+      }
+      try resolvePlaceholderDependency(placeholderModulePath: placeholderModulePath,
+                                       placeholderDependencyGraph: placeholderDependencyGraph)
+    }
+  }
+
+  /// Merge a given external module's dependency graph in place of a placeholder dependency
+  mutating public func resolvePlaceholderDependency(placeholderModulePath: AbsolutePath,
+                                                    placeholderDependencyGraph: InterModuleDependencyGraph)
+  throws {
+    // For every other module in the placeholder dependency graph, generate a new module info
+    // containing only the pre-compiled module path, and insert it into the current module's
+    // dependency graph, replacing equivalent (non pre-built) modules, if necessary.
+    for (moduleId, moduleInfo) in placeholderDependencyGraph.modules {
+      switch moduleId {
+        case .swift(_):
+          // Compute the compiled module path for this module.
+          // If this module is the placeholder itself, this information was passed from SwiftPM
+          // If this module is any other swift module, then the compiled module path is
+          // a part of the details field.
+          // Otherwise (for most other dependencies), it is the modulePath of the moduleInfo node.
+          // FIXME: Will the `else` case ever happen?
+          let compiledModulePath : String
+          if moduleId.moduleName == placeholderDependencyGraph.mainModuleName {
+            compiledModulePath = placeholderModulePath.description
+          } else if case .swift(let details) = moduleInfo.details,
+                    let explicitModulePath = details.explicitCompiledModulePath {
+            compiledModulePath = explicitModulePath
+          } else {
+            compiledModulePath = moduleInfo.modulePath.description
+          }
+
+          let swiftDetails =
+            SwiftModuleDetails(compiledModulePath: compiledModulePath)
+          print("For module: \(moduleId.moduleName) set the path to:\n\(compiledModulePath)")
+          let newInfo = ModuleInfo(modulePath: moduleInfo.modulePath.description,
+                                   sourceFiles: nil,
+                                   directDependencies: moduleInfo.directDependencies,
+                                   details: ModuleInfo.Details.swift(swiftDetails))
+          try insertOrReplaceModule(moduleId: moduleId, moduleInfo: newInfo)
+          print("New Info: \(newInfo)")
+        case .clang(_):
+          // Because PCM modules file names encode the specific pcmArguments of their dependees,
+          // we cannot use pre-built files here because we do not always know which target
+          // they corrspond to, nor do we have a way to map from a certain target to a specific
+          // pcm file. Because of this, all PCM dependencies, direct and transitive, have to be
+          // built for all modules.
+          if dependencyGraph.modules[moduleId] == nil {
+            dependencyGraph.modules[moduleId] = moduleInfo
+          }
+        case .swiftPlaceholder(_):
+          try insertOrReplaceModule(moduleId: moduleId, moduleInfo: moduleInfo)
+      }
+    }
+  }
+
+  /// Insert a module into the handler's dependency graph. If a module with this identifier already exists,
+  /// replace it's module with a moduleInfo that contains a path to an existing prebuilt .swiftmodule
+  mutating public func insertOrReplaceModule(moduleId: ModuleDependencyId,
+                                             moduleInfo: ModuleInfo) throws {
+    // Check for placeholders to be replaced
+    if dependencyGraph.modules[ModuleDependencyId.swiftPlaceholder(moduleId.moduleName)] != nil {
+      try replaceModule(originalId: .swiftPlaceholder(moduleId.moduleName), replacementId: moduleId,
+                        replacementInfo: moduleInfo)
+    }
+    // Check for modules with the same Identifier, and replace if found
+    else if dependencyGraph.modules[moduleId] != nil {
+      try replaceModule(originalId: moduleId, replacementId: moduleId, replacementInfo: moduleInfo)
+    // This module is new to the current dependency graph
+    } else {
+      dependencyGraph.modules[moduleId] = moduleInfo
+    }
+  }
+
+  /// Replace a module with a new one. Replace all references to the original module in other modules' dependencies
+  /// with the new module.
+  mutating public func replaceModule(originalId: ModuleDependencyId,
+                                     replacementId: ModuleDependencyId,
+                                     replacementInfo: ModuleInfo) throws {
+    dependencyGraph.modules.removeValue(forKey: originalId)
+    dependencyGraph.modules[replacementId] = replacementInfo
+    for moduleId in dependencyGraph.modules.keys {
+      var moduleInfo = dependencyGraph.modules[moduleId]!
+      // Skip over other placeholders, they do not have dependencies
+      if case .swiftPlaceholder(_) = moduleId {
+        continue
+      }
+      if let originalModuleIndex = moduleInfo.directDependencies?.firstIndex(of: originalId) {
+        moduleInfo.directDependencies![originalModuleIndex] = replacementId;
+      }
+      dependencyGraph.modules[moduleId] = moduleInfo
+    }
+  }
+}
+
+/// Used for creating new module infos during placeholder dependency resolution
+/// Modules created this way only contain a path to a pre-built module file.
+extension SwiftModuleDetails {
+  public init(compiledModulePath: String) {
+    self.moduleInterfacePath = nil
+    self.compiledModuleCandidates = nil
+    self.explicitCompiledModulePath = compiledModulePath
+    self.bridgingHeaderPath = nil
+    self.bridgingSourceFiles = nil
+    self.commandLine = nil
+    self.extraPcmArgs = nil
+  }
+}

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -43,7 +43,7 @@ extension Driver {
   }
 
   /// Form a job that emits a single module
-  mutating func emitModuleJob() throws -> Job {
+  @_spi(Testing) public mutating func emitModuleJob() throws -> Job {
     let moduleOutputPath = moduleOutputInfo.output!.outputPath
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -230,9 +230,11 @@ extension Driver {
                                 forceResponseFiles: forceResponseFiles,
                                 recordedInputModificationDates: recordedInputModificationDates)
 
-    explicitModuleBuildHandler = try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
-                                                                toolchain: toolchain,
-                                                                fileSystem: fileSystem)
+    explicitModuleBuildHandler =
+        try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
+                                       toolchain: toolchain,
+                                       fileSystem: fileSystem,
+                                       externalDependencyArtifactMap: externalDependencyArtifactMap ?? [:])
     return try explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
   }
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -133,7 +133,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
               from: ModuleDependenciesInputs.fastDependencyScannerOutput.data(using: .utf8)!)
       driver.explicitModuleBuildHandler = try ExplicitModuleBuildHandler(dependencyGraph: moduleDependencyGraph,
                                                                          toolchain: driver.toolchain,
-                                                                         fileSystem: localFileSystem)
+                                                                         fileSystem: localFileSystem,
+                                                                         externalDependencyArtifactMap: [:])
       let modulePrebuildJobs =
         try driver.explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
       XCTAssertEqual(modulePrebuildJobs.count, 4)

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -242,4 +242,192 @@ enum ModuleDependenciesInputs {
     }
     """
   }
+
+  static var fastDependencyScannerPlaceholderOutput: String {
+    """
+    {
+      "mainModuleName": "A",
+      "modules": [
+        {
+          "swift": "A"
+        },
+        {
+          "modulePath": "A.swiftmodule",
+          "sourceFiles": [
+            "main.swift",
+            "A.swift"
+          ],
+          "directDependencies": [
+            {
+              "swiftPlaceholder": "B"
+            },
+            {
+              "swift": "Swift"
+            },
+            {
+              "swift": "SwiftOnoneSupport"
+            }
+          ],
+          "details": {
+            "swift": {
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.10",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ]
+            }
+          }
+        },
+        {
+          "swiftPlaceholder": "B"
+        },
+        {
+          "modulePath": "/Volumes/Data/Current/Driver/ExplicitPMTest/.build/x86_64-apple-macosx/debug/B.swiftmodule",
+          "details": {
+            "swiftPlaceholder": {
+            }
+          }
+        },
+        {
+          "swift": "Swift"
+        },
+        {
+          "modulePath": "Swift.swiftmodule",
+          "sourceFiles": [
+          ],
+          "directDependencies": [
+          ],
+          "details": {
+            "swift": {
+              "moduleInterfacePath": "Swift.swiftmodule/x86_64-apple-macos.swiftinterface",
+              "contextHash": "30OCBGKPNG64V",
+              "commandLine": [
+                "-frontend",
+                "-compile-module-from-interface",
+                "-target",
+                "x86_64-apple-macosx10.10",
+                "-swift-version",
+                "5",
+                "-module-name",
+                "Swift"
+              ],
+              "compiledModuleCandidates": [
+              ],
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.9",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ]
+            }
+          }
+        },
+        {
+          "swift": "SwiftOnoneSupport"
+        },
+        {
+          "modulePath": "SwiftOnoneSupport.swiftmodule",
+          "sourceFiles": [
+          ],
+          "directDependencies": [
+            {
+              "swift": "Swift"
+            }
+          ],
+          "details": {
+            "swift": {
+              "moduleInterfacePath": "SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface",
+              "contextHash": "3GKS4RKE3GDZA",
+              "commandLine": [
+                "-frontend",
+                "-compile-module-from-interface",
+                "-target",
+                "x86_64-apple-macosx10.10",
+                "-swift-version",
+                "5",
+                "-module-name",
+                "SwiftOnoneSupport"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """
+  }
+
+  static var bPlaceHolderInput: String {
+    """
+    {
+      "mainModuleName": "B",
+      "modules": [
+        {
+          "swift": "B"
+        },
+        {
+          "modulePath": "B.swiftmodule",
+          "sourceFiles": [
+            "/B/B.swift"
+          ],
+          "directDependencies": [
+            {
+              "swift": "Swift"
+            },
+            {
+              "swift": "SwiftOnoneSupport"
+            }
+          ],
+          "details": {
+            "swift": {
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.10",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ]
+            }
+          }
+        },
+        {
+          "swift" : "Swift"
+        },
+        {
+          "modulePath" : "Swift.swiftmodule",
+          "directDependencies" : [
+          ],
+          "details" : {
+            "swift" : {
+              "explicitCompiledModulePath" : "M/Swift.swiftmodule"
+            }
+          }
+        },
+        {
+          "swift" : "SwiftOnoneSupport"
+        },
+        {
+          "modulePath" : "SwiftOnoneSupport.swiftmodule",
+          "directDependencies" : [
+            {
+              "swift" : "Swift"
+            }
+          ],
+          "details" : {
+            "swift" : {
+              "explicitCompiledModulePath" : "S/SwiftOnoneSupport.swiftmodule"
+            }
+          }
+        }
+      ]
+    }
+    """
+  }
 }
+
+


### PR DESCRIPTION
This change introduces support for external dependencies in Explicit Module Build compilation mode.

Building a Swift module in Explicit Module Build mode requires passing all of its module dependencies as explicit arguments to the build command.

When the driver's clients (build systems, e.g. SwiftPM) are planning a build that involves multiple Swift modules, planning for each individual module may take place before its dependencies have been built. This means that the dependency scanning action will not be able to discover such modules. In such cases, the clients must provide the driver with information about such external dependencies, including the path to where their compiled `.swiftmodule` will be located, once built, and a full inter-module dependency graph for each such dependence.

The driver will pass down the information about such external dependencies to the scanning action, which will generate `placeholder` swift modules for them in the resulting dependency graph. The driver will then use the complete dependency graph provided by the client for each external dependency and use it to "resolve" the dependency's "placeholder" module.

This PR:
- Adds API for the clients to pass in external module dependency artifacts (module file path and dependency graph).
- Updates the Inter Module Dependency Graph to represent `swiftPlaceholder` dependencies.
- Updates the scanning action invocation to pass in information about external dependencies.
- Introduces the placeholder dependency resolution logic that updates the dependency graph by substituting in dependency graphs of external modules in place of placeholder modules.

This change works in tandem with the corresponding Dependency Scanner change in:
https://github.com/apple/swift/pull/33032
And a corresponding SwiftPM change:
https://github.com/apple/swift-package-manager/pull/2827