### PR TITLE
[Explicit Module Builds] Pass down pre-built module candidates to the -compile-module-from-interface jobs

### DIFF
--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -157,6 +157,17 @@ import Foundation
     inputs.append(TypedVirtualPath(file: try VirtualPath(path: moduleInterfacePath),
                                    type: .swiftInterface))
 
+    // Add precompiled module candidates, if present
+    if let compiledCandidateList = moduleDetails.compiledModuleCandidates {
+      for compiledCandidate in compiledCandidateList {
+        commandLine.appendFlag("-candidate-module-file")
+        let compiledCandidatePath = try VirtualPath(path: compiledCandidate)
+        commandLine.appendPath(compiledCandidatePath)
+        inputs.append(TypedVirtualPath(file: compiledCandidatePath,
+                                       type: .swiftModule))
+      }
+    }
+
     swiftModuleBuildCache[moduleId] = Job(
       moduleName: moduleId.moduleName,
       kind: .emitModule,

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -58,7 +58,7 @@ extension ModuleDependencyId: Codable {
   public var moduleInterfacePath: String?
 
   /// The paths of potentially ready-to-use compiled modules for the interface.
-  var compiledModuleCandidates: [String]?
+  public var compiledModuleCandidates: [String]?
 
   /// The path to the already-compiled module.
   public var compiledModulePath: String?

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -29,6 +29,16 @@ private func checkExplicitModuleBuildJob(job: Job,
                          type: .swiftInterface)
       XCTAssertEqual(job.kind, .emitModule)
       XCTAssertTrue(job.inputs.contains(moduleInterfacePath))
+      if let compiledCandidateList = swiftModuleDetails.compiledModuleCandidates {
+        for compiledCandidate in compiledCandidateList {
+          let candidatePath = try VirtualPath(path: compiledCandidate)
+          let typedCandidatePath = TypedVirtualPath(file: candidatePath,
+                                                    type: .swiftModule)
+          XCTAssertTrue(job.inputs.contains(typedCandidatePath))
+          XCTAssertTrue(job.commandLine.contains(.path(candidatePath)))
+        }
+        XCTAssertTrue(job.commandLine.filter {$0 == .flag("-candidate-module-file")}.count == compiledCandidateList.count)
+      }
     case .clang(let clangModuleDetails):
       guard case .swift(let mainModuleSwiftDetails) = moduleDependencyGraph.mainModule.details else {
         XCTFail("Main module does not have Swift details field")

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -147,6 +147,10 @@ enum ModuleDependenciesInputs {
           "details": {
             "swift": {
               "moduleInterfacePath": "/Volumes/Compiler/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx/SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface",
+              "compiledModuleCandidates": [
+                "/dummy/path1/SwiftOnoneSupport.swiftmodule",
+                "/dummy/path2/SwiftOnoneSupport.swiftmodule"
+              ],
               "contextHash": "1PC0P8MX6CFZA",
               "commandLine": [
                 "-compile-module-from-interface",


### PR DESCRIPTION
`-scan-dependencies` now emits ready-to-use binary module candidates that can be imported by the compiler, e.g. modules adjacent to .swiftinterface files or in prebuilt module dirs. 
When invoking `-compile-module-from-interface`, pass down these module candidates so the compiler can emit forwarding modules to them, saving the effort of type-checking/serializing binary modules at all.

Resolves rdar://problem/66243229