### PR TITLE
Improve support for macOS 11/darwin 20 triple versioning

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -1549,9 +1549,16 @@ extension Triple {
         return nil
       }
 
-      version.micro = 0
-      version.minor = version.major - 4
-      version.major = 10
+      if version.major <= 19 {
+        version.micro = 0
+        version.minor = version.major - 4
+        version.major = 10
+      } else {
+        version.micro = 0
+        version.minor = 0
+        // darwin20+ corresponds to macOS 11+.
+        version.major = version.major - 9
+      }
 
     case .macosx:
       // Default to 10.4.
@@ -1560,7 +1567,7 @@ extension Triple {
         version.minor = 4
       }
 
-      if version.major != 10 && version.major != 11 {
+      if version.major < 10 {
         return nil
       }
 

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -842,6 +842,36 @@ final class TripleTests: XCTestCase {
     XCTAssertEqual(V?.minor, 0)
     XCTAssertEqual(V?.micro, 0)
 
+    T = Triple("x86_64-apple-darwin20")
+    XCTAssertTrue(T.os?.isMacOSX)
+    XCTAssertFalse(T.os?.isiOS)
+    XCTAssertFalse(T.arch?.is16Bit)
+    XCTAssertFalse(T.arch?.is32Bit)
+    XCTAssertTrue(T.arch?.is64Bit)
+    V = T._macOSVersion
+    XCTAssertEqual(V?.major, 11)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+    V = T._iOSVersion
+    XCTAssertEqual(V?.major, 5)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+
+    T = Triple("x86_64-apple-darwin21")
+    XCTAssertTrue(T.os?.isMacOSX)
+    XCTAssertFalse(T.os?.isiOS)
+    XCTAssertFalse(T.arch?.is16Bit)
+    XCTAssertFalse(T.arch?.is32Bit)
+    XCTAssertTrue(T.arch?.is64Bit)
+    V = T._macOSVersion
+    XCTAssertEqual(V?.major, 12)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+    V = T._iOSVersion
+    XCTAssertEqual(V?.major, 5)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+
     T = Triple("x86_64-apple-macosx")
     XCTAssertTrue(T.os?.isMacOSX)
     XCTAssertFalse(T.os?.isiOS)
@@ -866,6 +896,51 @@ final class TripleTests: XCTestCase {
     V = T._macOSVersion
     XCTAssertEqual(V?.major, 10)
     XCTAssertEqual(V?.minor, 7)
+    XCTAssertEqual(V?.micro, 0)
+    V = T._iOSVersion
+    XCTAssertEqual(V?.major, 5)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+
+    T = Triple("x86_64-apple-macosx11.0")
+    XCTAssertTrue(T.os?.isMacOSX)
+    XCTAssertFalse(T.os?.isiOS)
+    XCTAssertFalse(T.arch?.is16Bit)
+    XCTAssertFalse(T.arch?.is32Bit)
+    XCTAssertTrue(T.arch?.is64Bit)
+    V = T._macOSVersion
+    XCTAssertEqual(V?.major, 11)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+    V = T._iOSVersion
+    XCTAssertEqual(V?.major, 5)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+
+    T = Triple("x86_64-apple-macosx11.1")
+    XCTAssertTrue(T.os?.isMacOSX)
+    XCTAssertFalse(T.os?.isiOS)
+    XCTAssertFalse(T.arch?.is16Bit)
+    XCTAssertFalse(T.arch?.is32Bit)
+    XCTAssertTrue(T.arch?.is64Bit)
+    V = T._macOSVersion
+    XCTAssertEqual(V?.major, 11)
+    XCTAssertEqual(V?.minor, 1)
+    XCTAssertEqual(V?.micro, 0)
+    V = T._iOSVersion
+    XCTAssertEqual(V?.major, 5)
+    XCTAssertEqual(V?.minor, 0)
+    XCTAssertEqual(V?.micro, 0)
+
+    T = Triple("x86_64-apple-macosx12.0")
+    XCTAssertTrue(T.os?.isMacOSX)
+    XCTAssertFalse(T.os?.isiOS)
+    XCTAssertFalse(T.arch?.is16Bit)
+    XCTAssertFalse(T.arch?.is32Bit)
+    XCTAssertTrue(T.arch?.is64Bit)
+    V = T._macOSVersion
+    XCTAssertEqual(V?.major, 12)
+    XCTAssertEqual(V?.minor, 0)
     XCTAssertEqual(V?.micro, 0)
     V = T._iOSVersion
     XCTAssertEqual(V?.major, 5)


### PR DESCRIPTION
This is a direct port of some of the updates to clang/llvm. I didn't port over canonicalization of the fake "macOS 10.16" triples because it looks like that's already been mostly removed elsewhere.