### PR TITLE
Fix -debug-info-store-invocation logic on Darwin

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -199,7 +199,7 @@ extension Driver {
       }
     }
 
-    if parsedOptions.contains(.debugInfoStoreInvocation) &&
+    if parsedOptions.contains(.debugInfoStoreInvocation) ||
        toolchain.shouldStoreInvocationInDebugInfo {
       commandLine.appendFlag(.debugInfoStoreInvocation)
     }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -108,7 +108,7 @@ public final class DarwinToolchain: Toolchain {
 
   public var shouldStoreInvocationInDebugInfo: Bool {
     // This matches the behavior in Clang.
-    !(env["RC_DEBUG_OPTIONS"]?.isEmpty ?? false)
+    !(env["RC_DEBUG_OPTIONS"]?.isEmpty ?? true)
   }
 
   public func runtimeLibraryName(


### PR DESCRIPTION
Fixes DebugInfo/compiler-flags-macosx.swift

With these updates, swift-driver should now match the behavior of the integrated driver and clang by passing -debug-info-store-invocation only when it's passed to the driver or RC_DEBUG_OPTIONS is set.