### PR TITLE
Remove the fileSystem in ExplicitModuleBuildHandler

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -199,7 +199,7 @@ public struct Driver {
       return cwd.map { AbsolutePath($0, path) }
     case nil:
       return nil
-    case .standardInput, .standardOutput, .temporary, .fileList:
+    case .standardInput, .standardOutput, .temporary, .temporaryWithKnownContents, .fileList:
       fatalError("Frontend target information will never include a path of this type.")
     }
   }

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -84,14 +84,22 @@ public final class ArgsResolver {
     // Return the path from the temporary directory if this is a temporary file.
     if path.isTemporary {
       let actualPath = temporaryDirectory.appending(component: path.name)
-      if case let .fileList(_, fileList) = path {
-        switch fileList {
-        case let .list(items):
-          try createFileList(path: actualPath, contents: items)
-        case let .outputFileMap(map):
-          try createFileList(path: actualPath, outputFileMap: map)
+      switch path {
+      case .temporary:
+        break // No special behavior required.
+      case let .temporaryWithKnownContents(_, contents):
+        // FIXME: Need a way to support this for distributed build systems...
+        if let absolutePath = actualPath.absolutePath {
+          try fileSystem.writeFileContents(absolutePath, bytes: .init(contents))
         }
+      case let .fileList(_, .list(items)):
+        try createFileList(path: actualPath, contents: items)
+      case let .fileList(_, .outputFileMap(map)):
+        try createFileList(path: actualPath, outputFileMap: map)
+      case .relative, .absolute, .standardInput, .standardOutput:
+        fatalError("Not a temporary path.")
       }
+
       let result = actualPath.name
       pathMapping[path] = result
       return result

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitModuleBuildHandler.swift
@@ -38,24 +38,10 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
   /// The toolchain to be used for frontend job generation.
   private let toolchain: Toolchain
 
-  /// The file system which we should interact with.
-  /// FIXME: Our end goal is to not have any direct filesystem manipulation in here, but  that's dependent on getting the
-  /// dependency scanner/dependency job generation  moved into a Job.
-  private let fileSystem: FileSystem
-
-  /// Path to the directory that will contain the temporary files.
-  /// e.g. Explicit Swift module artifact files
-  /// FIXME: Our end goal is to not have any direct filesystem manipulation in here, but  that's dependent on getting the
-  /// dependency scanner/dependency job generation  moved into a Job.
-  private let temporaryDirectory: AbsolutePath
-
   public init(dependencyGraph: InterModuleDependencyGraph,
-              toolchain: Toolchain,
-              fileSystem: FileSystem) throws {
+              toolchain: Toolchain) throws {
     self.dependencyGraph = dependencyGraph
     self.toolchain = toolchain
-    self.fileSystem = fileSystem
-    self.temporaryDirectory = try determineTempDirectory()
   }
 
   /// Generate build jobs for all dependencies of the main module.
@@ -241,14 +227,11 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
   /// Store the output file artifacts for a given module in a JSON file, return the file's path.
   private func serializeModuleDependencies(for moduleId: ModuleDependencyId,
                                            dependencyArtifacts: [SwiftModuleArtifactInfo]
-  ) throws -> AbsolutePath {
-    let dependencyFilePath =
-      temporaryDirectory.appending(component: "\(moduleId.moduleName)-dependencies.json")
+  ) throws -> VirtualPath {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(dependencyArtifacts)
-    try fileSystem.writeFileContents(dependencyFilePath, bytes: ByteString(contents))
-    return dependencyFilePath
+    return .temporaryWithKnownContents(.init("\(moduleId.moduleName)-dependencies.json"), contents)
   }
 
   /// For the specified module, update the given command line flags and inputs
@@ -279,7 +262,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
         try serializeModuleDependencies(for: moduleId, dependencyArtifacts: swiftDependencyArtifacts)
       commandLine.appendFlag("-explicit-swift-module-map-file")
       commandLine.appendPath(dependencyFile)
-      inputs.append(TypedVirtualPath(file: try VirtualPath(path: dependencyFile.pathString),
+      inputs.append(TypedVirtualPath(file: dependencyFile,
                                      type: .jsonSwiftArtifacts))
       // Each individual module binary is still an "input" to ensure the build system gets the
       // order correctly.

--- a/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ModuleDependencyScanning.swift
@@ -54,11 +54,7 @@ extension Driver {
 
   /// Serialize a map of placeholder (external) dependencies for the dependency scanner.
   func serializeExternalDependencyArtifacts(externalTargetModulePathMap: ExternalTargetModulePathMap)
-  throws -> AbsolutePath {
-    let temporaryDirectory = try determineTempDirectory()
-    let placeholderMapFilePath =
-      temporaryDirectory.appending(component: "\(moduleOutputInfo.name)-placeholder-modules.json")
-
+  throws -> VirtualPath {
     var placeholderArtifacts: [SwiftModuleArtifactInfo] = []
     for (moduleId, binaryModulePath) in externalTargetModulePathMap {
       placeholderArtifacts.append(
@@ -68,8 +64,7 @@ extension Driver {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(placeholderArtifacts)
-    try fileSystem.writeFileContents(placeholderMapFilePath, bytes: ByteString(contents))
-    return placeholderMapFilePath
+    return .temporaryWithKnownContents(.init("\(moduleOutputInfo.name)-placeholder-modules.json"), contents)
   }
 
   mutating func performBatchDependencyScan(moduleInfos: [BatchScanModuleInfo])
@@ -162,15 +157,10 @@ extension Driver {
 
   /// Serialize a collection of modules into an input format expected by the batch module dependency scanner.
   func serializeBatchScanningModuleArtifacts(moduleInfos: [BatchScanModuleInfo])
-  throws -> AbsolutePath {
-    let temporaryDirectory = try determineTempDirectory()
-    let batchScanInputFilePath =
-      temporaryDirectory.appending(component: "\(moduleOutputInfo.name)-batch-module-scan.json")
-
+  throws -> VirtualPath {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(moduleInfos)
-    try fileSystem.writeFileContents(batchScanInputFilePath, bytes: ByteString(contents))
-    return batchScanInputFilePath
+    return .temporaryWithKnownContents(.init("\(moduleOutputInfo.name)-batch-module-scan.json"), contents)
   }
 }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -382,8 +382,7 @@ extension Driver {
     let dependencyGraph = try generateInterModuleDependencyGraph()
     explicitModuleBuildHandler =
         try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
-                                       toolchain: toolchain,
-                                       fileSystem: fileSystem)
+                                       toolchain: toolchain)
     return try explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
   }
 

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
+import Foundation
 
 /// A virtual path.
 public enum VirtualPath: Hashable {
@@ -28,6 +29,9 @@ public enum VirtualPath: Hashable {
 
   /// A temporary file with the given name.
   case temporary(RelativePath)
+
+  /// A temporary file with the given name and contents.
+  case temporaryWithKnownContents(RelativePath, Data)
 
   /// A temporary file that holds a list of paths.
   case fileList(RelativePath, FileList)
@@ -48,7 +52,8 @@ public enum VirtualPath: Hashable {
   /// The extension of this path, for relative or absolute paths.
   public var `extension`: String? {
     switch self {
-    case .relative(let path), .temporary(let path), .fileList(let path, _):
+    case .relative(let path), .temporary(let path),
+         .temporaryWithKnownContents(let path, _), .fileList(let path, _):
       return path.extension
     case .absolute(let path):
       return path.extension
@@ -62,7 +67,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case .relative, .absolute, .standardInput, .standardOutput:
       return false
-    case .temporary, .fileList:
+    case .temporary, .temporaryWithKnownContents, .fileList:
       return true
     }
   }
@@ -71,7 +76,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case let .absolute(absolutePath):
       return absolutePath
-    case .relative, .temporary, .fileList, .standardInput, .standardOutput:
+    case .relative, .temporary, .temporaryWithKnownContents, .fileList, .standardInput, .standardOutput:
       return nil
     }
   }
@@ -85,7 +90,9 @@ public enum VirtualPath: Hashable {
   /// representing its name.
   public var temporaryFileName: RelativePath? {
     switch self {
-    case .temporary(let name), .fileList(let name, _):
+    case .temporary(let name),
+         .fileList(let name, _),
+         .temporaryWithKnownContents(let name, _):
       return name
     case .absolute, .relative, .standardInput, .standardOutput:
       return nil
@@ -97,7 +104,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case .absolute(let path):
       return path.basename
-    case .relative(let path), .temporary(let path), .fileList(let path, _):
+    case .relative(let path), .temporary(let path), .temporaryWithKnownContents(let path, _), .fileList(let path, _):
       return path.basename
     case .standardInput, .standardOutput:
       return ""
@@ -109,7 +116,7 @@ public enum VirtualPath: Hashable {
     switch self {
     case .absolute(let path):
       return path.basenameWithoutExt
-    case .relative(let path), .temporary(let path), .fileList(let path, _):
+    case .relative(let path), .temporary(let path), .temporaryWithKnownContents(let path, _), .fileList(let path, _):
       return path.basenameWithoutExt
     case .standardInput, .standardOutput:
       return ""
@@ -123,7 +130,7 @@ public enum VirtualPath: Hashable {
       return .absolute(path.parentDirectory)
     case .relative(let path):
       return .relative(RelativePath(path.dirname))
-    case .temporary(let path):
+    case .temporary(let path), .temporaryWithKnownContents(let path, _):
       return .temporary(RelativePath(path.dirname))
     case .fileList(let path, _):
       return .temporary(RelativePath(path.dirname))
@@ -144,6 +151,8 @@ public enum VirtualPath: Hashable {
       return .relative(path.appending(component: component))
     case .temporary(let path):
       return .temporary(path.appending(component: component))
+    case let .temporaryWithKnownContents(path, contents):
+      return .temporaryWithKnownContents(path.appending(component: component), contents)
     case .fileList(let path, let content):
       return .fileList(path.appending(component: component), content)
     case .standardInput, .standardOutput:
@@ -163,6 +172,8 @@ public enum VirtualPath: Hashable {
       return .relative(RelativePath(path.pathString + suffix))
     case let .temporary(path):
       return .temporary(RelativePath(path.pathString + suffix))
+    case let .temporaryWithKnownContents(path, contents):
+      return .temporaryWithKnownContents(RelativePath(path.pathString + suffix), contents)
     case let .fileList(path, content):
       return .fileList(RelativePath(path.pathString + suffix), content)
     case .standardInput, .standardOutput:
@@ -174,7 +185,8 @@ public enum VirtualPath: Hashable {
 
 extension VirtualPath: Codable {
   private enum CodingKeys: String, CodingKey {
-    case relative, absolute, standardInput, standardOutput, temporary, fileList
+    case relative, absolute, standardInput, standardOutput, temporary,
+         temporaryWithKnownContents, fileList
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -193,6 +205,10 @@ extension VirtualPath: Codable {
     case .temporary(let a1):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .temporary)
       try unkeyedContainer.encode(a1)
+    case let .temporaryWithKnownContents(path, contents):
+      var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .temporaryWithKnownContents)
+      try unkeyedContainer.encode(path)
+      try unkeyedContainer.encode(contents)
     case .fileList(let path, let fileList):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .fileList)
       try unkeyedContainer.encode(path)
@@ -222,6 +238,11 @@ extension VirtualPath: Codable {
       var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
       let a1 = try unkeyedValues.decode(RelativePath.self)
       self = .temporary(a1)
+    case .temporaryWithKnownContents:
+      var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+      let path = try unkeyedValues.decode(RelativePath.self)
+      let contents = try unkeyedValues.decode(Data.self)
+      self = .temporaryWithKnownContents(path, contents)
     case .fileList:
       var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
       let path = try unkeyedValues.decode(RelativePath.self)
@@ -247,7 +268,8 @@ struct TextualVirtualPath: Codable {
       try container.encode(path.pathString)
     case .relative(let path):
       try container.encode(path.pathString)
-    case .temporary, .standardInput, .standardOutput, .fileList:
+    case .temporary, .temporaryWithKnownContents, .standardInput,
+         .standardOutput, .fileList:
       preconditionFailure("Path does not have a round-trippable textual representation")
     }
   }
@@ -265,7 +287,8 @@ extension VirtualPath: CustomStringConvertible {
     case .standardInput, .standardOutput:
       return "-"
 
-    case .temporary(let path), .fileList(let path, _):
+    case .temporary(let path), .temporaryWithKnownContents(let path, _),
+         .fileList(let path, _):
       return path.pathString
     }
   }
@@ -282,6 +305,8 @@ extension VirtualPath {
       return .relative(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)))
     case let .temporary(path):
       return .temporary(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)))
+    case let .temporaryWithKnownContents(path, contents):
+      return .temporaryWithKnownContents(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)), contents)
     case let .fileList(path, content):
       return .fileList(RelativePath(path.pathString.withoutExt(path.extension).appendingFileTypeExtension(fileType)), content)
     case .standardInput, .standardOutput:
@@ -320,7 +345,8 @@ extension TSCBasic.FileSystem {
         throw FileSystemError.noCurrentWorkingDirectory
       }
       return try f(.init(cwd, relPath))
-    case let .temporary(relPath), let .fileList(relPath, _):
+    case let .temporary(relPath), let .temporaryWithKnownContents(relPath, _),
+         let .fileList(relPath, _):
       throw FileSystemError.cannotResolveTempPath(relPath)
     case .standardInput:
       throw FileSystemError.cannotResolveStandardInput

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -84,10 +84,12 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
           XCTFail("No JSON dependency file path found.")
           return
         }
-        let contents =
-          try localFileSystem.readFileContents(jsonDepsPath.absolutePath!)
+        guard case let .temporaryWithKnownContents(_, contents) = jsonDepsPath else {
+          XCTFail("Unexpected path type")
+          return
+        }
         let dependencyInfoList = try JSONDecoder().decode(Array<SwiftModuleArtifactInfo>.self,
-                                                      from: Data(contents.contents))
+                                                      from: contents)
         let dependencyArtifacts =
           dependencyInfoList.first(where:{ $0.moduleName == dependencyId.moduleName })
         XCTAssertEqual(dependencyArtifacts!.modulePath, swiftDetails.explicitCompiledModulePath ?? dependencyInfo.modulePath)
@@ -142,8 +144,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
               InterModuleDependencyGraph.self,
               from: ModuleDependenciesInputs.fastDependencyScannerOutput.data(using: .utf8)!)
       driver.explicitModuleBuildHandler = try ExplicitModuleBuildHandler(dependencyGraph: moduleDependencyGraph,
-                                                                         toolchain: driver.toolchain,
-                                                                         fileSystem: localFileSystem)
+                                                                         toolchain: driver.toolchain)
       let modulePrebuildJobs =
         try driver.explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
       XCTAssertEqual(modulePrebuildJobs.count, 4)
@@ -209,8 +210,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try moduleDependencyGraph.resolvePlaceholderDependencies(
         using: (targetModulePathMap, externalModuleInfoMap))
       driver.explicitModuleBuildHandler = try ExplicitModuleBuildHandler(dependencyGraph: moduleDependencyGraph,
-                                                                         toolchain: driver.toolchain,
-                                                                         fileSystem: localFileSystem)
+                                                                         toolchain: driver.toolchain)
       let modulePrebuildJobs =
         try driver.explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
 
@@ -239,7 +239,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
             continue
           case .absolute(AbsolutePath("/Somewhere/B.swiftmodule")):
             continue
-          case .absolute(let filePath):
+          case .temporaryWithKnownContents(let filePath, _):
             XCTAssertEqual(filePath.basename, "A-dependencies.json")
             continue
           default:

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -304,4 +304,18 @@ final class JobExecutorTests: XCTestCase {
       }
     }
   }
+
+  func testTemporaryFileWriting() throws {
+    try withTemporaryDirectory { path in
+      let resolver = try ArgsResolver(fileSystem: localFileSystem, temporaryDirectory: .absolute(path))
+      let tmpPath = VirtualPath.temporaryWithKnownContents(.init("one.txt"), "hello, world!".data(using: .utf8)!)
+      let resolvedOnce = try resolver.resolve(.path(tmpPath))
+      let readContents = try localFileSystem.readFileContents(.init(validating: resolvedOnce))
+      XCTAssertEqual(readContents, "hello, world!")
+      let resolvedTwice = try resolver.resolve(.path(tmpPath))
+      XCTAssertEqual(resolvedOnce, resolvedTwice)
+      let readContents2 = try localFileSystem.readFileContents(.init(validating: resolvedTwice))
+      XCTAssertEqual(readContents2, readContents)
+    }
+  }
 }


### PR DESCRIPTION
I forgot to change the base branch on this so I had to reopen it to fix a merge conflict. Once https://github.com/apple/swift-package-manager/pull/2962 is merged I should be able to merge this without breaking the build.

This commit introduces a new VirtualPath case, temporaryFileWithKnownContents.
This allows the ExplicitModuleBuildHandler to indirectly delegate writing artifact info
temporary files to the ArgsResolver.