### PR TITLE
Add support for loaded module trace emission

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -467,13 +467,19 @@ public struct Driver {
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
-    self.loadedModuleTracePath = try Self.computeSupplementaryOutputPath(
+
+    if let loadedModuleTraceEnvVar = env["SWIFT_LOADED_MODULE_TRACE_FILE"] {
+      self.loadedModuleTracePath = try VirtualPath(path: loadedModuleTraceEnvVar)
+    } else {
+      self.loadedModuleTracePath = try Self.computeSupplementaryOutputPath(
         &parsedOptions, type: .moduleTrace, isOutputOptions: [.emitLoadedModuleTrace],
         outputPath: .emitLoadedModuleTracePath,
         compilerOutputType: compilerOutputType,
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
+    }
+
     self.tbdPath = try Self.computeSupplementaryOutputPath(
         &parsedOptions, type: .tbd, isOutputOptions: [.emitTbd],
         outputPath: .emitTbdPath,

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -159,7 +159,8 @@ extension Driver {
   /// Form a compile job, which executes the Swift frontend to produce various outputs.
   mutating func compileJob(primaryInputs: [TypedVirtualPath],
                            outputType: FileType?,
-                           addJobOutputs: ([TypedVirtualPath]) -> Void)
+                           addJobOutputs: ([TypedVirtualPath]) -> Void,
+                           emitModuleTrace: Bool)
   throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []
@@ -187,7 +188,8 @@ extension Driver {
 
     outputs += try addFrontendSupplementaryOutputArguments(commandLine: &commandLine,
                                                            primaryInputs: primaryInputs,
-                                                           inputOutputMap: inputOutputMap)
+                                                           inputOutputMap: inputOutputMap,
+                                                           includeModuleTracePath: emitModuleTrace)
 
     // Forward migrator flags.
     try commandLine.appendLast(.apiDiffDataFile, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -260,7 +260,8 @@ extension Driver {
 
   mutating func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate],
                                                         primaryInputs: [TypedVirtualPath],
-                                                        inputOutputMap: [TypedVirtualPath: TypedVirtualPath]) throws -> [TypedVirtualPath] {
+                                                        inputOutputMap: [TypedVirtualPath: TypedVirtualPath],
+                                                        includeModuleTracePath: Bool) throws -> [TypedVirtualPath] {
     var flaggedInputOutputPairs: [(flag: String, input: TypedVirtualPath?, output: TypedVirtualPath)] = []
 
     /// Add output of a particular type, if needed.
@@ -368,6 +369,12 @@ extension Driver {
         finalOutputPath: tbdPath,
         input: nil,
         flag: "-emit-tbd-path")
+    }
+
+    if includeModuleTracePath, let tracePath = loadedModuleTracePath {
+      flaggedInputOutputPairs.append((flag: "-emit-loaded-module-trace-path",
+                                      input: nil,
+                                      output: TypedVirtualPath(file: tracePath, type: .moduleTrace)))
     }
 
     // Question: outputs.count > fileListThreshold makes sense, but c++ does the following:


### PR DESCRIPTION
Since the docs for this aren't open source, I'm not sure my test cases are all that great, but all the relevant integration tests are passing now and the implementation wasn't as complicated as I expected. The use of a "claimed" bit on `Driver.loadedModuleTracePath` is definitely a bit of a hack though.

Fixes:
Driver/loaded_module_trace.swift
Driver/loaded_module_trace_append.swift
Driver/loaded_module_trace_env.swift
Driver/loaded_module_trace_foundation.swift
Driver/loaded_module_trace_header.swift
Driver/loaded_module_trace_multifile.swift
Driver/loaded_module_trace_spi.swift