### PR TITLE
Return the compiler resource directory as a VirtualPath and fixup clients

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -323,13 +323,6 @@ public struct Driver {
     // Determine the compilation mode.
     self.compilerMode = try Self.computeCompilerMode(&parsedOptions, driverKind: driverKind, diagnosticsEngine: diagnosticEngine)
 
-    // Build the toolchain and determine target information.
-    (self.toolchain, self.frontendTargetInfo, self.swiftCompilerPrefixArgs) =
-        try Self.computeToolchain(
-          &self.parsedOptions, diagnosticsEngine: diagnosticEngine,
-          compilerMode: self.compilerMode, env: env,
-          executor: self.executor, fileSystem: fileSystem)
-
     // Compute the working directory.
     workingDirectory = try parsedOptions.getLastArgument(.workingDirectory).map { workingDirectoryArg in
       let cwd = fileSystem.currentWorkingDirectory
@@ -340,6 +333,13 @@ public struct Driver {
     if let workingDirectory = self.workingDirectory {
       try Self.applyWorkingDirectory(workingDirectory, to: &self.parsedOptions)
     }
+
+    // Build the toolchain and determine target information.
+    (self.toolchain, self.frontendTargetInfo, self.swiftCompilerPrefixArgs) =
+        try Self.computeToolchain(
+          &self.parsedOptions, diagnosticsEngine: diagnosticEngine,
+          compilerMode: self.compilerMode, env: env,
+          executor: self.executor, fileSystem: fileSystem)
 
     // Classify and collect all of the input files.
     let inputFiles = try Self.collectInputFiles(&self.parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -136,7 +136,6 @@ extension Driver {
     try commandLine.appendLast(.moduleLinkName, from: &parsedOptions)
     try commandLine.appendLast(.nostdimport, from: &parsedOptions)
     try commandLine.appendLast(.parseStdlib, from: &parsedOptions)
-    try commandLine.appendLast(.resourceDir, from: &parsedOptions)
     try commandLine.appendLast(.solverMemoryThreshold, from: &parsedOptions)
     try commandLine.appendLast(.valueRecursionThreshold, from: &parsedOptions)
     try commandLine.appendLast(.warnSwift3ObjcInference, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -38,7 +38,7 @@ extension Driver {
 
     let extraEnvironment = try toolchain.platformSpecificInterpreterEnvironmentVariables(
       env: self.env, parsedOptions: &parsedOptions,
-      sdkPath: self.absoluteSDKPath?.pathString, targetTriple: self.targetTriple)
+      sdkPath: frontendTargetInfo.sdkPath?.path, targetTriple: self.targetTriple)
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -46,7 +46,6 @@ extension Driver {
       outputFile: outputFile,
       shouldUseInputFileList: shouldUseInputFileList,
       lto: lto,
-      sdkPath: self.absoluteSDKPath?.pathString,
       sanitizers: enabledSanitizers,
       targetInfo: frontendTargetInfo
     )

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -34,7 +34,7 @@ extension DarwinToolchain {
   public func platformSpecificInterpreterEnvironmentVariables(
     env: [String : String],
     parsedOptions: inout ParsedOptions,
-    sdkPath: String?,
+    sdkPath: VirtualPath?,
     targetTriple: Triple) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
@@ -43,7 +43,7 @@ extension DarwinToolchain {
       parsedOptions: &parsedOptions,
       sdkPath: sdkPath,
       isShared: true
-    ).map { $0.pathString }
+    ).map { $0.name }
 
     addPathEnvironmentVariableIfNeeded("DYLD_LIBRARY_PATH", to: &envVars,
                                        currentEnv: env, option: .L,
@@ -62,7 +62,7 @@ extension GenericUnixToolchain {
   public func platformSpecificInterpreterEnvironmentVariables(
     env: [String : String],
     parsedOptions: inout ParsedOptions,
-    sdkPath: String?,
+    sdkPath: VirtualPath?,
     targetTriple: Triple) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
@@ -71,7 +71,7 @@ extension GenericUnixToolchain {
       parsedOptions: &parsedOptions,
       sdkPath: sdkPath,
       isShared: true
-    ).map { $0.pathString }
+    ).map { $0.name }
 
     addPathEnvironmentVariableIfNeeded("LD_LIBRARY_PATH", to: &envVars,
                                        currentEnv: env, option: .L,

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -67,7 +67,6 @@ public enum Tool: Hashable {
     outputFile: VirtualPath,
     shouldUseInputFileList: Bool,
     lto: LTOKind?,
-    sdkPath: String?,
     sanitizers: Set<Sanitizer>,
     targetInfo: FrontendTargetInfo
   ) throws -> AbsolutePath
@@ -81,7 +80,7 @@ public enum Tool: Hashable {
   func platformSpecificInterpreterEnvironmentVariables(
     env: [String: String],
     parsedOptions: inout ParsedOptions,
-    sdkPath: String?,
+    sdkPath: VirtualPath?,
     targetTriple: Triple) throws -> [String: String]
 
   func addPlatformSpecificCommonFrontendOptions(

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -152,6 +152,16 @@ public enum VirtualPath: Hashable {
     }
   }
 
+  public func appending(components: String...) -> VirtualPath {
+    // FIXME: TSC should add non-variadic overloads of appending(components:)
+    // so we can forward arguments here instead of appending components one-by-one.
+    var result = self
+    components.forEach {
+      result = result.appending(component: $0)
+    }
+    return result
+  }
+
   /// Returns the virtual path with an additional suffix appended to base name.
   ///
   /// This should not be used with `.standardInput` or `.standardOutput`.
@@ -335,5 +345,9 @@ extension TSCBasic.FileSystem {
 
   func getFileInfo(_ path: VirtualPath) throws -> TSCBasic.FileInfo {
     try resolvingVirtualPath(path, apply: getFileInfo)
+  }
+
+  func exists(_ path: VirtualPath) throws -> Bool {
+    try resolvingVirtualPath(path, apply: exists)
   }
 }


### PR DESCRIPTION
In addition to the added tests, this also fixes Driver/linker-rpath.swift. It was kind of tricky to keep the scope of this change small, so this PR includes a few related changes.

- computeResourceDirPath now returns a VirtualPath and handles the case where the user overrides it to be relative. As a result, all the places we were computing paths based on the resource directory required minor, hopefully uncontroversial updates. We're still not using the resource dir from the frontend target info yet because it looks like there might be a few minor issues that need to be resolved first.
- Before this change, `-working-directory` was applied to arguments after frontend target info was fetched, now it is applied beforehand so that the combination of `-working-directory` and a relative `-resource-dir` works correctly
- `addCommonFrontendOptions` was adding `-resource-dir` twice if it was overridden on the command line, now it only appears once.