### PR TITLE
Pass -index-file-path as a primary file input

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2835,6 +2835,21 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testIndexFilePathHandling() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-index-file", "-index-file-path",
+                                     "bar.swift", "foo.swift", "bar.swift", "baz.swift"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      let job = plannedJobs[0]
+      XCTAssertTrue(job.commandLine.contains(subsequence: [.path(.relative(.init("foo.swift"))),
+                                                           "-primary-file",
+                                                           .path(.relative(.init("bar.swift"))),
+                                                           .path(.relative(.init("baz.swift")))]))
+    }
+  }
+
   func testEmbedBitcode() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-embed-bitcode", "embed-bitcode.swift"])


### PR DESCRIPTION
`-index-file` uses single compiles, but the `-index-file-path` needs to be passed as a `-primary-file` input. It looks like all the other indexing flags were already being handled correctly.

This fixes the remaining index store tests:
Index/Store/driver-index-with-auxiliary-outputs.swift
Index/Store/driver-index.swift
Index/Store/driver-multiple-inputs.swift
Index/Store/unit-one-file-multi-file-invocation.swift