### PR TITLE
Implement additional argument validation steps and record multiple failures before exiting

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -28,10 +28,8 @@ public struct Driver {
     case unableToDecodeFrontendTargetInfo
     case failedToRetrieveFrontendTargetInfo
     case missingProfilingData(String)
-    case cannotAssignToConditionalCompilationFlag(String)
     case conditionalCompilationFlagHasRedundantPrefix(String)
     case conditionalCompilationFlagIsNotValidIdentifier(String)
-    case frameworkSearchPathIncludesExtension(String)
     // Explicit Module Build Failures
     case malformedModuleDependency(String, String)
     case missingPCMArguments(String)
@@ -62,14 +60,10 @@ public struct Driver {
         return "failed to retrieve frontend target info"
       case .missingProfilingData(let arg):
         return "no profdata file exists at '\(arg)'"
-      case .cannotAssignToConditionalCompilationFlag(let name):
-        return "conditional compilation flags do not have values in Swift; they are either present or absent (rather than '\(name)')"
       case .conditionalCompilationFlagHasRedundantPrefix(let name):
         return "invalid argument '-D\(name)'; did you provide a redundant '-D' in your build settings?"
       case .conditionalCompilationFlagIsNotValidIdentifier(let name):
         return "conditional compilation flags must be valid Swift identifiers (rather than '\(name)')"
-      case .frameworkSearchPathIncludesExtension(let arg):
-        return "framework search path ends in \".framework\"; add directory containing framework instead: \(arg)"
       // Explicit Module Build Failures
       case .malformedModuleDependency(let moduleName, let errorDescription):
         return "Malformed Module Dependency: \(moduleName), \(errorDescription)"
@@ -1575,6 +1569,12 @@ extension Diagnostic.Message {
   static var error_bridging_header_module_interface: Diagnostic.Message {
     .error("using bridging headers with module interfaces is unsupported")
   }
+  static func warning_cannot_assign_to_compilation_condition(name: String) -> Diagnostic.Message {
+    .warning("conditional compilation flags do not have values in Swift; they are either present or absent (rather than '\(name)')")
+  }
+  static func warning_framework_search_path_includes_extension(path: String) -> Diagnostic.Message {
+    .warning("framework search path ends in \".framework\"; add directory containing framework instead: \(path)")
+  }
 }
 
 // MARK: Miscellaneous Argument Validation
@@ -1611,7 +1611,7 @@ extension Driver {
                                                diagnosticEngine: DiagnosticsEngine) {
     for arg in parsedOptions.arguments(for: .D).map(\.argument.asSingle) {
       if arg.contains("=") {
-        diagnosticEngine.emit(Error.cannotAssignToConditionalCompilationFlag(arg))
+        diagnosticEngine.emit(.warning_cannot_assign_to_compilation_condition(name: arg))
       } else if arg.hasPrefix("-D") {
         diagnosticEngine.emit(Error.conditionalCompilationFlagHasRedundantPrefix(arg))
       } else if !arg.sd_isSwiftIdentifier {
@@ -1624,7 +1624,7 @@ extension Driver {
                                               diagnosticEngine: DiagnosticsEngine) {
     for arg in parsedOptions.arguments(for: .F, .Fsystem).map(\.argument.asSingle) {
       if arg.hasSuffix(".framework") || arg.hasSuffix(".framework/") {
-        diagnosticEngine.emit(Error.frameworkSearchPathIncludesExtension(arg))
+        diagnosticEngine.emit(.warning_framework_search_path_includes_extension(path: arg))
       }
     }
   }

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -47,6 +47,10 @@ do {
   var driver = try Driver(args: arguments,
                           diagnosticsEngine: diagnosticsEngine,
                           executor: executor)
+  // FIXME: The following check should be at the end of Driver.init, but current
+  // usage of the DiagnosticVerifier in tests makes this difficult.
+  guard !driver.diagnosticEngine.hasErrors else { throw Diagnostics.fatalError }
+
   let jobs = try driver.planBuild()
   try driver.run(jobs: jobs)
 

--- a/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
+++ b/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
@@ -13,7 +13,6 @@
 import XCTest
 import SwiftDriver
 import TSCBasic
-import TSCUtility
 
 func assertDriverDiagnostics(
   args: [String],

--- a/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
+++ b/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
@@ -13,6 +13,7 @@
 import XCTest
 import SwiftDriver
 import TSCBasic
+import TSCUtility
 
 func assertDriverDiagnostics(
   args: [String],

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1706,6 +1706,22 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertNoThrow(try Driver(args: ["swiftc", "foo.swift", "-DFOO"]))
   }
 
+  func testFrameworkSearchPathArgValidation() throws {
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework"])) {
+      XCTAssertEqual($0 as? Driver.Error, .frameworkSearchPathIncludesExtension("/some/dir/xyz.framework"))
+    }
+
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework/"])) {
+      XCTAssertEqual($0 as? Driver.Error, .frameworkSearchPathIncludesExtension("/some/dir/xyz.framework/"))
+    }
+
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-Fsystem", "/some/dir/xyz.framework"])) {
+      XCTAssertEqual($0 as? Driver.Error, .frameworkSearchPathIncludesExtension("/some/dir/xyz.framework"))
+    }
+
+    XCTAssertNoThrow(try Driver(args: ["swiftc", "foo.swift", "-Fsystem", "/some/dir/"]))
+  }
+
   // Test cases ported from Driver/macabi-environment.swift
   func testDarwinSDKVersioning() throws {
     try withTemporaryDirectory { tmpDir in

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1690,7 +1690,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testConditionalCompilationArgValidation() throws {
     try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-DFOO=BAR"]) {
-      $1.expect(.error(Driver.Error.cannotAssignToConditionalCompilationFlag("FOO=BAR")))
+      $1.expect(.warning("conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'FOO=BAR')"))
     }
 
     try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-D-DFOO"]) {
@@ -1706,15 +1706,15 @@ final class SwiftDriverTests: XCTestCase {
 
   func testFrameworkSearchPathArgValidation() throws {
     try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework"]) {
-      $1.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework")))
+      $1.expect(.warning("framework search path ends in \".framework\"; add directory containing framework instead: /some/dir/xyz.framework"))
     }
 
     try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework/"]) {
-      $1.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework/")))
+      $1.expect(.warning("framework search path ends in \".framework\"; add directory containing framework instead: /some/dir/xyz.framework/"))
     }
 
     try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-Fsystem", "/some/dir/xyz.framework"]) {
-      $1.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework")))
+      $1.expect(.warning("framework search path ends in \".framework\"; add directory containing framework instead: /some/dir/xyz.framework"))
     }
 
    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-Fsystem", "/some/dir/")
@@ -1723,7 +1723,7 @@ final class SwiftDriverTests: XCTestCase {
   func testMultipleValidationFailures() throws {
     try assertDiagnostics { engine, verifier in
       verifier.expect(.error(Driver.Error.conditionalCompilationFlagIsNotValidIdentifier("not-an-identifier")))
-      verifier.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework")))
+      verifier.expect(.warning("framework search path ends in \".framework\"; add directory containing framework instead: /some/dir/xyz.framework"))
       _ = try Driver(args: ["swiftc", "foo.swift", "-Dnot-an-identifier", "-F/some/dir/xyz.framework"], diagnosticsEngine: engine)
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1665,61 +1665,67 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testProfileArgValidation() throws {
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-profile-generate", "-profile-use=profile.profdata"])) {
-      XCTAssertEqual($0 as? Driver.Error, .conflictingOptions(.profileGenerate, .profileUse))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-profile-generate", "-profile-use=profile.profdata"]) {
+      $1.expect(.error(Driver.Error.conflictingOptions(.profileGenerate, .profileUse)))
+      $1.expect(.error(Driver.Error.missingProfilingData("profile.profdata")))
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-profile-use=profile.profdata"])) {
-      XCTAssertEqual($0 as? Driver.Error, .missingProfilingData("profile.profdata"))
-    }
-
-    try withTemporaryDirectory { path in
-      try localFileSystem.writeFileContents(path.appending(component: "profile.profdata"), bytes: .init())
-      XCTAssertNoThrow(try Driver(args: ["swiftc", "-working-directory", path.pathString, "foo.swift", "-profile-use=profile.profdata"]))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-profile-use=profile.profdata"]) {
+      $1.expect(.error(Driver.Error.missingProfilingData("profile.profdata")))
     }
 
     try withTemporaryDirectory { path in
       try localFileSystem.writeFileContents(path.appending(component: "profile.profdata"), bytes: .init())
-      XCTAssertThrowsError(try Driver(args: ["swiftc", "-working-directory", path.pathString, "foo.swift",
-                                             "-profile-use=profile.profdata,profile2.profdata"])) {
-        guard case Driver.Error.missingProfilingData = $0 else {
-          XCTFail()
-          return
-        }
+      try assertNoDriverDiagnostics(args: "swiftc", "-working-directory", path.pathString, "foo.swift", "-profile-use=profile.profdata")
+    }
+
+    try withTemporaryDirectory { path in
+      try localFileSystem.writeFileContents(path.appending(component: "profile.profdata"), bytes: .init())
+      try assertDriverDiagnostics(args: ["swiftc", "-working-directory", path.pathString, "foo.swift",
+                                         "-profile-use=profile.profdata,profile2.profdata"]) {
+        $1.expect(.error(Driver.Error.missingProfilingData(path.appending(component: "profile2.profdata").pathString)))
       }
     }
   }
 
   func testConditionalCompilationArgValidation() throws {
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-DFOO=BAR"])) {
-      XCTAssertEqual($0 as? Driver.Error, .cannotAssignToConditionalCompilationFlag("FOO=BAR"))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-DFOO=BAR"]) {
+      $1.expect(.error(Driver.Error.cannotAssignToConditionalCompilationFlag("FOO=BAR")))
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-D-DFOO"])) {
-      XCTAssertEqual($0 as? Driver.Error, .conditionalCompilationFlagHasRedundantPrefix("-DFOO"))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-D-DFOO"]) {
+      $1.expect(.error(Driver.Error.conditionalCompilationFlagHasRedundantPrefix("-DFOO")))
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-Dnot-an-identifier"])) {
-      XCTAssertEqual($0 as? Driver.Error, .conditionalCompilationFlagIsNotValidIdentifier("not-an-identifier"))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-Dnot-an-identifier"]) {
+      $1.expect(.error(Driver.Error.conditionalCompilationFlagIsNotValidIdentifier("not-an-identifier")))
     }
 
-    XCTAssertNoThrow(try Driver(args: ["swiftc", "foo.swift", "-DFOO"]))
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-DFOO")
   }
 
   func testFrameworkSearchPathArgValidation() throws {
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework"])) {
-      XCTAssertEqual($0 as? Driver.Error, .frameworkSearchPathIncludesExtension("/some/dir/xyz.framework"))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework"]) {
+      $1.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework")))
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework/"])) {
-      XCTAssertEqual($0 as? Driver.Error, .frameworkSearchPathIncludesExtension("/some/dir/xyz.framework/"))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-F/some/dir/xyz.framework/"]) {
+      $1.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework/")))
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-Fsystem", "/some/dir/xyz.framework"])) {
-      XCTAssertEqual($0 as? Driver.Error, .frameworkSearchPathIncludesExtension("/some/dir/xyz.framework"))
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-Fsystem", "/some/dir/xyz.framework"]) {
+      $1.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework")))
     }
 
-    XCTAssertNoThrow(try Driver(args: ["swiftc", "foo.swift", "-Fsystem", "/some/dir/"]))
+   try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-Fsystem", "/some/dir/")
+  }
+
+  func testMultipleValidationFailures() throws {
+    try assertDiagnostics { engine, verifier in
+      verifier.expect(.error(Driver.Error.conditionalCompilationFlagIsNotValidIdentifier("not-an-identifier")))
+      verifier.expect(.error(Driver.Error.frameworkSearchPathIncludesExtension("/some/dir/xyz.framework")))
+      _ = try Driver(args: ["swiftc", "foo.swift", "-Dnot-an-identifier", "-F/some/dir/xyz.framework"], diagnosticsEngine: engine)
+    }
   }
 
   // Test cases ported from Driver/macabi-environment.swift
@@ -2368,8 +2374,8 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      XCTAssertThrowsError(try Driver(args: ["swift", "-no-warnings-as-errors", "-warnings-as-errors", "-suppress-warnings", "foo.swift"])) {
-        XCTAssertEqual($0 as? Driver.Error, Driver.Error.conflictingOptions(.warningsAsErrors, .suppressWarnings))
+      try assertDriverDiagnostics(args: ["swift", "-no-warnings-as-errors", "-warnings-as-errors", "-suppress-warnings", "foo.swift"]) {
+        $1.expect(.error(Driver.Error.conflictingOptions(.warningsAsErrors, .suppressWarnings)))
       }
     }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1690,6 +1690,22 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testConditionalCompilationArgValidation() throws {
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-DFOO=BAR"])) {
+      XCTAssertEqual($0 as? Driver.Error, .cannotAssignToConditionalCompilationFlag("FOO=BAR"))
+    }
+
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-D-DFOO"])) {
+      XCTAssertEqual($0 as? Driver.Error, .conditionalCompilationFlagHasRedundantPrefix("-DFOO"))
+    }
+
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "foo.swift", "-Dnot-an-identifier"])) {
+      XCTAssertEqual($0 as? Driver.Error, .conditionalCompilationFlagIsNotValidIdentifier("not-an-identifier"))
+    }
+
+    XCTAssertNoThrow(try Driver(args: ["swiftc", "foo.swift", "-DFOO"]))
+  }
+
   // Test cases ported from Driver/macabi-environment.swift
   func testDarwinSDKVersioning() throws {
     try withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
This PR adds validation for:
- conditional compilation arguments
- `-profile-generate` and `-profile-use`
- `-F` and `-Fsystem`

Additionally, if a validation step fails when initializing the driver, don't fail immediately. Instead, record any other validation failures and then exit before planning.