### PR TITLE
Preserve nested type info in swiftmodule files generated by the emit-module job

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -57,7 +57,7 @@ extension Driver {
       TypedVirtualPath(file: moduleOutputPath, type: .swiftModule)
     ]
 
-    commandLine.appendFlags("-frontend", "-emit-module", "-experimental-skip-non-inlinable-function-bodies")
+    commandLine.appendFlags("-frontend", "-emit-module", "-experimental-skip-non-inlinable-function-bodies-without-types")
 
     let swiftInputFiles = inputFiles.filter { $0.type.isPartOfSwiftCompilation }
 


### PR DESCRIPTION
Use the new frontend flag `-experimental-skip-non-inlinable-function-bodies-without-types` in emit-module jobs in order to preserve all type information that LLDB relies on.

Depends on https://github.com/apple/swift/pull/34612