### PR TITLE
[Explicit Module Builds] Re-use external build artifacts to avoid redundant Swift moduel re-scan

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(SwiftDriver
   "Explicit Module Builds/ClangModuleBuildJobCache.swift"
   "Explicit Module Builds/ClangVersionedDependencyResolution.swift"
   "Explicit Module Builds/CommonDependencyGraphOperations.swift"
-  "Explicit Module Builds/ExplicitModuleBuildHandler.swift"
+  "Explicit Module Builds/ExplicitDependencyBuildPlanner.swift"
   "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
   "Explicit Module Builds/PlaceholderDependencyResolution.swift"

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -252,10 +252,10 @@ public struct Driver {
   /// dependencies in parallel builds.
   var forceEmitModuleBeforeCompile: Bool = false
 
-  /// Handler for constructing module build jobs using Explicit Module Builds.
+  /// Planner for constructing module build jobs using Explicit Module Builds.
   /// Constructed during the planning phase only when all modules will be prebuilt and treated
   /// as explicit by the various compilation jobs.
-  @_spi(Testing) public var explicitModuleBuildHandler: ExplicitModuleBuildHandler? = nil
+  @_spi(Testing) public var explicitDependencyBuildPlanner: ExplicitDependencyBuildPlanner? = nil
 
   /// All external artifacts a build system (e.g. SwiftPM) may pass in as input to the explicit
   /// build of the current module. Consists of a map of externally-built targets, and a map of all previously

--- a/Sources/SwiftDriver/Explicit Module Builds/CommonDependencyGraphOperations.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/CommonDependencyGraphOperations.swift
@@ -110,8 +110,8 @@ internal extension InterModuleDependencyGraph {
       }
       if let originalModuleIndex = moduleInfo.directDependencies?.firstIndex(of: originalId) {
         moduleInfo.directDependencies![originalModuleIndex] = replacementId;
+        moduleInfoMap[moduleId] = moduleInfo
       }
-      moduleInfoMap[moduleId] = moduleInfo
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -424,19 +424,19 @@ extension Driver {
   /// to inputs and command line arguments of a compile job.
   func addExplicitModuleBuildArguments(inputs: inout [TypedVirtualPath],
                                        commandLine: inout [Job.ArgTemplate]) throws {
-    guard var handler = explicitModuleBuildHandler else {
-      fatalError("No handler in Explicit Module Build mode.")
+    guard var dependencyPlanner = explicitDependencyBuildPlanner else {
+      fatalError("No dependency planner in Explicit Module Build mode.")
     }
-    try handler.resolveMainModuleDependencies(inputs: &inputs, commandLine: &commandLine)
+    try dependencyPlanner.resolveMainModuleDependencies(inputs: &inputs, commandLine: &commandLine)
   }
 
   /// In Explicit Module Build mode, distinguish between main module jobs and intermediate dependency build jobs,
   /// such as Swift modules built from .swiftmodule files and Clang PCMs.
   public func isExplicitMainModuleJob(job: Job) -> Bool {
-    guard let handler = explicitModuleBuildHandler else {
-      fatalError("No handler in Explicit Module Build mode.")
+    guard let dependencyPlanner = explicitDependencyBuildPlanner else {
+      fatalError("No dependency planner in Explicit Module Build mode.")
     }
-    return job.moduleName == handler.dependencyGraph.mainModuleName
+    return job.moduleName == dependencyPlanner.dependencyGraph.mainModuleName
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -373,10 +373,10 @@ extension Driver {
   /// by re-scanning all Clang modules against all possible targets they will be built against.
   public mutating func generateExplicitModuleDependenciesJobs() throws -> [Job] {
     let dependencyGraph = try generateInterModuleDependencyGraph()
-    explicitModuleBuildHandler =
-        try ExplicitModuleBuildHandler(dependencyGraph: dependencyGraph,
+    explicitDependencyBuildPlanner =
+        try ExplicitDependencyBuildPlanner(dependencyGraph: dependencyGraph,
                                        toolchain: toolchain)
-    return try explicitModuleBuildHandler!.generateExplicitModuleDependenciesBuildJobs()
+    return try explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
   }
 
   private mutating func generateInterModuleDependencyGraph() throws -> InterModuleDependencyGraph {
@@ -390,7 +390,7 @@ extension Driver {
                                 recordedInputModificationDates: recordedInputModificationDates)
 
     // Resolve placeholder dependencies in the dependency graph, if any.
-    if externalBuildArtifacts != nil, !externalBuildArtifacts!.0.isEmpty {
+    if externalBuildArtifacts != nil {
       try dependencyGraph.resolvePlaceholderDependencies(using: externalBuildArtifacts!)
     }
 
@@ -491,7 +491,6 @@ extension Driver {
 
   /// Plan a build by producing a set of jobs to complete the build.
   public mutating func planBuild() throws -> [Job] {
-
     if let job = try immediateForwardingJob() {
       return [job]
     }

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -265,10 +265,10 @@ enum ModuleDependenciesInputs {
               "swiftPlaceholder": "B"
             },
             {
-              "swift": "Swift"
+              "swiftPlaceholder": "Swift"
             },
             {
-              "swift": "SwiftOnoneSupport"
+              "swiftPlaceholder": "SwiftOnoneSupport"
             }
           ],
           "details": {
@@ -300,7 +300,7 @@ enum ModuleDependenciesInputs {
           }
         },
         {
-          "swift": "Swift"
+          "swiftPlaceholder": "Swift"
         },
         {
           "modulePath": "Swift.swiftmodule",
@@ -309,65 +309,21 @@ enum ModuleDependenciesInputs {
           "directDependencies": [
           ],
           "details": {
-            "swift": {
-              "moduleInterfacePath": "Swift.swiftmodule/x86_64-apple-macos.swiftinterface",
-              "commandLine": [
-                "-frontend",
-                "-compile-module-from-interface",
-                "-target",
-                "x86_64-apple-macosx10.10",
-                "-swift-version",
-                "5",
-                "-module-name",
-                "Swift"
-              ],
-              "isFramework": false,
-              "extraPcmArgs": [
-                "-Xcc",
-                "-target",
-                "-Xcc",
-                "x86_64-apple-macosx10.9",
-                "-Xcc",
-                "-fapinotes-swift-version=5"
-              ]
+            "swiftPlaceholder": {
             }
           }
         },
         {
-          "swift": "SwiftOnoneSupport"
+          "swiftPlaceholder": "SwiftOnoneSupport"
         },
         {
           "modulePath": "SwiftOnoneSupport.swiftmodule",
           "sourceFiles": [
           ],
           "directDependencies": [
-            {
-              "swift": "Swift"
-            }
           ],
           "details": {
-            "swift": {
-              "moduleInterfacePath": "SwiftOnoneSupport.swiftmodule/x86_64-apple-macos.swiftinterface",
-              "contextHash": "3GKS4RKE3GDZA",
-              "isFramework": false,
-              "commandLine": [
-                "-frontend",
-                "-compile-module-from-interface",
-                "-target",
-                "x86_64-apple-macosx10.10",
-                "-swift-version",
-                "5",
-                "-module-name",
-                "SwiftOnoneSupport"
-              ],
-              "extraPcmArgs": [
-                "-Xcc",
-                "-target",
-                "-Xcc",
-                "x86_64-apple-macosx10.9",
-                "-Xcc",
-                "-fapinotes-swift-version=5"
-              ]
+            "swiftPlaceholder": {
             }
           }
         }


### PR DESCRIPTION
In contexts where SwiftDriver is used to plan a multi-module build (e.g. SwiftPM), use the `ModuleInfoMap` containing results of prior scans to avoid further redundant re-scanning.

_All_ previously-seen Swift modules are treated as potential placeholder dependencies during subsequent dependency-scanning actions. This causes the dependency scanner, upon encountering an `import` of such module, to not: search for its interface, parse it, and build a full dependency tree yet again.
The dependency scanner output, on subsequent re-scans, is therefore a much shallower graph with many placeholders, which get _resolved_ in the client (SwiftDriver) using the external `ModuleInfoMap` provided by the build system.

For planning the build of SwiftPM with _Explicit Modules_, this change reduces the build-planning time by ~2x. 

This PR:
- Serializes *all* previously-seen Swift modules, not just ones corresponding to build targets, as placeholder inputs to the dependency-scanning action.
- Adds resolve logic for additional, non-target Swift modules found in the initial inter-module dependency graph.
- Renames `ExplicitModuleBuildHandler` to `ExplicitDependencyBuildPlanner`.
- Modifies `testModuleDependencyWithExternalCommandGeneration` to exercise non-target placeholder resolution.