### PR TITLE
Disable intermittently-failing testStubProcessProtocol on Linux

### DIFF
--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -202,6 +202,11 @@ final class JobExecutorTests: XCTestCase {
   }
 
   func testStubProcessProtocol() throws {
+    // This test fails intermittently on Linux
+    // rdar://70067844
+    #if !os(macOS)
+      throw XCTSkip()
+    #endif
     let job = Job(
       moduleName: "main",
       kind: .compile,


### PR DESCRIPTION
Clear CI while we investigate the cause. 
Example failure:
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04-long-test/6931/console

