### PR TITLE
build: link Yams privately

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -83,7 +83,8 @@ target_link_libraries(SwiftDriver PUBLIC
   TSCBasic
   TSCUtility
   SwiftOptions
-  llbuildSwift
+  llbuildSwift)
+target_link_libraries(SwiftDriver PRIVATE
   CYaml
   Yams)
 


### PR DESCRIPTION
Because Yams is used with `@_implementationOnly`, the clients of
`SwiftDriver` do not need to link against `Yams` or `CYaml`.  This was
uncovered when building SourceKit-LSP.