### PR TITLE
Remove extra option to print explicit dependency build jobs.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -54,24 +54,9 @@ extension Driver {
 
   private mutating func addPrecompileModuleDependenciesJobs(addJob: (Job) -> Void) throws {
     // If asked, add jobs to precompile module dependencies
-    guard   parsedOptions.contains(.driverExplicitModuleBuild) ||
-            parsedOptions.contains(.driverPrintModuleDependenciesJobs)
-    else {
-      return
-    }
-    let modulePrebuildJobs = try generateExplicitModuleBuildJobs()
-    if parsedOptions.contains(.driverExplicitModuleBuild) {
-      modulePrebuildJobs.forEach(addJob)
-    }
-
-    // If we've been asked to prebuild module dependencies,
-    // for the time being, just print the jobs' compile commands.
-    if parsedOptions.contains(.driverPrintModuleDependenciesJobs) {
-      let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)
-      for job in modulePrebuildJobs {
-        print(try executor.description(of: job, forceResponseFiles: forceResponseFiles))
-      }
-    }
+    guard parsedOptions.contains(.driverExplicitModuleBuild) else { return }
+    let modulePrebuildJobs = try generateExplicitModuleDependenciesJobs()
+    modulePrebuildJobs.forEach(addJob)
   }
 
 
@@ -378,7 +363,7 @@ extension Driver {
   /// of jobs required to build all dependencies.
   /// Preprocess the graph by resolving placeholder dependencies, if any are present and
   /// by re-scanning all Clang modules against all possible targets they will be built against.
-  public mutating func generateExplicitModuleBuildJobs() throws -> [Job] {
+  public mutating func generateExplicitModuleDependenciesJobs() throws -> [Job] {
     let dependencyGraph = try generateInterModuleDependencyGraph()
     explicitModuleBuildHandler =
         try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -12,14 +12,12 @@
 extension Option {
   public static let driverPrintGraphviz: Option = Option("-driver-print-graphviz", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Write the job graph as a graphviz file", group: .internalDebug)
   public static let driverExplicitModuleBuild: Option = Option("-experimental-explicit-module-build", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
-  public static let driverPrintModuleDependenciesJobs: Option = Option("-driver-print-module-dependencies-jobs", .flag, attributes: [.helpHidden], helpText: "Print commands to explicitly build module dependencies")
   public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver.")
 
   public static var extraOptions: [Option] {
     return [
       Option.driverPrintGraphviz,
       Option.driverExplicitModuleBuild,
-      Option.driverPrintModuleDependenciesJobs,
       Option.driverWarnUnusedOptions
     ]
   }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -153,7 +153,7 @@ private func pcmArgsEncodedRelativeModulePath(for moduleName: String, with pcmAr
 final class ExplicitModuleBuildTests: XCTestCase {
   func testModuleDependencyBuildCommandGeneration() throws {
     do {
-      var driver = try Driver(args: ["swiftc", "-driver-print-module-dependencies-jobs",
+      var driver = try Driver(args: ["swiftc", "-experimental-explicit-module-build",
                                      "-module-name", "testModuleDependencyBuildCommandGeneration",
                                      "test.swift"])
       let pcmArgs = ["-Xcc","-target","-Xcc","x86_64-apple-macosx10.15"]
@@ -214,9 +214,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
               from: ModuleDependenciesInputs.fastDependencyScannerPlaceholderOutput.data(using: .utf8)!)
 
       // Construct the driver with explicit external dependency input
-      var commandLine = ["swiftc", "-driver-print-module-dependencies-jobs",
+      var commandLine = ["swiftc", "-experimental-explicit-module-build",
                          "test.swift", "-module-name", "A", "-g"]
-      commandLine.append("-experimental-explicit-module-build")
       let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
                                              processSet: ProcessSet(),
                                              fileSystem: localFileSystem,


### PR DESCRIPTION
Just using `-driver-print-jobs` works fine, if needed for debugging purposes.