### PR TITLE
Make print-output-map and print-bindings behaviour match the C++ driver.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -372,16 +372,6 @@ public struct Driver {
       self.outputFileMap = outputFileMap
     }
 
-    // If requested, print the output file map
-    if parsedOptions.contains(.driverPrintOutputFileMap) {
-      if let outputFileMap = self.outputFileMap {
-        stderrStream <<< outputFileMap.description
-        stderrStream.flush()
-      } else {
-        diagnosticsEngine.emit(.error_no_output_file_map_specified)
-      }
-    }
-
     self.fileListThreshold = try Self.computeFileListThreshold(&self.parsedOptions, diagnosticsEngine: diagnosticsEngine)
     self.shouldUseInputFileList = inputFiles.count > fileListThreshold
     if shouldUseInputFileList {
@@ -787,6 +777,16 @@ extension Driver {
       return
     }
 
+    if parsedOptions.contains(.driverPrintOutputFileMap) {
+      if let outputFileMap = self.outputFileMap {
+        stderrStream <<< outputFileMap.description
+        stderrStream.flush()
+      } else {
+        diagnosticEngine.emit(.error_no_output_file_map_specified)
+      }
+      return
+    }
+
     if parsedOptions.contains(.driverPrintBindings) {
       for job in jobs {
         printBindings(job)
@@ -859,7 +859,7 @@ extension Driver {
     stdoutStream <<< #"# ""# <<< targetTriple.triple
     stdoutStream <<< #"" - ""# <<< job.tool.basename
     stdoutStream <<< #"", inputs: ["#
-    stdoutStream <<< job.inputs.map { "\"" + $0.file.name + "\"" }.joined(separator: ", ")
+    stdoutStream <<< job.displayInputs.map { "\"" + $0.file.name + "\"" }.joined(separator: ", ")
 
     stdoutStream <<< "], output: {"
 

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -70,6 +70,7 @@ extension Driver {
       kind: .link,
       tool: .absolute(toolPath),
       commandLine: commandLine,
+      displayInputs: inputs,
       inputs: inputs,
       primaryInputs: [],
       outputs: [.init(file: outputFile, type: .image)]

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -215,7 +215,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
               from: ModuleDependenciesInputs.fastDependencyScannerPlaceholderOutput.data(using: .utf8)!)
 
       // Construct the driver with explicit external dependency input
-      var commandLine = ["swiftc", "-experimental-explicit-module-build",
+      let commandLine = ["swiftc", "-experimental-explicit-module-build",
                          "test.swift", "-module-name", "A", "-g"]
       let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
                                              processSet: ProcessSet(),

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2515,11 +2515,12 @@ final class SwiftDriverTests: XCTestCase {
       let outputFileMap = path.appending(component: "output_file_map.json")
       let fileMap = "{\"\(dummyInput.description)\": {\"object\": \"/build/basic_output_file_map.o\"}, \"\(path)/Inputs/main.swift\": {\"object\": \"/build/main.o\"}, \"\(path)/Inputs/lib.swift\": {\"object\": \"/build/lib.o\"}}"
       try localFileSystem.writeFileContents(outputFileMap) { $0 <<< fileMap }
-      _ = try Driver(args: ["swiftc", "-driver-print-output-file-map",
+      var driver = try Driver(args: ["swiftc", "-driver-print-output-file-map",
                                      "-target", "x86_64-apple-macosx10.9",
                                      "-o", "/build/basic_output_file_map.out",
                                      "-module-name", "OutputFileMap",
                                      "-output-file-map", outputFileMap.description])
+      try driver.run(jobs: [])
       let invocationError = try localFileSystem.readFileContents(errorOutputFile).description
       XCTAssertTrue(invocationError.contains("/Inputs/lib.swift -> object: \"/build/lib.o\""))
       XCTAssertTrue(invocationError.contains("/Inputs/main.swift -> object: \"/build/main.o\""))


### PR DESCRIPTION
- Move printing of the output map to the `run()` stage and exit after.
- Adjust the kind of inputs printed in `printBindings` to print `displayInputs`.
- Add `displayInputs` to the link job.

This change makes `test/Driver/basic_output_file_map.swift` pass.