### PR TITLE
Adjust to simulator compiler-rt change

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -202,15 +202,12 @@ extension DarwinToolchain {
     // FIXME: If we used Clang as a linker instead of going straight to ld,
     // we wouldn't have to replicate a bunch of Clang's logic here.
 
-    // Always link the regular compiler_rt if it's present. Note that the
-    // regular libclang_rt.a uses a fat binary for device and simulator; this is
-    // not true for all compiler_rt build products.
+    // Always link the regular compiler_rt if it's present.
     //
     // Note: Normally we'd just add this unconditionally, but it's valid to build
     // Swift and use it as a linker without building compiler_rt.
     let targetTriple = targetInfo.target.triple
-    let darwinPlatformSuffix =
-        targetTriple.darwinPlatform!.with(.device)!.libraryNameSuffix
+    let darwinPlatformSuffix = targetTriple.darwinPlatform!.libraryNameSuffix
     let compilerRTPath =
       try clangLibraryPath(
         for: targetTriple,

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -41,6 +41,15 @@ public struct Job: Codable, Equatable, Hashable {
 
     /// Represents a virtual path on disk.
     case path(VirtualPath)
+
+    public func hasSuffix(_ suffix: String) -> Bool {
+      switch self {
+      case .flag(let string):
+        return string.hasSuffix(suffix)
+      case .path(let virtualPath):
+        return virtualPath.basename == suffix
+      }
+    }
   }
 
   /// The Swift module this job involves.


### PR DESCRIPTION
Matches changes to legacy driver in apple/swift#33148:

> Previously, we packaged both the device and simulator versions of compiler-rt in a single static archive, relying on the fact that they used different architectures to differentiate between them. But Apple Silicon is now here to make us repay this technical debt. apple/llvm-project#1553 separated the simulator versions of compiler-rt into libraries with different names; this PR adjusts Swift to match.