### PR TITLE
Disable the REPL test when no LLDB is found in the toolchain.

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1359,6 +1359,22 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testRepl() throws {
+    // Do not run this test if no LLDB is found in the toolchain.
+    let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
+                                           processSet: ProcessSet(),
+                                           fileSystem: localFileSystem,
+                                           env: ProcessEnv.vars)
+    var toolchain: Toolchain
+    #if os(macOS)
+    toolchain = DarwinToolchain(env: ProcessEnv.vars, executor: executor)
+    #else
+    toolchain = GenericUnixToolchain(env: ProcessEnv.vars, executor: executor)
+    #endif
+    do {
+      _ = try toolchain.getToolPath(.lldb)
+    } catch ToolchainError.unableToFind {
+      return
+    }
 
     func isLLDBREPLFlag(_ arg: Job.ArgTemplate) -> Bool {
       if case .flag(let replString) = arg {


### PR DESCRIPTION
We have build bots that build `swift` but do not build `lldb`, this ensures that this test does not fail in that environment. 

Example of such build bot:
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04-long-test/6634/console
