### PR TITLE
Fix a regression affecting command line linker inputs

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -196,19 +196,18 @@ extension Driver {
     addLinkerInput: (TypedVirtualPath) -> Void,
     addJobOutputs: ([TypedVirtualPath]) -> Void)
   throws {
-    let swiftInputFiles = inputFiles.filter { inputFile in
-      inputFile.type.isPartOfSwiftCompilation
-    }
-    for (index, input) in swiftInputFiles.enumerated() {
+    let loadedModuleTraceInputIndex = inputFiles.firstIndex(where: {
+      $0.type.isPartOfSwiftCompilation && loadedModuleTracePath != nil
+    })
+    for (index, input) in inputFiles.enumerated() {
       // Only emit a loaded module trace from the first frontend job.
-      let emitModuleTrace = (index == swiftInputFiles.startIndex) && (loadedModuleTracePath != nil)
       try addJobForPrimaryInput(
         input: input,
         addJobGroup: addJobGroup,
         addModuleInput: addModuleInput,
         addLinkerInput: addLinkerInput,
         addJobOutputs: addJobOutputs,
-        emitModuleTrace: emitModuleTrace)
+        emitModuleTrace: index == loadedModuleTraceInputIndex)
     }
   }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -329,7 +329,7 @@ final class IncrementalCompilationTests: XCTestCase {
       }
       let args: [String] = [
         "swiftc",
-        "module-name", module,
+        "-module-name", module,
         "-o", derivedDataPath.appending(component: module + ".o").pathString,
         "-output-file-map", OFM.pathString,
         "-driver-show-incremental",


### PR DESCRIPTION
Object files and other linker inputs specified on the command line should be included in the linker job. Additionally, if a loaded module trace is emitted, it should be associated with the first input to a compile job, which isn't necessarily the first input.

I added a couple of regression tests, and this also fixes a large number of lit tests (it took me awhile to notice the regression because it didn't affect anything in the Driver folder, I'm not sure exactly when it happened)