### PR TITLE
Fix CMake Build

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(SwiftDriver
   "Explicit Module Builds/ClangVersionedDependencyResolution.swift"
   "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
-  "Explicit Module Builds/SerializableModuleArtifacts.swift
+  "Explicit Module Builds/SerializableModuleArtifacts.swift"
 
   Driver/CompilerMode.swift
   Driver/DebugInfo.swift


### PR DESCRIPTION
Correct missing quote mark in Sources/SwiftDriver/CMakeLists.txt.

Just as I was working on preventing this kind of thing...