### PR TITLE
Don't pass a precompiled header to module merging jobs

### DIFF
--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -53,7 +53,7 @@ extension Driver {
     commandLine.appendFlag(.disableDiagnosticPasses)
     commandLine.appendFlag(.disableSilPerfOptzns)
 
-    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
+    try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, bridgingHeaderHandling: .parsed)
     // FIXME: Add MSVC runtime library flags
 
     addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: true)


### PR DESCRIPTION
Fixes:
ClangImporter/pch-bridging-header-unittest-ok.swift
ClangImporter/pch-bridging-header-unittest-warn.swift
ClangImporter/pch-bridging-header-with-another-bridging-header.swift

The c++ driver uses the original header when creating module merging jobs, and trying to use a pch causes weird failures in the test suite. I really don't understand why some frontend actions support precompiled headers and others don't, so it's possible there's a better solution to be found.