### PR TITLE
Validate C++ and ObjC related args for Darwin toolchain

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -311,7 +311,8 @@ public struct Driver {
     Self.validateCoverageArgs(&parsedOptions, diagnosticsEngine: diagnosticEngine)
     try toolchain.validateArgs(&parsedOptions,
                                targetTriple: self.frontendTargetInfo.target.triple,
-                               targetVariantTriple: self.frontendTargetInfo.targetVariant?.triple)
+                               targetVariantTriple: self.frontendTargetInfo.targetVariant?.triple,
+                               diagnosticsEngine: diagnosticEngine)
 
     // Compute debug information output.
     self.debugInfo = Self.computeDebugInfo(&parsedOptions, diagnosticsEngine: diagnosticEngine)

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -13,7 +13,7 @@ import TSCBasic
 import SwiftOptions
 
 extension DarwinToolchain {
-  private func findARCLiteLibPath() throws -> AbsolutePath? {
+  internal func findARCLiteLibPath() throws -> AbsolutePath? {
     let path = try getToolPath(.swiftCompiler)
       .parentDirectory // 'swift'
       .parentDirectory // 'bin'

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -123,8 +123,10 @@ public final class DarwinToolchain: Toolchain {
 
   public enum ToolchainValidationError: Error, DiagnosticData {
     case osVersionBelowMinimumDeploymentTarget(String)
+    case argumentNotSupported(String)
     case iOSVersionAboveMaximumDeploymentTarget(Int)
     case unsupportedTargetVariant(variant: Triple)
+    case darwinOnlySupportsLibCxx
 
     public var description: String {
       switch self {
@@ -134,24 +136,38 @@ public final class DarwinToolchain: Toolchain {
         return "iOS \(version) does not support 32-bit programs"
       case .unsupportedTargetVariant(variant: let variant):
         return "unsupported '\(variant.isiOS ? "-target" : "-target-variant")' value '\(variant)'; use 'ios-macabi' instead"
+      case .argumentNotSupported(let argument):
+        return "\(argument) is no longer supported for Apple platforms"
+      case .darwinOnlySupportsLibCxx:
+        return "The only C++ standard library supported on Apple platforms is libc++"
       }
     }
   }
 
   public func validateArgs(_ parsedOptions: inout ParsedOptions,
                            targetTriple: Triple,
-                           targetVariantTriple: Triple?) throws {
-    // TODO: Validating arclite library path when link-objc-runtime.
-
+                           targetVariantTriple: Triple?,
+                           diagnosticsEngine: DiagnosticsEngine) throws {
+    // Validating arclite library path when link-objc-runtime.
+    validateLinkObjcRuntimeARCLiteLib(&parsedOptions,
+                                      targetTriple: targetTriple,
+                                      diagnosticsEngine: diagnosticsEngine)
     // Validating apple platforms deployment targets.
     try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple)
     if let targetVariantTriple = targetVariantTriple,
        !targetTriple.isValidForZipperingWithTriple(targetVariantTriple) {
       throw ToolchainValidationError.unsupportedTargetVariant(variant: targetVariantTriple)
     }
-
-    // TODO: Validating darwin unsupported -static-stdlib argument.
-    // TODO: If a C++ standard library is specified, it has to be libc++.
+    // Validating darwin unsupported -static-stdlib argument.
+    if parsedOptions.hasArgument(.staticStdlib) && targetTriple.isDarwin {
+        throw ToolchainValidationError.argumentNotSupported("-static-stdlib")
+    }
+    // If a C++ standard library is specified, it has to be libc++.
+    if let cxxLib = parsedOptions.getLastArgument(.experimentalCxxStdlib) {
+        if cxxLib.asSingle != "libc++" {
+            throw ToolchainValidationError.darwinOnlySupportsLibCxx
+        }
+    }
   }
 
   func validateDeploymentTarget(_ parsedOptions: inout ParsedOptions,
@@ -178,4 +194,24 @@ public final class DarwinToolchain: Toolchain {
       throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget("watchOS 2.0")
     }
   }
+    
+  func validateLinkObjcRuntimeARCLiteLib(_ parsedOptions: inout ParsedOptions,
+                                           targetTriple: Triple,
+                                           diagnosticsEngine: DiagnosticsEngine) {
+    if parsedOptions.hasFlag(positive: .linkObjcRuntime, negative: .noLinkObjcRuntime, default: targetTriple.supports(.compatibleObjCRuntime)) {
+        guard let _ = try? findARCLiteLibPath() else {
+            diagnosticsEngine.emit(.warn_arclite_not_found_when_link_objc_runtime)
+            return
+        }
+    }
+  }
+}
+
+extension Diagnostic.Message {
+    static var warn_arclite_not_found_when_link_objc_runtime: Diagnostic.Message {
+      .warning(
+        "unable to find Objective-C runtime support library 'arclite'; " +
+        "pass '-no-link-objc-runtime' to silence this warning"
+      )
+    }
 }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -159,7 +159,7 @@ public final class DarwinToolchain: Toolchain {
       throw ToolchainValidationError.unsupportedTargetVariant(variant: targetVariantTriple)
     }
     // Validating darwin unsupported -static-stdlib argument.
-    if parsedOptions.hasArgument(.staticStdlib) && targetTriple.isDarwin {
+    if parsedOptions.hasArgument(.staticStdlib) {
         throw ToolchainValidationError.argumentNotSupported("-static-stdlib")
     }
     // If a C++ standard library is specified, it has to be libc++.

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -56,7 +56,7 @@ public protocol Toolchain {
   /// Perform platform-specific argument validation.
   func validateArgs(_ parsedOptions: inout ParsedOptions,
                     targetTriple: Triple,
-                    targetVariantTriple: Triple?) throws
+                    targetVariantTriple: Triple?, diagnosticsEngine: DiagnosticsEngine) throws
 
   /// Adds platform-specific linker flags to the provided command line
   func addPlatformSpecificLinkerArgs(
@@ -155,7 +155,7 @@ extension Toolchain {
 
   public func validateArgs(_ parsedOptions: inout ParsedOptions,
                            targetTriple: Triple,
-                           targetVariantTriple: Triple?) {}
+                           targetVariantTriple: Triple?, diagnosticsEngine: DiagnosticsEngine) {}
 }
 
 public enum ToolchainError: Swift.Error {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1541,7 +1541,7 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
     
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-static-stdlib",
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-static-stdlib", "-target", "x86_64-apple-macosx10.14",
                                            "foo.swift"])) { error in
       guard case DarwinToolchain.ToolchainValidationError.argumentNotSupported("-static-stdlib") = error else {
         XCTFail()
@@ -1549,14 +1549,14 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
     
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-experimental-cxx-stdlib", "libstdc++",
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-macosx10.14", "-experimental-cxx-stdlib", "libstdc++",
                                            "foo.swift"])) { error in
         guard case DarwinToolchain.ToolchainValidationError.darwinOnlySupportsLibCxx = error else {
         XCTFail()
         return
       }
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "-c", "-link-objc-runtime", "foo.swift")
+    try assertNoDriverDiagnostics(args: "swiftc", "-c", "-target", "x86_64-apple-macosx10.14", "-link-objc-runtime", "foo.swift")
   }
 
   func testDSYMGeneration() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1540,6 +1540,23 @@ final class SwiftDriverTests: XCTestCase {
         return
       }
     }
+    
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-static-stdlib",
+                                           "foo.swift"])) { error in
+      guard case DarwinToolchain.ToolchainValidationError.argumentNotSupportedForPlatform("-static-stdlib", "Apple") = error else {
+        XCTFail()
+        return
+      }
+    }
+    
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-experimental-cxx-stdlib", "libstdc++",
+                                           "foo.swift"])) { error in
+        guard case DarwinToolchain.ToolchainValidationError.darwinOnlySupportsLibCxx = error else {
+        XCTFail()
+        return
+      }
+    }
+    try assertNoDriverDiagnostics(args: "swiftc", "-c", "-link-objc-runtime", "foo.swift")
   }
 
   func testDSYMGeneration() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1543,7 +1543,7 @@ final class SwiftDriverTests: XCTestCase {
     
     XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-static-stdlib",
                                            "foo.swift"])) { error in
-      guard case DarwinToolchain.ToolchainValidationError.argumentNotSupportedForPlatform("-static-stdlib", "Apple") = error else {
+      guard case DarwinToolchain.ToolchainValidationError.argumentNotSupported("-static-stdlib") = error else {
         XCTFail()
         return
       }


### PR DESCRIPTION
This commit  validates the following arguments to driver:
1. link-objc-runtime by checkin arc path,
2. experimentalCxxStdlib flag to limit it to libc++
3. -static-stdlib to flag that its not supported.

This commit is for SR-13255 https://bugs.swift.org/browse/SR-13255