### PR TITLE
Fix for simulator and linux -profile-generate linker args

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -116,12 +116,11 @@ extension DarwinToolchain {
     let clangPath = try clangLibraryPath(for: targetTriple,
                                          parsedOptions: &parsedOptions)
 
-    let runtime = targetTriple.darwinPlatform!.libraryNameSuffix
-
-    let clangRTPath = clangPath
-      .appending(component: "libclang_rt.profile_\(runtime).a")
-
-    commandLine.appendPath(clangRTPath)
+    for runtime in targetTriple.darwinPlatform!.profileLibraryNameSuffixes {
+      let clangRTPath = clangPath
+        .appending(component: "libclang_rt.profile_\(runtime).a")
+      commandLine.appendPath(clangRTPath)
+    }
   }
 
   private func addPlatformVersionArg(to commandLine: inout [Job.ArgTemplate],
@@ -370,5 +369,26 @@ extension DarwinToolchain {
     commandLine.appendPath(outputFile)
 
     return try getToolPath(linkerTool)
+  }
+}
+
+private extension DarwinPlatform {
+  var profileLibraryNameSuffixes: [String] {
+    switch self {
+    case .macOS, .iOS(.catalyst):
+      return ["osx"]
+    case .iOS(.device):
+      return ["ios"]
+    case .iOS(.simulator):
+      return ["iossim", "ios"]
+    case .tvOS(.device):
+      return ["tvos"]
+    case .tvOS(.simulator):
+      return ["tvossim", "tvos"]
+    case .watchOS(.device):
+      return ["watchos"]
+    case .watchOS(.simulator):
+      return ["watchossim", "watchos"]
+    }
   }
 }

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -244,7 +244,7 @@ extension GenericUnixToolchain {
         let libProfile = sharedResourceDirPath
           .parentDirectory // remove platform name
           .appending(components: "clang", "lib", targetTriple.osName,
-                                 "libclangrt_profile-\(targetTriple.archName).a")
+                                 "libclang_rt.profile-\(targetTriple.archName).a")
         commandLine.appendPath(libProfile)
 
         // HACK: Hard-coded from llvm::getInstrProfRuntimeHookVarName()

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2083,7 +2083,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssert(plannedJobs[1].commandLine.containsPathWithBasename("libclang_rt.profile_watchos.a"))
     }
 
-    // FIXME: These will fail when run on macOS, because
+    // FIXME: This will fail when run on macOS, because
     // swift-autolink-extract is not present
     #if os(Linux)
     do {
@@ -2095,18 +2095,6 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertEqual(plannedJobs[1].kind, .link)
       XCTAssert(plannedJobs[1].commandLine.containsPathWithBasename("libclang_rt.profile-x86_64.a"))
-      XCTAssert(plannedJobs[1].commandLine.contains { $0 == .flag("-u__llvm_profile_runtime") })
-    }
-
-    do {
-      var driver = try Driver(args: ["swiftc", "-profile-generate", "-target", "wasm32-unknown-wasi", "test.swift"])
-      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
-
-      XCTAssertEqual(plannedJobs.count, 2)
-      XCTAssertEqual(plannedJobs[0].kind, .compile)
-
-      XCTAssertEqual(plannedJobs[1].kind, .link)
-      XCTAssert(plannedJobs[1].commandLine.containsPathWithBasename("libclang_rt.profile-wasm32.a"))
       XCTAssert(plannedJobs[1].commandLine.contains { $0 == .flag("-u__llvm_profile_runtime") })
     }
     #endif


### PR DESCRIPTION
Need the `#if os(Linux)` tests to run in CI to verify they are correct because I wasn't able to run them. The swift docker images only seem to be for releases, and we require print-target-info changes from main.