### PR TITLE
[Integration Tests] Fixup the path to llvm's lit.py to reflect the monorepo structure

### DIFF
--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -156,11 +156,11 @@ final class IntegrationTests: IntegrationTestCase {
       /// The path to the real frontend we should use.
       let frontendFile = swiftBuildDir.appending(components: "bin", "swift")
 
-      /// The root directory, where build/, llvm/, and swift/ live.
+      /// The root directory, where build/, llvm-project/, and swift/ live.
       let swiftRootDir = swiftBuildDir.parentDirectory.parentDirectory.parentDirectory
 
       /// The path to lit.py.
-      let litFile = swiftRootDir.appending(components: "llvm", "utils", "lit",
+      let litFile = swiftRootDir.appending(components: "llvm-project", "llvm", "utils", "lit",
                                              "lit.py")
 
       /// The path to the test suite we want to run.


### PR DESCRIPTION
Matching the directory structure created by the `update-checkout` script.
With this change, we can run integration tests according to the instructions in the README. 