### PR TITLE
Describe generatePCM jobs with the module name, not the first display input.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -150,7 +150,7 @@ extension Job : CustomStringConvertible {
       return "Wrapping Swift module \(moduleName)"
 
     case .generatePCM:
-        return "Compiling Clang module \(displayInputs.first?.file.basename  ?? "")"
+        return "Compiling Clang module \(moduleName)"
 
     case .interpret:
         return "Interpreting \(displayInputs.first?.file.name ?? "")"

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -49,6 +49,7 @@ private func checkExplicitModuleBuildJob(job: Job,
         TypedVirtualPath(file: try VirtualPath(path: clangModuleDetails.moduleMapPath),
                          type: .clangModuleMap)
       XCTAssertEqual(job.kind, .generatePCM)
+      XCTAssertEqual(job.description, "Compiling Clang module \(moduleId.moduleName)")
       XCTAssertTrue(job.inputs.contains(moduleMapPath))
     case .swiftPlaceholder(_):
       XCTFail("Placeholder dependency found.")


### PR DESCRIPTION
We generate such jobs on a per-module basis anyways.
This will give slightly nicer status commands in SwiftPM. 