### PR TITLE
FIX - broken DriverInternals and DriverParseableOutput rst urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The new Swift driver is a work in progress, and there are numerous places for an
 
 ### Driver Documentation
 
-For a conceptual overview of the driver, see [The Swift Driver, Compilation Model, and Command-Line Experience](https://github.com/apple/swift/blob/master/docs/Driver.md). To learn more about the internals, see [Driver Design & Internals](https://github.com/apple/swift/blob/master/docs/DriverInternals.rst) and [Parseable Driver Output](https://github.com/apple/swift/blob/master/docs/DriverParseableOutput.rst).
+For a conceptual overview of the driver, see [The Swift Driver, Compilation Model, and Command-Line Experience](https://github.com/apple/swift/blob/master/docs/Driver.md). To learn more about the internals, see [Driver Design & Internals](https://github.com/apple/swift/blob/master/docs/DriverInternals.md) and [Parseable Driver Output](https://github.com/apple/swift/blob/master/docs/DriverParseableOutput.md).
 
 ### Testing
 


### PR DESCRIPTION
This PR updates `DriverInternals` and `DriverParseableOutput` from `.rst` to `.md` in the `README`.

The files were updated a couple months ago in the following commits:
https://github.com/apple/swift/commit/d2c3a78c5db3d7e9a730d24708c8c336552996ba
https://github.com/apple/swift/commit/229352318935734850fafd45a24b4621490aff29