### PR TITLE
Remove `computeResourceDirPath` and rely on the one reported by `-print-target-info`

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -193,12 +193,7 @@ extension Driver {
     commandLine.appendFlag(.resourceDir)
     commandLine.appendPath(frontendTargetInfo.runtimeResourcePath.path)
 
-    if parsedOptions.hasFlag(positive: .staticExecutable,
-                             negative: .noStaticExecutable,
-                             default: false) ||
-       parsedOptions.hasFlag(positive: .staticStdlib,
-                             negative: .noStaticStdlib,
-                             default: false) {
+    if self.useStaticResourceDir {
       commandLine.appendFlag("-use-static-resource-dir")
     }
 

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -132,7 +132,7 @@ extension GenericUnixToolchain {
       let hasRuntimeArgs = !(staticStdlib || staticExecutable)
 
       let runtimePaths = try runtimeLibraryPaths(
-        for: targetTriple,
+        for: targetInfo,
         parsedOptions: &parsedOptions,
         sdkPath: targetInfo.sdkPath?.path,
         isShared: hasRuntimeArgs

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -38,7 +38,7 @@ extension Driver {
 
     let extraEnvironment = try toolchain.platformSpecificInterpreterEnvironmentVariables(
       env: self.env, parsedOptions: &parsedOptions,
-      sdkPath: frontendTargetInfo.sdkPath?.path, targetTriple: self.targetTriple)
+      sdkPath: frontendTargetInfo.sdkPath?.path, targetInfo: self.frontendTargetInfo)
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -438,15 +438,6 @@ extension Driver {
     if parsedOptions.hasArgument(.printTargetInfo) {
       let sdkPath = try parsedOptions.getLastArgument(.sdk).map { try VirtualPath(path: $0.asSingle) }
       let resourceDirPath = try parsedOptions.getLastArgument(.resourceDir).map { try VirtualPath(path: $0.asSingle) }
-      var useStaticResourceDir = false
-      if parsedOptions.hasFlag(positive: .staticExecutable,
-                              negative: .noStaticExecutable,
-                              default: false) ||
-         parsedOptions.hasFlag(positive: .staticStdlib,
-                              negative: .noStaticStdlib,
-                              default: false) {
-        useStaticResourceDir = true
-      }
 
       return try toolchain.printTargetInfoJob(target: targetTriple,
                                               targetVariant: targetVariantTriple,

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -97,12 +97,12 @@ extension SwiftVersion: Codable {
     let librariesRequireRPath: Bool
   }
 
-  struct Paths: Codable {
+  @_spi(Testing) public struct Paths: Codable {
     /// The path to the SDK, if provided.
-    let sdkPath: TextualVirtualPath?
-    let runtimeLibraryPaths: [TextualVirtualPath]
-    let runtimeLibraryImportPaths: [TextualVirtualPath]
-    let runtimeResourcePath: TextualVirtualPath
+    public let sdkPath: TextualVirtualPath?
+    public let runtimeLibraryPaths: [TextualVirtualPath]
+    public let runtimeLibraryImportPaths: [TextualVirtualPath]
+    public let runtimeResourcePath: TextualVirtualPath
   }
 
   var compilerVersion: String
@@ -113,7 +113,7 @@ extension SwiftVersion: Codable {
 
 // Make members of `FrontendTargetInfo.Paths` accessible on `FrontendTargetInfo`.
 extension FrontendTargetInfo {
-  subscript<T>(dynamicMember dynamicMember: KeyPath<FrontendTargetInfo.Paths, T>) -> T {
+  @_spi(Testing) public subscript<T>(dynamicMember dynamicMember: KeyPath<FrontendTargetInfo.Paths, T>) -> T {
     self.paths[keyPath: dynamicMember]
   }
 }

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -35,11 +35,11 @@ extension DarwinToolchain {
     env: [String : String],
     parsedOptions: inout ParsedOptions,
     sdkPath: VirtualPath?,
-    targetTriple: Triple) throws -> [String: String] {
+    targetInfo: FrontendTargetInfo) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
     let runtimePaths = try runtimeLibraryPaths(
-      for: targetTriple,
+      for: targetInfo,
       parsedOptions: &parsedOptions,
       sdkPath: sdkPath,
       isShared: true
@@ -63,11 +63,11 @@ extension GenericUnixToolchain {
     env: [String : String],
     parsedOptions: inout ParsedOptions,
     sdkPath: VirtualPath?,
-    targetTriple: Triple) throws -> [String: String] {
+    targetInfo: FrontendTargetInfo) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
     let runtimePaths = try runtimeLibraryPaths(
-      for: targetTriple,
+      for: targetInfo,
       parsedOptions: &parsedOptions,
       sdkPath: sdkPath,
       isShared: true

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -78,15 +78,11 @@ extension WebAssemblyToolchain {
         isShared: false
       )
 
-      let resourceDirPath = try computeResourceDirPath(
-        for: targetTriple,
-        parsedOptions: &parsedOptions,
-        isShared: false
-      )
-
-      let swiftrtPath = resourceDirPath
+      let swiftrtPath = targetInfo.runtimeResourcePath.path
         .appending(
-          components: targetTriple.archName, "swiftrt.o"
+          components: targetTriple.platformName() ?? "",
+          targetTriple.archName,
+          "swiftrt.o"
         )
       commandLine.appendPath(swiftrtPath)
 
@@ -114,8 +110,11 @@ extension WebAssemblyToolchain {
       }
 
       // Link the standard library.
-      let linkFilePath: VirtualPath = resourceDirPath
-        .appending(components: "static-executable-args.lnk")
+      let linkFilePath: VirtualPath = targetInfo.runtimeResourcePath.path
+        .appending(
+          components: targetTriple.platformName() ?? "",
+          "static-executable-args.lnk"
+        )
 
       guard try fileSystem.exists(linkFilePath) else {
         fatalError("\(linkFilePath) not found")

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -72,7 +72,7 @@ extension WebAssemblyToolchain {
       }
 
       let runtimePaths = try runtimeLibraryPaths(
-        for: targetTriple,
+        for: targetInfo,
         parsedOptions: &parsedOptions,
         sdkPath: targetInfo.sdkPath?.path,
         isShared: false

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -83,7 +83,7 @@ public enum Tool: Hashable {
     env: [String: String],
     parsedOptions: inout ParsedOptions,
     sdkPath: VirtualPath?,
-    targetTriple: Triple) throws -> [String: String]
+    targetInfo: FrontendTargetInfo) throws -> [String: String]
 
   func addPlatformSpecificCommonFrontendOptions(
     commandLine: inout [Job.ArgTemplate],

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -123,7 +123,10 @@ import SwiftOptions
     throw Error.sanitizersUnsupportedForTarget(targetTriple.triple)
   }
 
-  public func platformSpecificInterpreterEnvironmentVariables(env: [String : String], parsedOptions: inout ParsedOptions, sdkPath: VirtualPath?, targetTriple: Triple) throws -> [String : String] {
-    throw Error.interactiveModeUnsupportedForTarget(targetTriple.triple)
+  public func platformSpecificInterpreterEnvironmentVariables(env: [String : String],
+                                                              parsedOptions: inout ParsedOptions,
+                                                              sdkPath: VirtualPath?,
+                                                              targetInfo: FrontendTargetInfo) throws -> [String : String] {
+    throw Error.interactiveModeUnsupportedForTarget(targetInfo.target.triple.triple)
   }
 }

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -263,15 +263,15 @@ extension VirtualPath: Codable {
 }
 
 /// A wrapper for easier decoding of absolute or relative VirtualPaths from strings.
-struct TextualVirtualPath: Codable {
-  var path: VirtualPath
+@_spi(Testing) public struct TextualVirtualPath: Codable {
+  public var path: VirtualPath
 
-  init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     path = try VirtualPath(path: container.decode(String.self))
   }
 
-  func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     switch path {
     case .absolute(let path):

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3856,6 +3856,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       let job = plannedJobs[0]
       XCTAssertFalse(job.commandLine.contains(.flag("-use-static-resource-dir")))
+      XCTAssertEqual(driver.frontendTargetInfo.runtimeResourcePath.path.basename, "swift")
     }
 
     do {
@@ -3863,6 +3864,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       let job = plannedJobs[0]
       XCTAssertFalse(job.commandLine.contains(.flag("-use-static-resource-dir")))
+      XCTAssertEqual(driver.frontendTargetInfo.runtimeResourcePath.path.basename, "swift")
     }
 
     do {
@@ -3870,6 +3872,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       let job = plannedJobs[0]
       XCTAssertFalse(job.commandLine.contains(.flag("-use-static-resource-dir")))
+      XCTAssertEqual(driver.frontendTargetInfo.runtimeResourcePath.path.basename, "swift")
     }
 
     do {
@@ -3877,6 +3880,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       let job = plannedJobs[0]
       XCTAssertTrue(job.commandLine.contains(.flag("-use-static-resource-dir")))
+      XCTAssertEqual(driver.frontendTargetInfo.runtimeResourcePath.path.basename, "swift_static")
     }
 
     do {
@@ -3884,6 +3888,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       let job = plannedJobs[0]
       XCTAssertTrue(job.commandLine.contains(.flag("-use-static-resource-dir")))
+      XCTAssertEqual(driver.frontendTargetInfo.runtimeResourcePath.path.basename, "swift_static")
     }
   }
 


### PR DESCRIPTION
In theory this is NFC, but I'll run full CI just in case (Edit: looks like it passed). In addition to replacing all uses of the old method with reference to the target info's `runtimeResourcePath`, I had to update the -print-target-info job in toolchain computation to ensure it returned the static resource directory when needed. I tried replacing all uses of runtime library paths with the -print-target-info version too but ran into some issues where the macosx paths weren't included for catalyst targets, I'll need to look into that more. 