### PR TITLE
[Build Script Helper] Avoid outputting install_name_tool failures

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -121,8 +121,7 @@ def delete_rpath(rpath, binary, verbose):
                                         stderr=subprocess.PIPE)
   stdout, stderr = installToolProcess.communicate()
   if installToolProcess.returncode != 0:
-    print('install_name_tool command failed: ')
-    print(stderr)
+    print('install_name_tool -delete_rpath command failed, assume incremental build and proceed.')
   if verbose:
     print(stdout)
 
@@ -135,8 +134,7 @@ def add_rpath(rpath, binary, verbose):
                                         stderr=subprocess.PIPE)
   stdout, stderr = installToolProcess.communicate()
   if installToolProcess.returncode != 0:
-    print('install_name_tool command failed: ')
-    print(stderr)
+    print('install_name_tool -add_rpath command failed, assume incremental build and proceed.')
   if verbose:
     print(stdout)
 


### PR DESCRIPTION
In incremental builds of the driver, these commands will fail, which is okay.

Failing to remove specified Rpaths means they are already missing, and failure to add specified Rpaths means they are already present. So we should ignore these failures and proceed with the installation, which we already do. Always outputting these errors pollutes build logs and leads people to mistakenly blame these errors for unrelated failures.