### PR TITLE
Fix the swift-driver build using CMake

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(SwiftDriver
   "Explicit Module Builds/ClangModuleBuildJobCache.swift"
   "Explicit Module Builds/ExplicitModuleBuildHandler.swift"
   "Explicit Module Builds/PlaceholderDependencyResolution.swift"
+  "Explicit Module Builds/ClangVersionedDependencyResolution"
   "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
   "Explicit Module Builds/ModuleArtifacts.swift"


### PR DESCRIPTION
Add missing file.

It seems that when I re-based https://github.com/apple/swift-driver/pull/217, I somehow managed to silently undo the CMakeLists change it meant to contain...