### PR TITLE
Pass -use-static-resource-dir to frontend when linking statically

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -186,6 +186,15 @@ extension Driver {
     commandLine.appendPath(
       try AbsolutePath(validating: frontendTargetInfo.paths.runtimeResourcePath))
 
+    if parsedOptions.hasFlag(positive: .staticExecutable,
+                             negative: .noStaticExecutable,
+                             default: false) ||
+       parsedOptions.hasFlag(positive: .staticStdlib,
+                             negative: .noStaticStdlib,
+                             default: false) {
+      commandLine.appendFlag("-use-static-resource-dir")
+    }
+
     // -g implies -enable-anonymous-context-mangled-names, because the extra
     // metadata aids debugging.
     if parsedOptions.getLast(in: .g) != nil {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -244,12 +244,22 @@ extension Driver {
     if parsedOptions.hasArgument(.printTargetInfo) {
       let sdkPath = try parsedOptions.getLastArgument(.sdk).map { try VirtualPath(path: $0.asSingle) }
       let resourceDirPath = try parsedOptions.getLastArgument(.resourceDir).map { try VirtualPath(path: $0.asSingle) }
+      var useStaticResourceDir = false
+      if parsedOptions.hasFlag(positive: .staticExecutable,
+                              negative: .noStaticExecutable,
+                              default: false) ||
+         parsedOptions.hasFlag(positive: .staticStdlib,
+                              negative: .noStaticStdlib,
+                              default: false) {
+        useStaticResourceDir = true
+      }
       
       return try toolchain.printTargetInfoJob(target: targetTriple,
                                               targetVariant: targetVariantTriple,
                                               sdkPath: sdkPath,
                                               resourceDirPath: resourceDirPath,
-                                              requiresInPlaceExecution: true)
+                                              requiresInPlaceExecution: true,
+                                              useStaticResourceDir: useStaticResourceDir)
     }
 
     if parsedOptions.hasArgument(.version) || parsedOptions.hasArgument(.version_) {

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -116,7 +116,8 @@ extension Toolchain {
                           sdkPath: VirtualPath? = nil,
                           resourceDirPath: VirtualPath? = nil,
                           runtimeCompatibilityVersion: String? = nil,
-                          requiresInPlaceExecution: Bool = false) throws -> Job {
+                          requiresInPlaceExecution: Bool = false,
+                          useStaticResourceDir: Bool = false) throws -> Job {
     var commandLine: [Job.ArgTemplate] = [.flag("-frontend"),
                                           .flag("-print-target-info")]
     // If we were given a target, include it. Otherwise, let the frontend
@@ -144,6 +145,10 @@ extension Toolchain {
         .flag(runtimeCompatibilityVersion)
       ]
     }
+
+    if useStaticResourceDir {
+       commandLine += [.flag("-use-static-resource-dir")]
+     }
 
     return Job(
       moduleName: "",

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1759,6 +1759,39 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(job.commandLine.contains(.flag("-sdk")))
       XCTAssertTrue(job.commandLine.contains(.flag("-resource-dir")))
     }
+
+    do {
+      var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-unknown-linux"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertTrue(plannedJobs.count == 1)
+      let job = plannedJobs[0]
+      XCTAssertEqual(job.kind, .printTargetInfo)
+      XCTAssertTrue(job.commandLine.contains(.flag("-print-target-info")))
+      XCTAssertTrue(job.commandLine.contains(.flag("-target")))
+      XCTAssertFalse(job.commandLine.contains(.flag("-use-static-resource-dir")))
+    }
+
+    do {
+      var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-unknown-linux", "-static-stdlib"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertTrue(plannedJobs.count == 1)
+      let job = plannedJobs[0]
+      XCTAssertEqual(job.kind, .printTargetInfo)
+      XCTAssertTrue(job.commandLine.contains(.flag("-print-target-info")))
+      XCTAssertTrue(job.commandLine.contains(.flag("-target")))
+      XCTAssertTrue(job.commandLine.contains(.flag("-use-static-resource-dir")))
+    }
+
+    do {
+      var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-unknown-linux", "-static-executable"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertTrue(plannedJobs.count == 1)
+      let job = plannedJobs[0]
+      XCTAssertEqual(job.kind, .printTargetInfo)
+      XCTAssertTrue(job.commandLine.contains(.flag("-print-target-info")))
+      XCTAssertTrue(job.commandLine.contains(.flag("-target")))
+      XCTAssertTrue(job.commandLine.contains(.flag("-use-static-resource-dir")))
+    }
   }
 
   func testDiagnosticOptions() throws {
@@ -2493,6 +2526,43 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(compileJob.outputs.count, 2)
       XCTAssertEqual(compileJob.outputs[0].file, .temporary(RelativePath("foo.swiftmodule")))
       XCTAssertEqual(compileJob.outputs[1].file, .temporary(RelativePath("foo.swiftdoc")))
+    }
+  }
+
+  func testUseStaticResourceDir() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "x86_64-unknown-linux", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertFalse(job.commandLine.contains(.flag("-use-static-resource-dir")))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "x86_64-unknown-linux", "-no-static-executable", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertFalse(job.commandLine.contains(.flag("-use-static-resource-dir")))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "x86_64-unknown-linux", "-no-static-stdlib", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertFalse(job.commandLine.contains(.flag("-use-static-resource-dir")))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "x86_64-unknown-linux", "-static-executable", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertTrue(job.commandLine.contains(.flag("-use-static-resource-dir")))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "x86_64-unknown-linux", "-static-stdlib", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertTrue(job.commandLine.contains(.flag("-use-static-resource-dir")))
     }
   }
 }


### PR DESCRIPTION
The compiler computes the resource folder based on its own executable path when it is not explicitly set, but it used to always pick the shared resource folder, because it did not have information about whether the binary will be statically or dynamically linked. This has been changed in https://github.com/apple/swift/pull/33168 and this PR adjusts the behavior to match that of the C++ implementation.