### PR TITLE
Make joinedArguments helper public so it can be used by SPM

### DIFF
--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -162,7 +162,7 @@ extension Array where Element == Job.ArgTemplate {
   }
 
   /// A shell-escaped string representation of the arguments, as they would appear on the command line.
-  var joinedArguments: String {
+  public var joinedArguments: String {
     return self.map {
       switch $0 {
         case .flag(let string):


### PR DESCRIPTION
This is a tiny change so that I can merge this, then update SPM to use its own executor instead of `SwiftDriverExecutor`, and then land https://github.com/apple/swift-driver/pull/263 without a cross-repository merge.