### PR TITLE
Add a version number indicating swift-driver's source version

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(SwiftDriver
   Driver/ModuleOutputInfo.swift
   Driver/OutputFileMap.swift
   Driver/ToolExecutionDelegate.swift
+  Driver/DriverVersion.swift
 
   Execution/ArgsResolver.swift
   Execution/DriverExecutor.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -830,6 +830,12 @@ extension Driver {
       buildRecordInfo == nil) {
       assert(jobs.count == 1, "Cannot execute in place for multi-job build plans")
       var job = jobs[0]
+      // Print the driver source version first before we print the compiler
+      // versions.
+      if job.kind == .versionRequest && !Driver.driverSourceVersion.isEmpty {
+        stderrStream <<< "swift-driver version: " <<< Driver.driverSourceVersion <<< "\n"
+        stderrStream.flush()
+      }
       // Require in-place execution for all single job plans.
       job.requiresInPlaceExecution = true
       try executor.execute(job: job,

--- a/Sources/SwiftDriver/Driver/DriverVersion.swift
+++ b/Sources/SwiftDriver/Driver/DriverVersion.swift
@@ -1,0 +1,18 @@
+//===------ DriverVersion.swift - Swift Driver Source Version--------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+extension Driver {
+#if SWIFT_DRIVER_VERSION_DEFINED
+  static let driverSourceVersion: String = SWIFT_DRIVER_VERSION
+#else
+  static let driverSourceVersion: String = ""
+#endif
+}


### PR DESCRIPTION
When swift-driver is releases separately from the compiler, an independent version number could help.