### PR TITLE
Add API so SPM doesn't need to switch over VirtualPath cases

### DIFF
--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -76,6 +76,22 @@ public enum VirtualPath: Hashable {
     }
   }
 
+  public var relativePath: RelativePath? {
+    guard case .relative(let relativePath) = self else { return nil }
+    return relativePath
+  }
+  
+  /// If the path is some kind of temporary file, returns the `RelativePath`
+  /// representing its name.
+  public var temporaryFileName: RelativePath? {
+    switch self {
+    case .temporary(let name), .fileList(let name, _):
+      return name
+    case .absolute, .relative, .standardInput, .standardOutput:
+      return nil
+    }
+  }
+
   /// Retrieve the basename of the path.
   public var basename: String {
     switch self {


### PR DESCRIPTION
This PR adds new public computed properties `relativePath` and `temporaryFileName` to `VirtualPath`. The goal is to use these in SPM's ManifestBuilder to avoid switching over all of the VirtualPath cases. This should unblock https://github.com/apple/swift-driver/pull/250 which adds a new enum case, and might help avoid some issues once SwiftDriver is being built with library evolution enabled in some contexts but not others.