### PR TITLE
Support adding a "joined" option with a path argument to a command line

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -75,6 +75,8 @@ public struct ArgsResolver {
       return path.name
     case .responseFilePath(let path):
       return "@\(try resolve(.path(path)))"
+    case let .joinedOptionAndPath(option, path):
+      return option + (try resolve(.path(path)))
     }
   }
 

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -101,7 +101,7 @@ extension Array where Element == Job.ArgTemplate {
 
     case .joined:
       if option.attributes.contains(.argumentIsPath) {
-        fatalError("Not currently implementable")
+        append(.joinedOptionAndPath(option.spelling, try VirtualPath(path: argument.asSingle)))
       } else {
         appendFlag(option.spelling + argument.asSingle)
       }
@@ -171,6 +171,8 @@ extension Array where Element == Job.ArgTemplate {
           return path.name.spm_shellEscaped()
       case .responseFilePath(let path):
         return "@\(path.name.spm_shellEscaped())"
+      case let .joinedOptionAndPath(option, path):
+        return option.spm_shellEscaped() + path.name.spm_shellEscaped()
       }
     }.joined(separator: " ")
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -117,6 +117,13 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testJoinedPathOptions() throws {
+    var driver = try Driver(args: ["swiftc", "-c", "-I=/some/dir", "-F=other/relative/dir", "foo.swift"])
+    let jobs = try driver.planBuild()
+    XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-I=", .absolute(.init("/some/dir")))))
+    XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-F=", .relative(.init("other/relative/dir")))))
+  }
+
   func testBatchModeDiagnostics() throws {
       try assertNoDriverDiagnostics(args: "swiftc", "-enable-batch-mode") { driver in
         switch driver.compilerMode {


### PR DESCRIPTION
Previously, appending a parsed option like '-I=/some/path' to a job's command line was unimplemented. This change represents these internally as a new Job.ArgTemplate case, joinedOptionAndPath.

I noticed this when running the full swift integration test suite with swift-driver. It turns out this was the only thing keeping all of the PlaygroundTransform tests from passing.