### PR TITLE
Add -require-explicit-availability and -require-explicit-availability-target to common frontend opts

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -166,6 +166,8 @@ extension Driver {
     try commandLine.appendLast(.enableDirectIntramoduleDependencies, .disableDirectIntramoduleDependencies, from: &parsedOptions)
     try commandLine.appendLast(.locale, from: &parsedOptions)
     try commandLine.appendLast(.localizationPath, from: &parsedOptions)
+    try commandLine.appendLast(.requireExplicitAvailability, from: &parsedOptions)
+    try commandLine.appendLast(.requireExplicitAvailabilityTarget, from: &parsedOptions)
     try commandLine.appendAll(.D, from: &parsedOptions)
     try commandLine.appendAll(.sanitizeEQ, from: &parsedOptions)
     try commandLine.appendAll(.debugPrefixMap, from: &parsedOptions)


### PR DESCRIPTION
This corresponds to this fix from January in the C++ driver: https://github.com/apple/swift/pull/29183