### PR TITLE
Fixup linker input handling and use -add_ast_path when needed

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -303,7 +303,16 @@ extension DarwinToolchain {
     }
 
     // Add inputs.
-    commandLine.append(contentsOf: inputs.map { .path($0.file) })
+    commandLine.append(contentsOf: inputs.flatMap {
+      (path: TypedVirtualPath) -> [Job.ArgTemplate] in
+      if path.type == .swiftModule {
+        return [.flag("-add_ast_path"), .path(path.file)]
+      } else if path.type == .object {
+        return [.path(path.file)]
+      } else {
+        return []
+      }
+    })
 
     // Add the output
     commandLine.appendFlag("-o")

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -158,12 +158,15 @@ extension GenericUnixToolchain {
         )
       commandLine.appendPath(swiftrtPath)
 
-      let inputFiles: [Job.ArgTemplate] = inputs.map { input in
+      let inputFiles: [Job.ArgTemplate] = inputs.compactMap { input in
         // Autolink inputs are handled specially
         if input.type == .autolink {
           return .responseFilePath(input.file)
+        } else if input.type == .object {
+          return .path(input.file)
+        } else {
+          return nil
         }
-        return .path(input.file)
       }
       commandLine.append(contentsOf: inputFiles)
 


### PR DESCRIPTION
While debugging why the TypeDecoder tests were all failing when run with swift-driver, I discovered that for invocations like `swiftc -emit-executable foo.swift -g -emit-module`, we weren't prefixing the swiftmodule file with -add_ast_path in the linker job. This PR fixes ~20 assorted integration test failures, and makes some minor cleanups to linker input handling on Linux as well.