### PR TITLE
Properly resolve paths to temporary response files when autolinking

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -73,6 +73,8 @@ public struct ArgsResolver {
 
       // Otherwise, return the path.
       return path.name
+    case .responseFilePath(let path):
+      return "@\(try resolve(.path(path)))"
     }
   }
 

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -169,6 +169,8 @@ extension Array where Element == Job.ArgTemplate {
           return string.spm_shellEscaped()
         case .path(let path):
           return path.name.spm_shellEscaped()
+      case .responseFilePath(let path):
+        return "@\(path.name.spm_shellEscaped())"
       }
     }.joined(separator: " ")
   }

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -161,7 +161,7 @@ extension GenericUnixToolchain {
       let inputFiles: [Job.ArgTemplate] = inputs.map { input in
         // Autolink inputs are handled specially
         if input.type == .autolink {
-          return .flag("@\(input.file.name)")
+          return .responseFilePath(input.file)
         }
         return .path(input.file)
       }
@@ -210,7 +210,7 @@ extension GenericUnixToolchain {
         guard fileSystem.isFile(linkFile) else {
           fatalError("\(linkFile.pathString) not found")
         }
-        commandLine.appendFlag("@\(linkFile.pathString)")
+        commandLine.append(.responseFilePath(.absolute(linkFile)))
       }
 
       // Explicitly pass the target to the linker

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -42,6 +42,9 @@ public struct Job: Codable, Equatable, Hashable {
 
     /// Represents a virtual path on disk.
     case path(VirtualPath)
+
+    /// Represents a response file path prefixed by '@'.
+    case responseFilePath(VirtualPath)
   }
 
   /// The Swift module this job involves.
@@ -211,7 +214,7 @@ extension Job.Kind {
 
 extension Job.ArgTemplate: Codable {
   private enum CodingKeys: String, CodingKey {
-    case flag, path
+    case flag, path, responseFilePath
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -222,6 +225,9 @@ extension Job.ArgTemplate: Codable {
       try unkeyedContainer.encode(a1)
     case let .path(a1):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .path)
+      try unkeyedContainer.encode(a1)
+    case let .responseFilePath(a1):
+      var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .responseFilePath)
       try unkeyedContainer.encode(a1)
     }
   }
@@ -240,6 +246,10 @@ extension Job.ArgTemplate: Codable {
       var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
       let a1 = try unkeyedValues.decode(VirtualPath.self)
       self = .path(a1)
+    case .responseFilePath:
+      var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+      let a1 = try unkeyedValues.decode(VirtualPath.self)
+      self = .responseFilePath(a1)
     }
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -859,6 +859,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-shared")))
       XCTAssertTrue(cmd.contains(.path(.temporary(RelativePath("foo.o")))))
       XCTAssertTrue(cmd.contains(.path(.temporary(RelativePath("bar.o")))))
+      XCTAssertTrue(cmd.contains(.responseFilePath(.temporary(RelativePath("Test.autolink")))))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.so"))
 
       XCTAssertFalse(cmd.contains(.flag("-dylib")))


### PR DESCRIPTION
Previously, .autolink files were passed as flags throughout the driver so that they could be prefixed by "@". This PR adds a new Job.ArgTemplateKind, `responseFilePath` to make sure we resolve the underlying path properly. This fixes most of the Driver/tools_directory integration test (there's at least one other remaining unrelated issue preventing it from passing)