### PR TITLE
Intro incremental build alternative to emit module files separately

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -248,10 +248,9 @@ public struct Driver {
   /// Path to the Swift module source information file.
   let moduleSourceInfoPath: VirtualPath?
 
-  /// If the driver should force emit module in a single invocation.
-  ///
-  /// This will force the driver to first emit the module and then run compile jobs.
-  var forceEmitModuleInSingleInvocation: Bool = false
+  /// Force the driver to emit the module first and then run compile jobs. This could be used to unblock
+  /// dependencies in parallel builds.
+  var forceEmitModuleBeforeCompile: Bool = false
 
   /// Handler for constructing module build jobs using Explicit Module Builds.
   /// Constructed during the planning phase only when all modules will be prebuilt and treated

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -285,8 +285,9 @@ extension Driver {
 
     addJobOutputs(outputs)
 
-    // If we're creating emit module job, order the compile jobs after that.
-    if shouldCreateEmitModuleJob {
+    // If we're prioritizing the emit module job, schedule the compile jobs
+    // after that.
+    if forceEmitModuleBeforeCompile {
       inputs.append(TypedVirtualPath(file: moduleOutputInfo.output!.outputPath, type: .swiftModule))
     }
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -33,7 +33,7 @@ extension Driver {
     addSupplementalOutput(path: objcGeneratedHeaderPath, flag: "-emit-objc-header-path", type: .objcHeader)
     addSupplementalOutput(path: tbdPath, flag: "-emit-tbd-path", type: .tbd)
 
-    if isMergeModule {
+    if isMergeModule || shouldCreateEmitModuleJob {
       return
     }
     // Add outputs that can't be merged
@@ -92,8 +92,7 @@ extension Driver {
 
   /// Returns true if the emit module job should be created.
   var shouldCreateEmitModuleJob: Bool {
-    return forceEmitModuleInSingleInvocation
-      && compilerOutputType != .swiftModule
-      && moduleOutputInfo.output != nil
+    return forceEmitModuleBeforeCompile
+      || parsedOptions.hasArgument(.emitModuleSeparately)
   }
 }

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -67,6 +67,10 @@ extension Driver {
       inputs.append(input)
     }
 
+    if let pchPath = bridgingPrecompiledHeader {
+      inputs.append(TypedVirtualPath(file: pchPath, type: .pch))
+    }
+
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: Add MSVC runtime library flags
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -57,7 +57,7 @@ extension Driver {
       TypedVirtualPath(file: moduleOutputPath, type: .swiftModule)
     ]
 
-    commandLine.appendFlags("-frontend", "-emit-module")
+    commandLine.appendFlags("-frontend", "-emit-module", "-experimental-skip-non-inlinable-function-bodies")
 
     let swiftInputFiles = inputFiles.filter { $0.type.isPartOfSwiftCompilation }
 

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -291,7 +291,7 @@ extension Driver {
 
     /// Add all of the outputs needed for a given input.
     func addAllOutputsFor(input: TypedVirtualPath?) {
-      if !forceEmitModuleInSingleInvocation {
+      if !shouldCreateEmitModuleJob {
         addOutputOfType(
           outputType: .swiftModule,
           finalOutputPath: moduleOutputInfo.output?.outputPath,
@@ -307,20 +307,22 @@ extension Driver {
           finalOutputPath: moduleSourceInfoPath,
           input: input,
           flag: "-emit-module-source-info-path")
+      }
+
+      addOutputOfType(
+        outputType: .dependencies,
+        finalOutputPath: dependenciesFilePath,
+        input: input,
+        flag: "-emit-dependencies-path")
+
+      if let input = input, let outputFileMap = outputFileMap {
+        let referenceDependenciesPath =
+          outputFileMap.existingOutput(inputFile: input.file, outputType: .swiftDeps)
         addOutputOfType(
-          outputType: .dependencies,
-          finalOutputPath: dependenciesFilePath,
+          outputType: .swiftDeps,
+          finalOutputPath: referenceDependenciesPath,
           input: input,
-          flag: "-emit-dependencies-path")
-        if let input = input, let outputFileMap = outputFileMap {
-          let referenceDependenciesPath =
-            outputFileMap.existingOutput(inputFile: input.file, outputType: .swiftDeps)
-          addOutputOfType(
-            outputType: .swiftDeps,
-            finalOutputPath: referenceDependenciesPath,
-            input: input,
-            flag: "-emit-reference-dependencies-path")
-        }
+          flag: "-emit-reference-dependencies-path")
       }
 
       addOutputOfType(

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -242,7 +242,9 @@ extension Driver {
           let job = try backendJob(input: input, addJobOutputs: addJobOutputs)
           addJob(job)
         }
-      } else {
+      } else if !(compilerOutputType == .swiftModule && shouldCreateEmitModuleJob) {
+        // We can skip the compile jobs if all we want is a module when it's
+        // built separately.
         let job = try compileJob(primaryInputs: primaryInputs,
                                  outputType: compilerOutputType,
                                  addJobOutputs: addJobOutputs,

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -13,12 +13,14 @@ extension Option {
   public static let driverPrintGraphviz: Option = Option("-driver-print-graphviz", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Write the job graph as a graphviz file", group: .internalDebug)
   public static let driverExplicitModuleBuild: Option = Option("-experimental-explicit-module-build", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
   public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver.")
+  public static let emitModuleSeparately: Option = Option("-experimental-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job")
 
   public static var extraOptions: [Option] {
     return [
       Option.driverPrintGraphviz,
       Option.driverExplicitModuleBuild,
-      Option.driverWarnUnusedOptions
+      Option.driverWarnUnusedOptions,
+      Option.emitModuleSeparately
     ]
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1569,6 +1569,19 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath("/foo/bar/Test.swiftdoc")))
       XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath("/foo/bar/Test.swiftsourceinfo")))
     }
+
+    do {
+      // We don't expect partial jobs when asking only for the swiftmodule with
+      // -experimental-emit-module-separately.
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", "/foo/bar/Test.swiftmodule", "-experimental-emit-module-separately"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
+      XCTAssertEqual(plannedJobs[0].outputs.count, 3)
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath("/foo/bar/Test.swiftmodule")))
+      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath("/foo/bar/Test.swiftdoc")))
+      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath("/foo/bar/Test.swiftsourceinfo")))
+    }
   }
 
   func testModuleWrapJob() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1558,6 +1558,19 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testEmitModuleSeparately() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", "/foo/bar/Test.swiftmodule", "-experimental-emit-module-separately", "-emit-library", "-target", "x86_64-apple-macosx10.15"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 4)
+      XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
+      XCTAssertEqual(plannedJobs[0].outputs.count, 3)
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath("/foo/bar/Test.swiftmodule")))
+      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath("/foo/bar/Test.swiftdoc")))
+      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath("/foo/bar/Test.swiftsourceinfo")))
+    }
+  }
+
   func testModuleWrapJob() throws {
     // FIXME: These tests will fail when run on macOS, because
     // swift-autolink-extract is not present


### PR DESCRIPTION
Incremental compilation currently relies on a merge-module phase. A typical
build plan for a module App composed of two source files (`A.swift` and `B.swift`)
involves four main jobs:

1. Compile `A.swift`, output `A.o` and `A~partial.swiftmodule`.
2. Compile `B.swift`, output `B.o` and `B~partial.swiftmodule`.
3. Link `A.o` and `B.o` in the final executable.
4. Merge-module: merging `A~partial.swiftmodule` and `B~partial.swiftmodule` to form
the final `App.swiftmodule`.

Jobs 3 and 4 must run after jobs 1 and 2 to use their outputs.

The flag `-experimental-emit-module-separately` replaces the merge-module job but
the emit-module job that can run in parallel to the other jobs and doesn’t need
the partial swiftmodules.

1. Compile `A.swift`, output `A.o`.
2. Compile `B.swift`, output `B.o`.
3. Link `A.o` and `B.o` in the final executable. (Only job 3 must run after jobs 1. and 2.)
4. Emit-module: Parse `A.swift` and `B.swift` to generate the final `App.swiftmodule`.

Early comparison with merge-module indicates similar performances and even a
slight gain with all of the optimizations applied here. However, the use of
`-experimental-skip-non-inlinable-function-bodies` may be too aggressive.

rdar://69330639