### PR TITLE
-dump-ast overrides -wmo and -index-file

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1033,6 +1033,28 @@ extension Driver {
     let hasIndexFile = parsedOptions.hasArgument(.indexFile)
     let wantBatchMode = parsedOptions.hasFlag(positive: .enableBatchMode, negative: .disableBatchMode, default: false)
 
+    // AST dump doesn't work with `-wmo`/`-index-file`. Since it's not common to want to dump
+    // the AST, we assume that's the priority and ignore those flags, but we warn the
+    // user about this decision.
+    if useWMO && parsedOptions.hasArgument(.dumpAst) {
+      diagnosticsEngine.emit(.warning_option_overrides_another(overridingOption: .dumpAst,
+                                                               overridenOption: .wmo))
+      parsedOptions.eraseArgument(.wmo)
+      return .standardCompile
+    }
+
+    if hasIndexFile && parsedOptions.hasArgument(.dumpAst) {
+      diagnosticsEngine.emit(.warning_option_overrides_another(overridingOption: .dumpAst,
+                                                               overridenOption: .indexFile))
+      parsedOptions.eraseArgument(.indexFile)
+      parsedOptions.eraseArgument(.indexFilePath)
+      parsedOptions.eraseArgument(.indexStorePath)
+      parsedOptions.eraseArgument(.indexIgnoreStdlib)
+      parsedOptions.eraseArgument(.indexSystemModules)
+      parsedOptions.eraseArgument(.indexIgnoreSystemModules)
+      return .standardCompile
+    }
+
     if useWMO || hasIndexFile {
       if wantBatchMode {
         let disablingOption: Option = useWMO ? .wholeModuleOptimization : .indexFile

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -84,4 +84,8 @@ extension Diagnostic.Message {
   static func error_unknown_target(_ target: String) -> Diagnostic.Message {
     .error("unknown target '\(target)'")
   }
+
+  static func warning_option_overrides_another(overridingOption: Option, overridenOption: Option) -> Diagnostic.Message {
+    .warning("ignoring '\(overridenOption.spelling)' because '\(overridingOption.spelling)' was also specified")
+  }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2344,6 +2344,35 @@ final class SwiftDriverTests: XCTestCase {
     _ = try driverWithEmptySDK.planBuild()
   }
 
+  func testDumpASTOverride() throws {
+    try assertDriverDiagnostics(args: ["swiftc", "-wmo", "-dump-ast", "foo.swift"]) {
+      $1.expect(.warning("ignoring '-wmo' because '-dump-ast' was also specified"))
+      let jobs = try $0.planBuild()
+      XCTAssertEqual(jobs[0].kind, .compile)
+      XCTAssertFalse(jobs[0].commandLine.contains("-wmo"))
+      XCTAssertTrue(jobs[0].commandLine.contains("-dump-ast"))
+    }
+    
+    try assertDriverDiagnostics(args: ["swiftc", "-index-file", "-dump-ast",
+                                       "foo.swift",
+                                       "-index-file-path", "foo.swift",
+                                       "-index-store-path", "store/path",
+                                       "-index-ignore-stdlib", "-index-system-modules",
+                                       "-index-ignore-system-modules"]) {
+      $1.expect(.warning("ignoring '-index-file' because '-dump-ast' was also specified"))
+      let jobs = try $0.planBuild()
+      XCTAssertEqual(jobs[0].kind, .compile)
+      XCTAssertFalse(jobs[0].commandLine.contains("-wmo"))
+      XCTAssertFalse(jobs[0].commandLine.contains("-index-file"))
+      XCTAssertFalse(jobs[0].commandLine.contains("-index-file-path"))
+      XCTAssertFalse(jobs[0].commandLine.contains("-index-store-path"))
+      XCTAssertFalse(jobs[0].commandLine.contains("-index-ignore-stdlib"))
+      XCTAssertFalse(jobs[0].commandLine.contains("-index-system-modules"))
+      XCTAssertFalse(jobs[0].commandLine.contains("-index-ignore-system-modules"))
+      XCTAssertTrue(jobs[0].commandLine.contains("-dump-ast"))
+    }
+  }
+
   func testToolchainClangPath() throws {
     // Overriding the swift executable to a specific location breaks this.
     guard ProcessEnv.vars["SWIFT_DRIVER_SWIFT_EXEC"] == nil,


### PR DESCRIPTION
This fixes the Driver/ast_dump_with_WMO.swift test, and expands the override to cover -index-file as well based on a FIXME in the C++ source. If both are specified, a warning is emitted: `ignoring '-wmo' because '-dump-ast' was also specified`