### PR TITLE
Set the line-width parameter on the Yams `serialize` routine to unlimited.

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -133,7 +133,9 @@ public final class ArgsResolver {
 
   private func quoteAndEscape(path: VirtualPath) -> String {
     let inputNode = Node.scalar(Node.Scalar(try! unsafeResolve(path: path), Tag(.str), .doubleQuoted))
-    let string = try! Yams.serialize(node: inputNode)
+    // Width parameter of -1 sets preferred line-width to unlimited so that no extraneous
+    // line-breaks will be inserted during serialization.
+    let string = try! Yams.serialize(node: inputNode, width: -1)
     // Remove the newline from the end
     return string.trimmingCharacters(in: .whitespacesAndNewlines)
   }


### PR DESCRIPTION
The default "preferred line-width" setting appears to be `80` characters. At that setting, encoding a filesystem path that is longer than `80` characters long and contains a whitespace at an index `> 80`, a line-break will be inserted at that index, which then results in serializing a malformed `outputFileMap` that contains invalid paths the frontend will not be able to read.