### PR TITLE
Make `FeatureAvailability` more explicit

### DIFF
--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -1074,10 +1074,10 @@ final class TripleTests: XCTestCase {
   }
 
   static let jetPacks = Triple.FeatureAvailability(
-    macOS: .init(10, 50, 0),
-    iOS: .init(50, 0, 0),
-    tvOS: .init(50, 0, 0),
-    watchOS: .init(50, 0, 0),
+    macOS: .available(since: .init(10, 50, 0)),
+    iOS: .available(since: .init(50, 0, 0)),
+    tvOS: .available(since: .init(50, 0, 0)),
+    watchOS: .available(since: .init(50, 0, 0)),
     nonDarwin: true
   )
 


### PR DESCRIPTION
Looking at the `Triple.FeatureAvailability` initializers, I came across this comment:
```swift
/// Each version parameter is `Optional`; a `nil` value means the feature is		
/// not supported on any version of that platform. Use `Triple.Version.zero`		
/// for a feature that is available in all versions.
```
It stuck out to me because Swift is a very expressive language and can model this better than with a convention described in a comment (which was repeated in both initializers). So I did:

```swift
public enum Availability {
  case unavailable
  case available(since: Version)
  case availableInAllVersions
}
```

I'm not thrilled about `availableInAllVersions`, but it is explicit. Also, nesting `Availability` in `FeatureAvailability` is probably not great, but I couldn't think of a better name.