### PR TITLE
[Explicit Module Builds] Add `isFramework` flag to the dependency graph and swift module info.

### DIFF
--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -97,6 +97,9 @@ public struct SwiftModuleDetails: Codable {
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
   @_spi(Testing) public var extraPcmArgs: [String]?
+
+  /// A flag to indicate whether or not this module is a framework.
+  @_spi(Testing) public var isFramework: Bool
 }
 
 /// Details specific to Swift external modules.

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleArtifacts.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleArtifacts.swift
@@ -25,12 +25,16 @@ public struct SwiftModuleArtifactInfo: Codable {
   public let docPath: String?
   /// The path for the module's .swiftsourceinfo file
   public let sourceInfoPath: String?
+  /// A flag to indicate whether this module is a framework
+  public let isFramework: Bool
 
-  init(name: String, modulePath: String, docPath: String? = nil, sourceInfoPath: String? = nil) {
+  init(name: String, modulePath: String, docPath: String? = nil,
+       sourceInfoPath: String? = nil, isFramework: Bool = false) {
     self.moduleName = name
     self.modulePath = modulePath
     self.docPath = docPath
     self.sourceInfoPath = sourceInfoPath
+    self.isFramework = isFramework
   }
 }
 

--- a/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
@@ -167,5 +167,6 @@ private extension SwiftModuleDetails {
     self.bridgingSourceFiles = nil
     self.commandLine = nil
     self.extraPcmArgs = extraPcmArgs
+    self.isFramework = false
   }
 }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -90,6 +90,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
         let dependencyArtifacts =
           dependencyInfoList.first(where:{ $0.moduleName == dependencyId.moduleName })
         XCTAssertEqual(dependencyArtifacts!.modulePath, swiftDetails.explicitCompiledModulePath ?? dependencyInfo.modulePath)
+        XCTAssertEqual(dependencyArtifacts!.isFramework, swiftDetails.isFramework)
       case .clang(let clangDependencyDetails):
         let clangDependencyModulePathString =
           try ExplicitModuleBuildHandler.targetEncodedClangModuleFilePath(
@@ -386,13 +387,15 @@ final class ExplicitModuleBuildTests: XCTestCase {
         "moduleName": "A",
         "modulePath": "A.swiftmodule",
         "docPath": "A.swiftdoc",
-        "sourceInfoPath": "A.swiftsourceinfo"
+        "sourceInfoPath": "A.swiftsourceinfo",
+        "isFramework": true
       },
       {
         "moduleName": "B",
         "modulePath": "B.swiftmodule",
         "docPath": "B.swiftdoc",
-        "sourceInfoPath": "B.swiftsourceinfo"
+        "sourceInfoPath": "B.swiftsourceinfo",
+        "isFramework": false
       }
     ]
     """
@@ -403,9 +406,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
     XCTAssertEqual(moduleMap[0].modulePath, "A.swiftmodule")
     XCTAssertEqual(moduleMap[0].docPath, "A.swiftdoc")
     XCTAssertEqual(moduleMap[0].sourceInfoPath, "A.swiftsourceinfo")
+    XCTAssertEqual(moduleMap[0].isFramework, true)
     XCTAssertEqual(moduleMap[1].moduleName, "B")
     XCTAssertEqual(moduleMap[1].modulePath, "B.swiftmodule")
     XCTAssertEqual(moduleMap[1].docPath, "B.swiftdoc")
     XCTAssertEqual(moduleMap[1].sourceInfoPath, "B.swiftsourceinfo")
+    XCTAssertEqual(moduleMap[1].isFramework, false)
   }
 }


### PR DESCRIPTION
Ensure the flag is propagated from a given swift module's dependency graph details to its swift module info passed in as an explicit module map to frontend jobs.

This is a companion PR to: 
https://github.com/apple/swift/pull/33430