### PR TITLE
Warn when a target environment is inferred to be a simulator

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1941,6 +1941,13 @@ extension Driver {
         }
       }
 
+      // Check if the simulator environment was inferred for backwards compatibility.
+      if let explicitTarget = explicitTarget,
+         explicitTarget.environment != .simulator && info.target.triple.environment == .simulator {
+        diagnosticsEngine.emit(.warning_inferring_simulator_target(originalTriple: explicitTarget,
+                                                                   inferredTriple: info.target.triple))
+      }
+
       return (toolchain, info, swiftCompilerPrefixArgs)
     } catch let JobExecutionError.decodingError(decodingError,
                                                 dataToDecode,

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -29,6 +29,10 @@ extension Diagnostic.Message {
     .error("invalid value '\(value)' in '\(arg.spelling)'")
   }
 
+  static func warning_inferring_simulator_target(originalTriple: Triple, inferredTriple: Triple) -> Diagnostic.Message {
+    .warning("inferring simulator environment for target '\(originalTriple.triple)'; use '-target \(inferredTriple.triple)' instead")
+  }
+
   static func error_argument_not_allowed_with(arg: String, other: String) -> Diagnostic.Message {
     .error("argument '\(arg)' is not allowed with '\(other)'")
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1672,6 +1672,16 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testEnvironmentInferenceWarning() throws {
+    try assertDriverDiagnostics(args: ["swiftc", "-target", "x86_64-apple-ios13.0", "foo.swift"]) {
+      $1.expect(.warning("inferring simulator environment for target 'x86_64-apple-ios13.0'; use '-target x86_64-apple-ios13.0-simulator'"))
+    }
+    try assertDriverDiagnostics(args: ["swiftc", "-target", "x86_64-apple-watchos6.0", "foo.swift"]) {
+      $1.expect(.warning("inferring simulator environment for target 'x86_64-apple-watchos6.0'; use '-target x86_64-apple-watchos6.0-simulator'"))
+    }
+    try assertNoDriverDiagnostics(args: "swiftc", "-target", "x86_64-apple-ios13.0-simulator", "foo.swift")
+  }
+
   func testDarwinToolchainArgumentValidation() throws {
     XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-ios6.0",
                                            "foo.swift"])) { error in


### PR DESCRIPTION
The frontend takes care of the actual inference, so here I just check if we're in a situation where the explicit triple does not have the simulator environment but the frontend target info one does.