### PR TITLE
Fix using the driver as a linker

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -104,7 +104,7 @@ extension Driver {
     addJobGroup: ([Job]) -> Void
   ) throws -> [TypedVirtualPath] {
 
-    var linkerInputs = [TypedVirtualPath]()
+    var linkerInputs = inputFiles.filter { $0.type == .object }
     func addLinkerInput(_ li: TypedVirtualPath) { linkerInputs.append(li) }
 
     var moduleInputs = [TypedVirtualPath]()


### PR DESCRIPTION
This fixes 16 Interpreter tests and 4 stdlib tests which relied on this functionality.