### PR TITLE
Remove temporary backwards-compatible SwiftPM interface

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -14,10 +14,6 @@ import TSCUtility
 import Foundation
 import SwiftOptions
 
-/// Temporary backwards-compatible API for SwiftPM
-public typealias ExternalDependencyArtifactMap =
-    [ModuleDependencyId: (AbsolutePath, InterModuleDependencyGraph)]
-
 /// The Swift driver.
 public struct Driver {
   public enum Error: Swift.Error, Equatable, DiagnosticData {
@@ -271,56 +267,6 @@ public struct Driver {
 
     stream <<< diagnostic.localizedDescription <<< "\n"
     stream.flush()
-  }
-
-  /// Temporary API for backwards-compatibility with the API currently used by SwiftPM
-  /// This is a workaround for SwiftPM's current lack of cross-repository testing with swift-driver.
-  /// It will be removed after the corresponding SwiftPM API change is submitted.
-  public init(
-    args: [String],
-    env: [String: String] = ProcessEnv.vars,
-    diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
-    fileSystem: FileSystem = localFileSystem,
-    executor: DriverExecutor,
-    externalModuleDependencies: ExternalDependencyArtifactMap
-  ) throws {
-    let externalBuildArtifacts: ExternalBuildArtifacts
-    var externalTargetModulePathMap: ExternalTargetModulePathMap = [:]
-    var moduleInfoMap: ModuleInfoMap = [:]
-    for (externalDependencyModuleId, (path, dependencyGraph)) in externalModuleDependencies {
-      externalTargetModulePathMap[externalDependencyModuleId] = path
-      for (moduleId, moduleInfo) in dependencyGraph.modules {
-        switch moduleId {
-          case .swift:
-            if moduleInfoMap[moduleId] == nil {
-              moduleInfoMap[moduleId] = moduleInfo
-            } else {
-              // Only update swift modules if we have an updated module path for them.
-              if moduleInfoMap[moduleId]!.modulePath == moduleId.moduleName + ".swiftmodule" {
-                moduleInfoMap[moduleId] = moduleInfo
-              }
-            }
-          case .clang:
-            if moduleInfoMap[moduleId] == nil {
-              moduleInfoMap[moduleId] = moduleInfo
-            } else {
-              // If this module *has* been seen before, merge the module infos to capture
-              // the super-set of so-far discovered dependencies of this module at various
-              // PCMArg scanning actions.
-              let combinedDependenciesInfo =
-                InterModuleDependencyGraph.mergeClangModuleInfoDependencies(moduleInfo,
-                                                                            moduleInfoMap[moduleId]!)
-              moduleInfoMap[moduleId] = combinedDependenciesInfo
-            }
-
-          case .swiftPlaceholder:
-            fatalError("Unresolved placeholder dependencies in Driver input: \(moduleId)")
-        }
-      }
-    }
-    externalBuildArtifacts = (externalTargetModulePathMap, moduleInfoMap)
-    try self.init(args: args, env: env, diagnosticsEngine: diagnosticsEngine, fileSystem: fileSystem,
-                  executor: executor, externalBuildArtifacts: externalBuildArtifacts)
   }
 
   /// Create the driver with the given arguments.


### PR DESCRIPTION
Now that https://github.com/apple/swift-package-manager/pull/2959 has been merged, this is no longer needed. 