### PR TITLE
[Explicit Module Builds] Provide API for a common dependency graph operation performed by SwiftPM

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -388,6 +388,32 @@ final class ExplicitModuleBuildTests: XCTestCase {
     #endif
   }
 
+  func testDependencyGraphMerge() throws {
+    let moduleDependencyGraph1 =
+          try JSONDecoder().decode(
+            InterModuleDependencyGraph.self,
+            from: ModuleDependenciesInputs.mergeGraphInput1.data(using: .utf8)!)
+    let moduleDependencyGraph2 =
+          try JSONDecoder().decode(
+            InterModuleDependencyGraph.self,
+            from: ModuleDependenciesInputs.mergeGraphInput2.data(using: .utf8)!)
+
+    var accumulatingModuleInfoMap: [ModuleDependencyId: ModuleInfo] = [:]
+
+    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph1,
+                                                into: &accumulatingModuleInfoMap)
+    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph2,
+                                                into: &accumulatingModuleInfoMap)
+
+    // Ensure the dependencies of the diplicate clang "B" module are merged
+    let clangIDs = accumulatingModuleInfoMap.keys.filter { $0.moduleName == "B" }
+    XCTAssertTrue(clangIDs.count == 1)
+    let clangBInfo = accumulatingModuleInfoMap[clangIDs[0]]!
+    XCTAssertTrue(clangBInfo.directDependencies!.count == 2)
+    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("D")))
+    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("C")))
+  }
+
   func testExplicitSwiftModuleMap() throws {
     let jsonExample : String = """
     [

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -375,6 +375,134 @@ enum ModuleDependenciesInputs {
     """
   }
 
+  static var mergeGraphInput1: String {
+    """
+    {
+      "mainModuleName": "A",
+      "modules": [
+        {
+          "swift": "A"
+        },
+        {
+          "modulePath": "A.swiftmodule",
+          "sourceFiles": [
+            "/A/A.swift"
+          ],
+          "directDependencies": [
+            {
+              "clang": "B"
+            }
+          ],
+          "details": {
+            "swift": {
+              "isFramework": false,
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.10",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ]
+            }
+          }
+        },
+        {
+          "clang": "B"
+        },
+        {
+          "modulePath": "B.pcm",
+          "sourceFiles": [
+            "/B/module.map",
+            "/B/include/b.h"
+          ],
+          "directDependencies": [
+               {
+                 "clang": "D"
+               }
+          ],
+          "details": {
+            "clang": {
+              "moduleMapPath": "/B/module.map",
+              "contextHash": "2QEMRLNY63H2N",
+              "commandLine": [
+                "-remove-preceeding-explicit-module-build-incompatible-options",
+                "-fno-implicit-modules",
+                "-emit-module",
+                "-fmodule-name=c_simd"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """
+  }
+
+  static var mergeGraphInput2: String {
+    """
+    {
+      "mainModuleName": "A",
+      "modules": [
+        {
+          "swift": "A"
+        },
+        {
+          "modulePath": "A.swiftmodule",
+          "sourceFiles": [
+            "/A/A.swift"
+          ],
+          "directDependencies": [
+            {
+              "clang": "B"
+            },
+          ],
+          "details": {
+            "swift": {
+              "isFramework": false,
+              "extraPcmArgs": [
+                "-Xcc",
+                "-target",
+                "-Xcc",
+                "x86_64-apple-macosx10.10",
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ]
+            }
+          }
+        },
+        {
+          "clang": "B"
+        },
+        {
+          "modulePath": "B.pcm",
+          "sourceFiles": [
+            "/B/module.map",
+            "/B/include/b.h"
+          ],
+          "directDependencies": [
+               {
+                 "clang": "C"
+               }
+          ],
+          "details": {
+            "clang": {
+              "moduleMapPath": "/B/module.map",
+              "contextHash": "2QEMRLNY63H2N",
+              "commandLine": [
+                "-remove-preceeding-explicit-module-build-incompatible-options",
+                "-fno-implicit-modules",
+                "-emit-module",
+                "-fmodule-name=c_simd"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """
+  }
+
   static var bPlaceHolderInput: String {
     """
     {


### PR DESCRIPTION
It will be much better for SwiftPM to not have to know how to mutate the graph in this way when it has to, and to have this code be common across other clients.