### PR TITLE
Implement -driver-print-actions for testing purposes

### DIFF
--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -19,7 +19,7 @@ public struct Job: Codable, Equatable, Hashable {
     case backend
     case mergeModule = "merge-module"
     case link
-    case generateDSYM = "generate-dsym"
+    case generateDSYM = "generate-dSYM"
     case autolinkExtract = "autolink-extract"
     case emitModule = "emit-module"
     case generatePCH = "generate-pch"


### PR DESCRIPTION
The C++ driver uses -driver-print-actions in several tests. We should implement the same
action in the Swift driver so we can run the compiler-side tests by using the Swift driver.
Printing the exactly same results is difficult but they should be semantically equivalent.