### PR TITLE
Make newly-added Frontend target info components optional.

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -89,7 +89,7 @@ public struct FrontendTargetInfo: Codable {
 
     /// The set of compatibility libraries that one needs to link against
     /// for this particular target.
-    let compatibilityLibraries: [CompatibilityLibrary]
+    let compatibilityLibraries: [CompatibilityLibrary]?
 
     /// Whether the Swift libraries need to be referenced in their system
     /// location (/usr/lib/swift) via rpath.
@@ -104,7 +104,7 @@ public struct FrontendTargetInfo: Codable {
     let runtimeResourcePath: String
   }
 
-  var compilerVersion: String
+  var compilerVersion: String?
   var target: Target
   var targetVariant: Target?
   let paths: Paths

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -144,7 +144,7 @@ extension DarwinToolchain {
       }
     }
 
-    for compatibilityLib in targetInfo.target.compatibilityLibraries {
+    targetInfo.target.compatibilityLibraries?.forEach { compatibilityLib in
       let shouldLink: Bool
       switch compatibilityLib.filter {
       case .all:


### PR DESCRIPTION
This is done in an effort to still be able to parse the target info produced by the latest shipping Xcode. 
This will allow the target info to be used with current toolchains and, for example, distinguish between the toolchain that includes a compiler version (sufficiently new) and doesn't. 