### PR TITLE
Better output from a decoding error

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2288,7 +2288,10 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertThrowsError(try Driver(args: ["swift", "-print-target-info"],
                                       executor: MockExecutor(resolver: ArgsResolver(fileSystem: InMemoryFileSystem())))) {
         error in
-        XCTAssertEqual(error as? Driver.Error, .unableToDecodeFrontendTargetInfo)
+        if case .unableToDecodeFrontendTargetInfo = error as? Driver.Error {}
+        else {
+          XCTFail("not a decoding error")
+        }
       }
     }
 


### PR DESCRIPTION
When the driver fails to get the target info from the frontend, print out more detailed information