### PR TITLE
Update tests to match latest toolchain expectations.

### DIFF
--- a/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
@@ -1,6 +1,7 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name A
 import Swift
+import SwiftOnoneSupport
 @_exported import A
 public func overlayFuncA() { }
 

--- a/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
@@ -1,4 +1,5 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name E
 import Swift
+import SwiftOnoneSupport
 public func funcE() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
@@ -1,5 +1,6 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name F
 import Swift
+import SwiftOnoneSupport
 @_exported import F
 public func funcF() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
@@ -3,6 +3,7 @@
 
 #if swift(>=5.0)
 import Swift
+import SwiftOnoneSupport
 @_exported import G
 public func overlayFuncG() { }
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -264,7 +264,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", swiftModuleInterfacesPath,
                                      "-experimental-explicit-module-build",
                                      "-working-directory", path.pathString,
-                                     main.pathString])
+                                     main.pathString],
+                              env: ProcessEnv.vars)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -234,7 +234,9 @@ final class JobExecutorTests: XCTestCase {
     // DarwinToolchain
     env.removeValue(forKey: envVarName)
     let normalSwiftPath = try DarwinToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
-    XCTAssertEqual(normalSwiftPath.basenameWithoutExt, "swift-frontend")
+    // Match Toolchain temporary shim of a fallback to looking for "swift" before failing.
+    XCTAssertTrue(normalSwiftPath.basenameWithoutExt == "swift-frontend" ||
+                  normalSwiftPath.basenameWithoutExt == "swift")
 
     env[envVarName] = dummyPath
     let overriddenSwiftPath = try DarwinToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
@@ -243,7 +245,8 @@ final class JobExecutorTests: XCTestCase {
     // GenericUnixToolchain
     env.removeValue(forKey: envVarName)
     let unixSwiftPath = try GenericUnixToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
-    XCTAssertEqual(unixSwiftPath.basenameWithoutExt, "swift-frontend")
+    XCTAssertTrue(unixSwiftPath.basenameWithoutExt == "swift-frontend" ||
+                  unixSwiftPath.basenameWithoutExt == "swift")
 
     env[envVarName] = dummyPath
     let unixOverriddenSwiftPath = try GenericUnixToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)


### PR DESCRIPTION
- Explicit Module Build test input .swiftinterface files to explicitly bring in SwiftONoneSupport
- Triple test to function when the toolchain uses fallback from `swift-driver` to `swift`