### PR TITLE
Add initial WebAssembly toolchain implementation

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -69,10 +69,12 @@ add_library(SwiftDriver
   Jobs/Toolchain+LinkerSupport.swift
   Jobs/VerifyDebugInfoJob.swift
   Jobs/VerifyModuleInterfaceJob.swift
+  Jobs/WebAssemblyToolchain+LinkerSupport.swift
 
   Toolchains/DarwinToolchain.swift
   Toolchains/GenericUnixToolchain.swift
   Toolchains/Toolchain.swift
+  Toolchains/WebAssemblyToolchain.swift
 
   Utilities/Bits.swift
   Utilities/Bitstream.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1844,6 +1844,8 @@ extension Triple {
       return GenericUnixToolchain.self
     case .freeBSD, .haiku:
       return GenericUnixToolchain.self
+    case .wasi:
+      return WebAssemblyToolchain.self
     case .win32:
       fatalError("Windows target not supported yet")
     default:

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -11,13 +11,13 @@
 //===----------------------------------------------------------------------===//
 import TSCBasic
 
-// On ELF platforms there's no built in autolinking mechanism, so we
+// On ELF/WASM platforms there's no built in autolinking mechanism, so we
 // pull the info we need from the .o files directly and pass them as an
 // argument input file to the linker.
 // FIXME: Also handle Cygwin and MinGW
 extension Driver {
   @_spi(Testing) public var isAutolinkExtractJobNeeded: Bool {
-    targetTriple.objectFormat == .elf && lto == nil
+    [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil
   }
 
   mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -24,7 +24,7 @@ extension Toolchain {
     let resourceDirBase: VirtualPath
     if let resourceDir = parsedOptions.getLastArgument(.resourceDir) {
       resourceDirBase = try VirtualPath(path: resourceDir.asSingle)
-    } else if !triple.isDarwin,
+    } else if !triple.isDarwin && triple.os != .wasi,
       let sdk = parsedOptions.getLastArgument(.sdk),
       let sdkPath = try? VirtualPath(path: sdk.asSingle) {
       resourceDirBase = sdkPath

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -1,0 +1,162 @@
+//===--------------- WebAssemblyToolchain+LinkerSupport.swift -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+import SwiftOptions
+
+extension WebAssemblyToolchain {
+  public func addPlatformSpecificLinkerArgs(
+    to commandLine: inout [Job.ArgTemplate],
+    parsedOptions: inout ParsedOptions,
+    linkerOutputType: LinkOutputType,
+    inputs: [TypedVirtualPath],
+    outputFile: VirtualPath,
+    shouldUseInputFileList: Bool,
+    lto: LTOKind?,
+    sanitizers: Set<Sanitizer>,
+    targetInfo: FrontendTargetInfo
+  ) throws -> AbsolutePath {
+    let targetTriple = targetInfo.target.triple
+    switch linkerOutputType {
+    case .dynamicLibrary:
+      throw Error.dynamicLibrariesUnsupportedForTarget(targetTriple.triple)
+    case .executable:
+      if !targetTriple.triple.isEmpty {
+        commandLine.appendFlag("-target")
+        commandLine.appendFlag(targetTriple.triple)
+      }
+
+      // Select the linker to use.
+      if let linkerArg = parsedOptions.getLastArgument(.useLd)?.asSingle {
+        commandLine.appendFlag("-fuse-ld=\(linkerArg)")
+      }
+
+      // Configure the toolchain.
+      //
+      // By default use the system `clang` to perform the link.  We use `clang` for
+      // the driver here because we do not wish to select a particular C++ runtime.
+      // Furthermore, until C++ interop is enabled, we cannot have a dependency on
+      // C++ code from pure Swift code.  If linked libraries are C++ based, they
+      // should properly link C++.  In the case of static linking, the user can
+      // explicitly specify the C++ runtime to link against.  This is particularly
+      // important for platforms like android where as it is a Linux platform, the
+      // default C++ runtime is `libstdc++` which is unsupported on the target but
+      // as the builds are usually cross-compiled from Linux, libstdc++ is going to
+      // be present.  This results in linking the wrong version of libstdc++
+      // generating invalid binaries.  It is also possible to use different C++
+      // runtimes than the default C++ runtime for the platform (e.g. libc++ on
+      // Windows rather than msvcprt).  When C++ interop is enabled, we will need to
+      // surface this via a driver flag.  For now, opt for the simpler approach of
+      // just using `clang` and avoid a dependency on the C++ runtime.
+      var clangPath = try getToolPath(.clang)
+      if let toolsDirPath = parsedOptions.getLastArgument(.toolsDirectory) {
+        // FIXME: What if this isn't an absolute path?
+        let toolsDir = try AbsolutePath(validating: toolsDirPath.asSingle)
+
+        // If there is a clang in the toolchain folder, use that instead.
+        if let tool = lookupExecutablePath(filename: "clang", searchPaths: [toolsDir]) {
+          clangPath = tool
+        }
+      }
+
+      guard !parsedOptions.hasArgument(.noStaticStdlib, .noStaticExecutable) else {
+        throw Error.dynamicLibrariesUnsupportedForTarget(targetTriple.triple)
+      }
+
+      let runtimePaths = try runtimeLibraryPaths(
+        for: targetTriple,
+        parsedOptions: &parsedOptions,
+        sdkPath: targetInfo.sdkPath?.path,
+        isShared: false
+      )
+
+      let resourceDirPath = try computeResourceDirPath(
+        for: targetTriple,
+        parsedOptions: &parsedOptions,
+        isShared: false
+      )
+
+      let swiftrtPath = resourceDirPath
+        .appending(
+          components: targetTriple.archName, "swiftrt.o"
+        )
+      commandLine.appendPath(swiftrtPath)
+
+      let inputFiles: [Job.ArgTemplate] = inputs.compactMap { input in
+        // Autolink inputs are handled specially
+        if input.type == .autolink {
+          return .responseFilePath(input.file)
+        } else if input.type == .object {
+          return .path(input.file)
+        } else {
+          return nil
+        }
+      }
+      commandLine.append(contentsOf: inputFiles)
+
+      if let path = targetInfo.sdkPath?.path {
+        commandLine.appendFlag("--sysroot")
+        commandLine.appendPath(path)
+      }
+
+      // Add the runtime library link paths.
+      for path in runtimePaths {
+        commandLine.appendFlag(.L)
+        commandLine.appendPath(path)
+      }
+
+      // Link the standard library.
+      let linkFilePath: VirtualPath = resourceDirPath
+        .appending(components: "static-executable-args.lnk")
+
+      guard try fileSystem.exists(linkFilePath) else {
+        fatalError("\(linkFilePath) not found")
+      }
+      commandLine.append(.responseFilePath(linkFilePath))
+
+      // Explicitly pass the target to the linker
+      commandLine.appendFlag("--target=\(targetTriple.triple)")
+
+      // Delegate to Clang for sanitizers. It will figure out the correct linker
+      // options.
+      guard sanitizers.isEmpty else {
+        fatalError("WebAssembly does not support sanitizers, but a runtime library was found")
+      }
+
+      guard !parsedOptions.hasArgument(.profileGenerate) else {
+        throw Error.profilingUnsupportedForTarget(targetTriple.triple)
+      }
+
+      // Run clang++ in verbose mode if "-v" is set
+      try commandLine.appendLast(.v, from: &parsedOptions)
+
+      // These custom arguments should be right before the object file at the
+      // end.
+      try commandLine.append(
+        contentsOf: parsedOptions.arguments(in: .linkerOption)
+      )
+      try commandLine.appendAllArguments(.Xlinker, from: &parsedOptions)
+      try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+
+        // This should be the last option, for convenience in checking output.
+      commandLine.appendFlag(.o)
+      commandLine.appendPath(outputFile)
+      return clangPath
+    case .staticLibrary:
+      // We're using 'ar' as a linker
+      commandLine.appendFlag("crs")
+      commandLine.appendPath(outputFile)
+
+      commandLine.append(contentsOf: inputs.map { .path($0.file) })
+      return try getToolPath(.staticLinker(lto))
+    }
+  }
+}

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -1,0 +1,129 @@
+//===-------- WebAssemblyToolchain.swift - Swift WASM Toolchain -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+import SwiftOptions
+
+/// Toolchain for WebAssembly-based systems.
+@_spi(Testing) public final class WebAssemblyToolchain: Toolchain {
+  @_spi(Testing) public enum Error: Swift.Error, DiagnosticData {
+    case interactiveModeUnsupportedForTarget(String)
+    case dynamicLibrariesUnsupportedForTarget(String)
+    case sanitizersUnsupportedForTarget(String)
+    case profilingUnsupportedForTarget(String)
+
+    public var description: String {
+      switch self {
+      case .interactiveModeUnsupportedForTarget(let triple):
+        return "interactive mode is unsupported for target '\(triple)'; use 'swiftc' instead"
+      case .dynamicLibrariesUnsupportedForTarget(let triple):
+        return "dynamic libraries are unsupported for target '\(triple)'"
+      case .sanitizersUnsupportedForTarget(let triple):
+        return "sanitizers are unsupported for target '\(triple)'"
+      case .profilingUnsupportedForTarget(let triple):
+        return "profiling is unsupported for target '\(triple)'"
+      }
+    }
+  }
+
+  public let env: [String: String]
+
+  /// The executor used to run processes used to find tools and retrieve target info.
+  public let executor: DriverExecutor
+
+  /// The file system to use for queries.
+  public let fileSystem: FileSystem
+
+  /// Doubles as path cache and point for overriding normal lookup
+  private var toolPaths = [Tool: AbsolutePath]()
+
+  public let toolDirectory: AbsolutePath?
+
+  public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, toolDirectory: AbsolutePath? = nil) {
+    self.env = env
+    self.executor = executor
+    self.fileSystem = fileSystem
+    self.toolDirectory = toolDirectory
+  }
+
+  public func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String {
+    switch type {
+    case .executable:
+      return moduleName
+    case .dynamicLibrary:
+      // WASM doesn't support dynamic libraries yet, but we'll report the error later.
+      return ""
+    case .staticLibrary:
+      return "lib\(moduleName).a"
+    }
+  }
+
+  /// Retrieve the absolute path for a given tool.
+  public func getToolPath(_ tool: Tool) throws -> AbsolutePath {
+    // Check the cache
+    if let toolPath = toolPaths[tool] {
+      return toolPath
+    }
+    let path = try lookupToolPath(tool)
+    // Cache the path
+    toolPaths[tool] = path
+    return path
+  }
+
+  private func lookupToolPath(_ tool: Tool) throws -> AbsolutePath {
+    switch tool {
+    case .swiftCompiler:
+      return try lookup(executable: "swift-frontend")
+    case .staticLinker(nil):
+      return try lookup(executable: "ar")
+    case .staticLinker(.llvmFull),
+         .staticLinker(.llvmThin):
+      return try lookup(executable: "llvm-ar")
+    case .dynamicLinker:
+      // FIXME: This needs to look in the tools_directory first.
+      return try lookup(executable: "clang")
+    case .clang:
+      return try lookup(executable: "clang")
+    case .swiftAutolinkExtract:
+      return try lookup(executable: "swift-autolink-extract")
+    case .dsymutil:
+      return try lookup(executable: "dsymutil")
+    case .lldb:
+      return try lookup(executable: "lldb")
+    case .dwarfdump:
+      return try lookup(executable: "dwarfdump")
+    case .swiftHelp:
+      return try lookup(executable: "swift-help")
+    }
+  }
+
+  public func overrideToolPath(_ tool: Tool, path: AbsolutePath) {
+    toolPaths[tool] = path
+  }
+
+  public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {
+    return nil
+  }
+
+  public var shouldStoreInvocationInDebugInfo: Bool { false }
+
+  public func runtimeLibraryName(
+    for sanitizer: Sanitizer,
+    targetTriple: Triple,
+    isShared: Bool
+  ) throws -> String {
+    throw Error.sanitizersUnsupportedForTarget(targetTriple.triple)
+  }
+
+  public func platformSpecificInterpreterEnvironmentVariables(env: [String : String], parsedOptions: inout ParsedOptions, sdkPath: VirtualPath?, targetTriple: Triple) throws -> [String : String] {
+    throw Error.interactiveModeUnsupportedForTarget(targetTriple.triple)
+  }
+}

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -289,13 +289,15 @@ extension Triple {
       return "ps4"
     case .haiku:
       return "haiku"
+    case .wasi:
+      return "wasi"
 
     // Explicitly spell out the remaining cases to force a compile error when
     // Triple updates
     case .ananas, .cloudABI, .dragonFly, .fuchsia, .kfreebsd, .lv2, .netbsd,
          .openbsd, .solaris, .minix, .rtems, .nacl, .cnk, .aix, .cuda, .nvcl,
          .amdhsa, .elfiamcu, .mesa3d, .contiki, .amdpal, .hermitcore, .hurd,
-         .wasi, .emscripten:
+         .emscripten:
       return nil
     }
   }


### PR DESCRIPTION
This is an initial implementation of a WebAssembly toolchain. It shares a lot of similarities with the GenericUnixToolchain, but it doesn't support dynamic libraries and other features like sanitizers, profiling, etc. Overall, there are enough differences that trying to subclass GenericUnixToolchain seemed potentially error-prone.

The functionality in this PR goes a bit beyond the current Wasm support in the main Swift repo. I tested this change by installing swift-driver into a toolchain snapshot from the SwiftWasm fork and then verifying I could compile a basic working program.