### PR TITLE
Remove FileSystem usage in ExplicitModuleBuildHandler

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -182,7 +182,7 @@ public struct Driver {
       return cwd.map { AbsolutePath($0, path) }
     case nil:
       return nil
-    case .standardInput, .standardOutput, .temporary, .fileList:
+    case .standardInput, .standardOutput, .temporary, .temporaryWithKnownContents, .fileList:
       fatalError("Frontend target information will never include a path of this type.")
     }
   }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -173,8 +173,18 @@ public struct Driver {
   public let incrementalCompilationState: IncrementalCompilationState
 
   /// The path of the SDK.
-  public var sdkPath: String? {
-    frontendTargetInfo.paths.sdkPath
+  public var absoluteSDKPath: AbsolutePath? {
+    switch frontendTargetInfo.sdkPath?.path {
+    case .absolute(let path):
+      return path
+    case .relative(let path):
+      let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory
+      return cwd.map { AbsolutePath($0, path) }
+    case nil:
+      return nil
+    case .standardInput, .standardOutput, .temporary, .fileList:
+      fatalError("Frontend target information will never include a path of this type.")
+    }
   }
 
   /// The path to the imported Objective-C header.

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -84,14 +84,22 @@ public final class ArgsResolver {
     // Return the path from the temporary directory if this is a temporary file.
     if path.isTemporary {
       let actualPath = temporaryDirectory.appending(component: path.name)
-      if case let .fileList(_, fileList) = path {
-        switch fileList {
-        case let .list(items):
-          try createFileList(path: actualPath, contents: items)
-        case let .outputFileMap(map):
-          try createFileList(path: actualPath, outputFileMap: map)
+      switch path {
+      case .temporary:
+        break // No special behavior required.
+      case let .temporaryWithKnownContents(_, contents):
+        // FIXME: Need a way to support this for distributed build systems...
+        if let absolutePath = actualPath.absolutePath {
+          try fileSystem.writeFileContents(absolutePath, bytes: .init(contents))
         }
+      case let .fileList(_, .list(items)):
+        try createFileList(path: actualPath, contents: items)
+      case let .fileList(_, .outputFileMap(map)):
+        try createFileList(path: actualPath, outputFileMap: map)
+      case .relative, .absolute, .standardInput, .standardOutput:
+        fatalError("Not a temporary path.")
       }
+
       let result = actualPath.name
       pathMapping[path] = result
       return result

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
@@ -54,11 +54,7 @@ extension Driver {
 
   /// Serialize a map of placeholder (external) dependencies for the dependency scanner.
   func serializeExternalDependencyArtifacts(externalDependencyArtifactMap: ExternalDependencyArtifactMap)
-  throws -> AbsolutePath {
-    let temporaryDirectory = try determineTempDirectory()
-    let placeholderMapFilePath =
-      temporaryDirectory.appending(component: "\(moduleOutputInfo.name)-placeholder-modules.json")
-
+  throws -> VirtualPath {
     var placeholderArtifacts: [SwiftModuleArtifactInfo] = []
     for (moduleId, dependencyInfo) in externalDependencyArtifactMap {
       placeholderArtifacts.append(
@@ -68,8 +64,7 @@ extension Driver {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(placeholderArtifacts)
-    try fileSystem.writeFileContents(placeholderMapFilePath, bytes: ByteString(contents))
-    return placeholderMapFilePath
+    return .temporaryWithKnownContents(.init("\(moduleOutputInfo.name)-placeholder-modules.json"), contents)
   }
 
   mutating func performBatchDependencyScan(moduleInfos: [BatchScanModuleInfo])
@@ -162,15 +157,10 @@ extension Driver {
 
   /// Serialize a collection of modules into an input format expected by the batch module dependency scanner.
   func serializeBatchScanningModuleArtifacts(moduleInfos: [BatchScanModuleInfo])
-  throws -> AbsolutePath {
-    let temporaryDirectory = try determineTempDirectory()
-    let batchScanInputFilePath =
-      temporaryDirectory.appending(component: "\(moduleOutputInfo.name)-batch-module-scan.json")
-
+  throws -> VirtualPath {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(moduleInfos)
-    try fileSystem.writeFileContents(batchScanInputFilePath, bytes: ByteString(contents))
-    return batchScanInputFilePath
+    return .temporaryWithKnownContents(.init("\(moduleOutputInfo.name)-batch-module-scan.json"), contents)
   }
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -94,9 +94,9 @@ extension Driver {
     // Handle the CPU and its preferences.
     try commandLine.appendLast(.targetCpu, from: &parsedOptions)
 
-    if let sdkPath = sdkPath {
+    if let sdkPath = frontendTargetInfo.sdkPath?.path {
       commandLine.appendFlag(.sdk)
-      commandLine.append(.path(try .init(path: sdkPath)))
+      commandLine.append(.path(sdkPath))
     }
 
     try commandLine.appendAll(.I, from: &parsedOptions)
@@ -186,8 +186,7 @@ extension Driver {
 
     // Resource directory.
     commandLine.appendFlag(.resourceDir)
-    commandLine.appendPath(
-      try AbsolutePath(validating: frontendTargetInfo.paths.runtimeResourcePath))
+    commandLine.appendPath(frontendTargetInfo.runtimeResourcePath.path)
 
     if parsedOptions.hasFlag(positive: .staticExecutable,
                              negative: .noStaticExecutable,

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -37,8 +37,8 @@ extension Driver {
     try commandLine.appendLast(.DASHDASH, from: &parsedOptions)
 
     let extraEnvironment = try toolchain.platformSpecificInterpreterEnvironmentVariables(
-      env: self.env, parsedOptions: &parsedOptions, sdkPath: self.sdkPath,
-      targetTriple: self.targetTriple)
+      env: self.env, parsedOptions: &parsedOptions,
+      sdkPath: self.absoluteSDKPath?.pathString, targetTriple: self.targetTriple)
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -45,7 +45,7 @@ extension Driver {
       inputs: inputs,
       outputFile: outputFile,
       shouldUseInputFileList: shouldUseInputFileList,
-      sdkPath: sdkPath,
+      sdkPath: self.absoluteSDKPath?.pathString,
       sanitizers: enabledSanitizers,
       targetInfo: frontendTargetInfo
     )

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -244,8 +244,7 @@ extension Driver {
     let dependencyGraph = try generateInterModuleDependencyGraph()
     explicitModuleBuildHandler =
         try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
-                                       toolchain: toolchain,
-                                       fileSystem: fileSystem)
+                                       toolchain: toolchain)
     return try explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
   }
 

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -62,6 +62,7 @@ extension SwiftVersion: Codable {
 }
 
 /// Describes information about the target as provided by the Swift frontend.
+@dynamicMemberLookup
 public struct FrontendTargetInfo: Codable {
   struct CompatibilityLibrary: Codable {
     enum Filter: String, Codable {
@@ -98,16 +99,23 @@ public struct FrontendTargetInfo: Codable {
 
   struct Paths: Codable {
     /// The path to the SDK, if provided.
-    let sdkPath: String?
-    let runtimeLibraryPaths: [String]
-    let runtimeLibraryImportPaths: [String]
-    let runtimeResourcePath: String
+    let sdkPath: TextualVirtualPath?
+    let runtimeLibraryPaths: [TextualVirtualPath]
+    let runtimeLibraryImportPaths: [TextualVirtualPath]
+    let runtimeResourcePath: TextualVirtualPath
   }
 
   var compilerVersion: String
   var target: Target
   var targetVariant: Target?
   let paths: Paths
+}
+
+// Make members of `FrontendTargetInfo.Paths` accessible on `FrontendTargetInfo`.
+extension FrontendTargetInfo {
+  subscript<T>(dynamicMember dynamicMember: KeyPath<FrontendTargetInfo.Paths, T>) -> T {
+    self.paths[keyPath: dynamicMember]
+  }
 }
 
 extension Toolchain {

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -290,7 +290,7 @@ public final class DarwinToolchain: Toolchain {
     inputs: inout [TypedVirtualPath],
     frontendTargetInfo: FrontendTargetInfo
   ) throws {
-    guard let sdkPath = try frontendTargetInfo.paths.sdkPath.map(VirtualPath.init(path:)),
+    guard let sdkPath = frontendTargetInfo.sdkPath?.path,
           let sdkInfo = getTargetSDKInfo(sdkPath: sdkPath) else { return }
 
     commandLine.append(.flag("-target-sdk-version"))

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -215,6 +215,28 @@ extension VirtualPath: Codable {
   }
 }
 
+/// A wrapper for easier decoding of absolute or relative VirtualPaths from strings.
+struct TextualVirtualPath: Codable {
+  var path: VirtualPath
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    path = try VirtualPath(path: container.decode(String.self))
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch path {
+    case .absolute(let path):
+      try container.encode(path.pathString)
+    case .relative(let path):
+      try container.encode(path.pathString)
+    case .temporary, .standardInput, .standardOutput, .fileList:
+      preconditionFailure("Path does not have a round-trippable textual representation")
+    }
+  }
+}
+
 extension VirtualPath: CustomStringConvertible {
   public var description: String {
     switch self {

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
+import Foundation
 
 /// A virtual path.
 public enum VirtualPath: Hashable {
@@ -28,6 +29,9 @@ public enum VirtualPath: Hashable {
 
   /// A temporary file with the given name.
   case temporary(RelativePath)
+
+  /// A temporary file with the given name and contents.
+  case temporaryWithKnownContents(RelativePath, Data)
 
   /// A temporary file that holds a list of paths.
   case fileList(RelativePath, FileList)
@@ -48,7 +52,8 @@ public enum VirtualPath: Hashable {
   /// The extension of this path, for relative or absolute paths.
   public var `extension`: String? {
     switch self {
-    case .relative(let path), .temporary(let path), .fileList(let path, _):
+    case .relative(let path), .temporary(let path),
+         .temporaryWithKnownContents(let path, _), .fileList(let path, _):
       return path.extension
     case .absolute(let path):
       return path.extension
@@ -62,7 +67,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case .relative, .absolute, .standardInput, .standardOutput:
       return false
-    case .temporary, .fileList:
+    case .temporary, .temporaryWithKnownContents, .fileList:
       return true
     }
   }
@@ -71,7 +76,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case let .absolute(absolutePath):
       return absolutePath
-    case .relative, .temporary, .fileList, .standardInput, .standardOutput:
+    case .relative, .temporary, .temporaryWithKnownContents, .fileList, .standardInput, .standardOutput:
       return nil
     }
   }
@@ -81,7 +86,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case .absolute(let path):
       return path.basename
-    case .relative(let path), .temporary(let path), .fileList(let path, _):
+    case .relative(let path), .temporary(let path), .temporaryWithKnownContents(let path, _), .fileList(let path, _):
       return path.basename
     case .standardInput, .standardOutput:
       return ""
@@ -93,7 +98,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case .absolute(let path):
       return path.basenameWithoutExt
-    case .relative(let path), .temporary(let path), .fileList(let path, _):
+    case .relative(let path), .temporary(let path), .temporaryWithKnownContents(let path, _), .fileList(let path, _):
       return path.basenameWithoutExt
     case .standardInput, .standardOutput:
       return ""
@@ -107,7 +112,7 @@ public enum VirtualPath: Hashable {
       return .absolute(path.parentDirectory)
     case .relative(let path):
       return .relative(RelativePath(path.dirname))
-    case .temporary(let path):
+    case .temporary(let path), .temporaryWithKnownContents(let path, _):
       return .temporary(RelativePath(path.dirname))
     case .fileList(let path, _):
       return .temporary(RelativePath(path.dirname))
@@ -128,6 +133,8 @@ public enum VirtualPath: Hashable {
       return .relative(path.appending(component: component))
     case .temporary(let path):
       return .temporary(path.appending(component: component))
+    case let .temporaryWithKnownContents(path, contents):
+      return .temporaryWithKnownContents(path.appending(component: component), contents)
     case .fileList(let path, let content):
       return .fileList(path.appending(component: component), content)
     case .standardInput, .standardOutput:
@@ -147,6 +154,8 @@ public enum VirtualPath: Hashable {
       return .relative(RelativePath(path.pathString + suffix))
     case let .temporary(path):
       return .temporary(RelativePath(path.pathString + suffix))
+    case let .temporaryWithKnownContents(path, contents):
+      return .temporaryWithKnownContents(RelativePath(path.pathString + suffix), contents)
     case let .fileList(path, content):
       return .fileList(RelativePath(path.pathString + suffix), content)
     case .standardInput, .standardOutput:
@@ -158,7 +167,8 @@ public enum VirtualPath: Hashable {
 
 extension VirtualPath: Codable {
   private enum CodingKeys: String, CodingKey {
-    case relative, absolute, standardInput, standardOutput, temporary, fileList
+    case relative, absolute, standardInput, standardOutput, temporary,
+         temporaryWithKnownContents, fileList
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -177,6 +187,10 @@ extension VirtualPath: Codable {
     case .temporary(let a1):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .temporary)
       try unkeyedContainer.encode(a1)
+    case let .temporaryWithKnownContents(path, contents):
+      var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .temporaryWithKnownContents)
+      try unkeyedContainer.encode(path)
+      try unkeyedContainer.encode(contents)
     case .fileList(let path, let fileList):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .fileList)
       try unkeyedContainer.encode(path)
@@ -206,6 +220,11 @@ extension VirtualPath: Codable {
       var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
       let a1 = try unkeyedValues.decode(RelativePath.self)
       self = .temporary(a1)
+    case .temporaryWithKnownContents:
+      var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+      let path = try unkeyedValues.decode(RelativePath.self)
+      let contents = try unkeyedValues.decode(Data.self)
+      self = .temporaryWithKnownContents(path, contents)
     case .fileList:
       var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
       let path = try unkeyedValues.decode(RelativePath.self)
@@ -231,7 +250,8 @@ struct TextualVirtualPath: Codable {
       try container.encode(path.pathString)
     case .relative(let path):
       try container.encode(path.pathString)
-    case .temporary, .standardInput, .standardOutput, .fileList:
+    case .temporary, .temporaryWithKnownContents, .standardInput,
+         .standardOutput, .fileList:
       preconditionFailure("Path does not have a round-trippable textual representation")
     }
   }
@@ -249,7 +269,8 @@ extension VirtualPath: CustomStringConvertible {
     case .standardInput, .standardOutput:
       return "-"
 
-    case .temporary(let path), .fileList(let path, _):
+    case .temporary(let path), .temporaryWithKnownContents(let path, _),
+         .fileList(let path, _):
       return path.pathString
     }
   }
@@ -266,6 +287,8 @@ extension VirtualPath {
       return .relative(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)))
     case let .temporary(path):
       return .temporary(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)))
+    case let .temporaryWithKnownContents(path, contents):
+      return .temporaryWithKnownContents(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)), contents)
     case let .fileList(path, content):
       return .fileList(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)), content)
     case .standardInput, .standardOutput:
@@ -304,7 +327,8 @@ extension TSCBasic.FileSystem {
         throw FileSystemError.noCurrentWorkingDirectory
       }
       return try f(.init(cwd, relPath))
-    case let .temporary(relPath), let .fileList(relPath, _):
+    case let .temporary(relPath), let .temporaryWithKnownContents(relPath, _),
+         let .fileList(relPath, _):
       throw FileSystemError.cannotResolveTempPath(relPath)
     case .standardInput:
       throw FileSystemError.cannotResolveStandardInput

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -303,4 +303,18 @@ final class JobExecutorTests: XCTestCase {
       }
     }
   }
+
+  func testTemporaryFileWriting() throws {
+    try withTemporaryDirectory { path in
+      let resolver = try ArgsResolver(fileSystem: localFileSystem, temporaryDirectory: .absolute(path))
+      let tmpPath = VirtualPath.temporaryWithKnownContents(.init("one.txt"), "hello, world!".data(using: .utf8)!)
+      let resolvedOnce = try resolver.resolve(.path(tmpPath))
+      let readContents = try localFileSystem.readFileContents(.init(validating: resolvedOnce))
+      XCTAssertEqual(readContents, "hello, world!")
+      let resolvedTwice = try resolver.resolve(.path(tmpPath))
+      XCTAssertEqual(resolvedOnce, resolvedTwice)
+      let readContents2 = try localFileSystem.readFileContents(.init(validating: resolvedTwice))
+      XCTAssertEqual(readContents2, readContents)
+    }
+  }
 }


### PR DESCRIPTION
Instead of writing temporary files directly, it now uses a new VirtualPath case, temporaryFileWithKnownContents, to record the encoded artifact info. ArgsResolver is then responsible for writing the contents to a temporary file. This works pretty similar to file lists, but the contents of the files in this case don't require any path resolution.

Builds on #248, but only to avoid merge conflicts. Only the second commit is new.