### PR TITLE
[Explicit Module Builds] Point module dependency modules to be put into the module cache

### DIFF
--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -175,6 +175,10 @@ public typealias ExternalDependencyArtifactMap =
       }
     }
 
+    // Set the output path
+    commandLine.appendFlag(.o)
+    commandLine.appendPath(try VirtualPath(path: moduleInfo.modulePath))
+
     swiftModuleBuildCache[moduleId] = Job(
       moduleName: moduleId.moduleName,
       kind: .emitModule,


### PR DESCRIPTION
Preprocess the dependency graph, setting module paths to be relative to the module cache path, if one is present.
Only do so for modules that do not already specify a path.
