### PR TITLE
Bumped minimum platform version to 10.13 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import class Foundation.ProcessInfo
 let package = Package(
   name: "swift-driver",
   platforms: [
-    .macOS(.v10_10),
+    .macOS(.v10_13),
   ],
   products: [
     .executable(


### PR DESCRIPTION
Required for PR [Support for Netrc for Downloader](https://github.com/apple/swift-tools-support-core/pull/88)  & [SPM mirror](https://github.com/apple/swift-package-manager/pull/2833).
Discussed: [SPM support basic auth for non-git binary dependency hosts](https://forums.swift.org/t/spm-support-basic-auth-for-non-git-binary-dependency-hosts/37878/10?u=sstadelman).