### PR TITLE
[Explicit Module Builds] Re-scan all clang modules against all targets against which they will be built.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -205,7 +205,7 @@ public struct Driver {
   /// A collection describing external dependencies for the current main module that may be invisible to
   /// the driver itself, but visible to its clients (e.g. build systems like SwiftPM). Along with the external dependencies'
   /// module dependency graphs.
-  internal var externalDependencyArtifactMap: ExternalDependencyArtifactMap? = nil
+  @_spi(Testing) public var externalDependencyArtifactMap: ExternalDependencyArtifactMap? = nil
 
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in
@@ -1004,6 +1004,9 @@ extension Driver {
 
       case .scanDependencies:
         compilerOutputType = .jsonDependencies
+
+      case .scanClangDependencies:
+        compilerOutputType = .jsonClangDependencies
 
       default:
         fatalError("unhandled output mode option \(outputOption)")

--- a/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
@@ -1,0 +1,120 @@
+//===-------------- ClangVersionedDependencyResolution.swift --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A map from a module identifier to a set of module dependency graphs
+/// Used to compute distinct graphs corresponding to different target versions for a given clang module
+public typealias ModuleVersionedGraphMap = [ModuleDependencyId: [InterModuleDependencyGraph]]
+
+internal extension Driver {
+  // Dependency scanning results may vary depending on the target version specified on the
+  // dependency scanning action. If the scanning action is performed at a fixed target, and the
+  // scanned module is later compiled with a higher version target, miscomputation may occur
+  // due to dependencies present only at the higher version number and thus not detected by
+  // the dependency scanner. We must ensure to re-scan Clang modules at all targets at which
+  // they will be compiled and record a super-set of the module's dependencies at all targets.
+  /// For each clang module, compute its dependencies at all targets at which it will be compiled.
+  mutating func resolveVersionedClangDependencies(dependencyGraph: inout InterModuleDependencyGraph)
+  throws {
+    // Traverse the dependency graph, collecting extraPCMArgs along each path
+    // to all Clang modules, and compute a set of distinct PCMArgs across all paths to a
+    // given Clang module in the graph.
+    let modulePCMArgsSetMap = try dependencyGraph.computePCMArgSetsForClangModules()
+    var moduleVersionedGraphMap: [ModuleDependencyId: [InterModuleDependencyGraph]] = [:]
+    for (moduleId, pcmArgSet) in modulePCMArgsSetMap {
+      for pcmArgs in pcmArgSet {
+        let pcmSpecificDepGraph = try scanClangModule(moduleId: moduleId,
+                                                      pcmArgs: pcmArgs)
+        if moduleVersionedGraphMap[moduleId] != nil {
+          moduleVersionedGraphMap[moduleId]!.append(pcmSpecificDepGraph)
+        } else {
+          moduleVersionedGraphMap[moduleId] = [pcmSpecificDepGraph]
+        }
+      }
+    }
+
+    try dependencyGraph.resolveVersionedClangModules(using: moduleVersionedGraphMap)
+  }
+}
+
+private extension InterModuleDependencyGraph {
+  mutating func resolveVersionedClangModules(using versionedGraphMap: ModuleVersionedGraphMap)
+  throws {
+    for (moduleId, graphList) in versionedGraphMap {
+      var currentModuleInfo = modules[moduleId]!
+      for versionedGraph in graphList {
+        guard let versionedModuleInfo = versionedGraph.modules[moduleId] else {
+          throw Driver.Error.missingModuleDependency(moduleId.moduleName)
+        }
+
+        versionedModuleInfo.directDependencies?.forEach { dependencyId in
+          // If a not-seen-before dependency has been found, add it to the info
+          // and its module to the main graph
+          if !currentModuleInfo.directDependencies!.contains(dependencyId) {
+            currentModuleInfo.directDependencies!.append(dependencyId)
+            // In case this dependency is a module the "main" dependency graph does not contain,
+            // add it.
+            if modules[dependencyId] == nil {
+              modules[dependencyId] = versionedGraph.modules[dependencyId]!
+            }
+          }
+        }
+
+      }
+      // Update the moduleInfo with the one whose dependencies consist of a super-set
+      // of dependencies across all of the versioned dependency graphs
+      modules[moduleId] = currentModuleInfo
+    }
+  }
+
+  /// DFS from the main module to all clang modules, accumulating distinct
+  /// PCMArgs along all paths to a given Clang module
+  func computePCMArgSetsForClangModules() throws -> [ModuleDependencyId : Set<[String]>] {
+    let mainModuleId: ModuleDependencyId = .swift(mainModuleName)
+    var pcmArgSetMap: [ModuleDependencyId : Set<[String]>] = [:]
+
+    func visit(_ moduleId: ModuleDependencyId,
+               pathPCMArtSet: Set<[String]>,
+               pcmArgSetMap: inout [ModuleDependencyId : Set<[String]>])
+    throws {
+      switch moduleId {
+        case .swift:
+          // Add extraPCMArgs of the visited node to the current path set
+          // and proceed to visit all direct dependencies
+          let modulePCMArgs = try swiftModulePCMArgs(of: moduleId)
+          var newPathPCMArgSet = pathPCMArtSet
+          newPathPCMArgSet.insert(modulePCMArgs)
+          for dependencyId in try moduleInfo(of: moduleId).directDependencies! {
+            try visit(dependencyId,
+                      pathPCMArtSet: newPathPCMArgSet,
+                      pcmArgSetMap: &pcmArgSetMap)
+          }
+        case .clang:
+          // Add current path's PCMArgs to the SetMap and stop traversal
+          if pcmArgSetMap[moduleId] != nil {
+            pathPCMArtSet.forEach { pcmArgSetMap[moduleId]!.insert($0) }
+          } else {
+            pcmArgSetMap[moduleId] = pathPCMArtSet
+          }
+          return
+        case .swiftPlaceholder:
+          fatalError("Unresolved placeholder dependencies at planning stage: \(moduleId)")
+      }
+    }
+
+    try visit(mainModuleId,
+              pathPCMArtSet: [],
+              pcmArgSetMap: &pcmArgSetMap)
+    return pcmArgSetMap
+  }
+}

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -34,9 +34,6 @@ public typealias ExternalDependencyArtifactMap =
   /// The toolchain to be used for frontend job generation.
   private let toolchain: Toolchain
 
-  /// A collection of external dependency modules, and their binary module file paths and dependency graph.
-  internal let externalDependencyArtifactMap: ExternalDependencyArtifactMap
-
   /// The file system which we should interact with.
   /// FIXME: Our end goal is to not have any direct filesystem manipulation in here, but  that's dependent on getting the
   /// dependency scanner/dependency job generation  moved into a Job.
@@ -48,12 +45,11 @@ public typealias ExternalDependencyArtifactMap =
   /// dependency scanner/dependency job generation  moved into a Job.
   private let temporaryDirectory: AbsolutePath
 
-  public init(dependencyGraph: InterModuleDependencyGraph, toolchain: Toolchain,
-              fileSystem: FileSystem,
-              externalDependencyArtifactMap: ExternalDependencyArtifactMap) throws {
+  public init(dependencyGraph: InterModuleDependencyGraph,
+              toolchain: Toolchain,
+              fileSystem: FileSystem) throws {
     self.dependencyGraph = dependencyGraph
     self.toolchain = toolchain
-    self.externalDependencyArtifactMap = externalDependencyArtifactMap
     self.fileSystem = fileSystem
     self.temporaryDirectory = try determineTempDirectory()
   }
@@ -119,11 +115,6 @@ public typealias ExternalDependencyArtifactMap =
   /// - Generate Job: S1
   ///
   mutating public func generateExplicitModuleDependenciesBuildJobs() throws -> [Job] {
-    // Resolve placeholder dependencies in the dependency graph, if any.
-    if (!externalDependencyArtifactMap.isEmpty) {
-      try resolvePlaceholderDependencies()
-    }
-
     // Compute jobs for all main module dependencies
     var mainModuleInputs: [TypedVirtualPath] = []
     var mainModuleCommandLine: [Job.ArgTemplate] = []
@@ -444,7 +435,7 @@ extension ExplicitModuleBuildHandler {
 
 /// Encapsulates some of the common queries of the ExplicitModuleBuildeHandler with error-checking
 /// on the dependency graph's structure.
-private extension InterModuleDependencyGraph {
+internal extension InterModuleDependencyGraph {
   func moduleInfo(of moduleId: ModuleDependencyId) throws -> ModuleInfo {
     guard let moduleInfo = modules[moduleId] else {
       throw Driver.Error.missingModuleDependency(moduleId.moduleName)

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
@@ -11,10 +11,11 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 import TSCBasic
+import SwiftOptions
 
 extension Driver {
   /// Precompute the dependencies for a given Swift compilation, producing a
-  /// complete dependency graph including all Swift and C module files and
+  /// dependency graph including all Swift and C module files and
   /// source files.
   mutating func dependencyScanningJob() throws -> Job {
     var inputs: [TypedVirtualPath] = []
@@ -72,5 +73,67 @@ extension Driver {
     let contents = try encoder.encode(placeholderArtifacts)
     try fileSystem.writeFileContents(placeholderMapFilePath, bytes: ByteString(contents))
     return placeholderMapFilePath
+  }
+
+  /// Compute the dependencies for a given Clang module, by invoking the Clang dependency scanning action
+  /// with the given module's name and a set of arguments (including the target version)
+  mutating func clangDependencyScanningJob(moduleId: ModuleDependencyId,
+                                           pcmArgs: [String]) throws -> Job {
+    var inputs: [TypedVirtualPath] = []
+
+    // Aggregate the fast dependency scanner arguments
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    commandLine.appendFlag("-frontend")
+    commandLine.appendFlag("-scan-clang-dependencies")
+
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
+                                 bridgingHeaderHandling: .precompiled,
+                                 moduleDependencyGraphUse: .dependencyScan)
+
+    // Ensure the `-target` option is inherited from the dependent Swift module's PCM args
+    if let targetOptionIndex = pcmArgs.firstIndex(of: Option.target.spelling) {
+      // PCM args are formulated as Clang command line options specified with:
+      // -Xcc <option> -Xcc <option_value>
+      assert(pcmArgs.count > targetOptionIndex + 1 && pcmArgs[targetOptionIndex + 1] == "-Xcc")
+      let pcmArgTriple = Triple(pcmArgs[targetOptionIndex + 2])
+      // Override the invocation's default target argument by appending the one extracted from
+      // the pcmArgs
+      commandLine.appendFlag(.target)
+      commandLine.appendFlag(pcmArgTriple.triple)
+    }
+
+    // Add the PCM args specific to this scan
+    pcmArgs.forEach { commandLine.appendFlags($0) }
+
+    // This action does not require any input files, but all frontend actions require
+    // at least one input so pick any input of the current compilation.
+    let inputFile = inputFiles.first { $0.type == .swift }
+    commandLine.appendPath(inputFile!.file)
+    inputs.append(inputFile!)
+
+    commandLine.appendFlags("-module-name", moduleId.moduleName)
+    // Construct the scanning job.
+    return Job(moduleName: moduleOutputInfo.name,
+               kind: .scanClangDependencies,
+               tool: VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler)),
+               commandLine: commandLine,
+               displayInputs: inputs,
+               inputs: inputs,
+               outputs: [TypedVirtualPath(file: .standardOutput, type: .jsonDependencies)],
+               supportsResponseFiles: true)
+  }
+
+  mutating func scanClangModule(moduleId: ModuleDependencyId, pcmArgs: [String])
+  throws -> InterModuleDependencyGraph {
+    let clangDependencyScannerJob = try clangDependencyScanningJob(moduleId: moduleId,
+                                                                   pcmArgs: pcmArgs)
+    let forceResponseFiles = parsedOptions.hasArgument(.driverForceResponseFiles)
+
+    let dependencyGraph =
+      try self.executor.execute(job: clangDependencyScannerJob,
+                                capturingJSONOutputAs: InterModuleDependencyGraph.self,
+                                forceResponseFiles: forceResponseFiles,
+                                recordedInputModificationDates: recordedInputModificationDates)
+    return dependencyGraph
   }
 }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -70,7 +70,7 @@ extension Driver {
          .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
          .objcHeader, .swiftDeps, .remap, .importedModules, .tbd, .moduleTrace,
          .indexData, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
-         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, nil:
+         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies, nil:
       return false
     }
   }
@@ -262,6 +262,8 @@ extension FileType {
       return .updateCode
     case .jsonDependencies:
       return .scanDependencies
+    case .jsonClangDependencies:
+      return .scanClangDependencies
     case .jsonTargetInfo:
       return .printTargetInfo
 

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -158,6 +158,7 @@ extension Driver {
     try commandLine.appendLast(.disableParserLookup, from: &parsedOptions)
     try commandLine.appendLast(.sanitizeRecoverEQ, from: &parsedOptions)
     try commandLine.appendLast(.scanDependencies, from: &parsedOptions)
+    try commandLine.appendLast(.scanClangDependencies, from: &parsedOptions)
     try commandLine.appendLast(.fineGrainedDependencyIncludeIntrafile, from: &parsedOptions)
     try commandLine.appendLast(.enableExperimentalConcisePoundFile, from: &parsedOptions)
     try commandLine.appendLast(.printEducationalNotes, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -33,6 +33,7 @@ public struct Job: Codable, Equatable, Hashable {
     case printTargetInfo = "print-target-info"
     case versionRequest = "version-request"
     case scanDependencies = "scan-dependencies"
+    case scanClangDependencies = "scan-clang-dependencies"
     case help
   }
 
@@ -175,6 +176,9 @@ extension Job : CustomStringConvertible {
 
     case .scanDependencies:
       return "Scanning dependencies for module \(moduleName)"
+
+    case .scanClangDependencies:
+      return "Scanning dependencies for Clang module \(moduleName)"
     }
   }
 }
@@ -185,7 +189,7 @@ extension Job.Kind {
     switch self {
     case .backend, .compile, .mergeModule, .emitModule, .generatePCH,
         .generatePCM, .interpret, .repl, .printTargetInfo,
-        .versionRequest, .scanDependencies:
+        .versionRequest, .scanDependencies, .scanClangDependencies:
         return true
 
     case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo, .moduleWrap:
@@ -202,7 +206,7 @@ extension Job.Kind {
          .generatePCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
          .help, .link, .verifyDebugInfo, .scanDependencies,
-         .moduleWrap:
+         .moduleWrap, .scanClangDependencies:
       return false
     }
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -236,22 +236,35 @@ extension Driver {
 
   /// Prescan the source files to produce a module dependency graph and turn it into a set
   /// of jobs required to build all dependencies.
+  /// Preprocess the graph by resolving placeholder dependencies, if any are present and
+  /// by re-scanning all Clang modules against all possible targets they will be built against.
   public mutating func generateExplicitModuleBuildJobs() throws -> [Job] {
+    let dependencyGraph = try generateInterModuleDependencyGraph()
+    explicitModuleBuildHandler =
+        try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
+                                       toolchain: toolchain,
+                                       fileSystem: fileSystem)
+    return try explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
+  }
+
+  private mutating func generateInterModuleDependencyGraph() throws -> InterModuleDependencyGraph {
     let dependencyScannerJob = try dependencyScanningJob()
     let forceResponseFiles = parsedOptions.hasArgument(.driverForceResponseFiles)
 
-    let dependencyGraph =
+    var dependencyGraph =
       try self.executor.execute(job: dependencyScannerJob,
                                 capturingJSONOutputAs: InterModuleDependencyGraph.self,
                                 forceResponseFiles: forceResponseFiles,
                                 recordedInputModificationDates: recordedInputModificationDates)
 
-    explicitModuleBuildHandler =
-        try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
-                                       toolchain: toolchain,
-                                       fileSystem: fileSystem,
-                                       externalDependencyArtifactMap: externalDependencyArtifactMap ?? [:])
-    return try explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
+    // Resolve placeholder dependencies in the dependency graph, if any.
+    if externalDependencyArtifactMap != nil, !externalDependencyArtifactMap!.isEmpty {
+      try dependencyGraph.resolvePlaceholderDependencies(using: externalDependencyArtifactMap!)
+    }
+
+    // Re-scan Clang modules at all the targets they will be built against
+    try resolveVersionedClangDependencies(dependencyGraph: &dependencyGraph)
+    return dependencyGraph
   }
 
   /// Create a job if needed for simple requests that can be immediately

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -90,6 +90,11 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// JSON-based Module Dependency Scanner output
   case jsonDependencies = "dependencies.json"
 
+  // FIXME: We enforce a 1-1 map from FileType to frontendCompileOption,
+  // which prevents us from re-using the above jsonDependencies here
+  /// JSON-based Module Dependency Scanner output for a single clang module
+  case jsonClangDependencies = "clang-dependencies.json"
+
   /// JSON-based -print-target-info output
   case jsonTargetInfo = "targetInfo.json"
 
@@ -156,6 +161,9 @@ extension FileType: CustomStringConvertible {
     case .jsonDependencies:
       return "json-dependencies"
 
+    case .jsonClangDependencies:
+      return "json-clang-dependencies"
+
     case .jsonTargetInfo:
       return "json-target-info"
 
@@ -195,7 +203,7 @@ extension FileType {
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
          .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
          .swiftSourceInfoFile, .jsonDependencies, .clangModuleMap, .jsonTargetInfo,
-         .jsonSwiftArtifacts:
+         .jsonSwiftArtifacts, .jsonClangDependencies:
       return false
     }
   }
@@ -266,6 +274,8 @@ extension FileType {
       return "swift-dependencies"
     case .jsonDependencies:
       return "json-dependencies"
+    case .jsonClangDependencies:
+      return "json-clang-dependencies"
     case .jsonTargetInfo:
       return "json-target-info"
     case .jsonSwiftArtifacts:
@@ -291,8 +301,8 @@ extension FileType {
     switch self {
     case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
-         .yamlOptimizationRecord, .swiftInterface, .jsonDependencies, .clangModuleMap, .jsonTargetInfo,
-         .jsonSwiftArtifacts:
+         .yamlOptimizationRecord, .swiftInterface, .jsonDependencies, .clangModuleMap,
+         .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -311,7 +321,8 @@ extension FileType {
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile,
          .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap, .importedModules,
          .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
-         .pcm, .pch, .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts:
+         .pcm, .pch, .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts,
+         .jsonClangDependencies:
       return false
     }
   }

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -25,6 +25,7 @@ extension Option {
   public static let buildModuleFromParseableInterface: Option = Option("-build-module-from-parseable-interface", .flag, alias: Option.compileModuleFromInterface, attributes: [.helpHidden, .frontend, .noDriver], group: .modes)
   public static let buildRequestDependencyGraph: Option = Option("-build-request-dependency-graph", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Build request dependency graph")
   public static let bypassBatchModeChecks: Option = Option("-bypass-batch-mode-checks", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Bypass checks for batch-mode errors.")
+  public static let candidateModuleFile: Option = Option("-candidate-module-file", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<path>", helpText: "Specify Swift module may be ready to use for an interface")
   public static let checkOnoneCompleteness: Option = Option("-check-onone-completeness", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Print errors if the compile OnoneSupport module is missing symbols")
   public static let codeCompleteCallPatternHeuristics: Option = Option("-code-complete-call-pattern-heuristics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Use heuristics to guess whether we want call pattern completions")
   public static let codeCompleteInitsInPostfixExpr: Option = Option("-code-complete-inits-in-postfix-expr", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Include initializers when completing a postfix expression")
@@ -50,7 +51,6 @@ extension Option {
   public static let debugInfoFormat: Option = Option("-debug-info-format=", .joined, attributes: [.frontend], helpText: "Specify the debug info format type to either 'dwarf' or 'codeview'")
   public static let debugInfoStoreInvocation: Option = Option("-debug-info-store-invocation", .flag, attributes: [.frontend], helpText: "Emit the compiler invocation in the debug info.")
   public static let debugPrefixMap: Option = Option("-debug-prefix-map", .separate, attributes: [.frontend], helpText: "Remap source paths in debug info")
-  public static let debugTimeCompilation: Option = Option("-debug-time-compilation", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Prints the time taken by each compilation phase")
   public static let debugTimeExpressionTypeChecking: Option = Option("-debug-time-expression-type-checking", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Dumps the time it takes to type-check each expression")
   public static let debugTimeFunctionBodies: Option = Option("-debug-time-function-bodies", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Dumps the time it takes to type-check each function body")
   public static let debuggerSupport: Option = Option("-debugger-support", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Process swift code as if running in the debugger")
@@ -77,6 +77,7 @@ extension Option {
   public static let disableDeserializationRecovery: Option = Option("-disable-deserialization-recovery", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't attempt to recover from missing xrefs (etc) in swiftmodules")
   public static let disableDiagnosticPasses: Option = Option("-disable-diagnostic-passes", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't run diagnostic passes")
   public static let disableDirectIntramoduleDependencies: Option = Option("-disable-direct-intramodule-dependencies", .flag, attributes: [.helpHidden, .frontend], helpText: "Disable experimental dependency tracking that never cascades")
+  public static let disableFuzzyForwardScanTrailingClosureMatching: Option = Option("-disable-fuzzy-forward-scan-trailing-closure-matching", .flag, attributes: [.frontend], helpText: "Disable fuzzy forward-scan trailing closure matching")
   public static let disableGenericMetadataPrespecialization: Option = Option("-disable-generic-metadata-prespecialization", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Do not statically specialize metadata for generic types at types that are known to be used in source.")
   public static let disableImplicitSwiftModules: Option = Option("-disable-implicit-swift-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Disable building Swift modules explicitly by the compiler")
   public static let disableIncrementalLlvmCodegeneration: Option = Option("-disable-incremental-llvm-codegen", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable incremental llvm code generation.")
@@ -145,6 +146,7 @@ extension Option {
   public static let dumpAst: Option = Option("-dump-ast", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Parse and type-check input file(s) and dump AST(s)", group: .modes)
   public static let dumpClangDiagnostics: Option = Option("-dump-clang-diagnostics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Dump Clang diagnostics to stderr")
   public static let dumpInterfaceHash: Option = Option("-dump-interface-hash", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Parse input file(s) and dump interface token hash(es)", group: .modes)
+  public static let dumpJit: Option = Option("-dump-jit", .joinedOrSeparate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Dump JIT contents")
   public static let dumpMigrationStatesDir: Option = Option("-dump-migration-states-dir", .separate, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild, .argumentIsPath], metaVar: "<path>", helpText: "Dump the input text, output text, and states for migration to <path>")
   public static let dumpParse: Option = Option("-dump-parse", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Parse input file(s) and dump AST(s)", group: .modes)
   public static let dumpPcm: Option = Option("-dump-pcm", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Dump debugging information about a precompiled Clang module", group: .modes)
@@ -163,7 +165,7 @@ extension Option {
   public static let emitDependenciesPath: Option = Option("-emit-dependencies-path", .separate, attributes: [.frontend, .noDriver], metaVar: "<path>", helpText: "Output basic Make-compatible dependencies file to <path>")
   public static let emitDependencies: Option = Option("-emit-dependencies", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild, .supplementaryOutput], helpText: "Emit basic Make-compatible dependencies files")
   public static let emitExecutable: Option = Option("-emit-executable", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit a linked executable", group: .modes)
-  public static let emitFineGrainedDependencySourcefileDotFiles: Option = Option("-emit-fine-grained-dependency-sourcefile-dot-files", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Emit dot files for every source file.", group: .internalDebug)
+  public static let emitFineGrainedDependencySourcefileDotFiles: Option = Option("-emit-fine-grained-dependency-sourcefile-dot-files", .flag, attributes: [.helpHidden, .frontend], helpText: "Emit dot files for every source file.")
   public static let emitFixitsPath: Option = Option("-emit-fixits-path", .separate, attributes: [.frontend, .noDriver], metaVar: "<path>", helpText: "Output compiler fixits as source edits to <path>")
   public static let emitImportedModules: Option = Option("-emit-imported-modules", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit a list of the imported modules", group: .modes)
   public static let emitIr: Option = Option("-emit-ir", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit LLVM IR file(s)", group: .modes)
@@ -217,10 +219,12 @@ extension Option {
   public static let enableDirectIntramoduleDependencies: Option = Option("-enable-direct-intramodule-dependencies", .flag, attributes: [.helpHidden, .frontend], helpText: "Enable experimental dependency tracking that never cascades")
   public static let enableDynamicReplacementChaining: Option = Option("-enable-dynamic-replacement-chaining", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable chaining of dynamic replacements")
   public static let enableExperimentalAdditiveArithmeticDerivation: Option = Option("-enable-experimental-additive-arithmetic-derivation", .flag, attributes: [.frontend], helpText: "Enable experimental 'AdditiveArithmetic' derived conformances")
-  public static let enableExperimentalConcisePoundFile: Option = Option("-enable-experimental-concise-pound-file", .flag, attributes: [.frontend], helpText: "Enable experimental concise '#file' identifier")
+  public static let enableExperimentalConcisePoundFile: Option = Option("-enable-experimental-concise-pound-file", .flag, attributes: [.frontend, .moduleInterface], helpText: "Enable experimental concise '#file' identifier")
+  public static let enableExperimentalConcurrency: Option = Option("-enable-experimental-concurrency", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental concurrency model")
   public static let enableExperimentalCxxInterop: Option = Option("-enable-experimental-cxx-interop", .flag, helpText: "Allow importing C++ modules into Swift (experimental feature)")
   public static let enableExperimentalForwardModeDifferentiation: Option = Option("-enable-experimental-forward-mode-differentiation", .flag, attributes: [.frontend], helpText: "Enable experimental forward mode differentiation")
   public static let enableExperimentalStaticAssert: Option = Option("-enable-experimental-static-assert", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental #assert")
+  public static let enableFuzzyForwardScanTrailingClosureMatching: Option = Option("-enable-fuzzy-forward-scan-trailing-closure-matching", .flag, attributes: [.frontend], helpText: "Enable fuzzy forward-scan trailing closure matching")
   public static let enableImplicitDynamic: Option = Option("-enable-implicit-dynamic", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Add 'dynamic' to all declarations")
   public static let enableInferImportAsMember: Option = Option("-enable-infer-import-as-member", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Infer when a global could be imported as a member")
   public static let enableInvalidEphemeralnessAsError: Option = Option("-enable-invalid-ephemeralness-as-error", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Diagnose invalid ephemeral to non-ephemeral conversions as errors")
@@ -251,11 +255,13 @@ extension Option {
   public static let enableTypeFingerprints: Option = Option("-enable-type-fingerprints", .flag, attributes: [.helpHidden, .frontend], helpText: "Enable per-nominal and extension body fingerprints")
   public static let enableTypeLayouts: Option = Option("-enable-type-layout", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable type layout based lowering")
   public static let enableVerifyExclusivity: Option = Option("-enable-verify-exclusivity", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable verification of access markers used to enforce exclusivity.")
+  public static let enableVolatileModules: Option = Option("-enable-volatile-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Load Swift modules in memory")
   public static let enforceExclusivityEQ: Option = Option("-enforce-exclusivity=", .joined, attributes: [.frontend, .moduleInterface], metaVar: "<enforcement>", helpText: "Enforce law of exclusivity")
   public static let experimentalCxxStdlib: Option = Option("-experimental-cxx-stdlib", .separate, helpText: "C++ standard library to use; forwarded to Clang's -stdlib flag")
   public static let experimentalOneWayClosureParams: Option = Option("-experimental-one-way-closure-params", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental support for one-way closure parameters")
   public static let experimentalPrintFullConvention: Option = Option("-experimental-print-full-convention", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "When emitting a module interface, emit additional @convention arguments, regardless of whether they were written in the source")
   public static let experimentalSkipNonInlinableFunctionBodies: Option = Option("-experimental-skip-non-inlinable-function-bodies", .flag, attributes: [.helpHidden, .frontend], helpText: "Skip type-checking and SIL generation for non-inlinable function bodies")
+  public static let experimentalSpiImports: Option = Option("-experimental-spi-imports", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental support for SPI imports")
   public static let explictSwiftModuleMap: Option = Option("-explicit-swift-module-map-file", .separate, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], metaVar: "<path>", helpText: "Specify a JSON file containing information of explict Swift modules")
   public static let externalPassPipelineFilename: Option = Option("-external-pass-pipeline-filename", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<pass_pipeline_file>", helpText: "Use the pass pipeline defined by <pass_pipeline_file>")
   public static let FEQ: Option = Option("-F=", .joined, alias: Option.F, attributes: [.frontend, .argumentIsPath])
@@ -352,6 +358,7 @@ extension Option {
   public static let pcMacro: Option = Option("-pc-macro", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Apply the 'program counter simulation' macro")
   public static let pchDisableValidation: Option = Option("-pch-disable-validation", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable validating the persistent PCH")
   public static let pchOutputDir: Option = Option("-pch-output-dir", .separate, attributes: [.helpHidden, .frontend, .argumentIsPath], helpText: "Directory to persist automatically created precompiled bridging headers")
+  public static let placeholderDependencyModuleMap: Option = Option("-placeholder-dependency-module-map-file", .separate, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], metaVar: "<path>", helpText: "Specify a JSON file containing information of external Swift module dependencies")
   public static let playgroundHighPerformance: Option = Option("-playground-high-performance", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Omit instrumentation that has a high runtime performance impact")
   public static let playground: Option = Option("-playground", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Apply the playground semantics and transformation")
   public static let prebuiltModuleCachePathEQ: Option = Option("-prebuilt-module-cache-path=", .joined, alias: Option.prebuiltModuleCachePath, attributes: [.helpHidden, .frontend, .noDriver])
@@ -394,6 +401,7 @@ extension Option {
   public static let saveOptimizationRecord: Option = Option("-save-optimization-record", .flag, attributes: [.frontend], helpText: "Generate a YAML optimization record file")
   public static let saveTemps: Option = Option("-save-temps", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "Save intermediate compilation results")
   public static let scanDependencies: Option = Option("-scan-dependencies", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Scan dependencies of the given Swift sources", group: .modes)
+  public static let scanClangDependencies: Option = Option("-scan-clang-dependencies", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Scan dependencies of the given Clang module", group: .modes)
   public static let sdk: Option = Option("-sdk", .separate, attributes: [.frontend, .argumentIsPath], metaVar: "<sdk>", helpText: "Compile against <sdk>")
   public static let serializeDebuggingOptions: Option = Option("-serialize-debugging-options", .flag, attributes: [.frontend, .noDriver], helpText: "Always serialize options for debugging (default: only for apps)")
   public static let serializeDiagnosticsPathEQ: Option = Option("-serialize-diagnostics-path=", .joined, alias: Option.serializeDiagnosticsPath, attributes: [.frontend, .noBatch, .doesNotAffectIncrementalBuild, .argumentIsPath, .supplementaryOutput])
@@ -453,6 +461,7 @@ extension Option {
   public static let useJit: Option = Option("-use-jit", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Register Objective-C classes as if the JIT were in use")
   public static let useLd: Option = Option("-use-ld=", .joined, attributes: [.doesNotAffectIncrementalBuild], helpText: "Specifies the linker to be used")
   public static let useMalloc: Option = Option("-use-malloc", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Allocate internal data structures using malloc (for memory debugging)")
+  public static let useStaticResourceDir: Option = Option("-use-static-resource-dir", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Use resources in the static resource directory")
   public static let useTabs: Option = Option("-use-tabs", .flag, attributes: [.noInteractive, .noBatch, .indent], helpText: "Use tabs for indentation.", group: .codeFormatting)
   public static let validateTbdAgainstIrEQ: Option = Option("-validate-tbd-against-ir=", .joined, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<level>", helpText: "Compare the symbols in the IR against the TBD file that would be generated.")
   public static let valueRecursionThreshold: Option = Option("-value-recursion-threshold", .separate, attributes: [.helpHidden, .frontend, .doesNotAffectIncrementalBuild], helpText: "Set the maximum depth for direct recursion in value types")
@@ -509,6 +518,7 @@ extension Option {
       Option.buildModuleFromParseableInterface,
       Option.buildRequestDependencyGraph,
       Option.bypassBatchModeChecks,
+      Option.candidateModuleFile,
       Option.checkOnoneCompleteness,
       Option.codeCompleteCallPatternHeuristics,
       Option.codeCompleteInitsInPostfixExpr,
@@ -534,7 +544,6 @@ extension Option {
       Option.debugInfoFormat,
       Option.debugInfoStoreInvocation,
       Option.debugPrefixMap,
-      Option.debugTimeCompilation,
       Option.debugTimeExpressionTypeChecking,
       Option.debugTimeFunctionBodies,
       Option.debuggerSupport,
@@ -561,6 +570,7 @@ extension Option {
       Option.disableDeserializationRecovery,
       Option.disableDiagnosticPasses,
       Option.disableDirectIntramoduleDependencies,
+      Option.disableFuzzyForwardScanTrailingClosureMatching,
       Option.disableGenericMetadataPrespecialization,
       Option.disableImplicitSwiftModules,
       Option.disableIncrementalLlvmCodegeneration,
@@ -629,6 +639,7 @@ extension Option {
       Option.dumpAst,
       Option.dumpClangDiagnostics,
       Option.dumpInterfaceHash,
+      Option.dumpJit,
       Option.dumpMigrationStatesDir,
       Option.dumpParse,
       Option.dumpPcm,
@@ -702,9 +713,11 @@ extension Option {
       Option.enableDynamicReplacementChaining,
       Option.enableExperimentalAdditiveArithmeticDerivation,
       Option.enableExperimentalConcisePoundFile,
+      Option.enableExperimentalConcurrency,
       Option.enableExperimentalCxxInterop,
       Option.enableExperimentalForwardModeDifferentiation,
       Option.enableExperimentalStaticAssert,
+      Option.enableFuzzyForwardScanTrailingClosureMatching,
       Option.enableImplicitDynamic,
       Option.enableInferImportAsMember,
       Option.enableInvalidEphemeralnessAsError,
@@ -735,11 +748,13 @@ extension Option {
       Option.enableTypeFingerprints,
       Option.enableTypeLayouts,
       Option.enableVerifyExclusivity,
+      Option.enableVolatileModules,
       Option.enforceExclusivityEQ,
       Option.experimentalCxxStdlib,
       Option.experimentalOneWayClosureParams,
       Option.experimentalPrintFullConvention,
       Option.experimentalSkipNonInlinableFunctionBodies,
+      Option.experimentalSpiImports,
       Option.explictSwiftModuleMap,
       Option.externalPassPipelineFilename,
       Option.FEQ,
@@ -836,6 +851,7 @@ extension Option {
       Option.pcMacro,
       Option.pchDisableValidation,
       Option.pchOutputDir,
+      Option.placeholderDependencyModuleMap,
       Option.playgroundHighPerformance,
       Option.playground,
       Option.prebuiltModuleCachePathEQ,
@@ -937,6 +953,7 @@ extension Option {
       Option.useJit,
       Option.useLd,
       Option.useMalloc,
+      Option.useStaticResourceDir,
       Option.useTabs,
       Option.validateTbdAgainstIrEQ,
       Option.valueRecursionThreshold,

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/C.h
@@ -1,3 +1,4 @@
 #include "B.h"
 
 void funcC(void);
+const char* stringC() { return "Module"; }

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
@@ -1,1 +1,5 @@
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 110000
+#include "X.h"
+#endif
+
 void funcG(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/X.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/X.h
@@ -1,0 +1,1 @@
+void funcX(void);

--- a/TestInputs/ExplicitModuleBuilds/CHeaders/module.modulemap
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/module.modulemap
@@ -27,3 +27,8 @@ module G {
   header "G.h"
   export *
 }
+
+module X {
+  header "X.h"
+  export *
+}

--- a/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/A.swiftinterface
@@ -1,7 +1,6 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name A
 import Swift
-import SwiftOnoneSupport
 @_exported import A
 public func overlayFuncA() { }
 

--- a/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
@@ -1,5 +1,4 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name E
 import Swift
-import SwiftOnoneSupport
-public func funcE() { }
+public func funcE()

--- a/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/F.swiftinterface
@@ -1,6 +1,5 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name F
 import Swift
-import SwiftOnoneSupport
 @_exported import F
 public func funcF() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
@@ -1,10 +1,8 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name G -swift-version 5
-
+// swift-module-flags: -module-name G -swift-version 5 -target x86_64-apple-macosx10.9
 #if swift(>=5.0)
-import Swift
-import SwiftOnoneSupport
 @_exported import G
+import Swift
 public func overlayFuncG() { }
-
+let stringG : String = "Build"
 #endif

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -1,8 +1,8 @@
-//===--- ExplicitModuleDependencyBuildInputs.swift - Test Inputs ----------===//
+//===------ ExplicitModuleDependencyBuildInputs.swift - Test Inputs -------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -39,6 +39,7 @@ enum ModuleDependenciesInputs {
           ],
           "details": {
             "swift": {
+              "isFramework": false,
               "extraPcmArgs": [
                 "-Xcc",
                 "-target",
@@ -123,6 +124,7 @@ enum ModuleDependenciesInputs {
                 "-module-name",
                 "Swift"
               ],
+              "isFramework": false,
               "extraPcmArgs": [
                 "-Xcc",
                 "-target",
@@ -187,6 +189,7 @@ enum ModuleDependenciesInputs {
                 "-module-name",
                 "SwiftOnoneSupport"
               ],
+              "isFramework": true,
               "extraPcmArgs": [
                 "-Xcc",
                 "-target",
@@ -270,6 +273,7 @@ enum ModuleDependenciesInputs {
           ],
           "details": {
             "swift": {
+              "isFramework": false,
               "extraPcmArgs": [
                 "-Xcc",
                 "-target",
@@ -316,6 +320,7 @@ enum ModuleDependenciesInputs {
               ],
               "compiledModuleCandidates": [
               ],
+              "isFramework": false,
               "extraPcmArgs": [
                 "-Xcc",
                 "-target",
@@ -343,6 +348,7 @@ enum ModuleDependenciesInputs {
             "swift": {
               "moduleInterfacePath": "SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface",
               "contextHash": "3GKS4RKE3GDZA",
+              "isFramework": false,
               "commandLine": [
                 "-frontend",
                 "-compile-module-from-interface",
@@ -352,6 +358,14 @@ enum ModuleDependenciesInputs {
                 "5",
                 "-module-name",
                 "SwiftOnoneSupport"
+              ],
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.9",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
               ]
             }
           }
@@ -384,6 +398,7 @@ enum ModuleDependenciesInputs {
           ],
           "details": {
             "swift": {
+              "isFramework": false,
               "extraPcmArgs": [
                 "-Xcc",
                 "-target",
@@ -404,6 +419,15 @@ enum ModuleDependenciesInputs {
           ],
           "details" : {
             "swift" : {
+              "isFramework": false,
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.9",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ],
               "explicitCompiledModulePath" : "M/Swift.swiftmodule"
             }
           }
@@ -420,6 +444,15 @@ enum ModuleDependenciesInputs {
           ],
           "details" : {
             "swift" : {
+              "isFramework": false,
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.9",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ],
               "explicitCompiledModulePath" : "S/SwiftOnoneSupport.swiftmodule"
             }
           }
@@ -429,5 +462,4 @@ enum ModuleDependenciesInputs {
     """
   }
 }
-
 


### PR DESCRIPTION
- Factor out placeholder dependency resolution out of the ExplicitModuleHandler into the Driver
- Generate and post-process the dependency graph before passing it on to the ExplicitModuleHandler:
  - Run the Swift Fast Dependency Scanner.
  - Resolve placeholder dependencies, if any.
  - Re-scan and update Clang modules with a super-set of their dependencies against all compilation targets.

**Some background on this issue:**
When building a Swift module at a fixed target version, the module may have dependencies which specify a different target version. It is possible that in this case, multiple swift modules, with different targets, have a dependency on the same Clang module. There is a hard requirement that the target version of the Clang module compilation match exactly the target version of the depending Swift module compilation. 

**The problem this PR addresses:**
Dependency scanning results may vary depending on the target version specified on the dependency scanning action. If the scanning action is performed at a fixed target, and the scanned module is later compiled with a higher version target, miscomputation may occur due to dependencies present only at the higher version number and thus not detected by the dependency scanner. 

Uses the newly-added Clang dependency scanning mode in the swift-frontend, added here:
https://github.com/apple/swift/pull/33522

Resolves rdar://67079780