### PR TITLE
Attempt to use SDKSettings.json on Darwin platforms to set -target-sdk-version

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(SwiftDriver
   Utilities/Triple+Platforms.swift
   Utilities/Triple.swift
   Utilities/TypedVirtualPath.swift
+  Utilities/VersionExtensions.swift
   Utilities/VirtualPath.swift)
 
 target_link_libraries(SwiftDriver PUBLIC

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -230,6 +230,10 @@ extension Driver {
     if compilerMode != .repl {
       commandLine.appendFlags("-module-name", moduleOutputInfo.name)
     }
+
+    try toolchain.addPlatformSpecificCommonFrontendOptions(commandLine: &commandLine,
+                                                           inputs: &inputs,
+                                                           frontendTargetInfo: frontendTargetInfo)
   }
 
   mutating func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate], primaryInputs: [TypedVirtualPath]) throws -> [TypedVirtualPath] {

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -81,6 +81,12 @@ public protocol Toolchain {
     parsedOptions: inout ParsedOptions,
     sdkPath: String?,
     targetTriple: Triple) throws -> [String: String]
+
+  func addPlatformSpecificCommonFrontendOptions(
+    commandLine: inout [Job.ArgTemplate],
+    inputs: inout [TypedVirtualPath],
+    frontendTargetInfo: FrontendTargetInfo
+  ) throws
 }
 
 extension Toolchain {
@@ -156,6 +162,12 @@ extension Toolchain {
   public func validateArgs(_ parsedOptions: inout ParsedOptions,
                            targetTriple: Triple,
                            targetVariantTriple: Triple?, diagnosticsEngine: DiagnosticsEngine) {}
+
+  public func addPlatformSpecificCommonFrontendOptions(
+    commandLine: inout [Job.ArgTemplate],
+    inputs: inout [TypedVirtualPath],
+    frontendTargetInfo: FrontendTargetInfo
+  ) throws {}
 }
 
 public enum ToolchainError: Swift.Error {

--- a/Sources/SwiftDriver/Utilities/VersionExtensions.swift
+++ b/Sources/SwiftDriver/Utilities/VersionExtensions.swift
@@ -1,0 +1,60 @@
+//===---------- VersionExtensions.swift - Version Parsing Utilities -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCUtility
+
+// TODO: maybe move this to TSC.
+extension Version {
+  /// Create a version from a string, replacing unknown trailing components with '0'.
+  init?(potentiallyIncompleteVersionString string: String) {
+    // This is a copied version of TSC's version parsing, modified to fill
+    // in missing components if needed.
+    let prereleaseStartIndex = string.firstIndex(of: "-")
+    let metadataStartIndex = string.firstIndex(of: "+")
+
+    let requiredEndIndex = prereleaseStartIndex ?? metadataStartIndex ?? string.endIndex
+    let requiredCharacters = string.prefix(upTo: requiredEndIndex)
+    var requiredComponents = requiredCharacters
+      .split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
+      .map(String.init).compactMap({ Int($0) }).filter({ $0 >= 0 })
+
+    requiredComponents.append(contentsOf:
+                                Array(repeating: 0,
+                                      count: max(0, 3 - requiredComponents.count)))
+
+    let major = requiredComponents[0]
+    let minor = requiredComponents[1]
+    let patch = requiredComponents[2]
+
+    func identifiers(start: String.Index?, end: String.Index) -> [String] {
+      guard let start = start else { return [] }
+      let identifiers = string[string.index(after: start)..<end]
+      return identifiers.split(separator: ".").map(String.init)
+    }
+
+    let prereleaseIdentifiers = identifiers(
+      start: prereleaseStartIndex,
+      end: metadataStartIndex ?? string.endIndex)
+    let buildMetadataIdentifiers = identifiers(
+      start: metadataStartIndex,
+      end: string.endIndex)
+
+    self.init(major, minor, patch,
+              prereleaseIdentifiers: prereleaseIdentifiers,
+              buildMetadataIdentifiers: buildMetadataIdentifiers)
+  }
+
+  /// Returns the version with out any build/release metadata numbers.
+  var withoutBuildNumbers: Version {
+    return Version(self.major, self.minor, self.patch)
+  }
+}


### PR DESCRIPTION
This fixes the Driver/sdk-version.swift integration test, and it's also a prerequisite to begin modernizing linker deployment targets to use -platform_version instead of the old flags.

Unfortunately, SDKSettings.json doesn't work very well with Codable synthesis and the implementation of Codable for `Version` in TSC, so there's a lot of manual decoding. Also, this implementation sometimes includes a minor version of `0` where the integrated driver would not (for example -target-sdk-version 13.4.0 instead of 13.4); as far as I know this won't break anything, and it makes the version remapping much simpler.