### PR TITLE
Support module wrapping for debugging on Linux

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(SwiftDriver
   Jobs/Job.swift
   Jobs/LinkJob.swift
   Jobs/MergeModuleJob.swift
+  Jobs/ModuleWrapJob.swift
   Jobs/Planning.swift
   Jobs/PrintTargetInfoJob.swift
   Jobs/ReplJob.swift

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -23,6 +23,7 @@ public struct Job: Codable, Equatable, Hashable {
     case autolinkExtract = "autolink-extract"
     case emitModule = "emit-module"
     case generatePCH = "generate-pch"
+    case moduleWrap = "module-wrap"
 
     /// Generate a compiled Clang module.
     case generatePCM = "generate-pcm"
@@ -145,6 +146,9 @@ extension Job : CustomStringConvertible {
     case .generatePCH:
         return "Compiling bridging header \(displayInputs.first?.file.basename ?? "")"
 
+    case .moduleWrap:
+      return "Wrapping Swift module \(moduleName)"
+
     case .generatePCM:
         return "Compiling Clang module \(displayInputs.first?.file.basename  ?? "")"
 
@@ -184,7 +188,7 @@ extension Job.Kind {
         .versionRequest, .scanDependencies:
         return true
 
-    case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo:
+    case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo, .moduleWrap:
         return false
     }
   }
@@ -197,7 +201,8 @@ extension Job.Kind {
     case .backend, .mergeModule, .emitModule, .generatePCH,
          .generatePCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
-         .help, .link, .verifyDebugInfo, .scanDependencies:
+         .help, .link, .verifyDebugInfo, .scanDependencies,
+         .moduleWrap:
       return false
     }
   }

--- a/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
+++ b/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
@@ -1,0 +1,39 @@
+//===--------------- ModuleWrapJob.swift - Swift Module Wrapping ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Driver {
+  mutating func moduleWrapJob(moduleInput: TypedVirtualPath) throws -> Job {
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+
+    commandLine.appendFlags("-modulewrap")
+
+    // Add the input.
+    commandLine.append(.path(moduleInput.file))
+    assert(compilerOutputType == .object, "-modulewrap mode only produces object files")
+
+    commandLine.appendFlags("-target", targetTriple.triple)
+
+    let outputPath = try moduleInput.file.replacingExtension(with: .object)
+    commandLine.appendFlag("-o")
+    commandLine.appendPath(outputPath)
+
+    return Job(
+      moduleName: moduleOutputInfo.name,
+      kind: .moduleWrap,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      inputs: [moduleInput],
+      outputs: [.init(file: outputPath, type: .object)],
+      supportsResponseFiles: true
+    )
+  }
+}

--- a/Tests/SwiftDriverTests/XCTestManifests.swift
+++ b/Tests/SwiftDriverTests/XCTestManifests.swift
@@ -21,6 +21,7 @@ extension ExplicitModuleBuildTests {
         ("testExplicitModuleBuildJobs", testExplicitModuleBuildJobs),
         ("testExplicitSwiftModuleMap", testExplicitSwiftModuleMap),
         ("testModuleDependencyBuildCommandGeneration", testModuleDependencyBuildCommandGeneration),
+        ("testModuleDependencyWithExternalCommandGeneration", testModuleDependencyWithExternalCommandGeneration),
     ]
 }
 
@@ -107,6 +108,7 @@ extension SwiftDriverTests {
         ("testModuleNameFallbacks", testModuleNameFallbacks),
         ("testModuleNaming", testModuleNaming),
         ("testModuleSettings", testModuleSettings),
+        ("testModuleWrapJob", testModuleWrapJob),
         ("testMultiThreadedWholeModuleOptimizationCompiles", testMultiThreadedWholeModuleOptimizationCompiles),
         ("testMultithreading", testMultithreading),
         ("testMultithreadingDiagnostics", testMultithreadingDiagnostics),


### PR DESCRIPTION
In addition to the added tests, this fixes Driver/modulewrap.swift. I did also find a bug while working on this where we aren't always planning an autolinking job when we should. I'm pretty sure that's an unrelated issue with how we're setting the object file format of triples though.