### PR TITLE
[Incremental] Testable debugging outputs & tests

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -135,6 +135,9 @@ public struct Driver {
   /// The set of parsed options.
   var parsedOptions: ParsedOptions
 
+  /// Whether to print out extra info regarding jobs
+  let showJobLifecycle: Bool
+
   /// Extra command-line arguments to pass to the Swift compiler.
   let swiftCompilerPrefixArgs: [String]
 
@@ -321,6 +324,7 @@ public struct Driver {
     self.driverKind = try Self.determineDriverKind(args: &args)
     self.optionTable = OptionTable()
     self.parsedOptions = try optionTable.parse(Array(args), for: self.driverKind)
+    self.showJobLifecycle = parsedOptions.contains(.driverShowJobLifecycle)
 
     // Determine the compilation mode.
     self.compilerMode = try Self.computeCompilerMode(&parsedOptions, driverKind: driverKind, diagnosticsEngine: diagnosticEngine)
@@ -440,7 +444,8 @@ public struct Driver {
       fileSystem: fileSystem,
       inputFiles: inputFiles,
       outputFileMap: outputFileMap,
-      parsedOptions: &parsedOptions)
+      parsedOptions: &parsedOptions,
+      showJobLifecycle: showJobLifecycle)
 
     // Local variable to alias the target triple, because self.targetTriple
     // is not available until the end of this initializer.
@@ -852,7 +857,12 @@ extension Driver {
       mode = .verbose
     }
 
-    return ToolExecutionDelegate(mode: mode)
+    return ToolExecutionDelegate(
+      mode: mode,
+      buildRecordInfo: buildRecordInfo,
+      incrementalCompilationState: incrementalCompilationState,
+      showJobLifecycle: showJobLifecycle,
+      diagnosticEngine: diagnosticEngine)
   }
 
   private func printBindings(_ job: Job) {

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -139,7 +139,7 @@ import SwiftOptions
     }
   }
 
-  func job(_ job: Job, finishedWithResult result: ProcessResult) {
+  func jobFinished(job: Job, result: ProcessResult) {
     // REDUNDANT?
     if let _ = finishedJobResults.updateValue(result, forKey: job) {
       fatalError("job finished twice?!")

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
@@ -157,7 +157,10 @@ extension ModuleDependencyGraph {
   ) -> Set<SwiftDeps>
   where Nodes.Element == Node
   {
-    let affectedNodes = Tracer.findPreviouslyUntracedUsesOf(defs: nodes, in: self)
+    let affectedNodes = Tracer.findPreviouslyUntracedUsesOf(
+      defs: nodes,
+      in: self,
+      diagnosticEngine: diagnosticEngine)
       .tracedUses
     return Set(affectedNodes.compactMap {$0.swiftDeps})
   }

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -11,13 +11,17 @@
 //===----------------------------------------------------------------------===//
 import TSCBasic
 
+// On ELF platforms there's no built in autolinking mechanism, so we
+// pull the info we need from the .o files directly and pass them as an
+// argument input file to the linker.
+// FIXME: Also handle Cygwin and MinGW
 extension Driver {
+  @_spi(Testing) public var isAutolinkExtractJobNeeded: Bool {
+    targetTriple.objectFormat == .elf && lto == nil
+  }
+
   mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {
-    // On ELF platforms there's no built in autolinking mechanism, so we
-    // pull the info we need from the .o files directly and pass them as an
-    // argument input file to the linker.
-    // FIXME: Also handle Cygwin and MinGW
-    guard inputs.count > 0 && targetTriple.objectFormat == .elf && lto == nil else {
+    guard inputs.count > 0 && isAutolinkExtractJobNeeded else {
       return nil
     }
 


### PR DESCRIPTION
1. Centralize the `parsedOptions` interrogation for `-driver-show-job-lifecycle`
2. Use diagnostic remarks for `-driver-show-job-lifecycle` and `-driver-show-incremental`
    Why? Much easier to test, may not mess up Xcode's reading of the compiler's output.
    Why not? We'll have to fix some integration tests, as it differs from legacy front end.
3. Add tests for these outputs
4. Call back into `BuildRecordInfo` and `IncrementalCompilationState` when jobs finish.

Robert floated, and I like the idea of mimicking the legacy driver's messages. However, since we don't have the same sort of task queue (at the present), I'm not sure it's feasible.