### PR TITLE
Include prefix args from -driver-use-frontend-path in -print-target-info jobs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1967,7 +1967,8 @@ extension Driver {
           target: explicitTarget, targetVariant: explicitTargetVariant,
           sdkPath: sdkPath, resourceDirPath: resourceDirPath,
           runtimeCompatibilityVersion:
-            parsedOptions.getLastArgument(.runtimeCompatibilityVersion)?.asSingle
+            parsedOptions.getLastArgument(.runtimeCompatibilityVersion)?.asSingle,
+          swiftCompilerPrefixArgs: swiftCompilerPrefixArgs
         ),
         capturingJSONOutputAs: FrontendTargetInfo.self,
         forceResponseFiles: false,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -456,7 +456,8 @@ extension Driver {
                                               sdkPath: sdkPath,
                                               resourceDirPath: resourceDirPath,
                                               requiresInPlaceExecution: true,
-                                              useStaticResourceDir: useStaticResourceDir)
+                                              useStaticResourceDir: useStaticResourceDir,
+                                              swiftCompilerPrefixArgs: swiftCompilerPrefixArgs)
     }
 
     if parsedOptions.hasArgument(.version) || parsedOptions.hasArgument(.version_) {

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -125,9 +125,11 @@ extension Toolchain {
                           resourceDirPath: VirtualPath? = nil,
                           runtimeCompatibilityVersion: String? = nil,
                           requiresInPlaceExecution: Bool = false,
-                          useStaticResourceDir: Bool = false) throws -> Job {
-    var commandLine: [Job.ArgTemplate] = [.flag("-frontend"),
-                                          .flag("-print-target-info")]
+                          useStaticResourceDir: Bool = false,
+                          swiftCompilerPrefixArgs: [String]) throws -> Job {
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    commandLine.append(contentsOf: [.flag("-frontend"),
+                                    .flag("-print-target-info")])
     // If we were given a target, include it. Otherwise, let the frontend
     // tell us the host target.
     if let target = target {


### PR DESCRIPTION
This, along with https://github.com/apple/swift/pull/34405 will let us see real failures in the incremental dependency lit tests. Without these changes, nearly all the tests fail immediately because they rely on fake frontends and the -print-target-info decoding fails.