### PR TITLE
[Explicit Module Builds] Refactor the InterModuleDependencyGraph to distinguish prebuilt external dependencies.

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -8,11 +8,12 @@
 
 add_library(SwiftDriver
   "Explicit Module Builds/ClangModuleBuildJobCache.swift"
-  "Explicit Module Builds/ExplicitModuleBuildHandler.swift"
-  "Explicit Module Builds/PlaceholderDependencyResolution.swift"
   "Explicit Module Builds/ClangVersionedDependencyResolution.swift"
+  "Explicit Module Builds/CommonDependencyGraphOperations.swift"
+  "Explicit Module Builds/ExplicitModuleBuildHandler.swift"
   "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
+  "Explicit Module Builds/PlaceholderDependencyResolution.swift"
   "Explicit Module Builds/SerializableModuleArtifacts.swift"
 
   Driver/CompilerMode.swift

--- a/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
@@ -134,6 +134,15 @@ private extension InterModuleDependencyGraph {
             pcmArgSetMap[moduleId] = newPCMArgSet
           }
           return
+        case .swiftPrebuiltExternal:
+          // We can rely on the fact that this pre-built module already has its
+          // versioned-PCM dependencies satisfied, so we do not need to add additional
+          // arguments. Proceed traversal to its dependencies.
+          for dependencyId in try moduleInfo(of: moduleId).directDependencies! {
+            try visit(dependencyId,
+                      pathPCMArtSet: pathPCMArtSet,
+                      pcmArgSetMap: &pcmArgSetMap)
+          }
         case .swiftPlaceholder:
           fatalError("Unresolved placeholder dependencies at planning stage: \(moduleId)")
       }

--- a/Sources/SwiftDriver/Explicit Module Builds/CommonDependencyGraphOperations.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/CommonDependencyGraphOperations.swift
@@ -1,0 +1,117 @@
+//===-------------- CommonDependencyGraphOperations.swift -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public extension InterModuleDependencyGraph {
+  /// An API to allow clients to accumulate InterModuleDependencyGraphs across mutiple main modules/targets
+  /// into a single collection of discovered modules.
+  static func mergeModules(
+    from dependencyGraph: InterModuleDependencyGraph,
+    into discoveredModules: inout ModuleInfoMap
+  ) throws {
+    for (moduleId, moduleInfo) in dependencyGraph.modules {
+      try mergeModule(moduleId, moduleInfo, into: &discoveredModules)
+    }
+  }
+}
+
+internal extension InterModuleDependencyGraph {
+  /// Merge a module with a given ID and Info into a ModuleInfoMap
+  static func mergeModule(_ moduleId: ModuleDependencyId,
+                          _ moduleInfo: ModuleInfo,
+                          into moduleInfoMap: inout ModuleInfoMap) throws {
+    switch moduleId {
+      case .swift:
+        let prebuiltExternalModuleEquivalentId =
+          ModuleDependencyId.swiftPrebuiltExternal(moduleId.moduleName)
+        let placeholderEquivalentId =
+          ModuleDependencyId.swiftPlaceholder(moduleId.moduleName)
+        if moduleInfoMap[prebuiltExternalModuleEquivalentId] != nil ||
+            moduleInfoMap[moduleId] != nil {
+          // If the set of discovered modules contains a .swiftPrebuiltExternal or .swift module
+          // with the same name, do not replace it.
+          break
+        } else if moduleInfoMap[placeholderEquivalentId] != nil {
+          // Replace the placeholder module with a full .swift ModuleInfo
+          // and fixup other modules' dependencies
+          replaceModule(originalId: placeholderEquivalentId, replacementId: moduleId,
+                        replacementInfo: moduleInfo, in: &moduleInfoMap)
+        } else {
+          // Insert the new module
+          moduleInfoMap[moduleId] = moduleInfo
+        }
+
+      case .swiftPrebuiltExternal:
+        // If the set of discovered modules contains a .swift module with the same name,
+        // replace it with the prebuilt version and fixup other modules' dependencies
+        let swiftModuleEquivalentId = ModuleDependencyId.swift(moduleId.moduleName)
+        let swiftPlaceholderEquivalentId = ModuleDependencyId.swiftPlaceholder(moduleId.moduleName)
+        if moduleInfoMap[swiftModuleEquivalentId] != nil {
+          // If the ModuleInfoMap contains an equivalent .swift module, replace it with the prebuilt
+          // version and update all other modules' dependencies
+          replaceModule(originalId: swiftModuleEquivalentId, replacementId: moduleId,
+                        replacementInfo: moduleInfo, in: &moduleInfoMap)
+        } else if moduleInfoMap[swiftPlaceholderEquivalentId] != nil {
+          // If the moduleInfoMap contains an equivalent .swiftPlaceholder module, replace it with
+          // the prebuilt version and update all other modules' dependencies
+          replaceModule(originalId: swiftPlaceholderEquivalentId, replacementId: moduleId,
+                        replacementInfo: moduleInfo, in: &moduleInfoMap)
+        } else {
+          // Insert the new module
+          moduleInfoMap[moduleId] = moduleInfo
+        }
+
+      case .clang:
+        guard let existingModuleInfo = moduleInfoMap[moduleId] else {
+          moduleInfoMap[moduleId] = moduleInfo
+          break
+        }
+        // If this module *has* been seen before, merge the module infos to capture
+        // the super-set of so-far discovered dependencies of this module at various
+        // PCMArg scanning actions.
+        let combinedDependenciesInfo = mergeClangModuleInfoDependencies(moduleInfo,
+                                                                        existingModuleInfo)
+        replaceModule(originalId: moduleId, replacementId: moduleId,
+                      replacementInfo: combinedDependenciesInfo, in: &moduleInfoMap)
+      case .swiftPlaceholder:
+        fatalError("Unresolved placeholder dependency at graph merge operation: \(moduleId)")
+    }
+  }
+
+  /// Replace an existing module in the moduleInfoMap
+  static func replaceModule(originalId: ModuleDependencyId, replacementId: ModuleDependencyId,
+                            replacementInfo: ModuleInfo,
+                            in moduleInfoMap: inout ModuleInfoMap) {
+    precondition(moduleInfoMap[originalId] != nil)
+    moduleInfoMap.removeValue(forKey: originalId)
+    moduleInfoMap[replacementId] = replacementInfo
+    if originalId != replacementId {
+      updateDependencies(from: originalId, to: replacementId, in: &moduleInfoMap)
+    }
+  }
+
+  /// Replace all references to the original module in other modules' dependencies with the new module.
+  static func updateDependencies(from originalId: ModuleDependencyId,
+                                 to replacementId: ModuleDependencyId,
+                                 in moduleInfoMap: inout ModuleInfoMap) {
+    for moduleId in moduleInfoMap.keys {
+      var moduleInfo = moduleInfoMap[moduleId]!
+      // Skip over placeholders, they do not have dependencies
+      if case .swiftPlaceholder(_) = moduleId {
+        continue
+      }
+      if let originalModuleIndex = moduleInfo.directDependencies?.firstIndex(of: originalId) {
+        moduleInfo.directDependencies![originalModuleIndex] = replacementId;
+      }
+      moduleInfoMap[moduleId] = moduleInfo
+    }
+  }
+}

--- a/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/InterModuleDependencyGraph.swift
@@ -10,17 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
-
+/// A map from a module identifier to its info
+public typealias ModuleInfoMap = [ModuleDependencyId: ModuleInfo]
 
 public enum ModuleDependencyId: Hashable {
   case swift(String)
   case swiftPlaceholder(String)
+  case swiftPrebuiltExternal(String)
   case clang(String)
 
   public var moduleName: String {
     switch self {
     case .swift(let name): return name
     case .swiftPlaceholder(let name): return name
+    case .swiftPrebuiltExternal(let name): return name
     case .clang(let name): return name
     }
   }
@@ -30,6 +33,7 @@ extension ModuleDependencyId: Codable {
   enum CodingKeys: CodingKey {
     case swift
     case swiftPlaceholder
+    case swiftPrebuiltExternal
     case clang
   }
 
@@ -43,8 +47,13 @@ extension ModuleDependencyId: Codable {
         let moduleName =  try container.decode(String.self, forKey: .swiftPlaceholder)
         self = .swiftPlaceholder(moduleName)
       } catch {
-        let moduleName =  try container.decode(String.self, forKey: .clang)
-        self = .clang(moduleName)
+        do {
+          let moduleName =  try container.decode(String.self, forKey: .swiftPrebuiltExternal)
+          self = .swiftPrebuiltExternal(moduleName)
+        } catch {
+          let moduleName =  try container.decode(String.self, forKey: .clang)
+          self = .clang(moduleName)
+        }
       }
     }
   }
@@ -55,7 +64,9 @@ extension ModuleDependencyId: Codable {
       case .swift(let moduleName):
         try container.encode(moduleName, forKey: .swift)
       case .swiftPlaceholder(let moduleName):
-        try container.encode(moduleName, forKey: .swift)
+        try container.encode(moduleName, forKey: .swiftPlaceholder)
+      case .swiftPrebuiltExternal(let moduleName):
+        try container.encode(moduleName, forKey: .swiftPrebuiltExternal)
       case .clang(let moduleName):
         try container.encode(moduleName, forKey: .clang)
     }
@@ -77,13 +88,6 @@ public struct SwiftModuleDetails: Codable {
   /// The paths of potentially ready-to-use compiled modules for the interface.
   @_spi(Testing) public var compiledModuleCandidates: [String]?
 
-  /// The path to the already-compiled module that must be used instead of
-  /// generating a job to build this module. In standard compilation, the dependency scanner
-  /// may discover compiled module candidates to be used instead of re-compiling from interface.
-  /// In contrast, this explicitCompiledModulePath is only to be used for precompiled modules
-  /// external dependencies in Explicit Module Build mode
-  @_spi(Testing) public var explicitCompiledModulePath: String?
-
   /// The bridging header, if any.
   var bridgingHeaderPath: String?
 
@@ -96,14 +100,27 @@ public struct SwiftModuleDetails: Codable {
   /// To build a PCM to be used by this Swift module, we need to append these
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
-  @_spi(Testing) public var extraPcmArgs: [String]?
+  @_spi(Testing) public var extraPcmArgs: [String]
 
   /// A flag to indicate whether or not this module is a framework.
   @_spi(Testing) public var isFramework: Bool
 }
 
-/// Details specific to Swift external modules.
+/// Details specific to Swift placeholder dependencies.
 public struct SwiftPlaceholderModuleDetails: Codable {
+  /// The path to the .swiftModuleDoc file.
+  var moduleDocPath: String?
+
+  /// The path to the .swiftSourceInfo file.
+  var moduleSourceInfoPath: String?
+}
+
+/// Details specific to Swift externally-pre-built modules.
+public struct SwiftPrebuiltExternalModuleDetails: Codable {
+  /// The path to the already-compiled module that must be used instead of
+  /// generating a job to build this module.
+  @_spi(Testing) public var compiledModulePath: String
+
   /// The path to the .swiftModuleDoc file.
   var moduleDocPath: String?
 
@@ -121,7 +138,7 @@ public struct ClangModuleDetails: Codable {
   public var dependenciesCapturedPCMArgs: Set<[String]>?
 
   /// clang-generated context hash
-  var contextHash: String?
+  var contextHash: String
 
   /// Options to the compile command
   var commandLine: [String] = []
@@ -132,10 +149,10 @@ public struct ModuleInfo: Codable {
   public var modulePath: String
 
   /// The source files used to build this module.
-  public var sourceFiles: [String]? = []
+  public var sourceFiles: [String]?
 
   /// The set of direct module dependencies of this module.
-  public var directDependencies: [ModuleDependencyId]? = []
+  public var directDependencies: [ModuleDependencyId]?
 
   /// Specific details of a particular kind of module.
   public var details: Details
@@ -146,9 +163,12 @@ public struct ModuleInfo: Codable {
     /// a bridging header.
     case swift(SwiftModuleDetails)
 
-    /// Swift external modules carry additional details that specify their
+    /// Swift placeholder modules carry additional details that specify their
     /// module doc path and source info paths.
     case swiftPlaceholder(SwiftPlaceholderModuleDetails)
+
+    /// Swift externally-prebuilt modules must communicate the path to pre-built binary artifacts
+    case swiftPrebuiltExternal(SwiftPrebuiltExternalModuleDetails)
 
     /// Clang modules are built from a module map file.
     case clang(ClangModuleDetails)
@@ -159,6 +179,7 @@ extension ModuleInfo.Details: Codable {
   enum CodingKeys: CodingKey {
     case swift
     case swiftPlaceholder
+    case swiftPrebuiltExternal
     case clang
   }
 
@@ -169,11 +190,18 @@ extension ModuleInfo.Details: Codable {
       self = .swift(details)
     } catch {
       do {
-        let details = try container.decode(SwiftPlaceholderModuleDetails.self, forKey: .swiftPlaceholder)
+        let details = try container.decode(SwiftPlaceholderModuleDetails.self,
+                                           forKey: .swiftPlaceholder)
         self = .swiftPlaceholder(details)
       } catch {
-        let details = try container.decode(ClangModuleDetails.self, forKey: .clang)
-        self = .clang(details)
+        do {
+          let details = try container.decode(SwiftPrebuiltExternalModuleDetails.self,
+                                             forKey: .swiftPrebuiltExternal)
+          self = .swiftPrebuiltExternal(details)
+        } catch {
+          let details = try container.decode(ClangModuleDetails.self, forKey: .clang)
+          self = .clang(details)
+        }
       }
     }
   }
@@ -185,6 +213,8 @@ extension ModuleInfo.Details: Codable {
         try container.encode(details, forKey: .swift)
       case .swiftPlaceholder(let details):
         try container.encode(details, forKey: .swiftPlaceholder)
+      case .swiftPrebuiltExternal(let details):
+        try container.encode(details, forKey: .swiftPrebuiltExternal)
       case .clang(let details):
         try container.encode(details, forKey: .clang)
     }
@@ -198,7 +228,7 @@ public struct InterModuleDependencyGraph: Codable {
   public var mainModuleName: String
 
   /// The complete set of modules discovered
-  public var modules: [ModuleDependencyId: ModuleInfo] = [:]
+  public var modules: ModuleInfoMap = [:]
 
   /// Information about the main module.
   public var mainModule: ModuleInfo { modules[.swift(mainModuleName)]! }

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -290,6 +290,10 @@ enum ModuleDependenciesInputs {
         },
         {
           "modulePath": "/Volumes/Data/Current/Driver/ExplicitPMTest/.build/x86_64-apple-macosx/debug/B.swiftmodule",
+          "sourceFiles": [
+          ],
+          "directDependencies" : [
+          ],
           "details": {
             "swiftPlaceholder": {
             }
@@ -307,7 +311,6 @@ enum ModuleDependenciesInputs {
           "details": {
             "swift": {
               "moduleInterfacePath": "Swift.swiftmodule/x86_64-apple-macos.swiftinterface",
-              "contextHash": "30OCBGKPNG64V",
               "commandLine": [
                 "-frontend",
                 "-compile-module-from-interface",
@@ -317,8 +320,6 @@ enum ModuleDependenciesInputs {
                 "5",
                 "-module-name",
                 "Swift"
-              ],
-              "compiledModuleCandidates": [
               ],
               "isFramework": false,
               "extraPcmArgs": [
@@ -543,10 +544,13 @@ enum ModuleDependenciesInputs {
         },
         {
           "modulePath" : "Swift.swiftmodule",
+          "sourceFiles": [
+          ],
           "directDependencies" : [
           ],
           "details" : {
             "swift" : {
+              "moduleInterfacePath": "Swift.swiftmodule/x86_64-apple-macos.swiftinterface",
               "isFramework": false,
               "extraPcmArgs": [
                 "-Xcc",
@@ -565,6 +569,8 @@ enum ModuleDependenciesInputs {
         },
         {
           "modulePath" : "SwiftOnoneSupport.swiftmodule",
+          "sourceFiles": [
+          ],
           "directDependencies" : [
             {
               "swift" : "Swift"
@@ -572,6 +578,7 @@ enum ModuleDependenciesInputs {
           ],
           "details" : {
             "swift" : {
+              "moduleInterfacePath": "SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface",
               "isFramework": false,
               "extraPcmArgs": [
                 "-Xcc",


### PR DESCRIPTION
This is a refactoring change intended to reduce ambiguity in what nodes in the dependency graph can represent. As dependency graph structure and individual modules are being communicated and merged among different components, such ambiguities in the graph introduce additional, unnecessary complexity to graph operations.

- Introduce a new module kind: `.swiftPrebuiltExternalDependency`.
This node kind is to be used for external target dependencies built by build system clients. Previously we were using `.swift` modules to represent both pre-compiled external targets and Swift module dependencies that require a build job to be created by the driver. This new structure means that every `.swift` module dependency must have a build job constructed for it, and every `.swiftPrebuiltExternal` module dependency does not require to be built.
- Factor out and unify common graph operations, so that placeholder resolution and external API for graph merging use common logic. 

