### PR TITLE
[NFC] Use frontend target info to print compiler version in -v mode

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -841,7 +841,8 @@ extension Driver {
   }
 
   private func printVersion<S: OutputByteStream>(outputStream: inout S) throws {
-    outputStream.write(try executor.checkNonZeroExit(args: toolchain.getToolPath(.swiftCompiler).pathString, "--version", environment: env))
+    outputStream <<< frontendTargetInfo.compilerVersion <<< "\n"
+    outputStream <<< "Target: \(frontendTargetInfo.target.triple.triple)\n"
     outputStream.flush()
   }
 }


### PR DESCRIPTION
No functional changes, but it eliminates an unnecessary frontend invocation