### PR TITLE
SwiftDriver: use `ucrt` instead of `MSVCRT`

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -14,7 +14,7 @@ import TSCBasic
 #if canImport(Darwin)
 import Darwin.C
 #elseif os(Windows)
-import MSVCRT
+import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc


### PR DESCRIPTION
There is nothing that requires the use of `MSVCRT` (i.e. `stderr`,
`stdout`, or the overloaded math routines).  This eases the removal of
the `visualc` module from the Swift standard library.