### PR TITLE
Decode paths as VirtualPaths from -print-target-info output

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -190,8 +190,18 @@ public struct Driver {
   @_spi(Testing) public let incrementalCompilationState: IncrementalCompilationState
 
   /// The path of the SDK.
-  var sdkPath: String? {
-    frontendTargetInfo.paths.sdkPath
+  public var absoluteSDKPath: AbsolutePath? {
+    switch frontendTargetInfo.sdkPath?.path {
+    case .absolute(let path):
+      return path
+    case .relative(let path):
+      let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory
+      return cwd.map { AbsolutePath($0, path) }
+    case nil:
+      return nil
+    case .standardInput, .standardOutput, .temporary, .fileList:
+      fatalError("Frontend target information will never include a path of this type.")
+    }
   }
 
   /// The path to the imported Objective-C header.

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -103,9 +103,9 @@ extension Driver {
     // Handle the CPU and its preferences.
     try commandLine.appendLast(.targetCpu, from: &parsedOptions)
 
-    if let sdkPath = sdkPath {
+    if let sdkPath = frontendTargetInfo.sdkPath?.path {
       commandLine.appendFlag(.sdk)
-      commandLine.append(.path(try .init(path: sdkPath)))
+      commandLine.append(.path(sdkPath))
     }
 
     try commandLine.appendAll(.I, from: &parsedOptions)
@@ -196,8 +196,7 @@ extension Driver {
 
     // Resource directory.
     commandLine.appendFlag(.resourceDir)
-    commandLine.appendPath(
-      try AbsolutePath(validating: frontendTargetInfo.paths.runtimeResourcePath))
+    commandLine.appendPath(frontendTargetInfo.runtimeResourcePath.path)
 
     if parsedOptions.hasFlag(positive: .staticExecutable,
                              negative: .noStaticExecutable,

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -37,8 +37,8 @@ extension Driver {
     try commandLine.appendLast(.DASHDASH, from: &parsedOptions)
 
     let extraEnvironment = try toolchain.platformSpecificInterpreterEnvironmentVariables(
-      env: self.env, parsedOptions: &parsedOptions, sdkPath: self.sdkPath,
-      targetTriple: self.targetTriple)
+      env: self.env, parsedOptions: &parsedOptions,
+      sdkPath: self.absoluteSDKPath?.pathString, targetTriple: self.targetTriple)
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -46,7 +46,7 @@ extension Driver {
       outputFile: outputFile,
       shouldUseInputFileList: shouldUseInputFileList,
       lto: lto,
-      sdkPath: sdkPath,
+      sdkPath: self.absoluteSDKPath?.pathString,
       sanitizers: enabledSanitizers,
       targetInfo: frontendTargetInfo
     )

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -62,6 +62,7 @@ extension SwiftVersion: Codable {
 }
 
 /// Describes information about the target as provided by the Swift frontend.
+@dynamicMemberLookup
 @_spi(Testing) public struct FrontendTargetInfo: Codable {
   struct CompatibilityLibrary: Codable {
     enum Filter: String, Codable {
@@ -98,16 +99,23 @@ extension SwiftVersion: Codable {
 
   struct Paths: Codable {
     /// The path to the SDK, if provided.
-    let sdkPath: String?
-    let runtimeLibraryPaths: [String]
-    let runtimeLibraryImportPaths: [String]
-    let runtimeResourcePath: String
+    let sdkPath: TextualVirtualPath?
+    let runtimeLibraryPaths: [TextualVirtualPath]
+    let runtimeLibraryImportPaths: [TextualVirtualPath]
+    let runtimeResourcePath: TextualVirtualPath
   }
 
   var compilerVersion: String
   var target: Target
   var targetVariant: Target?
   let paths: Paths
+}
+
+// Make members of `FrontendTargetInfo.Paths` accessible on `FrontendTargetInfo`.
+extension FrontendTargetInfo {
+  subscript<T>(dynamicMember dynamicMember: KeyPath<FrontendTargetInfo.Paths, T>) -> T {
+    self.paths[keyPath: dynamicMember]
+  }
 }
 
 extension Toolchain {

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -290,7 +290,7 @@ import SwiftOptions
     inputs: inout [TypedVirtualPath],
     frontendTargetInfo: FrontendTargetInfo
   ) throws {
-    guard let sdkPath = try frontendTargetInfo.paths.sdkPath.map(VirtualPath.init(path:)),
+    guard let sdkPath = frontendTargetInfo.sdkPath?.path,
           let sdkInfo = getTargetSDKInfo(sdkPath: sdkPath) else { return }
 
     commandLine.append(.flag("-target-sdk-version"))

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -215,6 +215,28 @@ extension VirtualPath: Codable {
   }
 }
 
+/// A wrapper for easier decoding of absolute or relative VirtualPaths from strings.
+struct TextualVirtualPath: Codable {
+  var path: VirtualPath
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    path = try VirtualPath(path: container.decode(String.self))
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch path {
+    case .absolute(let path):
+      try container.encode(path.pathString)
+    case .relative(let path):
+      try container.encode(path.pathString)
+    case .temporary, .standardInput, .standardOutput, .fileList:
+      preconditionFailure("Path does not have a round-trippable textual representation")
+    }
+  }
+}
+
 extension VirtualPath: CustomStringConvertible {
   public var description: String {
     switch self {


### PR DESCRIPTION
This change decodes the paths in `-print-target-info` as `VirtualPath`s to simplify their use throughout the driver. This initial change is pretty small, but I think it'll make it easier to use the runtime library and resource dir paths reported by the frontend throughout the rest of the driver. 

I thought about modifying the frontend so it always resolves these paths to absolute, but I think that would just create problems for distributed build systems in the future.