### PR TITLE
Add a BuildPlan type to encapsulate jobs and job execution delegates

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(SwiftDriver
   Driver/LinkKind.swift
   Driver/ModuleOutputInfo.swift
   Driver/OutputFileMap.swift
-  Driver/ToolExecutionDelegate.swift
+  Driver/TextualOutputJobExecutionDelegate.swift
 
   Execution/ArgsResolver.swift
   Execution/MultiJobExecutor.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -697,7 +697,7 @@ extension Driver {
 
     // Perform the build
     try executor.execute(jobs: jobs,
-                         delegate: executorDelegate,
+                         delegates: [executorDelegate],
                          numParallelJobs: numParallelJobs ?? 1,
                          forceResponseFiles: forceResponseFiles,
                          recordedInputModificationDates: recordedInputModificationDates)

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -642,11 +642,13 @@ extension Driver {
 
   /// Run the driver.
   public mutating func run(
-    jobs: [Job]
+    buildPlan: BuildPlan
   ) throws {
     if parsedOptions.hasArgument(.v) {
       try printVersion(outputStream: &stderrStream)
     }
+
+    let jobs = buildPlan.jobs
 
     guard !jobs.isEmpty else {
       guard !inputFiles.isEmpty else {
@@ -692,12 +694,9 @@ extension Driver {
       return
     }
 
-    // Create and use the tool execution delegate if one is not provided explicitly.
-    let executorDelegate = createToolExecutionDelegate()
-
     // Perform the build
-    try executor.execute(jobs: jobs,
-                         delegates: [executorDelegate],
+    try executor.execute(jobs: buildPlan.jobs,
+                         delegates: buildPlan.jobExecutionDelegates,
                          numParallelJobs: numParallelJobs ?? 1,
                          forceResponseFiles: forceResponseFiles,
                          recordedInputModificationDates: recordedInputModificationDates)

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -702,8 +702,8 @@ extension Driver {
                          recordedInputModificationDates: recordedInputModificationDates)
   }
 
-  public mutating func createToolExecutionDelegate() -> ToolExecutionDelegate {
-    var mode: ToolExecutionDelegate.Mode = .regular
+  public mutating func createTextualOutputExecutionDelegate() -> TextualOutputJobExecutionDelegate {
+    var mode: TextualOutputJobExecutionDelegate.Mode = .regular
 
     // FIXME: Old driver does _something_ if both are passed. Not sure if we want to support that.
     if parsedOptions.contains(.parseableOutput) {
@@ -712,7 +712,7 @@ extension Driver {
       mode = .verbose
     }
 
-    return ToolExecutionDelegate(mode: mode)
+    return TextualOutputJobExecutionDelegate(mode: mode)
   }
 
   private func printBindings(_ job: Job) {

--- a/Sources/SwiftDriver/Driver/TextualOutputJobExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/TextualOutputJobExecutionDelegate.swift
@@ -23,7 +23,7 @@ import Glibc
 #endif
 
 /// Delegate for printing execution information on the command-line.
-public struct ToolExecutionDelegate: JobExecutionDelegate {
+public struct TextualOutputJobExecutionDelegate: JobExecutionDelegate {
   public enum Mode {
     case verbose
     case parsableOutput

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -59,7 +59,7 @@ public struct ToolExecutionDelegate: JobExecutionDelegate {
     }
   }
 
-  public func jobFinished(job: Job, result: ProcessResult, pid: Int) {
+  public func jobFinished(job: Job, result: ProcessResult, pid: Int) -> [Job] {
     switch mode {
     case .regular, .verbose:
       let output = (try? result.utf8Output() + result.utf8stderrOutput()) ?? ""
@@ -84,6 +84,7 @@ public struct ToolExecutionDelegate: JobExecutionDelegate {
       }
       emit(message)
     }
+    return []
   }
 
   private func emit(_ message: ParsableMessage) {

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -72,8 +72,8 @@ public protocol JobExecutionDelegate {
   /// Called when a job starts executing.
   func jobStarted(job: Job, arguments: [String], pid: Int)
   
-  /// Called when a job finished.
-  func jobFinished(job: Job, result: ProcessResult, pid: Int)
+  /// Called when a job finished. May return newly discovered jobs.
+  func jobFinished(job: Job, result: ProcessResult, pid: Int) -> [Job]
 }
 
 public final class SwiftDriverExecutor: DriverExecutor {

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -22,7 +22,7 @@ public protocol DriverExecutor {
   
   /// Execute multiple jobs, tracking job status using the provided execution delegate.
   func execute(jobs: [Job],
-               delegate: JobExecutionDelegate,
+               delegates: [JobExecutionDelegate],
                numParallelJobs: Int,
                forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath: Date]
@@ -120,14 +120,14 @@ public final class SwiftDriverExecutor: DriverExecutor {
   }
   
   public func execute(jobs: [Job],
-                      delegate: JobExecutionDelegate,
+                      delegates: [JobExecutionDelegate],
                       numParallelJobs: Int = 1,
                       forceResponseFiles: Bool = false,
                       recordedInputModificationDates: [TypedVirtualPath: Date] = [:]
   ) throws {
     let llbuildExecutor = MultiJobExecutor(jobs: jobs,
                                            resolver: resolver,
-                                           executorDelegate: delegate,
+                                           executorDelegates: delegates,
                                            diagnosticsEngine: diagnosticsEngine,
                                            numParallelJobs: numParallelJobs,
                                            processSet: processSet,

--- a/Sources/SwiftDriver/Execution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriver/Execution/MultiJobExecutor.swift
@@ -18,13 +18,13 @@ import Dispatch
 public final class MultiJobExecutor {
 
   /// The context required during job execution.
-  struct Context {
+  final class Context {
 
     /// This contains mapping from an output to the index(in the jobs array) of the job that produces that output.
     let producerMap: [VirtualPath: Int]
 
     /// All the jobs being executed.
-    let jobs: [Job]
+    var jobs: [Job]
 
     /// The resolver for argument template.
     let argsResolver: ArgsResolver
@@ -194,7 +194,7 @@ struct JobExecutorBuildDelegate: LLBuildEngineDelegate {
   func lookupRule(rule: String, key: Key) -> Rule {
     switch rule {
     case ExecuteAllJobsRule.ruleName:
-      return ExecuteAllJobsRule(key, jobs: context.jobs, fileSystem: context.fileSystem)
+      return ExecuteAllJobsRule(key, context: context, fileSystem: context.fileSystem)
     case ExecuteJobRule.ruleName:
       return ExecuteJobRule(key, context: context)
     default:
@@ -215,8 +215,11 @@ struct DriverBuildValue: LLBuildValue {
   /// The kind of build value.
   var kind: Kind
 
-  static func jobExecution(success: Bool) -> DriverBuildValue {
-    return .init(success: success, kind: .jobExecution)
+  /// Newly discovered jobs.
+  var discoveredJobs: [Job]
+
+  static func jobExecution(success: Bool, discoveredJobs: [Job]) -> DriverBuildValue {
+    return .init(success: success, kind: .jobExecution, discoveredJobs: discoveredJobs)
   }
 }
 
@@ -229,19 +232,19 @@ class ExecuteAllJobsRule: LLBuildRule {
   override class var ruleName: String { "\(ExecuteAllJobsRule.self)" }
 
   private let key: RuleKey
-  private let jobs: [Job]
+  private var context: MultiJobExecutor.Context
 
   /// True if any of the inputs had any error.
   private var allInputsSucceeded: Bool = true
 
-  init(_ key: Key, jobs: [Job], fileSystem: FileSystem) {
+  init(_ key: Key, context: MultiJobExecutor.Context, fileSystem: FileSystem) {
     self.key = RuleKey(key)
-    self.jobs = jobs
+    self.context = context
     super.init(fileSystem: fileSystem)
   }
 
   override func start(_ engine: LLTaskBuildEngine) {
-    for index in jobs.indices {
+    for index in context.jobs.indices {
       let key = ExecuteJobRule.RuleKey(index: index)
       engine.taskNeedsInput(key, inputID: index)
     }
@@ -255,13 +258,18 @@ class ExecuteAllJobsRule: LLBuildRule {
     do {
       let buildValue = try DriverBuildValue(value)
       allInputsSucceeded = allInputsSucceeded && buildValue.success
+      for job in buildValue.discoveredJobs {
+        context.jobs.append(job)
+        let index = context.jobs.count - 1
+        engine.taskNeedsInput(ExecuteJobRule.RuleKey(index: index), inputID: index)
+      }
     } catch {
       allInputsSucceeded = false
     }
   }
 
   override func inputsAvailable(_ engine: LLTaskBuildEngine) {
-    engine.taskIsComplete(DriverBuildValue.jobExecution(success: allInputsSucceeded))
+    engine.taskIsComplete(DriverBuildValue.jobExecution(success: allInputsSucceeded, discoveredJobs: []))
   }
 }
 
@@ -312,7 +320,7 @@ class ExecuteJobRule: LLBuildRule {
   override func inputsAvailable(_ engine: LLTaskBuildEngine) {
     // Return early any of the input failed.
     guard allInputsSucceeded else {
-      return engine.taskIsComplete(DriverBuildValue.jobExecution(success: false))
+      return engine.taskIsComplete(DriverBuildValue.jobExecution(success: false, discoveredJobs: []))
     }
 
     context.jobQueue.addOperation {
@@ -364,11 +372,12 @@ class ExecuteJobRule: LLBuildRule {
       }
 
       // Inform the delegate about job finishing.
-      context.delegateQueue.async {
-        context.executorDelegates.forEach { $0.jobFinished(job: job, result: result, pid: pid) }
+      var discoveredJobs: [Job] = []
+      context.delegateQueue.sync {
+        context.executorDelegates.forEach { discoveredJobs += $0.jobFinished(job: job, result: result, pid: pid) }
       }
 
-      value = .jobExecution(success: success)
+      value = .jobExecution(success: success, discoveredJobs: discoveredJobs)
     } catch {
       if error is DiagnosticData {
         context.diagnosticsEngine.emit(error)
@@ -381,9 +390,9 @@ class ExecuteJobRule: LLBuildRule {
           output: Result.success([]),
           stderrOutput: Result.success([])
         )
-        context.executorDelegates.forEach{ $0.jobFinished(job: job, result: result, pid: 0) }
+        context.executorDelegates.forEach{ _ = $0.jobFinished(job: job, result: result, pid: 0) }
       }
-      value = .jobExecution(success: false)
+      value = .jobExecution(success: false, discoveredJobs: [])
     }
 
     engine.taskIsComplete(value)

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -316,7 +316,7 @@ extension Driver {
 
     let jobs = try planJobs()
 
-    return BuildPlan(jobs: jobs, jobExecutionDelegates: [createToolExecutionDelegate()])
+    return BuildPlan(jobs: jobs, jobExecutionDelegates: [createTextualOutputExecutionDelegate()])
   }
 }
 

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -47,8 +47,8 @@ do {
   var driver = try Driver(args: arguments,
                           diagnosticsEngine: diagnosticsEngine,
                           executor: executor)
-  let jobs = try driver.planBuild()
-  try driver.run(jobs: jobs)
+  let plan = try driver.planBuild()
+  try driver.run(buildPlan: plan)
 
   if driver.diagnosticEngine.hasErrors {
     exit(EXIT_FAILURE)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -173,7 +173,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-experimental-explicit-module-build",
                                      main.pathString])
 
-      let jobs = try driver.planBuild()
+      let jobs = try driver.planBuild().jobs
       // Figure out which Triples to use.
       let dependencyGraph = driver.explicitModuleBuildHandler!.dependencyGraph
       guard case .swift(let mainModuleSwiftDetails) = dependencyGraph.mainModule.details else {
@@ -265,8 +265,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-experimental-explicit-module-build",
                                      "-working-directory", path.pathString,
                                      main.pathString])
-      let jobs = try driver.planBuild()
-      try driver.run(jobs: jobs)
+      let plan = try driver.planBuild()
+      try driver.run(buildPlan: plan)
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
     }
     #endif

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -185,7 +185,7 @@ final class JobExecutorTests: XCTestCase {
       )
 
       let delegate = JobCollectingDelegate()
-      let executor = MultiJobExecutor(jobs: [compileFoo, compileMain, link], resolver: resolver, executorDelegate: delegate, diagnosticsEngine: DiagnosticsEngine())
+      let executor = MultiJobExecutor(jobs: [compileFoo, compileMain, link], resolver: resolver, executorDelegates: [delegate], diagnosticsEngine: DiagnosticsEngine())
       try executor.execute(env: toolchain.env, fileSystem: localFileSystem)
 
       let output = try TSCBasic.Process.checkNonZeroExit(args: exec.pathString)
@@ -213,7 +213,7 @@ final class JobExecutorTests: XCTestCase {
     let delegate = JobCollectingDelegate()
     let executor = MultiJobExecutor(
       jobs: [job], resolver: try ArgsResolver(fileSystem: localFileSystem),
-      executorDelegate: delegate,
+      executorDelegates: [delegate],
       diagnosticsEngine: DiagnosticsEngine(),
       processType: JobCollectingDelegate.StubProcess.self
     )

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -840,7 +840,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       // linux target
       var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-unknown-linux"])
-      let plannedJobs = try driver.planBuild()
+      let plannedJobs = try driver.planBuild().jobs
 
       XCTAssertEqual(plannedJobs.count, 4)
 
@@ -872,7 +872,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       // static linux linking
       var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-target", "x86_64-unknown-linux"])
-      let plannedJobs = try driver.planBuild()
+      let plannedJobs = try driver.planBuild().jobs
 
       XCTAssertEqual(plannedJobs.count, 4)
 
@@ -1088,7 +1088,7 @@ final class SwiftDriverTests: XCTestCase {
           "-sanitize=address", "-sanitize=undefined"
         ]
       )
-      let plannedJobs = try driver.planBuild()
+      let plannedJobs = try driver.planBuild().jobs
 
       XCTAssertEqual(plannedJobs.count, 4)
 


### PR DESCRIPTION
This builds on the proposed changes in https://github.com/apple/swift-driver/pull/180, but it'll require SwiftPM changes. I think it should be enough to start bringing up an `IncrementalBuildJobExecutionDelegate`