### PR TITLE
Update the no inputs error to allow invocations like 'swiftc -v'

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -19,7 +19,7 @@ public struct Driver {
   public enum Error: Swift.Error, Equatable, DiagnosticData {
     case invalidDriverName(String)
     case invalidInput(String)
-    case noJobsPassedToDriverFromEmptyInputFileList
+    case noInputFiles
     case relativeFrontendPath(String)
     case subcommandPassedToDriver
     case integratedReplRemoved
@@ -40,7 +40,7 @@ public struct Driver {
         return "invalid driver name: \(driverName)"
       case .invalidInput(let input):
         return "invalid input: \(input)"
-      case .noJobsPassedToDriverFromEmptyInputFileList:
+      case .noInputFiles:
         return "no input files"
       case .relativeFrontendPath(let path):
         // TODO: where is this error thrown
@@ -671,13 +671,6 @@ extension Driver {
   ) throws {
     if parsedOptions.hasArgument(.v) {
       try printVersion(outputStream: &stderrStream)
-    }
-
-    guard !jobs.isEmpty else {
-      guard !inputFiles.isEmpty else {
-        throw Error.noJobsPassedToDriverFromEmptyInputFileList
-      }
-      return
     }
 
     let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -327,6 +327,15 @@ extension Driver {
       return [job]
     }
 
+    // The REPL doesn't require input files, but all other modes do.
+    guard !inputFiles.isEmpty || compilerMode == .repl else {
+      if parsedOptions.hasArgument(.v) {
+        // `swiftc -v` is allowed and prints version information.
+        return []
+      }
+      throw Error.noInputFiles
+    }
+
     // Plan the build.
     switch compilerMode {
     case .repl:

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2121,6 +2121,33 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testNoInputs() throws {
+    do {
+      var driver = try Driver(args: ["swift"])
+      XCTAssertNoThrow(try driver.planBuild())
+    }
+    do {
+      var driver = try Driver(args: ["swiftc"])
+      XCTAssertThrowsError(try driver.planBuild()) {
+        XCTAssertEqual($0 as? Driver.Error, .noInputFiles)
+      }
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "-v"])
+      XCTAssertNoThrow(try driver.planBuild())
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "-v", "-whole-module-optimization"])
+      XCTAssertNoThrow(try driver.planBuild())
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "-whole-module-optimization"])
+      XCTAssertThrowsError(try driver.planBuild()) {
+        XCTAssertEqual($0 as? Driver.Error, .noInputFiles)
+      }
+    }
+  }
+
   func testPrintTargetInfo() throws {
     do {
       var driver = try Driver(args: ["swift", "-print-target-info", "-target", "arm64-apple-ios12.0", "-sdk", "bar", "-resource-dir", "baz"])


### PR DESCRIPTION
This fixes the Driver/no-inputs.swift integration test, and by moving the check to the start of build planning, it also eliminates a couple of crashes where when we were creating compile jobs we assumed there was at least 1 input file.