### PR TITLE
Add a lit feature for the c++ driver

### DIFF
--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -184,6 +184,7 @@ final class IntegrationTests: IntegrationTestCase {
         litFile.pathString, "-svi", "--time-tests",
         "--param", "copy_env=SWIFT_DRIVER_SWIFT_EXEC",
         "--param", "swift_site_config=\(litConfigFile.pathString)",
+        "--param", "swift_driver",
         testDir.pathString
       ]
 


### PR DESCRIPTION
Counterpart to https://github.com/apple/swift/pull/33961 which has the context.

This PR passes the swift_driver parameter to lit so that it disables the integrated_driver feature.