### PR TITLE
Add the module interface input to the command line of a verification job

### DIFF
--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -13,8 +13,9 @@
 extension Driver {
   mutating func verifyModuleInterfaceJob(interfaceInput: TypedVirtualPath) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
-    var inputs: [TypedVirtualPath] = []
+    var inputs: [TypedVirtualPath] = [interfaceInput]
     commandLine.appendFlags("-frontend", "-typecheck-module-from-interface")
+    commandLine.appendPath(interfaceInput.file)
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
@@ -32,8 +33,8 @@ extension Driver {
       kind: .verifyModuleInterface,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,
-      displayInputs: [],
-      inputs: [interfaceInput],
+      displayInputs: [interfaceInput],
+      inputs: inputs,
       primaryInputs: [],
       outputs: [outputFile]
     )

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2643,6 +2643,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(verifyJob.kind, .verifyModuleInterface)
       XCTAssertTrue(verifyJob.inputs.count == 1)
       XCTAssertTrue(verifyJob.inputs[0] == mergeInterfaceOutputs[0])
+      XCTAssertTrue(verifyJob.commandLine.contains(.path(mergeInterfaceOutputs[0].file)))
     }
     // No Evolution
     do {


### PR DESCRIPTION
This fixes the ModuleInterface/verify-module-interfaces.swift test. Previously, the module interface was correctly being added as a job input, but it wasn't added to the command line.