### PR TITLE
Update swift-argument-parser dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "15351c1cd009eba0b6e438bfef55ea9847a8dc4a",
-          "version": "0.3.0"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,10 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
     .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "4.0.0")),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.3.0"))
+    // The 'swift-argument-parser' version declared here must match that
+    // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
+    // dependency version changes here with those projects.
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.3.1")),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
The issue with `swift-argument-parser` version 0.3.1 is being resolved in https://github.com/apple/swift-package-manager/pull/2919, so we need to coordinate the dependency update here as well.