### PR TITLE
Reapply "Infer object format when it can't be determined from a triple's successfully parsed environment"

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -167,6 +167,8 @@ public struct Triple {
     if let parsedEnv = parsedEnv {
       self.environment = parsedEnv.value.environment
       self.objectFormat = parsedEnv.value.objectFormat
+        ?? ObjectFormat.infer(arch: parsedArch?.value.arch,
+                              os: parsedOS?.value)
     }
     else {
       self.environment = Environment.infer(archName: parsedArch?.substring)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -322,6 +322,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
           case .relative(RelativePath("main")):
             XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
             XCTAssertEqual(job.kind, .link)
+
+          case .temporary(RelativePath("main.autolink")):
+            XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
+            XCTAssertEqual(job.kind, .autolinkExtract)
+
           default:
             XCTFail("Unexpected module dependency build job output: \(job.outputs[0].file)")
         }

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -1008,7 +1008,9 @@ final class TripleTests: XCTestCase {
   }
 
   func testFileFormat() {
-//    XCTAssertEqual(.elf, Triple("i686-unknown-linux-gnu").objectFormat)
+    XCTAssertEqual(.elf, Triple("i686-unknown-linux-gnu").objectFormat)
+    XCTAssertEqual(.elf, Triple("x86_64-unknown-linux-gnu").objectFormat)
+    XCTAssertEqual(.elf, Triple("x86_64-gnu-linux").objectFormat)
     XCTAssertEqual(.elf, Triple("i686-unknown-freebsd").objectFormat)
     XCTAssertEqual(.elf, Triple("i686-unknown-netbsd").objectFormat)
     XCTAssertEqual(.elf, Triple("i686--win32-elf").objectFormat)


### PR DESCRIPTION
Reverts apple/swift-driver#203

I suspect https://github.com/apple/swift-driver/pull/206 fixed the failures this caused in the SPM CI tests.