### PR TITLE
Add trunk snapshot requirement to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The `swift-driver` project is a new implementation of the Swift compiler driver 
 
 ## Getting Started
 
+**Note:** Currently, swift-driver is only compatible with trunk development snapshots from [swift.org](https://swift.org/download/#snapshots).
+
 The preferred way to build `swift-driver` is to use the Swift package manager:
 
 ```


### PR DESCRIPTION
A 5.3 snapshot is able to build the driver, but will fail most of the tests, which can be confusing for anyone who doesn't follow the development closely.