### PR TITLE
[Explicit Module Builds] Keep track of PCMArgs at which clang modules have been scanned

### DIFF
--- a/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
@@ -31,6 +31,8 @@ internal extension Driver {
     // to all Clang modules, and compute a set of distinct PCMArgs across all paths to a
     // given Clang module in the graph.
     let modulePCMArgsSetMap = try dependencyGraph.computePCMArgSetsForClangModules()
+
+    // Set up the batch scan input
     let temporaryDirectory = try determineTempDirectory()
     let batchScanInputList =
       try modulePCMArgsSetMap.compactMap { (moduleId, pcmArgsSet) throws -> [BatchScanModuleInfo] in
@@ -53,10 +55,13 @@ internal extension Driver {
         return moduleInfos
       }.reduce([], +)
 
-    // Batch scan all clang modules for each discovered unique set of PCMArgs, per module
+    // Batch scan all clang modules for each discovered new, unique set of PCMArgs, per module
     let moduleVersionedGraphMap: [ModuleDependencyId: [InterModuleDependencyGraph]] =
       try performBatchDependencyScan(moduleInfos: batchScanInputList)
+
+    // Update the dependency graph to reflect the newly-discovered dependencies
     try dependencyGraph.resolveVersionedClangModules(using: moduleVersionedGraphMap)
+    try dependencyGraph.updateCapturedPCMArgClangDependencies(using: modulePCMArgsSetMap)
   }
 }
 
@@ -138,5 +143,19 @@ private extension InterModuleDependencyGraph {
               pathPCMArtSet: [],
               pcmArgSetMap: &pcmArgSetMap)
     return pcmArgSetMap
+  }
+
+  /// Update the set of all PCMArgs against which a given clang module was re-scanned
+  mutating func updateCapturedPCMArgClangDependencies(using pcmArgSetMap:
+                                                        [ModuleDependencyId : Set<[String]>]
+  ) throws {
+    for (moduleId, newPCMArgs) in pcmArgSetMap {
+      var moduleDetails = try clangModuleDetails(of: moduleId)
+      if moduleDetails.dependenciesCapturedPCMArgs == nil {
+        moduleDetails.dependenciesCapturedPCMArgs = Set<[String]>()
+      }
+      newPCMArgs.forEach { moduleDetails.dependenciesCapturedPCMArgs!.insert($0) }
+      modules[moduleId]!.details = .clang(moduleDetails)
+    }
   }
 }

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -116,6 +116,10 @@ public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
   @_spi(Testing) public var moduleMapPath: String
 
+  /// Set of PCM Arguments of depending modules which
+  /// are covered by the directDependencies info of this module
+  var dependenciesCapturedPCMArgs: Set<[String]>?
+
   /// clang-generated context hash
   var contextHash: String?
 


### PR DESCRIPTION
- Add a new `InterModuleDependencyGraph` field in `ClangModuleDetails` to capture against which targets this module has been scanned. The `directDependencies` of this module then represent the super-set of dependencies at all of the specified targets. 
- When performing a batched, versioned-PCM re-scan, only perform the re-scan at sets of PCMArgs that are "new" to this module to potentially discover additional dependencies. 

On its own, this change will not yield much improvement, but it is a necessary piece of the puzzle for a follow-up change that will build on top of this to drastically reduce the amount of redundant re-scanning that is currently happening in multi-module build contexts. 