### PR TITLE
[Incremental] Interleave waves by adding llbuild rules dynamically

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -880,29 +880,16 @@ extension Driver {
     allJobs: [Job],
     forceResponseFiles: Bool
   ) throws {
-    // Create and use the tool execution delegate if one is not provided explicitly.
-    let executorDelegate = createToolExecutionDelegate()
-
-    func execute(jobs: [Job]) throws {
-      try executor.execute(jobs: jobs,
-                           delegate: executorDelegate,
-                           numParallelJobs: numParallelJobs ?? 1,
-                           forceResponseFiles: forceResponseFiles,
-                           recordedInputModificationDates: recordedInputModificationDates)
+    var numParallelJobs: Int {
+      self.numParallelJobs ?? 1
     }
-
-    guard let incrementalCompilationState = incrementalCompilationState else {
-      try execute(jobs: allJobs)
-      return
-    }
-    while let jobs = incrementalCompilationState.preOrCompileJobs.dequeue() {
-      try execute(jobs: formBatchedJobs(jobs, forIncremental: true))
-    }
-    guard let postCompileJobs = incrementalCompilationState.postCompileJobs
-    else {
-      fatalError("planning must have finished by now")
-    }
-    try execute(jobs: postCompileJobs)
+    try executor.execute(
+      jobs: allJobs,
+      incrementalCompilationState: incrementalCompilationState,
+      delegate: createToolExecutionDelegate(),
+      numParallelJobs: numParallelJobs,
+      forceResponseFiles: forceResponseFiles,
+      recordedInputModificationDates: recordedInputModificationDates)
   }
 
   private func printBindings(_ job: Job) {

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -880,14 +880,11 @@ extension Driver {
     allJobs: [Job],
     forceResponseFiles: Bool
   ) throws {
-    var numParallelJobs: Int {
-      self.numParallelJobs ?? 1
-    }
     try executor.execute(
       jobs: allJobs,
       incrementalCompilationState: incrementalCompilationState,
       delegate: createToolExecutionDelegate(),
-      numParallelJobs: numParallelJobs,
+      numParallelJobs: numParallelJobs ?? 1,
       forceResponseFiles: forceResponseFiles,
       recordedInputModificationDates: recordedInputModificationDates)
   }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -881,8 +881,7 @@ extension Driver {
     forceResponseFiles: Bool
   ) throws {
     try executor.execute(
-      jobs: allJobs,
-      incrementalCompilationState: incrementalCompilationState,
+      workload: .init(allJobs, incrementalCompilationState),
       delegate: createToolExecutionDelegate(),
       numParallelJobs: numParallelJobs ?? 1,
       forceResponseFiles: forceResponseFiles,

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -73,7 +73,6 @@ struct ToolExecutionDelegate: JobExecutionDelegate {
     }
 
     buildRecordInfo?.jobFinished(job: job, result: result)
-    incrementalCompilationState?.jobFinished(job: job, result: result)
 
     switch mode {
     case .regular, .verbose:

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -23,13 +23,23 @@ public protocol DriverExecutor {
                recordedInputModificationDates: [TypedVirtualPath: Date]) throws -> ProcessResult
   
   /// Execute multiple jobs, tracking job status using the provided execution delegate.
+  /// Pass in the `IncrementalCompilationState` to allow for incremental compilation.
+  func execute(jobs: [Job],
+               incrementalCompilationState: IncrementalCompilationState?,
+               delegate: JobExecutionDelegate,
+               numParallelJobs: Int,
+               forceResponseFiles: Bool,
+               recordedInputModificationDates: [TypedVirtualPath: Date]
+  ) throws
+
+  /// Execute multiple jobs, tracking job status using the provided execution delegate.
   func execute(jobs: [Job],
                delegate: JobExecutionDelegate,
                numParallelJobs: Int,
                forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath: Date]
   ) throws
-  
+
   /// Launch a process with the given command line and report the result.
   @discardableResult
   func checkNonZeroExit(args: String..., environment: [String: String]) throws -> String
@@ -68,6 +78,22 @@ extension DriverExecutor {
     catch let err as DecodingError {
       throw JobExecutionError.decodingError(err, outputData, result)
     }
+  }
+
+  public func execute(
+    jobs: [Job],
+    delegate: JobExecutionDelegate,
+    numParallelJobs: Int,
+    forceResponseFiles: Bool,
+    recordedInputModificationDates: [TypedVirtualPath: Date]
+  ) throws {
+    try execute(
+      jobs: jobs,
+      incrementalCompilationState: nil,
+      delegate: delegate,
+      numParallelJobs: numParallelJobs,
+      forceResponseFiles: forceResponseFiles,
+      recordedInputModificationDates: recordedInputModificationDates)
   }
 
   static func computeReturnCode(exitStatus: ProcessResult.ExitStatus) -> Int {

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -439,7 +439,7 @@ extension IncrementalCompilationState {
     if finishedJob.kind == .compile {
       finishedJob.primaryInputs.forEach {
         if pendingInputs.remove($0) == nil {
-          fatalError("should have been pending")
+          fatalError("\($0) input to newly-finished \(finishedJob) should have been pending")
         }
       }
     }

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -33,7 +33,7 @@ public class IncrementalCompilationState {
 
   /// Input files that were skipped.
   /// May shrink if one of these moves into pendingInputs. In that case, it will be an input to a
-  /// "secondary" job.
+  /// "newly-discovered" job.
   private(set) var skippedCompilationInputs: Set<TypedVirtualPath>
 
   /// Job groups that were skipped.

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -32,7 +32,8 @@ public class IncrementalCompilationState {
   private var pendingInputs = Set<TypedVirtualPath>()
 
   /// Input files that were skipped.
-  /// May shrink if one of these moves into pendingInputs.
+  /// May shrink if one of these moves into pendingInputs. In that case, it will be an input to a
+  /// "secondary" job.
   private(set) var skippedCompilationInputs: Set<TypedVirtualPath>
 
   /// Job groups that were skipped.
@@ -40,7 +41,7 @@ public class IncrementalCompilationState {
   /// treated as a unit.
   private var skippedCompileGroups = [TypedVirtualPath: [Job]]()
 
-  /// Jobs to run after the last compile
+  /// Jobs to run *after* the last compile, for instance, link-editing.
   public private(set) var tertiaryJobs = [Job]()
 
   /// A check for reentrancy.

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -169,7 +169,7 @@ fileprivate extension IncrementalCompilationState {
 }
 
 extension Diagnostic.Message {
-  static var warning_incremental_requires_output_file_map: Diagnostic.Message {
+  fileprivate static var warning_incremental_requires_output_file_map: Diagnostic.Message {
     .warning("ignoring -incremental (currently requires an output file map)")
   }
   static var warning_incremental_requires_build_record_entry: Diagnostic.Message {
@@ -178,10 +178,10 @@ extension Diagnostic.Message {
         "output file map has no master dependencies entry under \(FileType.swiftDeps)"
     )
   }
-  static func remark_incremental_compilation_disabled(because why: String) -> Diagnostic.Message {
+  fileprivate static func remark_incremental_compilation_disabled(because why: String) -> Diagnostic.Message {
     .remark("Incremental compilation has been disabled, because \(why)")
   }
-  static func remark_incremental_compilation(because why: String) -> Diagnostic.Message {
+  fileprivate static func remark_incremental_compilation(because why: String) -> Diagnostic.Message {
     .remark("Incremental compilation: \(why)")
   }
 }
@@ -379,7 +379,7 @@ extension IncrementalCompilationState {
 
   /// Remember that `group` (a compilation and possibly bitcode generation)
   /// must definitely be executed.
-  func scheduleMandatoryPreOrCompile(group: [Job]) {
+  private func scheduleMandatoryPreOrCompile(group: [Job]) {
     if let report = reportIncrementalDecision {
       for job in group {
         report("Queuing \(job.descriptionForLifecycle)", nil)
@@ -393,7 +393,7 @@ extension IncrementalCompilationState {
   }
 
   /// Decide if this job does not need to run, unless some yet-to-be-discovered dependency changes.
-  func isSkipped(_ job: Job) -> Bool {
+  private func isSkipped(_ job: Job) -> Bool {
     guard job.kind == .compile else {
       return false
     }
@@ -402,7 +402,7 @@ extension IncrementalCompilationState {
   }
 
   /// Remember that this job-group will be skipped (but may be needed later)
-  func recordSkippedGroup(_ group: [Job]) {
+  private func recordSkippedGroup(_ group: [Job]) {
     let job = group.first!
     for input in job.primaryInputs {
       if let _ = skippedCompileGroups.updateValue(group, forKey: input) {

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -374,7 +374,7 @@ extension IncrementalCompilationState {
         recordSkippedGroup(group)
       }
       else {
-        try scheduleMandatoryPreOrCompile(group: group, formBatchedJobs: formBatchedJobs)
+        try scheduleMandatoryPreOrCompile(group: group)
       }
     }
   }
@@ -382,19 +382,17 @@ extension IncrementalCompilationState {
   /// Remember that `group` (a compilation and possibly bitcode generation)
   /// must definitely be executed.
   private func scheduleMandatoryPreOrCompile(
-    group: [Job],
-    formBatchedJobs: ([Job]) throws -> [Job]
-  ) throws {
+    group: [Job]) {
     if let report = reportIncrementalDecision {
       for job in group {
         report("Queuing \(job.descriptionForLifecycle)", nil)
       }
     }
-    mandatoryPreOrCompileJobsInOrder.append(contentsOf: try formBatchedJobs(group))
+    mandatoryPreOrCompileJobsInOrder.append(contentsOf: group)
     unfinishedMandatoryJobs.formUnion(group)
-    let mandantoryCompilationInputs = group
+    let mandatoryCompilationInputs = group
       .flatMap {$0.kind == .compile ? $0.primaryInputs : []}
-    pendingInputs.formUnion(mandantoryCompilationInputs)
+    pendingInputs.formUnion(mandatoryCompilationInputs)
   }
 
   /// Decide if this job does not need to run, unless some yet-to-be-discovered dependency changes.

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -60,7 +60,9 @@ extension Driver {
     try addPrecompileModuleDependenciesJobs(addJob: addPreOrCompileJob)
     try addPrecompileBridgingHeaderJob(addJob: addPreOrCompileJob)
     try addEmitModuleJob(addJob: addPreOrCompileJob)
-    let linkerInputs = try addJobsFeedingLinker(addJobGroup: addPreOrCompileJobGroup)
+    let linkerInputs = try addJobsFeedingLinker(
+      addJobGroup: addPreOrCompileJobGroup,
+      addPostCompileJob: addPostCompileJob)
     try addLinkAndPostLinkJobs(linkerInputs: linkerInputs,
                                debugInfo: debugInfo,
                                addJob: addPostCompileJob)
@@ -101,7 +103,8 @@ extension Driver {
   }
 
   private mutating func addJobsFeedingLinker(
-    addJobGroup: ([Job]) -> Void
+    addJobGroup: ([Job]) -> Void,
+    addPostCompileJob: (Job) -> Void
   ) throws -> [TypedVirtualPath] {
 
     var linkerInputs = [TypedVirtualPath]()
@@ -143,17 +146,17 @@ extension Driver {
 
     try addAutolinkExtractJob(linkerInputs: linkerInputs,
                               addLinkerInput: addLinkerInput,
-                              addJob: addJob)
+                              addJob: addPostCompileJob)
 
     if let mergeJob = try mergeModuleJob(
         moduleInputs: moduleInputs,
         moduleInputsFromJobOutputs: moduleInputsFromJobOutputs) {
-      addJob(mergeJob)
-      try addVerifyJobs(mergeJob: mergeJob, addJob: addJob)
+      addPostCompileJob(mergeJob)
+      try addVerifyJobs(mergeJob: mergeJob, addJob: addPostCompileJob)
       try addWrapJobOrMergeOutputs(
         mergeJob: mergeJob,
         debugInfo: debugInfo,
-        addJob: addJob,
+        addJob: addPostCompileJob,
         addLinkerInput: addLinkerInput)
     }
     return linkerInputs

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -599,14 +599,14 @@ extension Driver {
           diagnosticEngine
             .emit(
               .remark(
-                "Adding {compile: \($0.file.basename)} to batch \(idx)\n"))
+                "Adding {compile: \($0.file.basename)} to batch \(idx)"))
         }
 
         let constituents = primaryInputs.map {$0.file.basename}.joined(separator: ", ")
         diagnosticEngine
           .emit(
             .remark(
-              "Forming batch job from \(primaryInputs.count) constituents: \(constituents)\n"))
+              "Forming batch job from \(primaryInputs.count) constituents: \(constituents)"))
       }
       let constituentsEmittedModuleTrace = !inputsRequiringModuleTrace.intersection(primaryInputs).isEmpty
       // no need to add job outputs again

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -65,8 +65,8 @@ extension Driver {
                                debugInfo: debugInfo,
                                addJob: addPostCompileJob)
 
-    incrementalCompilationState?.addPreOrCompileJobGroups(preAndCompileJobGroups)
-    incrementalCompilationState?.addPostCompileJobs(postCompileJobs)
+    incrementalCompilationState?.addPrimaryOrSkippedJobGroups(preAndCompileJobGroups)
+    incrementalCompilationState?.addTertiaryJobs(postCompileJobs)
 
     return try formBatchedJobs(allJobs, forIncremental: false)
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -67,7 +67,9 @@ extension Driver {
                                debugInfo: debugInfo,
                                addJob: addPostCompileJob)
 
-    incrementalCompilationState?.addPreOrCompileJobGroups(preAndCompileJobGroups)
+    try incrementalCompilationState?.addPreOrCompileJobGroups(preAndCompileJobGroups) {
+      try formBatchedJobs($0, forIncremental: true)
+    }
     incrementalCompilationState?.addPostCompileJobs(postCompileJobs)
 
     return try formBatchedJobs(allJobs, forIncremental: false)

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -67,8 +67,8 @@ extension Driver {
                                debugInfo: debugInfo,
                                addJob: addPostCompileJob)
 
-    incrementalCompilationState?.addPrimaryOrSkippedJobGroups(preAndCompileJobGroups)
-    incrementalCompilationState?.addTertiaryJobs(postCompileJobs)
+    incrementalCompilationState?.addPreOrCompileJobGroups(preAndCompileJobGroups)
+    incrementalCompilationState?.addPostCompileJobs(postCompileJobs)
 
     return try formBatchedJobs(allJobs, forIncremental: false)
   }

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -138,12 +138,12 @@ public final class MultiJobExecutor {
       let primaryIndices, tertiaryIndices: Range<Int>
       if let incrementalCompilationState = incrementalCompilationState {
         primaryIndices = Self.addJobs(
-          incrementalCompilationState.primaryJobsInOrder,
+          incrementalCompilationState.mandatoryPreOrCompileJobsInOrder,
           to: &jobs,
           producing: &producerMap
           )
         tertiaryIndices = Self.addJobs(
-          incrementalCompilationState.tertiaryJobs,
+          incrementalCompilationState.postCompileJobs,
           to: &jobs,
           producing: &producerMap)
       }
@@ -201,7 +201,7 @@ public final class MultiJobExecutor {
         return
       }
       if let newJobs = incrementalCompilationState?
-          .getSecondaryJobsAfterFinishing(job: job, result: result) {
+          .getJobsDiscoveredToBeNeededAfterFinishing(job: job, result: result) {
         let newJobIndices = Self.addJobs(newJobs, to: &jobs, producing: &producerMap)
         needInputFor(indices: newJobIndices)
       }

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -58,19 +58,22 @@ public final class SwiftDriverExecutor: DriverExecutor {
   }
 
   public func execute(jobs: [Job],
+                      incrementalCompilationState: IncrementalCompilationState?,
                       delegate: JobExecutionDelegate,
                       numParallelJobs: Int = 1,
                       forceResponseFiles: Bool = false,
                       recordedInputModificationDates: [TypedVirtualPath: Date] = [:]
   ) throws {
-    let llbuildExecutor = MultiJobExecutor(jobs: jobs,
-                                           resolver: resolver,
-                                           executorDelegate: delegate,
-                                           diagnosticsEngine: diagnosticsEngine,
-                                           numParallelJobs: numParallelJobs,
-                                           processSet: processSet,
-                                           forceResponseFiles: forceResponseFiles,
-                                           recordedInputModificationDates: recordedInputModificationDates)
+    let llbuildExecutor = MultiJobExecutor(
+      jobs: jobs,
+      incrementalCompilationState: incrementalCompilationState,
+      resolver: resolver,
+      executorDelegate: delegate,
+      diagnosticsEngine: diagnosticsEngine,
+      numParallelJobs: numParallelJobs,
+      processSet: processSet,
+      forceResponseFiles: forceResponseFiles,
+      recordedInputModificationDates: recordedInputModificationDates)
     try llbuildExecutor.execute(env: env, fileSystem: fileSystem)
   }
 

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -57,16 +57,14 @@ public final class SwiftDriverExecutor: DriverExecutor {
     }
   }
 
-  public func execute(jobs: [Job],
-                      incrementalCompilationState: IncrementalCompilationState?,
+  public func execute(workload: DriverExecutorWorkload,
                       delegate: JobExecutionDelegate,
                       numParallelJobs: Int = 1,
                       forceResponseFiles: Bool = false,
                       recordedInputModificationDates: [TypedVirtualPath: Date] = [:]
   ) throws {
     let llbuildExecutor = MultiJobExecutor(
-      jobs: jobs,
-      incrementalCompilationState: incrementalCompilationState,
+      workload: workload,
       resolver: resolver,
       executorDelegate: delegate,
       diagnosticsEngine: diagnosticsEngine,

--- a/Sources/SwiftDriverExecution/llbuild.swift
+++ b/Sources/SwiftDriverExecution/llbuild.swift
@@ -178,6 +178,10 @@ class LLBuildRule: Rule, Task {
 
   func inputsAvailable(_ engine: LLTaskBuildEngine) {
   }
+
+  // Not strictly needed, but permits overriding for debugging
+  func updateStatus(_ status: RuleStatus) {
+  }
 }
 
 // MARK:- Helpers

--- a/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
+++ b/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
@@ -130,7 +130,7 @@ final class DiagnosticVerifier {
   fileprivate var permitted: Set<Diagnostic.Behavior> = [.note, .remark, .ignored]
 
   /// Callback for the diagnostic engine or driver to use.
-  fileprivate func emit(_ diag: Diagnostic) {
+  func emit(_ diag: Diagnostic) {
     guard let queue = queue else {
       fatalError("Diagnostic emitted after the test was complete! \(diag)")
     }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -286,7 +286,7 @@ final class NonincrementalCompilationTests: XCTestCase {
 }
 
 
-final class IncrementalCompilationUnitTests: XCTestCase {
+final class IncrementalCompilationTests: XCTestCase {
 
   var tempDir: AbsolutePath = AbsolutePath("/tmp")
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -368,6 +368,7 @@ final class IncrementalCompilationTests: XCTestCase {
     #if true // sometimes want to skip for debugging
     tryNoChange(checkDiagnostics)
     tryTouchingOther(checkDiagnostics)
+    tryTouchingBoth(checkDiagnostics)
     #endif
     tryReplacingMain(checkDiagnostics)
   }
@@ -417,9 +418,39 @@ final class IncrementalCompilationTests: XCTestCase {
         "Incremental compilation: Queuing (initial): {compile: other.o <= other.swift}",
         "Incremental compilation: not scheduling dependents of other.swift; unknown changes",
         "Incremental compilation: Skipping input: {compile: main.o <= main.swift}",
+        "Found 1 batchable job",
+        "Forming into 1 batch",
+        "Adding {compile: other.swift} to batch 0",
+        "Forming batch job from 1 constituents: other.swift",
         "Incremental compilation: Queuing Compiling other.swift",
         "Starting Compiling other.swift",
         "Finished Compiling other.swift",
+        "Starting Linking theModule",
+        "Finished Linking theModule",
+    ],
+    whenAutolinking: autolinkLifecycleExpectations)
+  }
+  func tryTouchingBoth(_ checkDiagnostics: Bool) {
+    touch("main")
+    touch("other")
+    try! doABuild(
+      "non-propagating, both touched",
+      checkDiagnostics: checkDiagnostics,
+      expectingRemarks: [
+        "Incremental compilation: Scheduing changed input {compile: main.o <= main.swift}",
+        "Incremental compilation: Scheduing changed input {compile: other.o <= other.swift}",
+        "Incremental compilation: Queuing (initial): {compile: main.o <= main.swift}",
+        "Incremental compilation: Queuing (initial): {compile: other.o <= other.swift}",
+        "Incremental compilation: not scheduling dependents of main.swift; unknown changes",
+        "Incremental compilation: not scheduling dependents of other.swift; unknown changes",
+        "Found 2 batchable jobs",
+        "Forming into 1 batch",
+        "Adding {compile: main.swift} to batch 0",
+        "Adding {compile: other.swift} to batch 0",
+        "Forming batch job from 2 constituents: main.swift, other.swift",
+        "Incremental compilation: Queuing Compiling main.swift, other.swift",
+        "Starting Compiling main.swift, other.swift",
+        "Finished Compiling main.swift, other.swift",
         "Starting Linking theModule",
         "Finished Linking theModule",
     ],
@@ -437,6 +468,10 @@ final class IncrementalCompilationTests: XCTestCase {
         "Incremental compilation: Queuing (initial): {compile: main.o <= main.swift}",
         "Incremental compilation: not scheduling dependents of main.swift; unknown changes",
         "Incremental compilation: Skipping input: {compile: other.o <= other.swift}",
+        "Found 1 batchable job",
+        "Forming into 1 batch",
+        "Adding {compile: main.swift} to batch 0",
+        "Forming batch job from 1 constituents: main.swift",
         "Incremental compilation: Queuing Compiling main.swift",
         "Starting Compiling main.swift",
         "Incremental compilation: Traced: interface of main.swiftdeps -> interface of top-level name foo -> implementation of other.swiftdeps",

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -404,7 +404,7 @@ final class IncrementalCompilationTests: XCTestCase {
         "Incremental compilation: Skipping input: {compile: main.o <= main.swift}",
         "Incremental compilation: Skipping input: {compile: other.o <= other.swift}",
       ],
-      whenAutolinking: autolinkIncrementalExpectations + autolinkLifecycleExpectations)
+      whenAutolinking: [])
   }
   func tryTouchingOther(_ checkDiagnostics: Bool) {
     touch("other")
@@ -423,7 +423,7 @@ final class IncrementalCompilationTests: XCTestCase {
         "Starting Linking theModule",
         "Finished Linking theModule",
     ],
-    whenAutolinking: autolinkIncrementalExpectations + autolinkLifecycleExpectations)
+    whenAutolinking: autolinkLifecycleExpectations)
   }
 
   func tryReplacingMain(_ checkDiagnostics: Bool) {
@@ -448,7 +448,7 @@ final class IncrementalCompilationTests: XCTestCase {
         "Starting Linking theModule",
         "Finished Linking theModule",
       ],
-      whenAutolinking: autolinkIncrementalExpectations + autolinkLifecycleExpectations)
+      whenAutolinking: autolinkLifecycleExpectations)
   }
 
   func touch(_ name: String) {

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -188,7 +188,8 @@ final class JobExecutorTests: XCTestCase {
       )
 
       let delegate = JobCollectingDelegate()
-      let executor = MultiJobExecutor(jobs: [compileFoo, compileMain, link], resolver: resolver, executorDelegate: delegate, diagnosticsEngine: DiagnosticsEngine())
+      let executor = MultiJobExecutor(workload: .all([compileFoo, compileMain, link]),
+                                      resolver: resolver, executorDelegate: delegate, diagnosticsEngine: DiagnosticsEngine())
       try executor.execute(env: toolchain.env, fileSystem: localFileSystem)
 
       let output = try TSCBasic.Process.checkNonZeroExit(args: exec.pathString)
@@ -221,7 +222,7 @@ final class JobExecutorTests: XCTestCase {
 
     let delegate = JobCollectingDelegate()
     let executor = MultiJobExecutor(
-      jobs: [job], resolver: try ArgsResolver(fileSystem: localFileSystem),
+      workload: .all([job]), resolver: try ArgsResolver(fileSystem: localFileSystem),
       executorDelegate: delegate,
       diagnosticsEngine: DiagnosticsEngine(),
       processType: JobCollectingDelegate.StubProcess.self

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2842,7 +2842,12 @@ final class SwiftDriverTests: XCTestCase {
         func execute(job: Job, forceResponseFiles: Bool, recordedInputModificationDates: [TypedVirtualPath : Date]) throws -> ProcessResult {
           return ProcessResult(arguments: [], environment: [:], exitStatus: .terminated(code: 0), output: .success(Array("bad JSON".utf8)), stderrOutput: .success([]))
         }
-        func execute(jobs: [Job], delegate: JobExecutionDelegate, numParallelJobs: Int, forceResponseFiles: Bool, recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
+        func execute(jobs: [Job],
+                     incrementalCompilationState: IncrementalCompilationState?,
+                     delegate: JobExecutionDelegate,
+                     numParallelJobs: Int,
+                     forceResponseFiles: Bool,
+                     recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
           fatalError()
         }
         func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2842,8 +2842,7 @@ final class SwiftDriverTests: XCTestCase {
         func execute(job: Job, forceResponseFiles: Bool, recordedInputModificationDates: [TypedVirtualPath : Date]) throws -> ProcessResult {
           return ProcessResult(arguments: [], environment: [:], exitStatus: .terminated(code: 0), output: .success(Array("bad JSON".utf8)), stderrOutput: .success([]))
         }
-        func execute(jobs: [Job],
-                     incrementalCompilationState: IncrementalCompilationState?,
+        func execute(workload: DriverExecutorWorkload,
                      delegate: JobExecutionDelegate,
                      numParallelJobs: Int,
                      forceResponseFiles: Bool,

--- a/Tests/SwiftDriverTests/XCTestManifests.swift
+++ b/Tests/SwiftDriverTests/XCTestManifests.swift
@@ -32,6 +32,7 @@ extension IncrementalCompilationTests {
     // to regenerate.
     static let __allTests__IncrementalCompilationTests = [
         ("testIncremental", testIncremental),
+        ("testIncrementalDiagnostics", testIncrementalDiagnostics),
     ]
 }
 
@@ -117,6 +118,7 @@ extension NonincrementalCompilationTests {
     static let __allTests__NonincrementalCompilationTests = [
         ("testBuildRecordReading", testBuildRecordReading),
         ("testDateConversion", testDateConversion),
+        ("testExtractSourceFileDependencyGraphFromSwiftModule", testExtractSourceFileDependencyGraphFromSwiftModule),
         ("testNoIncremental", testNoIncremental),
         ("testReadAndWriteBuildRecord", testReadAndWriteBuildRecord),
         ("testReadBinarySourceFileDependencyGraph", testReadBinarySourceFileDependencyGraph),
@@ -176,12 +178,14 @@ extension SwiftDriverTests {
         ("testDarwinToolchainArgumentValidation", testDarwinToolchainArgumentValidation),
         ("testDashDashPassingDownInput", testDashDashPassingDownInput),
         ("testDebugSettings", testDebugSettings),
+        ("testDeriveSwiftDocPath", testDeriveSwiftDocPath),
         ("testDiagnosticOptions", testDiagnosticOptions),
         ("testDOTFileEmission", testDOTFileEmission),
         ("testDriverKindParsing", testDriverKindParsing),
         ("testDSYMGeneration", testDSYMGeneration),
         ("testDumpASTOverride", testDumpASTOverride),
         ("testEmbedBitcode", testEmbedBitcode),
+        ("testEmitModuleSeparately", testEmitModuleSeparately),
         ("testEmitModuleTrace", testEmitModuleTrace),
         ("testEnvironmentInferenceWarning", testEnvironmentInferenceWarning),
         ("testExecutableFallbackPath", testExecutableFallbackPath),
@@ -195,6 +199,7 @@ extension SwiftDriverTests {
         ("testJoinedPathOptions", testJoinedPathOptions),
         ("testLEqualPassedDownToLinkerInvocation", testLEqualPassedDownToLinkerInvocation),
         ("testLinking", testLinking),
+        ("testLTOLibraryArg", testLTOLibraryArg),
         ("testLTOOption", testLTOOption),
         ("testLTOOutputs", testLTOOutputs),
         ("testMergeModuleEmittingDependencies", testMergeModuleEmittingDependencies),
@@ -222,6 +227,7 @@ extension SwiftDriverTests {
         ("testPrintOutputFileMap", testPrintOutputFileMap),
         ("testPrintTargetInfo", testPrintTargetInfo),
         ("testProfileArgValidation", testProfileArgValidation),
+        ("testProfileLinkerArgs", testProfileLinkerArgs),
         ("testRecordedInputModificationDates", testRecordedInputModificationDates),
         ("testRegressions", testRegressions),
         ("testRelativeOptionOrdering", testRelativeOptionOrdering),


### PR DESCRIPTION
Redo the interaction between `llbuild` and `IncrementalBuildState` in order to allow 2nd wave compilations to interleave with first wave compilations. As each first wave job finishes, add rules for discovered 2nd wave jobs.