### PR TITLE
Revert "Use platform_version to pass deployment target information to the linker"

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -137,7 +137,7 @@ public final class DarwinToolchain: Toolchain {
       case .iOSVersionAboveMaximumDeploymentTarget(let version):
         return "iOS \(version) does not support 32-bit programs"
       case .unsupportedTargetVariant(variant: let variant):
-        return "unsupported '\(variant.isiOS ? "-target-variant" : "-target")' value '\(variant.triple)'; use 'ios-macabi' instead"
+        return "unsupported '\(variant.isiOS ? "-target" : "-target-variant")' value '\(variant)'; use 'ios-macabi' instead"
       case .argumentNotSupported(let argument):
         return "\(argument) is no longer supported for Apple platforms"
       case .darwinOnlySupportsLibCxx:
@@ -208,14 +208,14 @@ public final class DarwinToolchain: Toolchain {
     }
   }
 
-  struct DarwinSDKInfo: Decodable {
-    private enum CodingKeys: String, CodingKey {
+  private struct DarwinSDKInfo: Decodable {
+    enum CodingKeys: String, CodingKey {
       case version = "Version"
       case versionMap = "VersionMap"
     }
 
     struct VersionMap: Decodable {
-      private enum CodingKeys: String, CodingKey {
+      enum CodingKeys: String, CodingKey {
         case macOSToCatalystMapping = "macOS_iOSMac"
       }
 
@@ -242,8 +242,8 @@ public final class DarwinToolchain: Toolchain {
       }
     }
 
-    private var version: Version
-    private var versionMap: VersionMap
+    var version: Version
+    var versionMap: VersionMap
 
     init(from decoder: Decoder) throws {
       let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
@@ -272,7 +272,7 @@ public final class DarwinToolchain: Toolchain {
   // SDK info is computed lazily. This should not generally be accessed directly.
   private var _sdkInfo: DarwinSDKInfo? = nil
 
-  func getTargetSDKInfo(sdkPath: VirtualPath) -> DarwinSDKInfo? {
+  private func getTargetSDKInfo(sdkPath: VirtualPath) -> DarwinSDKInfo? {
     if let info = _sdkInfo {
       return info
     } else {

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -102,29 +102,6 @@ public enum DarwinPlatform: Hashable {
     }
   }
 
-  /// The name the linker uses to identify this platform.
-  public var linkerPlatformName: String {
-    switch self {
-    case .macOS:
-      return "macos"
-    case .iOS(.device):
-      return "ios"
-    case .iOS(.simulator):
-      return "ios-simulator"
-    case .iOS(.catalyst):
-      return "mac-catalyst"
-    case .tvOS(.device):
-      return "tvos"
-    case .tvOS(.simulator):
-      return "tvos-simulator"
-    case .watchOS(.device):
-      return "watchos"
-    case .watchOS(.simulator):
-      return "watchos-simulator"
-    }
-  }
-
-
   /// The name used to identify this platform in compiler_rt file names.
   public var libraryNameSuffix: String {
     switch self {
@@ -204,53 +181,6 @@ extension Triple {
       return .tvOS(makeEnvironment())
     default:
       return nil
-    }
-  }
-
-  // The Darwin platform version used for linking.
-  public var darwinLinkerPlatformVersion: Version {
-    precondition(self.isDarwin)
-    switch darwinPlatform! {
-    case .macOS:
-      // The integrated driver falls back to `osVersion` for ivalid macOS
-      // versions, this decision might be worth revisiting.
-      let macVersion = _macOSVersion ?? osVersion
-      // The first deployment of arm64 for macOS is version 11
-      if macVersion.major < 11 && arch == .aarch64 {
-        return Version(11, 0, 0)
-      }
-
-      return macVersion
-    case .iOS(.catalyst):
-      // Mac Catalyst on arm was introduced with an iOS deployment target of
-      // 14.0; the linker doesn't want to see a deployment target before that.
-      if _iOSVersion.major < 14 && arch == .aarch64 {
-        return Version(14, 0, 0)
-      }
-
-      // Mac Catalyst was introduced with an iOS deployment target of 13.0;
-      // the linker doesn't want to see a deployment target before that.
-      if _iOSVersion.major < 13 {
-        return Version(13, 0, 0)
-      }
-
-      return _iOSVersion
-    case .iOS(.device), .iOS(.simulator), .tvOS(_):
-      // The first deployment of arm64 simulators is iOS/tvOS 14.0;
-      // the linker doesn't want to see a deployment target before that.
-      if _isSimulatorEnvironment && _iOSVersion.major < 14 && arch == .aarch64 {
-        return Version(14, 0, 0)
-      }
-
-      return _iOSVersion
-    case .watchOS(_):
-      // The first deployment of arm64 simulators is watchOS 7;
-      // the linker doesn't want to see a deployment target before that.
-      if _isSimulatorEnvironment && osVersion.major < 7 && arch == .aarch64 {
-        return Version(7, 0, 0)
-      }
-
-      return osVersion
     }
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -709,7 +709,8 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dylib")))
       XCTAssertTrue(cmd.contains(.flag("-arch")))
       XCTAssertTrue(cmd.contains(.flag("x86_64")))
-      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "macos", "10.15.0", "0.0.0"]))
+      XCTAssertTrue(cmd.contains(.flag("-macosx_version_min")))
+      XCTAssertTrue(cmd.contains(.flag("10.15.0")))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
@@ -731,7 +732,8 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dylib")))
       XCTAssertTrue(cmd.contains(.flag("-arch")))
       XCTAssertTrue(cmd.contains(.flag("arm64")))
-      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "ios", "10.0.0", "0.0.0"]))
+      XCTAssertTrue(cmd.contains(.flag("-iphoneos_version_min")))
+      XCTAssertTrue(cmd.contains(.flag("10.0.0")))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
@@ -753,7 +755,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dylib")))
       XCTAssertTrue(cmd.contains(.flag("-arch")))
       XCTAssertTrue(cmd.contains(.flag("x86_64")))
-      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "mac-catalyst", "13.0.0", "0.0.0"]))
+      XCTAssertTrue(cmd.contains(.flag("-maccatalyst_version_min")))
       XCTAssertTrue(cmd.contains(.flag("13.0.0")))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
@@ -1537,10 +1539,10 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
 
       XCTAssertEqual(plannedJobs[1].kind, .link)
-      XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [
-        "-platform_version", "mac-catalyst", "13.0.0", "0.0.0",
-        "-platform_version", "macos", "10.14.0", "0.0.0"
-      ]))
+      XCTAssert(plannedJobs[1].commandLine.contains(.flag("-maccatalyst_version_min")))
+      XCTAssert(plannedJobs[1].commandLine.contains(.flag("13.0.0")))
+      XCTAssert(plannedJobs[1].commandLine.contains(.flag("-macosx_version_min")))
+      XCTAssert(plannedJobs[1].commandLine.contains(.flag("10.14.0")))
     }
 
     // Test -target-variant is passed to generate pch job
@@ -1563,10 +1565,10 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssert(plannedJobs[1].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
 
       XCTAssertEqual(plannedJobs[2].kind, .link)
-      XCTAssertTrue(plannedJobs[2].commandLine.contains(subsequence: [
-        "-platform_version", "mac-catalyst", "13.0.0", "0.0.0",
-        "-platform_version", "macos", "10.14.0", "0.0.0"
-      ]))
+      XCTAssert(plannedJobs[2].commandLine.contains(.flag("-maccatalyst_version_min")))
+      XCTAssert(plannedJobs[2].commandLine.contains(.flag("13.0.0")))
+      XCTAssert(plannedJobs[2].commandLine.contains(.flag("-macosx_version_min")))
+      XCTAssert(plannedJobs[2].commandLine.contains(.flag("10.14.0")))
     }
   }
 
@@ -1688,13 +1690,6 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-sdk-version"),
           .flag("10.15.0")
         ]))
-        XCTAssertEqual(frontendJobs[1].kind, .link)
-        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-          .flag("-platform_version"),
-          .flag("macos"),
-          .flag("10.14.0"),
-          .flag("10.15.0"),
-        ]))
       }
 
       do {
@@ -1709,18 +1704,7 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-sdk-version"),
           .flag("10.15.0"),
           .flag("-target-variant-sdk-version"),
-          .flag("13.1.0"),
-        ]))
-        XCTAssertEqual(frontendJobs[1].kind, .link)
-        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-          .flag("-platform_version"),
-          .flag("macos"),
-          .flag("10.14.0"),
-          .flag("10.15.0"),
-          .flag("-platform_version"),
-          .flag("mac-catalyst"),
-          .flag("13.0.0"),
-          .flag("13.1.0"),
+          .flag("13.1.0")
         ]))
       }
 
@@ -1738,17 +1722,6 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-variant-sdk-version"),
           .flag("13.4.0")
         ]))
-        XCTAssertEqual(frontendJobs[1].kind, .link)
-        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-          .flag("-platform_version"),
-          .flag("macos"),
-          .flag("10.14.0"),
-          .flag("10.15.4"),
-          .flag("-platform_version"),
-          .flag("mac-catalyst"),
-          .flag("13.0.0"),
-          .flag("13.4.0"),
-        ]))
       }
 
       do {
@@ -1765,154 +1738,7 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-variant-sdk-version"),
           .flag("10.15.4")
         ]))
-        XCTAssertEqual(frontendJobs[1].kind, .link)
-        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-          .flag("-platform_version"),
-          .flag("mac-catalyst"),
-          .flag("13.0.0"),
-          .flag("13.4.0"),
-          .flag("-platform_version"),
-          .flag("macos"),
-          .flag("10.14.0"),
-          .flag("10.15.4"),
-        ]))
       }
-    }
-  }
-
-  func testDarwinLinkerPlatformVersion() throws {
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "x86_64-apple-macos10.15",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("macos"),
-        .flag("10.15.0"),
-      ]))
-    }
-
-    // Mac gained aarch64 support in v11
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "arm64-apple-macos10.15",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("macos"),
-        .flag("11.0.0"),
-      ]))
-    }
-
-    // Mac Catalyst on x86_64 was introduced in v13.
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "x86_64-apple-ios12.0-macabi",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("mac-catalyst"),
-        .flag("13.0.0"),
-      ]))
-    }
-
-    // Mac Catalyst on arm was introduced in v14.
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "aarch64-apple-ios12.0-macabi",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("mac-catalyst"),
-        .flag("14.0.0"),
-      ]))
-    }
-
-    // Regular iOS
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "aarch64-apple-ios12.0",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("ios"),
-        .flag("12.0.0"),
-      ]))
-    }
-
-    // Regular tvOS
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "aarch64-apple-tvos12.0",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("tvos"),
-        .flag("12.0.0"),
-      ]))
-    }
-
-    // Regular watchOS
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "aarch64-apple-watchos6.0",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("watchos"),
-        .flag("6.0.0"),
-      ]))
-    }
-
-    // x86_64 iOS simulator
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "x86_64-apple-ios12.0-simulator",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("ios-simulator"),
-        .flag("12.0.0"),
-      ]))
-    }
-
-    // aarch64 iOS simulator
-    do {
-      var driver = try Driver(args: ["swiftc",
-                                     "-target", "aarch64-apple-ios12.0-simulator",
-                                     "foo.swift"])
-      let frontendJobs = try driver.planBuild()
-
-      XCTAssertEqual(frontendJobs[1].kind, .link)
-      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
-        .flag("-platform_version"),
-        .flag("ios-simulator"),
-        .flag("14.0.0"),
-      ]))
     }
   }
 


### PR DESCRIPTION
Reverts apple/swift-driver#211

This fails on main Swift CI, not sure why yet