### PR TITLE
Update isTopLevelOutput predicate

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -59,15 +59,16 @@ extension Driver {
   /// Is this compile job top-level
   func isTopLevelOutput(type: FileType?) -> Bool {
     switch type {
-    case .assembly, .sil, .raw_sil, .llvmIR, .ast, .jsonDependencies:
+    case .assembly, .sil, .raw_sil, .llvmIR, .ast, .jsonDependencies, .sib, .raw_sib, .importedModules, .indexData:
       return true
     case .object:
       return (linkerOutputType == nil)
     case .swiftModule:
       return compilerMode.isSingleCompilation && moduleOutputInfo.output?.isTopLevel ?? false
-    case .swift, .sib, .image, .dSYM, .dependencies, .autolink,
-         .swiftDocumentation, .swiftInterface,
-         .swiftSourceInfoFile, .raw_sib, .llvmBitcode, .diagnostics,
+    case .llvmBitcode:
+      return compilerOutputType == type
+    case .swift, .image, .dSYM, .dependencies, .autolink,
+         .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile, .diagnostics,
          .objcHeader, .swiftDeps, .remap, .importedModules, .tbd, .moduleTrace,
          .indexData, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
          .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies, nil:


### PR DESCRIPTION
- canonical sib, raw sib, imported modules, and index data are always top level (as far as I know)
- bitcode is top-level if it's the compiler output type (in other words, it's not being embedded)

This fixes:
- Frontend/sil-primary-file-with-sib.swift
- reproducible-builds/swiftc-emit-bc.swift
- reproducible-builds/swiftc-emit-sib.swift
- reproducible-builds/swiftc-emit-sibgen.swift