### PR TITLE
Add missing flags to compile jobs

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -204,6 +204,8 @@ extension Driver {
       commandLine.appendFlag(.debugInfoStoreInvocation)
     }
 
+    try commandLine.appendLast(.trackSystemDependencies, from: &parsedOptions)
+    try commandLine.appendLast(.CrossModuleOptimization, from: &parsedOptions)
     try commandLine.appendLast(.disableAutolinkingRuntimeCompatibility, from: &parsedOptions)
     try commandLine.appendLast(.runtimeCompatibilityVersion, from: &parsedOptions)
     try commandLine.appendLast(.disableAutolinkingRuntimeCompatibilityDynamicReplacements, from: &parsedOptions)


### PR DESCRIPTION
Previously, -track-system-dependencies and -cross-module-optimization weren't being forwarded to the frontend. This fixes up a couple miscellaneous integration tests.