### PR TITLE
Reapply "Use platform_version to pass deployment target info to the linker"

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
+import TSCUtility
 import SwiftOptions
 
 extension DarwinToolchain {
@@ -112,49 +113,36 @@ extension DarwinToolchain {
     commandLine.appendPath(clangRTPath)
   }
 
+  private func addPlatformVersionArg(to commandLine: inout [Job.ArgTemplate],
+                                     for triple: Triple, sdkPath: VirtualPath?) {
+    assert(triple.isDarwin)
+    let platformName = triple.darwinPlatform!.linkerPlatformName
+    let platformVersion = triple.darwinLinkerPlatformVersion
+    let sdkVersion: Version
+    if let sdkPath = sdkPath,
+       let sdkInfo = getTargetSDKInfo(sdkPath: sdkPath) {
+      sdkVersion = sdkInfo.sdkVersion(for: triple)
+    } else {
+      sdkVersion = Version(0, 0, 0)
+    }
+
+    commandLine.append(.flag("-platform_version"))
+    commandLine.append(.flag(platformName))
+    commandLine.append(.flag(platformVersion.description))
+    commandLine.append(.flag(sdkVersion.description))
+  }
+
   private func addDeploymentTargetArgs(
     to commandLine: inout [Job.ArgTemplate],
     targetTriple: Triple,
-    targetVariantTriple: Triple?
+    targetVariantTriple: Triple?,
+    sdkPath: VirtualPath?
   ) {
-    // FIXME: Properly handle deployment targets.
-
-    let flag: String
-
-    switch targetTriple.darwinPlatform! {
-    case .iOS(.device):
-      flag = "-iphoneos_version_min"
-    case .iOS(.simulator):
-      flag = "-ios_simulator_version_min"
-    case .iOS(.catalyst):
-      flag = "-maccatalyst_version_min"
-    case .macOS:
-      flag = "-macosx_version_min"
-    case .tvOS(.device):
-      flag = "-tvos_version_min"
-    case .tvOS(.simulator):
-      flag = "-tvos_simulator_version_min"
-    case .watchOS(.device):
-      flag = "-watchos_version_min"
-    case .watchOS(.simulator):
-      flag = "-watchos_simulator_version_min"
-    }
-
-    commandLine.appendFlag(flag)
-    commandLine.appendFlag(targetTriple.version().description)
-
-    if let variant = targetVariantTriple {
-      if targetTriple.isiOS {
-        assert(targetTriple.isValidForZipperingWithTriple(variant))
-        assert(variant.isMacOSX)
-        commandLine.appendFlag("-macosx_version_min")
-        commandLine.appendFlag(variant.version().description)
-      } else {
-        assert(targetTriple.isValidForZipperingWithTriple(variant))
-        assert(variant.isMacCatalyst)
-        commandLine.appendFlag("-maccatalyst_version_min")
-        commandLine.appendFlag(variant.version().description)
-      }
+    addPlatformVersionArg(to: &commandLine, for: targetTriple, sdkPath: sdkPath)
+    if let variantTriple = targetVariantTriple {
+      assert(targetTriple.isValidForZipperingWithTriple(variantTriple))
+      addPlatformVersionArg(to: &commandLine, for: variantTriple,
+                            sdkPath: sdkPath)
     }
   }
 
@@ -284,7 +272,8 @@ extension DarwinToolchain {
     addDeploymentTargetArgs(
       to: &commandLine,
       targetTriple: targetTriple,
-      targetVariantTriple: targetVariantTriple
+      targetVariantTriple: targetVariantTriple,
+      sdkPath: try sdkPath.map(VirtualPath.init(path:))
     )
     try addProfileGenerationArgs(
       to: &commandLine,

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -137,7 +137,7 @@ public final class DarwinToolchain: Toolchain {
       case .iOSVersionAboveMaximumDeploymentTarget(let version):
         return "iOS \(version) does not support 32-bit programs"
       case .unsupportedTargetVariant(variant: let variant):
-        return "unsupported '\(variant.isiOS ? "-target" : "-target-variant")' value '\(variant)'; use 'ios-macabi' instead"
+        return "unsupported '\(variant.isiOS ? "-target-variant" : "-target")' value '\(variant.triple)'; use 'ios-macabi' instead"
       case .argumentNotSupported(let argument):
         return "\(argument) is no longer supported for Apple platforms"
       case .darwinOnlySupportsLibCxx:
@@ -208,14 +208,14 @@ public final class DarwinToolchain: Toolchain {
     }
   }
 
-  private struct DarwinSDKInfo: Decodable {
-    enum CodingKeys: String, CodingKey {
+  struct DarwinSDKInfo: Decodable {
+    private enum CodingKeys: String, CodingKey {
       case version = "Version"
       case versionMap = "VersionMap"
     }
 
     struct VersionMap: Decodable {
-      enum CodingKeys: String, CodingKey {
+      private enum CodingKeys: String, CodingKey {
         case macOSToCatalystMapping = "macOS_iOSMac"
       }
 
@@ -242,8 +242,8 @@ public final class DarwinToolchain: Toolchain {
       }
     }
 
-    var version: Version
-    var versionMap: VersionMap
+    private var version: Version
+    private var versionMap: VersionMap
 
     init(from decoder: Decoder) throws {
       let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
@@ -272,7 +272,7 @@ public final class DarwinToolchain: Toolchain {
   // SDK info is computed lazily. This should not generally be accessed directly.
   private var _sdkInfo: DarwinSDKInfo? = nil
 
-  private func getTargetSDKInfo(sdkPath: VirtualPath) -> DarwinSDKInfo? {
+  func getTargetSDKInfo(sdkPath: VirtualPath) -> DarwinSDKInfo? {
     if let info = _sdkInfo {
       return info
     } else {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -709,8 +709,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dylib")))
       XCTAssertTrue(cmd.contains(.flag("-arch")))
       XCTAssertTrue(cmd.contains(.flag("x86_64")))
-      XCTAssertTrue(cmd.contains(.flag("-macosx_version_min")))
-      XCTAssertTrue(cmd.contains(.flag("10.15.0")))
+      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "macos", "10.15.0"]))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
@@ -732,8 +731,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dylib")))
       XCTAssertTrue(cmd.contains(.flag("-arch")))
       XCTAssertTrue(cmd.contains(.flag("arm64")))
-      XCTAssertTrue(cmd.contains(.flag("-iphoneos_version_min")))
-      XCTAssertTrue(cmd.contains(.flag("10.0.0")))
+      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "ios", "10.0.0"]))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
@@ -755,7 +753,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dylib")))
       XCTAssertTrue(cmd.contains(.flag("-arch")))
       XCTAssertTrue(cmd.contains(.flag("x86_64")))
-      XCTAssertTrue(cmd.contains(.flag("-maccatalyst_version_min")))
+      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "mac-catalyst", "13.0.0"]))
       XCTAssertTrue(cmd.contains(.flag("13.0.0")))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
@@ -1536,10 +1534,10 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
 
       XCTAssertEqual(plannedJobs[1].kind, .link)
-      XCTAssert(plannedJobs[1].commandLine.contains(.flag("-maccatalyst_version_min")))
-      XCTAssert(plannedJobs[1].commandLine.contains(.flag("13.0.0")))
-      XCTAssert(plannedJobs[1].commandLine.contains(.flag("-macosx_version_min")))
-      XCTAssert(plannedJobs[1].commandLine.contains(.flag("10.14.0")))
+      XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [
+        "-platform_version", "mac-catalyst", "13.0.0"]))
+      XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [
+        "-platform_version", "macos", "10.14.0"]))
     }
 
     // Test -target-variant is passed to generate pch job
@@ -1562,10 +1560,10 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssert(plannedJobs[1].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
 
       XCTAssertEqual(plannedJobs[2].kind, .link)
-      XCTAssert(plannedJobs[2].commandLine.contains(.flag("-maccatalyst_version_min")))
-      XCTAssert(plannedJobs[2].commandLine.contains(.flag("13.0.0")))
-      XCTAssert(plannedJobs[2].commandLine.contains(.flag("-macosx_version_min")))
-      XCTAssert(plannedJobs[2].commandLine.contains(.flag("10.14.0")))
+      XCTAssertTrue(plannedJobs[2].commandLine.contains(subsequence: [
+        "-platform_version", "mac-catalyst", "13.0.0"]))
+      XCTAssertTrue(plannedJobs[2].commandLine.contains(subsequence: [
+        "-platform_version", "macos", "10.14.0"]))
     }
   }
 
@@ -1687,6 +1685,13 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-sdk-version"),
           .flag("10.15.0")
         ]))
+        XCTAssertEqual(frontendJobs[1].kind, .link)
+        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+          .flag("-platform_version"),
+          .flag("macos"),
+          .flag("10.14.0"),
+          .flag("10.15.0"),
+        ]))
       }
 
       do {
@@ -1701,7 +1706,18 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-sdk-version"),
           .flag("10.15.0"),
           .flag("-target-variant-sdk-version"),
-          .flag("13.1.0")
+          .flag("13.1.0"),
+        ]))
+        XCTAssertEqual(frontendJobs[1].kind, .link)
+        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+          .flag("-platform_version"),
+          .flag("macos"),
+          .flag("10.14.0"),
+          .flag("10.15.0"),
+          .flag("-platform_version"),
+          .flag("mac-catalyst"),
+          .flag("13.0.0"),
+          .flag("13.1.0"),
         ]))
       }
 
@@ -1719,6 +1735,17 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-variant-sdk-version"),
           .flag("13.4.0")
         ]))
+        XCTAssertEqual(frontendJobs[1].kind, .link)
+        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+          .flag("-platform_version"),
+          .flag("macos"),
+          .flag("10.14.0"),
+          .flag("10.15.4"),
+          .flag("-platform_version"),
+          .flag("mac-catalyst"),
+          .flag("13.0.0"),
+          .flag("13.4.0"),
+        ]))
       }
 
       do {
@@ -1735,7 +1762,154 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-variant-sdk-version"),
           .flag("10.15.4")
         ]))
+        XCTAssertEqual(frontendJobs[1].kind, .link)
+        XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+          .flag("-platform_version"),
+          .flag("mac-catalyst"),
+          .flag("13.0.0"),
+          .flag("13.4.0"),
+          .flag("-platform_version"),
+          .flag("macos"),
+          .flag("10.14.0"),
+          .flag("10.15.4"),
+        ]))
       }
+    }
+  }
+
+  func testDarwinLinkerPlatformVersion() throws {
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "x86_64-apple-macos10.15",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("macos"),
+        .flag("10.15.0"),
+      ]))
+    }
+
+    // Mac gained aarch64 support in v11
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "arm64-apple-macos10.15",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("macos"),
+        .flag("11.0.0"),
+      ]))
+    }
+
+    // Mac Catalyst on x86_64 was introduced in v13.
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "x86_64-apple-ios12.0-macabi",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("mac-catalyst"),
+        .flag("13.0.0"),
+      ]))
+    }
+
+    // Mac Catalyst on arm was introduced in v14.
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "aarch64-apple-ios12.0-macabi",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("mac-catalyst"),
+        .flag("14.0.0"),
+      ]))
+    }
+
+    // Regular iOS
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "aarch64-apple-ios12.0",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("ios"),
+        .flag("12.0.0"),
+      ]))
+    }
+
+    // Regular tvOS
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "aarch64-apple-tvos12.0",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("tvos"),
+        .flag("12.0.0"),
+      ]))
+    }
+
+    // Regular watchOS
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "aarch64-apple-watchos6.0",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("watchos"),
+        .flag("6.0.0"),
+      ]))
+    }
+
+    // x86_64 iOS simulator
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "x86_64-apple-ios12.0-simulator",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("ios-simulator"),
+        .flag("12.0.0"),
+      ]))
+    }
+
+    // aarch64 iOS simulator
+    do {
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "aarch64-apple-ios12.0-simulator",
+                                     "foo.swift"])
+      let frontendJobs = try driver.planBuild()
+
+      XCTAssertEqual(frontendJobs[1].kind, .link)
+      XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+        .flag("-platform_version"),
+        .flag("ios-simulator"),
+        .flag("14.0.0"),
+      ]))
     }
   }
 


### PR DESCRIPTION
I haven't been able to reproduce the issue that caused this to be reverted locally, so running on Swift CI to try and diagnose the problem