### PR TITLE
Add a -driver-warn-unused-options flag for debugging

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -638,6 +638,12 @@ extension Driver {
   }
 }
 
+extension Diagnostic.Message {
+  static func warn_unused_option(_ option: ParsedOption) -> Diagnostic.Message {
+    .warning("Unused option: \(option)")
+  }
+}
+
 extension Driver {
   /// Determine the driver kind based on the command-line arguments, consuming the arguments
   /// conveying this information.
@@ -719,6 +725,13 @@ extension Driver {
                          numParallelJobs: numParallelJobs ?? 1,
                          forceResponseFiles: forceResponseFiles,
                          recordedInputModificationDates: recordedInputModificationDates)
+
+    // If requested, warn for options that weren't used by the driver after the build is finished.
+    if parsedOptions.hasArgument(.driverWarnUnusedOptions) {
+      for option in parsedOptions.unconsumedOptions {
+        diagnosticEngine.emit(.warn_unused_option(option))
+      }
+    }
   }
 
   public mutating func createToolExecutionDelegate() -> ToolExecutionDelegate {

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -13,12 +13,14 @@ extension Option {
   public static let driverPrintGraphviz: Option = Option("-driver-print-graphviz", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Write the job graph as a graphviz file", group: .internalDebug)
   public static let driverExplicitModuleBuild: Option = Option("-experimental-explicit-module-build", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
   public static let driverPrintModuleDependenciesJobs: Option = Option("-driver-print-module-dependencies-jobs", .flag, attributes: [.helpHidden], helpText: "Print commands to explicitly build module dependencies")
+  public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver.")
 
   public static var extraOptions: [Option] {
     return [
       Option.driverPrintGraphviz,
       Option.driverExplicitModuleBuild,
-      Option.driverPrintModuleDependenciesJobs
+      Option.driverPrintModuleDependenciesJobs,
+      Option.driverWarnUnusedOptions
     ]
   }
 }

--- a/Sources/SwiftOptions/ParsedOptions.swift
+++ b/Sources/SwiftOptions/ParsedOptions.swift
@@ -318,4 +318,8 @@ extension ParsedOptions {
       groupIndex[group]?.removeAll { $0.option == option }
     }
   }
+
+  public var unconsumedOptions: [ParsedOption] {
+    zip(parsedOptions, consumed).filter { !$0.1 }.map(\.0)
+  }
 }


### PR DESCRIPTION
This has been pretty useful for debugging some of the integration tests failures, so I think it makes sense to include, at least as an internal debugging option. Putting the check at the end of `Driver.run` seemed like the best way to avoid false positives, but I can move it somewhere else if anyone has a better idea.