### PR TITLE
[Explicit Module Builds] Change interface used by SwiftPM to communicate external dependencies.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -14,6 +14,10 @@ import TSCUtility
 import Foundation
 import SwiftOptions
 
+/// Temporary backwards-compatible API for SwiftPM
+public typealias ExternalDependencyArtifactMap =
+    [ModuleDependencyId: (AbsolutePath, InterModuleDependencyGraph)]
+
 /// The Swift driver.
 public struct Driver {
   public enum Error: Swift.Error, Equatable, DiagnosticData {
@@ -267,6 +271,56 @@ public struct Driver {
 
     stream <<< diagnostic.localizedDescription <<< "\n"
     stream.flush()
+  }
+
+  /// Temporary API for backwards-compatibility with the API currently used by SwiftPM
+  /// This is a workaround for SwiftPM's current lack of cross-repository testing with swift-driver.
+  /// It will be removed after the corresponding SwiftPM API change is submitted.
+  public init(
+    args: [String],
+    env: [String: String] = ProcessEnv.vars,
+    diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
+    fileSystem: FileSystem = localFileSystem,
+    executor: DriverExecutor,
+    externalModuleDependencies: ExternalDependencyArtifactMap
+  ) throws {
+    let externalBuildArtifacts: ExternalBuildArtifacts
+    var externalTargetModulePathMap: ExternalTargetModulePathMap = [:]
+    var moduleInfoMap: ModuleInfoMap = [:]
+    for (externalDependencyModuleId, (path, dependencyGraph)) in externalModuleDependencies {
+      externalTargetModulePathMap[externalDependencyModuleId] = path
+      for (moduleId, moduleInfo) in dependencyGraph.modules {
+        switch moduleId {
+          case .swift:
+            if moduleInfoMap[moduleId] == nil {
+              moduleInfoMap[moduleId] = moduleInfo
+            } else {
+              // Only update swift modules if we have an updated module path for them.
+              if moduleInfoMap[moduleId]!.modulePath == moduleId.moduleName + ".swiftmodule" {
+                moduleInfoMap[moduleId] = moduleInfo
+              }
+            }
+          case .clang:
+            if moduleInfoMap[moduleId] == nil {
+              moduleInfoMap[moduleId] = moduleInfo
+            } else {
+              // If this module *has* been seen before, merge the module infos to capture
+              // the super-set of so-far discovered dependencies of this module at various
+              // PCMArg scanning actions.
+              let combinedDependenciesInfo =
+                InterModuleDependencyGraph.mergeClangModuleInfoDependencies(moduleInfo,
+                                                                            moduleInfoMap[moduleId]!)
+              moduleInfoMap[moduleId] = combinedDependenciesInfo
+            }
+
+          case .swiftPlaceholder:
+            fatalError("Unresolved placeholder dependencies in Driver input: \(moduleId)")
+        }
+      }
+    }
+    externalBuildArtifacts = (externalTargetModulePathMap, moduleInfoMap)
+    try self.init(args: args, env: env, diagnosticsEngine: diagnosticsEngine, fileSystem: fileSystem,
+                  executor: executor, externalBuildArtifacts: externalBuildArtifacts)
   }
 
   /// Create the driver with the given arguments.

--- a/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
@@ -161,47 +161,46 @@ private extension InterModuleDependencyGraph {
 }
 
 public extension InterModuleDependencyGraph {
-    /// Given two moduleInfos of clang modules, merge them by combining their directDependencies and
-    /// dependenciesCapturedPCMArgs fields
-    static func mergeClangModuleInfoDependencies(_ firstInfo: ModuleInfo, _ secondInfo:ModuleInfo
-    ) -> ModuleInfo {
-        // All fields other than dependency-related ones must be identical
-        precondition(firstInfo.modulePath == secondInfo.modulePath)
-        precondition(firstInfo.sourceFiles == secondInfo.sourceFiles)
-        guard case .clang(let firstDetails) = firstInfo.details,
-              case .clang(let secondDetails) = secondInfo.details
-        else {
-            fatalError("Clang ModuleInfo without a corresponding clangModuleDetails field")
-        }
-        precondition(firstDetails.moduleMapPath == secondDetails.moduleMapPath)
-        precondition(firstDetails.contextHash == secondDetails.contextHash)
-        precondition(firstDetails.commandLine == secondDetails.commandLine)
-
-        // As far as their dependencies go, these module infos are identical
-        if firstInfo.directDependencies == secondInfo.directDependencies,
-           firstDetails.dependenciesCapturedPCMArgs ==
-            secondDetails.dependenciesCapturedPCMArgs {
-            return firstInfo
-        }
-
-        // Create a new moduleInfo that represents this module with combined dependency information
-        let firstModuleDependencies = firstInfo.directDependencies ?? []
-        let secondModuleDependencies = secondInfo.directDependencies ?? []
-        let combinedDependencies = Array(Set(firstModuleDependencies + secondModuleDependencies))
-
-        let firstModuleCapturedPCMArgs = firstDetails.dependenciesCapturedPCMArgs ?? Set<[String]>()
-        let secondModuleCapturedPCMArgs = secondDetails.dependenciesCapturedPCMArgs ?? Set<[String]>()
-        let combinedCapturedPCMArgs = firstModuleCapturedPCMArgs.union(secondModuleCapturedPCMArgs)
-
-        let combinedModuleDetails =
-            ClangModuleDetails(moduleMapPath: firstDetails.moduleMapPath,
-                               dependenciesCapturedPCMArgs: combinedCapturedPCMArgs,
-                               contextHash: firstDetails.contextHash,
-                               commandLine: firstDetails.commandLine)
-
-        return ModuleInfo(modulePath: firstInfo.modulePath,
-                          sourceFiles: firstInfo.sourceFiles,
-                          directDependencies: combinedDependencies,
-                          details: .clang(combinedModuleDetails))
+  /// Given two moduleInfos of clang modules, merge them by combining their directDependencies and
+  /// dependenciesCapturedPCMArgs and sourceFiles fields. These fields may differ across the same module
+  /// scanned at different PCMArgs (e.g. -target option).
+  static func mergeClangModuleInfoDependencies(_ firstInfo: ModuleInfo, _ secondInfo:ModuleInfo
+  ) -> ModuleInfo {
+    guard case .clang(let firstDetails) = firstInfo.details,
+          case .clang(let secondDetails) = secondInfo.details
+    else {
+      fatalError("mergeClangModules expected two valid ClangModuleDetails objects.")
     }
+
+    // As far as their dependencies go, these module infos are identical
+    if firstInfo.directDependencies == secondInfo.directDependencies,
+       firstDetails.dependenciesCapturedPCMArgs == secondDetails.dependenciesCapturedPCMArgs,
+       firstInfo.sourceFiles == secondInfo.sourceFiles {
+      return firstInfo
+    }
+
+    // Create a new moduleInfo that represents this module with combined dependency information
+    let firstModuleSources = firstInfo.sourceFiles ?? []
+    let secondModuleSources = secondInfo.sourceFiles ?? []
+    let combinedSourceFiles = Array(Set(firstModuleSources + secondModuleSources))
+
+    let firstModuleDependencies = firstInfo.directDependencies ?? []
+    let secondModuleDependencies = secondInfo.directDependencies ?? []
+    let combinedDependencies = Array(Set(firstModuleDependencies + secondModuleDependencies))
+
+    let firstModuleCapturedPCMArgs = firstDetails.dependenciesCapturedPCMArgs ?? Set<[String]>()
+    let secondModuleCapturedPCMArgs = secondDetails.dependenciesCapturedPCMArgs ?? Set<[String]>()
+    let combinedCapturedPCMArgs = firstModuleCapturedPCMArgs.union(secondModuleCapturedPCMArgs)
+
+    let combinedModuleDetails =
+      ClangModuleDetails(moduleMapPath: firstDetails.moduleMapPath,
+                         dependenciesCapturedPCMArgs: combinedCapturedPCMArgs,
+                         contextHash: firstDetails.contextHash,
+                         commandLine: firstDetails.commandLine)
+
+    return ModuleInfo(modulePath: firstInfo.modulePath,
+                      sourceFiles: combinedSourceFiles,
+                      directDependencies: combinedDependencies,
+                      details: .clang(combinedModuleDetails))
+  }
 }

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -13,9 +13,13 @@ import TSCBasic
 import TSCUtility
 import Foundation
 
-/// A map from a module identifier to a pair consisting of a path to its .swiftmodule file and its module dependency graph.
-public typealias ExternalDependencyArtifactMap =
-    [ModuleDependencyId: (AbsolutePath, InterModuleDependencyGraph)]
+/// A map from a module identifier to a pair consisting of a path to its .swiftmodule file.
+public typealias ExternalTargetModulePathMap = [ModuleDependencyId: AbsolutePath]
+/// A map from a module identifier to its info
+public typealias ModuleInfoMap = [ModuleDependencyId: ModuleInfo]
+/// A tuple all external artifacts a build system may pass in as input to the explicit build of the current module
+/// Consists of a map of externally-built targets, and a map of all previously discovered/scanned modules.
+public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleInfoMap)
 
 /// In Explicit Module Build mode, this handler is responsible for generating and providing
 /// build jobs for all module dependencies and providing compile command options
@@ -201,7 +205,7 @@ public typealias ExternalDependencyArtifactMap =
 
     // First, take the command line options provided in the dependency information
     let moduleDetails = try dependencyGraph.clangModuleDetails(of: moduleId)
-    moduleDetails.commandLine?.forEach { commandLine.appendFlags($0) }
+    moduleDetails.commandLine.forEach { commandLine.appendFlags($0) }
 
     // Add the `-target` option as inherited from the dependent Swift module's PCM args
     pcmArgs.forEach { commandLine.appendFlags($0) }

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -118,7 +118,7 @@ public struct ClangModuleDetails: Codable {
 
   /// Set of PCM Arguments of depending modules which
   /// are covered by the directDependencies info of this module
-  var dependenciesCapturedPCMArgs: Set<[String]>?
+  public var dependenciesCapturedPCMArgs: Set<[String]>?
 
   /// clang-generated context hash
   var contextHash: String?

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -124,7 +124,7 @@ public struct ClangModuleDetails: Codable {
   var contextHash: String?
 
   /// Options to the compile command
-  var commandLine: [String]? = []
+  var commandLine: [String] = []
 }
 
 public struct ModuleInfo: Codable {

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
@@ -29,11 +29,11 @@ extension Driver {
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
-    // Pass in external dependencies to be treated as placeholder dependencies by the scanner
-    if let externalDependencyArtifactMap = externalDependencyArtifactMap {
+    // Pass in external target dependencies to be treated as placeholder dependencies by the scanner
+    if let externalBuildArtifacts = externalBuildArtifacts {
       let dependencyPlaceholderMapFile =
-        try serializeExternalDependencyArtifacts(externalDependencyArtifactMap:
-                                                  externalDependencyArtifactMap)
+        try serializeExternalDependencyArtifacts(externalTargetModulePathMap:
+                                                  externalBuildArtifacts.0)
       commandLine.appendFlag("-placeholder-dependency-module-map-file")
       commandLine.appendPath(dependencyPlaceholderMapFile)
     }
@@ -53,17 +53,17 @@ extension Driver {
   }
 
   /// Serialize a map of placeholder (external) dependencies for the dependency scanner.
-  func serializeExternalDependencyArtifacts(externalDependencyArtifactMap: ExternalDependencyArtifactMap)
+  func serializeExternalDependencyArtifacts(externalTargetModulePathMap: ExternalTargetModulePathMap)
   throws -> AbsolutePath {
     let temporaryDirectory = try determineTempDirectory()
     let placeholderMapFilePath =
       temporaryDirectory.appending(component: "\(moduleOutputInfo.name)-placeholder-modules.json")
 
     var placeholderArtifacts: [SwiftModuleArtifactInfo] = []
-    for (moduleId, dependencyInfo) in externalDependencyArtifactMap {
+    for (moduleId, binaryModulePath) in externalTargetModulePathMap {
       placeholderArtifacts.append(
           SwiftModuleArtifactInfo(name: moduleId.moduleName,
-                                  modulePath: dependencyInfo.0.description))
+                                  modulePath: binaryModulePath.description))
     }
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -398,8 +398,8 @@ extension Driver {
                                 recordedInputModificationDates: recordedInputModificationDates)
 
     // Resolve placeholder dependencies in the dependency graph, if any.
-    if externalDependencyArtifactMap != nil, !externalDependencyArtifactMap!.isEmpty {
-      try dependencyGraph.resolvePlaceholderDependencies(using: externalDependencyArtifactMap!)
+    if externalBuildArtifacts != nil, !externalBuildArtifacts!.0.isEmpty {
+      try dependencyGraph.resolvePlaceholderDependencies(using: externalBuildArtifacts!)
     }
 
     // Re-scan Clang modules at all the targets they will be built against.


### PR DESCRIPTION
Instead of SwiftPM passing in a set of external targets along with their dependency graphs, SwiftPM will now pass in:
- A set of external targets along with the location of their resulting `.swiftmodule` files, as before 
- a collection of *all* modules seen so far across all targets already planned in this build.

The second point replaces previous behaviour, where SwiftPM only passed in the dependency graphs of targets which are dependencies of the target swift-driver is currently planning the build for. Having access to *all* previously-seen modules will allow us to be more intelligent with knowing what modules do not need scanning as well as what clang modules require a re-scan, as each re-scan updates Clang module's details with the set of PCMArgs their dependencies currently capture and propagate it up to the depending modules' build planning actions. 

This PR produces an API change that is matched with a corresponding depending SwiftPM change: https://github.com/apple/swift-package-manager/pull/2959. 

When used together with #279 and the respective SwiftPM changes, this change results in a significant reduction in the amount of versioned batched re-scanning we perform. 

For example: 
When constructing the build manifest for building SwiftPM, this change reduces the total sum of batch sizes of all versioned PCM re-scans involved in the build from _2525_ to _303_ (**8.2x** improvement).

Further followup change will address redundant re-scanning of Swift modules by using the additional information SwiftPM now provides to create more placeholder modules in the dependency scanning action input. 
