### PR TITLE
Reword *-prefix-map diagnostic messages

### DIFF
--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -25,7 +25,7 @@ extension Diagnostic.Message {
   }
 
   static func error_opt_invalid_mapping(option: Option, value: String) -> Diagnostic.Message {
-    .error("values for '\(option.spelling)' must be in the format original=remapped not '\(value)'")
+    .error("values for '\(option.spelling)' must be in the format 'original=remapped', but '\(value)' was provided")
   }
 
   static func error_invalid_arg_value(arg: Option, value: String) -> Diagnostic.Message {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -333,8 +333,8 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-debug-prefix-map", "foo", "-debug-prefix-map", "bar") {
-        $1.expect(.error("values for '-debug-prefix-map' must be in the format original=remapped not 'foo'"))
-        $1.expect(.error("values for '-debug-prefix-map' must be in the format original=remapped not 'bar'"))
+        $1.expect(.error("values for '-debug-prefix-map' must be in the format 'original=remapped', but 'foo' was provided"))
+        $1.expect(.error("values for '-debug-prefix-map' must be in the format 'original=remapped', but 'bar' was provided"))
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=codeview") { driver in
@@ -365,8 +365,8 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-coverage-prefix-map", "foo", "-coverage-prefix-map", "bar") {
-      $1.expect(.error("values for '-coverage-prefix-map' must be in the format original=remapped not 'foo'"))
-      $1.expect(.error("values for '-coverage-prefix-map' must be in the format original=remapped not 'bar'"))
+      $1.expect(.error("values for '-coverage-prefix-map' must be in the format 'original=remapped', but 'foo' was provided"))
+      $1.expect(.error("values for '-coverage-prefix-map' must be in the format 'original=remapped', but 'bar' was provided"))
     }
   }
 


### PR DESCRIPTION
This slightly updates the message to `values for '-debug-prefix-map' must be in the format 'original=remapped', not 'foo'`, and makes it consistent with the c++ driver after https://github.com/apple/swift/pull/33706. Once both are merged, Driver/debug-prefix-map.swift and Driver/coverage-prefix-map.swift should pass.