### PR TITLE
SwiftDriver: repair the build on non-Darwin after #295

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -869,14 +869,14 @@ extension Driver {
     defer {
       stdoutStream.flush()
     }
-    var jobIdMap = Dictionary<Job, uint>()
+    var jobIdMap = Dictionary<Job, UInt>()
     // The C++ driver treats each input as an action, we should print them as
     // an action too for testing purposes.
-    var inputIdMap = Dictionary<TypedVirtualPath, uint>()
-    var nextId: uint = 0
+    var inputIdMap = Dictionary<TypedVirtualPath, UInt>()
+    var nextId: UInt = 0
     for job in jobs {
       // All input action IDs for this action.
-      var inputIds = Set<uint>()
+      var inputIds = Set<UInt>()
       // Collect input job IDs.
       for input in job.displayInputs.isEmpty ? job.inputs : job.displayInputs {
         var foundInput = false


### PR DESCRIPTION
`uint` is a typedef that is made available on Darwin targets.  The Swift
spelling for this type is `UInt`.  Adjust it to repair the build on
Windows.