### PR TITLE
Revert #185: Bump minimum platform version to 10.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import class Foundation.ProcessInfo
 let package = Package(
   name: "swift-driver",
   platforms: [
-    .macOS(.v10_13),
+    .macOS(.v10_10),
   ],
   products: [
     .executable(


### PR DESCRIPTION
It was merged prematurely and is causing breaks in other projects (SwiftPM and, cascadingly, everything that relies on it).

