### PR TITLE
[Explicit Module Builds] Introduce an InterModuleDependencyOracle abstraction for tracking and sharing dependency scanning results

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -9,12 +9,13 @@
 add_library(SwiftDriver
   "Explicit Module Builds/ClangModuleBuildJobCache.swift"
   "Explicit Module Builds/ClangVersionedDependencyResolution.swift"
-  "Explicit Module Builds/CommonDependencyGraphOperations.swift"
   "Explicit Module Builds/ExplicitDependencyBuildPlanner.swift"
-  "Explicit Module Builds/InterModuleDependencyGraph.swift"
   "Explicit Module Builds/ModuleDependencyScanning.swift"
   "Explicit Module Builds/PlaceholderDependencyResolution.swift"
   "Explicit Module Builds/SerializableModuleArtifacts.swift"
+  "Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift"
+  "Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyGraph.swift"
+  "Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift"
 
   Driver/CompilerMode.swift
   Driver/DebugInfo.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -390,6 +390,14 @@ public struct Driver {
       self.interModuleDependencyOracle = dependencyOracle
     } else {
       self.interModuleDependencyOracle = InterModuleDependencyOracle()
+
+      // This is a shim for backwards-compatibility with ModuleInfoMap-based API
+      // used by SwiftPM
+      if let externalArtifacts = externalBuildArtifacts {
+        if !externalArtifacts.1.isEmpty {
+          try self.interModuleDependencyOracle.mergeModules(from: externalArtifacts.1)
+        }
+      }
     }
     
     do {    

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -257,11 +257,11 @@ public struct Driver {
   var forceEmitModuleBeforeCompile: Bool = false
 
   // FIXME: We should soon be able to remove this from being in the Driver's state.
-  // Its only remaining use outside of actual dependency-build planning is in
-  // command-line option generation for the main module compile.
+  // Its only remaining use outside of actual dependency build planning is in
+  // command-line input option generation for the explicit main module compile job.
   /// Planner for constructing module build jobs using Explicit Module Builds.
-  /// Constructed during the planning phase only when all modules will be prebuilt and treated
-  /// as explicit by the various compilation jobs.
+  /// Constructed during the planning phase only when all module dependencies will be prebuilt and treated
+  /// as explicit inputs by the various compilation jobs.
   @_spi(Testing) public var explicitDependencyBuildPlanner: ExplicitDependencyBuildPlanner? = nil
 
   /// An oracle for querying inter-module dependencies

--- a/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ClangVersionedDependencyResolution.swift
@@ -65,9 +65,6 @@ internal extension Driver {
   }
 }
 
-/// Resolution of versioned clang dependencies.
-/// FIXME: This code currently operates on instances of InterModuleDependencyGraph,
-/// It should be transitioned to operate on an instance of an InterModuleDependencyOracle.
 private extension InterModuleDependencyGraph {
   /// For each module scanned at multiple target versions, combine their dependencies across version-specific graphs.
   mutating func resolveVersionedClangModules(using versionedGraphMap: ModuleVersionedGraphMap)

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitDependencyBuildPlanner.swift
@@ -23,8 +23,11 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
 /// build jobs for all module dependencies and providing compile command options
 /// that specify said explicit module dependencies.
 @_spi(Testing) public struct ExplicitDependencyBuildPlanner {
-  /// The module dependency graph.
-  public var dependencyGraph: InterModuleDependencyGraph
+  /// The module ID of the main module for the current target
+  public let mainModuleId: ModuleDependencyId
+
+  /// The module dependency oracle.
+  public let dependencyOracle: InterModuleDependencyOracle
 
   /// Cache Clang modules for which a build job has already been constructed with a given
   /// target triple.
@@ -36,9 +39,11 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
   /// The toolchain to be used for frontend job generation.
   private let toolchain: Toolchain
 
-  public init(dependencyGraph: InterModuleDependencyGraph,
+  public init(mainModuleId: ModuleDependencyId,
+              dependencyOracle: InterModuleDependencyOracle,
               toolchain: Toolchain) throws {
-    self.dependencyGraph = dependencyGraph
+    self.mainModuleId = mainModuleId
+    self.dependencyOracle = dependencyOracle
     self.toolchain = toolchain
   }
 
@@ -116,9 +121,9 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
   /// inputs and command line flags.
   mutating public func resolveMainModuleDependencies(inputs: inout [TypedVirtualPath],
                                                      commandLine: inout [Job.ArgTemplate]) throws {
-    let mainModuleId: ModuleDependencyId = .swift(dependencyGraph.mainModuleName)
     try resolveExplicitModuleDependencies(moduleId: mainModuleId,
-                                          pcmArgs: try dependencyGraph.swiftModulePCMArgs(of: mainModuleId),
+                                          pcmArgs:
+                                            try dependencyOracle.getSwiftModulePCMArgs(of: mainModuleId),
                                           inputs: &inputs,
                                           commandLine: &commandLine)
   }
@@ -127,7 +132,9 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
   /// Resolving a module's dependencies will ensure that the dependencies' build jobs are also
   /// generated.
   mutating private func genSwiftModuleBuildJob(moduleId: ModuleDependencyId) throws {
-    let moduleInfo = try dependencyGraph.moduleInfo(of: moduleId)
+    guard let moduleInfo = dependencyOracle.getModuleInfo(of: moduleId) else {
+      throw Driver.Error.missingModuleDependency(moduleId.moduleName)
+    }
     var inputs: [TypedVirtualPath] = []
     let outputs: [TypedVirtualPath] = [
       TypedVirtualPath(file: try VirtualPath(path: moduleInfo.modulePath), type: .swiftModule)
@@ -135,12 +142,13 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
     var commandLine: [Job.ArgTemplate] = []
 
     // First, take the command line options provided in the dependency information
-    let moduleDetails = try dependencyGraph.swiftModuleDetails(of: moduleId)
+    let moduleDetails = try dependencyOracle.getSwiftModuleDetails(of: moduleId)
     moduleDetails.commandLine?.forEach { commandLine.appendFlags($0) }
 
     // Resolve all dependency module inputs for this Swift module
     try resolveExplicitModuleDependencies(moduleId: moduleId,
-                                          pcmArgs: dependencyGraph.swiftModulePCMArgs(of: moduleId),
+                                          pcmArgs:
+                                            dependencyOracle.getSwiftModulePCMArgs(of: moduleId),
                                           inputs: &inputs, commandLine: &commandLine)
 
     // Build the .swiftinterfaces file using a list of command line options specified in the
@@ -183,13 +191,15 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
   /// generated.
   mutating private func genClangModuleBuildJob(moduleId: ModuleDependencyId,
                                                pcmArgs: [String]) throws {
-    let moduleInfo = try dependencyGraph.moduleInfo(of: moduleId)
+    guard let moduleInfo = dependencyOracle.getModuleInfo(of: moduleId) else {
+      throw Driver.Error.missingModuleDependency(moduleId.moduleName)
+    }
     var inputs: [TypedVirtualPath] = []
     var outputs: [TypedVirtualPath] = []
     var commandLine: [Job.ArgTemplate] = []
 
     // First, take the command line options provided in the dependency information
-    let moduleDetails = try dependencyGraph.clangModuleDetails(of: moduleId)
+    let moduleDetails = try dependencyOracle.getClangModuleDetails(of: moduleId)
     moduleDetails.commandLine.forEach { commandLine.appendFlags($0) }
 
     // Add the `-target` option as inherited from the dependent Swift module's PCM args
@@ -295,7 +305,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
                                               clangDependencyArtifacts: inout [ClangModuleArtifactInfo],
                                               swiftDependencyArtifacts: inout [SwiftModuleArtifactInfo]
   ) throws {
-    for dependencyId in try dependencyGraph.moduleInfo(of: moduleId).directDependencies! {
+    for dependencyId in dependencyOracle.getDependencies(of: moduleId)! {
       guard addedDependenciesSet.insert(dependencyId).inserted else {
         continue
       }
@@ -336,7 +346,9 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
                                                  swiftDependencyArtifacts: inout [SwiftModuleArtifactInfo]
   ) throws {
     // Add it as an explicit dependency
-    let dependencyInfo = try dependencyGraph.moduleInfo(of: dependencyId)
+    guard let dependencyInfo = dependencyOracle.getModuleInfo(of: dependencyId) else {
+      throw Driver.Error.missingModuleDependency(moduleId.moduleName)
+    }
     let swiftModulePath: TypedVirtualPath
     let isFramework: Bool
 
@@ -347,7 +359,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
     }
     swiftModulePath = .init(file: try VirtualPath(path: dependencyInfo.modulePath),
                             type: .swiftModule)
-    isFramework = try dependencyGraph.swiftModuleDetails(of: dependencyId).isFramework
+    isFramework = try dependencyOracle.getSwiftModuleDetails(of: dependencyId).isFramework
 
     // Collect the required information about this module
     // TODO: add .swiftdoc and .swiftsourceinfo for this module.
@@ -381,8 +393,10 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
     }
 
     // Add it as an explicit dependency
-    let dependencyInfo = try dependencyGraph.moduleInfo(of: dependencyId)
-    let dependencyClangModuleDetails = try dependencyGraph.clangModuleDetails(of: dependencyId)
+    guard let dependencyInfo = dependencyOracle.getModuleInfo(of: dependencyId) else {
+      throw Driver.Error.missingModuleDependency(moduleId.moduleName)
+    }
+    let dependencyClangModuleDetails = try dependencyOracle.getClangModuleDetails(of: dependencyId)
     let clangModulePath =
       try ExplicitDependencyBuildPlanner.targetEncodedClangModuleFilePath(for: dependencyInfo,
                                                                       pcmArgs: pcmArgs)
@@ -409,9 +423,8 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
                                                    swiftDependencyArtifacts: inout [SwiftModuleArtifactInfo]
   ) throws {
     // Add it as an explicit dependency
-    let compiledModulePath = try dependencyGraph
-                                   .swiftPrebuiltDetails(of: dependencyId)
-                                   .compiledModulePath
+    let compiledModulePath =
+      try dependencyOracle.getSwiftPrebuiltDetails(of: dependencyId).compiledModulePath
     let swiftModulePath: TypedVirtualPath = .init(file: try VirtualPath(path: compiledModulePath),
                                                   type: .swiftModule)
 
@@ -466,58 +479,33 @@ extension ExplicitDependencyBuildPlanner {
 
 /// Encapsulates some of the common queries of the ExplicitDependencyBuildPlanner with error-checking
 /// on the dependency graph's structure.
-internal extension InterModuleDependencyGraph {
-  func moduleInfo(of moduleId: ModuleDependencyId) throws -> ModuleInfo {
-    guard let moduleInfo = modules[moduleId] else {
-      throw Driver.Error.missingModuleDependency(moduleId.moduleName)
-    }
-    return moduleInfo
-  }
-
-  func swiftModuleDetails(of moduleId: ModuleDependencyId) throws -> SwiftModuleDetails {
-    guard case .swift(let swiftModuleDetails) = try moduleInfo(of: moduleId).details else {
+internal extension InterModuleDependencyOracle {
+  func getSwiftModuleDetails(of moduleId: ModuleDependencyId) throws -> SwiftModuleDetails {
+    guard case .swift(let swiftModuleDetails) = getModuleInfo(of: moduleId)?.details else {
       throw Driver.Error.malformedModuleDependency(moduleId.moduleName, "no Swift `details` object")
     }
     return swiftModuleDetails
   }
 
-  func swiftPrebuiltDetails(of moduleId: ModuleDependencyId)
+  func getSwiftPrebuiltDetails(of moduleId: ModuleDependencyId)
   throws -> SwiftPrebuiltExternalModuleDetails {
     guard case .swiftPrebuiltExternal(let prebuiltModuleDetails) =
-            try moduleInfo(of: moduleId).details else {
+            getModuleInfo(of: moduleId)?.details else {
       throw Driver.Error.malformedModuleDependency(moduleId.moduleName,
                                                    "no SwiftPrebuiltExternal `details` object")
     }
     return prebuiltModuleDetails
   }
 
-  func clangModuleDetails(of moduleId: ModuleDependencyId) throws -> ClangModuleDetails {
-    guard case .clang(let clangModuleDetails) = try moduleInfo(of: moduleId).details else {
+  func getClangModuleDetails(of moduleId: ModuleDependencyId) throws -> ClangModuleDetails {
+    guard case .clang(let clangModuleDetails) = getModuleInfo(of: moduleId)?.details else {
       throw Driver.Error.malformedModuleDependency(moduleId.moduleName, "no Clang `details` object")
     }
     return clangModuleDetails
   }
 
-  func swiftModulePCMArgs(of moduleId: ModuleDependencyId) throws -> [String] {
-    let moduleDetails = try swiftModuleDetails(of: moduleId)
+  func getSwiftModulePCMArgs(of moduleId: ModuleDependencyId) throws -> [String] {
+    let moduleDetails = try getSwiftModuleDetails(of: moduleId)
     return moduleDetails.extraPcmArgs
-  }
-}
-
-// InterModuleDependencyGraph printing, useful for debugging
-internal extension InterModuleDependencyGraph {
-  func prettyPrintString() throws -> String {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted]
-    let contents = try encoder.encode(self)
-    return String(data: contents, encoding: .utf8)!
-  }
-}
-
-// To keep the ExplicitDependencyBuildPlanner an implementation detail, provide an API
-// to access the dependency graph
-extension Driver {
-  public var interModuleDependencyGraph: InterModuleDependencyGraph? {
-    return explicitDependencyBuildPlanner?.dependencyGraph
   }
 }

--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitDependencyBuildPlanner.swift
@@ -15,6 +15,9 @@ import Foundation
 
 /// A map from a module identifier to a path to its .swiftmodule file.
 public typealias ExternalTargetModulePathMap = [ModuleDependencyId: AbsolutePath]
+
+// FIXME: ExternalBuildArtifacts is a temporary backwards-compatibility shim
+// to help transition SwiftPM to the new API.
 /// A tuple all external artifacts a build system may pass in as input to the explicit build of the current module
 /// Consists of a map of externally-built targets, and a map of all previously discovered/scanned modules.
 public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleInfoMap)

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
@@ -20,7 +20,6 @@
   }
 }
 
-// This is a backwards-compatibility shim 
 public extension InterModuleDependencyGraph {
   // This is a shim for backwards-compatibility with existing API used by SwiftPM.
   // TODO: After SwiftPM switches to using the oracle, this should be deleted.

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
@@ -14,16 +14,20 @@
   /// An API to allow clients to accumulate InterModuleDependencyGraphs across mutiple main modules/targets
   /// into a single collection of discovered modules.
   func mergeModules(from dependencyGraph: InterModuleDependencyGraph) throws {
-    for (moduleId, moduleInfo) in dependencyGraph.modules {
-      try InterModuleDependencyGraph.mergeModule(moduleId, moduleInfo, into: &modules)
+    try self.lock.withLock {
+      for (moduleId, moduleInfo) in dependencyGraph.modules {
+        try InterModuleDependencyGraph.mergeModule(moduleId, moduleInfo, into: &modules)
+      }
     }
   }
 
   // This is a backwards-compatibility shim to handle existing ModuleInfoMap-based API
   // used by SwiftPM
   func mergeModules(from moduleInfoMap: ModuleInfoMap) throws {
-    for (moduleId, moduleInfo) in moduleInfoMap {
-      try InterModuleDependencyGraph.mergeModule(moduleId, moduleInfo, into: &modules)
+    try self.lock.withLock {
+      for (moduleId, moduleInfo) in moduleInfoMap {
+        try InterModuleDependencyGraph.mergeModule(moduleId, moduleInfo, into: &modules)
+      }
     }
   }
 }

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
@@ -18,6 +18,14 @@
       try InterModuleDependencyGraph.mergeModule(moduleId, moduleInfo, into: &modules)
     }
   }
+
+  // This is a backwards-compatibility shim to handle existing ModuleInfoMap-based API
+  // used by SwiftPM
+  func mergeModules(from moduleInfoMap: ModuleInfoMap) throws {
+    for (moduleId, moduleInfo) in moduleInfoMap {
+      try InterModuleDependencyGraph.mergeModule(moduleId, moduleInfo, into: &modules)
+    }
+  }
 }
 
 public extension InterModuleDependencyGraph {

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/CommonDependencyOperations.swift
@@ -20,7 +20,22 @@
   }
 }
 
-internal extension InterModuleDependencyGraph {
+// This is a backwards-compatibility shim 
+public extension InterModuleDependencyGraph {
+  // This is a shim for backwards-compatibility with existing API used by SwiftPM.
+  // TODO: After SwiftPM switches to using the oracle, this should be deleted.
+  static func mergeModules(
+    from dependencyGraph: InterModuleDependencyGraph,
+    into discoveredModules: inout ModuleInfoMap
+  ) throws {
+    for (moduleId, moduleInfo) in dependencyGraph.modules {
+      try mergeModule(moduleId, moduleInfo, into: &discoveredModules)
+    }
+  }
+}
+
+
+@_spi(Testing) public extension InterModuleDependencyGraph {
   /// Merge a module with a given ID and Info into a ModuleInfoMap
   static func mergeModule(_ moduleId: ModuleDependencyId,
                           _ moduleInfo: ModuleInfo,

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyGraph.swift
@@ -83,27 +83,27 @@ public struct BridgingHeader: Codable {
 /// Details specific to Swift modules.
 public struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
-  @_spi(Testing) public var moduleInterfacePath: String?
+  public var moduleInterfacePath: String?
 
   /// The paths of potentially ready-to-use compiled modules for the interface.
-  @_spi(Testing) public var compiledModuleCandidates: [String]?
+  public var compiledModuleCandidates: [String]?
 
   /// The bridging header, if any.
-  var bridgingHeaderPath: String?
+  public var bridgingHeaderPath: String?
 
   /// The source files referenced by the bridging header.
-  var bridgingSourceFiles: [String]? = []
+  public var bridgingSourceFiles: [String]? = []
 
   /// Options to the compile command
-  var commandLine: [String]? = []
+  public var commandLine: [String]? = []
 
   /// To build a PCM to be used by this Swift module, we need to append these
   /// arguments to the generic PCM build arguments reported from the dependency
   /// graph.
-  @_spi(Testing) public var extraPcmArgs: [String]
+  public var extraPcmArgs: [String]
 
   /// A flag to indicate whether or not this module is a framework.
-  @_spi(Testing) public var isFramework: Bool
+  public var isFramework: Bool
 }
 
 /// Details specific to Swift placeholder dependencies.
@@ -119,29 +119,47 @@ public struct SwiftPlaceholderModuleDetails: Codable {
 public struct SwiftPrebuiltExternalModuleDetails: Codable {
   /// The path to the already-compiled module that must be used instead of
   /// generating a job to build this module.
-  @_spi(Testing) public var compiledModulePath: String
+  public var compiledModulePath: String
 
   /// The path to the .swiftModuleDoc file.
-  var moduleDocPath: String?
+  public var moduleDocPath: String?
 
   /// The path to the .swiftSourceInfo file.
-  var moduleSourceInfoPath: String?
+  public var moduleSourceInfoPath: String?
+
+  public init(compiledModulePath: String,
+              moduleDocPath: String? = nil,
+              moduleSourceInfoPath: String? = nil) {
+    self.compiledModulePath = compiledModulePath
+    self.moduleDocPath = moduleDocPath
+    self.moduleSourceInfoPath = moduleSourceInfoPath
+  }
 }
 
 /// Details specific to Clang modules.
 public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
-  @_spi(Testing) public var moduleMapPath: String
+  public var moduleMapPath: String
 
   /// Set of PCM Arguments of depending modules which
   /// are covered by the directDependencies info of this module
   public var dependenciesCapturedPCMArgs: Set<[String]>?
 
   /// clang-generated context hash
-  var contextHash: String
+  public var contextHash: String
 
   /// Options to the compile command
-  var commandLine: [String] = []
+  public var commandLine: [String] = []
+
+  public init(moduleMapPath: String,
+              dependenciesCapturedPCMArgs: Set<[String]>?,
+              contextHash: String,
+              commandLine: [String]) {
+    self.moduleMapPath = moduleMapPath
+    self.dependenciesCapturedPCMArgs = dependenciesCapturedPCMArgs
+    self.contextHash = contextHash
+    self.commandLine = commandLine
+  }
 }
 
 public struct ModuleInfo: Codable {
@@ -172,6 +190,16 @@ public struct ModuleInfo: Codable {
 
     /// Clang modules are built from a module map file.
     case clang(ClangModuleDetails)
+  }
+
+  public init(modulePath: String,
+              sourceFiles: [String]?,
+              directDependencies: [ModuleDependencyId]?,
+              details: Details) {
+    self.modulePath = modulePath
+    self.sourceFiles = sourceFiles
+    self.directDependencies = directDependencies
+    self.details = details
   }
 }
 

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
@@ -10,39 +10,69 @@
 //
 //===----------------------------------------------------------------------===//
 
-
+// An inter-module dependency oracle, responsible for responding to queries about
+// dependencies of a given module, caching already-discovered dependencies along the way.
+//
 // The oracle is currently implemented as a simple store of ModuleInfo nodes.
-// It is the currently responsibility of the swift-driver to populate and update
+// It is the responsibility of the Driver to populate and update
 // the store. It does so by invoking individual -scan-dependencies jobs and
-// accumulating resulting dependency graphs.
+// accumulating resulting dependency graphs into the oracle's store.
 //
 // The design of the oracle's public API is meant to abstract that away,
-// allowing us to, in the future, replace the underlying implementation with
+// allowing us to replace the underlying implementation in the future, with
 // a persistent-across-targets dependency scanning library.
 //
 /// An abstraction of a cache and query-engine of inter-module dependencies
 public class InterModuleDependencyOracle {
-  // MARK: Public API
   /// Query the ModuleInfo of a module with a given ID
-  public func getModuleInfo(of moduleId: ModuleDependencyId) -> ModuleInfo? {
+  @_spi(Testing) public func getModuleInfo(of moduleId: ModuleDependencyId) -> ModuleInfo? {
     return modules[moduleId]
   }
 
   /// Query the direct dependencies of a module with a given ID
-  public func getDependencies(of moduleId: ModuleDependencyId) -> [ModuleDependencyId]? {
+  @_spi(Testing) public func getDependencies(of moduleId: ModuleDependencyId)
+  -> [ModuleDependencyId]? {
     return modules[moduleId]?.directDependencies
   }
-
-  // MARK: Private Implementation
 
   // TODO: This will require a SwiftDriver entry-point for scanning a module given
   // a command invocation and a set of source-files. As-is, the driver itself is responsible
   // for executing individual module dependency-scanning actions and updating oracle state.
+  // (Implemented with InterModuleDependencyOracle::mergeModules extension)
+  //
+  // func getFullDependencies(inputs: [TypedVirtualPath],
+  //                          commandLine: [Job.ArgTemplate]) -> InterModuleDependencyGraph {}
+  //
 
   /// The complete set of modules discovered so far, spanning potentially multiple targets
   internal var modules: ModuleInfoMap = [:]
 
-  /// Override the default initializer's internal access level for test access
+  /// Override the default initializer's access level for test access
   @_spi(Testing) public init() {}
 }
 
+// This is a shim for backwards-compatibility with existing API used by SwiftPM.
+// TODO: After SwiftPM switches to using the oracle, this should be deleted.
+extension Driver {
+  public var interModuleDependencyGraph: InterModuleDependencyGraph? {
+    let mainModuleId : ModuleDependencyId = .swift(moduleOutputInfo.name)
+    var mainModuleDependencyGraph =
+      InterModuleDependencyGraph(mainModuleName: moduleOutputInfo.name)
+
+    addModule(moduleId: mainModuleId,
+              moduleInfo: interModuleDependencyOracle.getModuleInfo(of: mainModuleId)!,
+              into: &mainModuleDependencyGraph)
+    return mainModuleDependencyGraph
+  }
+
+  private func addModule(moduleId: ModuleDependencyId,
+                         moduleInfo: ModuleInfo,
+                         into dependencyGraph: inout InterModuleDependencyGraph) {
+    dependencyGraph.modules[moduleId] = moduleInfo
+    moduleInfo.directDependencies?.forEach { dependencyId in
+      addModule(moduleId: dependencyId,
+                moduleInfo: interModuleDependencyOracle.getModuleInfo(of: dependencyId)!,
+                into: &dependencyGraph)
+    }
+  }
+}

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
@@ -47,8 +47,8 @@ public class InterModuleDependencyOracle {
   /// The complete set of modules discovered so far, spanning potentially multiple targets
   internal var modules: ModuleInfoMap = [:]
 
-  /// Override the default initializer's access level for test access
-  @_spi(Testing) public init() {}
+  /// Allow external clients to instantiate the oracle
+  public init() {}
 }
 
 // This is a shim for backwards-compatibility with existing API used by SwiftPM.

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
@@ -1,0 +1,48 @@
+//===--------------- InterModuleDependencyOracle.swift --------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+// The oracle is currently implemented as a simple store of ModuleInfo nodes.
+// It is the currently responsibility of the swift-driver to populate and update
+// the store. It does so by invoking individual -scan-dependencies jobs and
+// accumulating resulting dependency graphs.
+//
+// The design of the oracle's public API is meant to abstract that away,
+// allowing us to, in the future, replace the underlying implementation with
+// a persistent-across-targets dependency scanning library.
+//
+/// An abstraction of a cache and query-engine of inter-module dependencies
+public class InterModuleDependencyOracle {
+  // MARK: Public API
+  /// Query the ModuleInfo of a module with a given ID
+  public func getModuleInfo(of moduleId: ModuleDependencyId) -> ModuleInfo? {
+    return modules[moduleId]
+  }
+
+  /// Query the direct dependencies of a module with a given ID
+  public func getDependencies(of moduleId: ModuleDependencyId) -> [ModuleDependencyId]? {
+    return modules[moduleId]?.directDependencies
+  }
+
+  // MARK: Private Implementation
+
+  // TODO: This will require a SwiftDriver entry-point for scanning a module given
+  // a command invocation and a set of source-files. As-is, the driver itself is responsible
+  // for executing individual module dependency-scanning actions and updating oracle state.
+
+  /// The complete set of modules discovered so far, spanning potentially multiple targets
+  internal var modules: ModuleInfoMap = [:]
+
+  /// Override the default initializer's internal access level for test access
+  @_spi(Testing) public init() {}
+}
+

--- a/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/Inter Module Dependencies/InterModuleDependencyOracle.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import TSCBasic
+
 // An inter-module dependency oracle, responsible for responding to queries about
 // dependencies of a given module, caching already-discovered dependencies along the way.
 //
@@ -26,13 +28,15 @@
 public class InterModuleDependencyOracle {
   /// Query the ModuleInfo of a module with a given ID
   @_spi(Testing) public func getModuleInfo(of moduleId: ModuleDependencyId) -> ModuleInfo? {
-    return modules[moduleId]
+    self.lock.withLock {
+      return modules[moduleId]
+    }
   }
 
   /// Query the direct dependencies of a module with a given ID
   @_spi(Testing) public func getDependencies(of moduleId: ModuleDependencyId)
   -> [ModuleDependencyId]? {
-    return modules[moduleId]?.directDependencies
+    return getModuleInfo(of: moduleId)?.directDependencies
   }
 
   // TODO: This will require a SwiftDriver entry-point for scanning a module given
@@ -43,6 +47,8 @@ public class InterModuleDependencyOracle {
   // func getFullDependencies(inputs: [TypedVirtualPath],
   //                          commandLine: [Job.ArgTemplate]) -> InterModuleDependencyGraph {}
   //
+
+  internal let lock = Lock()
 
   /// The complete set of modules discovered so far, spanning potentially multiple targets
   internal var modules: ModuleInfoMap = [:]

--- a/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
@@ -41,10 +41,11 @@ import Foundation
   // which the driver will then resolve using B's full dependency graph provided by the client.
 
   /// Resolve all placeholder dependencies using external dependency information provided by the client
-  mutating func resolvePlaceholderDependencies(using externalBuildArtifacts: ExternalBuildArtifacts)
+  mutating func resolvePlaceholderDependencies(for externalBuildArtifacts: ExternalBuildArtifacts,
+                                               using dependencyOracle: InterModuleDependencyOracle)
   throws {
     let externalTargetModulePathMap = externalBuildArtifacts.0
-    let externalModuleInfoMap = externalBuildArtifacts.1
+    //let externalModuleInfoMap = externalBuildArtifacts.1
     let placeholderFilter : (ModuleDependencyId) -> Bool = {
       if case .swiftPlaceholder(_) = $0 {
         return true
@@ -61,7 +62,7 @@ import Foundation
       }
       try resolveTargetPlaceholder(placeholderId: moduleId,
                                    placeholderPath: placeholderModulePath,
-                                   externalModuleInfoMap: externalModuleInfoMap)
+                                   dependencyOracle: dependencyOracle)
     }
 
     // Process remaining placeholders until there are none left
@@ -70,17 +71,17 @@ import Foundation
       let moduleId = placeholderModules.first!
       let swiftModuleId = ModuleDependencyId.swift(moduleId.moduleName)
 
-      guard externalModuleInfoMap[swiftModuleId] != nil else {
+      guard dependencyOracle.getModuleInfo(of: swiftModuleId) != nil else {
         throw Driver.Error.missingExternalDependency(moduleId.moduleName)
       }
-      let moduleInfo = externalModuleInfoMap[swiftModuleId]!
+      let moduleInfo = dependencyOracle.getModuleInfo(of: swiftModuleId)!
 
       // Insert the resolved module, replacing the placeholder.
       try Self.mergeModule(swiftModuleId, moduleInfo, into: &modules)
 
       // Traverse and add all of this external module's dependencies to the current graph.
       try resolvePlaceholderModuleDependencies(moduleId: swiftModuleId,
-                                               externalModuleInfoMap: externalModuleInfoMap)
+                                               dependencyOracle: dependencyOracle)
 
       // Update the set of remaining placeholders to resolve
       placeholderModules = modules.keys.filter(placeholderFilter)
@@ -92,7 +93,7 @@ fileprivate extension InterModuleDependencyGraph {
   /// Resolve a placeholder dependency that is an external target.
   mutating func resolveTargetPlaceholder(placeholderId: ModuleDependencyId,
                                          placeholderPath: AbsolutePath,
-                                         externalModuleInfoMap: ModuleInfoMap)
+                                         dependencyOracle: InterModuleDependencyOracle)
   throws {
     // For this placeholder dependency, generate a new module info containing only the pre-compiled
     // module path, and insert it into the current module's dependency graph,
@@ -113,15 +114,15 @@ fileprivate extension InterModuleDependencyGraph {
     let swiftPrebuiltModuleId = ModuleDependencyId.swiftPrebuiltExternal(placeholderId.moduleName)
 
     let externalModuleId: ModuleDependencyId
-    if externalModuleInfoMap[swiftModuleId] != nil {
+    if dependencyOracle.getModuleInfo(of: swiftModuleId) != nil {
       externalModuleId = swiftModuleId
-    } else if externalModuleInfoMap[swiftPrebuiltModuleId] != nil {
+    } else if dependencyOracle.getModuleInfo(of: swiftPrebuiltModuleId) != nil {
       externalModuleId = swiftPrebuiltModuleId
     } else {
       throw Driver.Error.missingExternalDependency(placeholderId.moduleName)
     }
 
-    let externalModuleInfo = externalModuleInfoMap[externalModuleId]!
+    let externalModuleInfo = dependencyOracle.getModuleInfo(of: externalModuleId)!
     let newExternalModuleDetails =
       SwiftPrebuiltExternalModuleDetails(compiledModulePath: placeholderPath.description)
     let newInfo = ModuleInfo(modulePath: placeholderPath.description,
@@ -134,13 +135,14 @@ fileprivate extension InterModuleDependencyGraph {
 
     // Traverse and add all of this external target's dependencies to the current graph.
     try resolvePlaceholderModuleDependencies(moduleId: externalModuleId,
-                                             externalModuleInfoMap: externalModuleInfoMap)
+                                             dependencyOracle: dependencyOracle)
   }
 
   /// Resolve all dependencies of a placeholder module (direct and transitive), but merging them into the current graph.
   mutating func resolvePlaceholderModuleDependencies(moduleId: ModuleDependencyId,
-                                                     externalModuleInfoMap: ModuleInfoMap) throws {
-    guard let resolvingModuleInfo = externalModuleInfoMap[moduleId] else {
+                                                     dependencyOracle: InterModuleDependencyOracle)
+  throws {
+    guard let resolvingModuleInfo = dependencyOracle.getModuleInfo(of: moduleId) else {
       throw Driver.Error.missingExternalDependency(moduleId.moduleName)
     }
 
@@ -151,7 +153,7 @@ fileprivate extension InterModuleDependencyGraph {
     while let currentId = toVisit[currentIndex...].first {
       currentIndex += 1
       visited.insert(currentId)
-      guard let currentInfo = externalModuleInfoMap[currentId] else {
+      guard let currentInfo = dependencyOracle.getModuleInfo(of: currentId) else {
         throw Driver.Error.missingExternalDependency(currentId.moduleName)
       }
 

--- a/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
@@ -45,7 +45,6 @@ import Foundation
                                                using dependencyOracle: InterModuleDependencyOracle)
   throws {
     let externalTargetModulePathMap = externalBuildArtifacts.0
-    //let externalModuleInfoMap = externalBuildArtifacts.1
     let placeholderFilter : (ModuleDependencyId) -> Bool = {
       if case .swiftPlaceholder(_) = $0 {
         return true

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -428,10 +428,7 @@ extension Driver {
   /// In Explicit Module Build mode, distinguish between main module jobs and intermediate dependency build jobs,
   /// such as Swift modules built from .swiftmodule files and Clang PCMs.
   public func isExplicitMainModuleJob(job: Job) -> Bool {
-    guard let dependencyPlanner = explicitDependencyBuildPlanner else {
-      fatalError("No dependency planner in Explicit Module Build mode.")
-    }
-    return job.moduleName == dependencyPlanner.dependencyGraph.mainModuleName
+    return job.moduleName == moduleOutputInfo.name
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -407,6 +407,7 @@ extension Driver {
     }
 
     // Re-scan Clang modules at all the targets they will be built against.
+    // TODO: Should be deprecated once switched over to libSwiftScan
     try resolveVersionedClangDependencies(dependencyGraph: &dependencyGraph)
 
     // Set dependency modules' paths to be saved in the module cache.

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -379,14 +379,19 @@ extension Driver {
   /// Preprocess the graph by resolving placeholder dependencies, if any are present and
   /// by re-scanning all Clang modules against all possible targets they will be built against.
   public mutating func generateExplicitModuleDependenciesJobs() throws -> [Job] {
-    let dependencyGraph = try generateInterModuleDependencyGraph()
+    // Run the dependency scanner and update the dependency oracle with the results
+    try gatherModuleDependencies(into: interModuleDependencyOracle)
+
+    // Plan build jobs for all direct and transitive module dependencies of the current target
     explicitDependencyBuildPlanner =
-        try ExplicitDependencyBuildPlanner(dependencyGraph: dependencyGraph,
-                                       toolchain: toolchain)
+      try ExplicitDependencyBuildPlanner(mainModuleId: .swift(moduleOutputInfo.name),
+                                         dependencyOracle: interModuleDependencyOracle,
+                                         toolchain: toolchain)
     return try explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
   }
 
-  private mutating func generateInterModuleDependencyGraph() throws -> InterModuleDependencyGraph {
+  private mutating func gatherModuleDependencies(into dependencyOracle: InterModuleDependencyOracle)
+  throws {
     let dependencyScannerJob = try dependencyScanningJob()
     let forceResponseFiles = parsedOptions.hasArgument(.driverForceResponseFiles)
 
@@ -407,7 +412,8 @@ extension Driver {
     // Set dependency modules' paths to be saved in the module cache.
     try updateDependencyModulesWithModuleCachePath(dependencyGraph: &dependencyGraph)
 
-    return dependencyGraph
+    // Update the dependency oracle, adding this new dependency graph to its store
+    try dependencyOracle.mergeModules(from: dependencyGraph)
   }
 
   /// Update the given inter-module dependency graph to set module paths to be within the module cache,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -403,7 +403,8 @@ extension Driver {
 
     // Resolve placeholder dependencies in the dependency graph, if any.
     if externalBuildArtifacts != nil {
-      try dependencyGraph.resolvePlaceholderDependencies(using: externalBuildArtifacts!)
+      try dependencyGraph.resolvePlaceholderDependencies(for: externalBuildArtifacts!,
+                                                         using: dependencyOracle)
     }
 
     // Re-scan Clang modules at all the targets they will be built against.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -162,9 +162,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let dependencyOracle = InterModuleDependencyOracle()
       try dependencyOracle.mergeModules(from: moduleDependencyGraph)
       driver.explicitDependencyBuildPlanner =
-        try ExplicitDependencyBuildPlanner(mainModuleId:
-                                            .swift("test"),
-                                           dependencyOracle: dependencyOracle,
+        try ExplicitDependencyBuildPlanner(dependencyGraph: moduleDependencyGraph,
                                            toolchain: driver.toolchain)
       let modulePrebuildJobs =
         try driver.explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
@@ -243,8 +241,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // Merge the resolved version of the graph into the oracle
       try dependencyOracle.mergeModules(from: moduleDependencyGraph)
       driver.explicitDependencyBuildPlanner =
-        try ExplicitDependencyBuildPlanner(mainModuleId: .swift("A"),
-                                           dependencyOracle: dependencyOracle,
+        try ExplicitDependencyBuildPlanner(dependencyGraph: moduleDependencyGraph,
                                            toolchain: driver.toolchain)
       let modulePrebuildJobs =
         try driver.explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
@@ -411,29 +408,29 @@ final class ExplicitModuleBuildTests: XCTestCase {
   }
 
   func testDependencyGraphMerge() throws {
-//    let moduleDependencyGraph1 =
-//          try JSONDecoder().decode(
-//            InterModuleDependencyGraph.self,
-//            from: ModuleDependenciesInputs.mergeGraphInput1.data(using: .utf8)!)
-//    let moduleDependencyGraph2 =
-//          try JSONDecoder().decode(
-//            InterModuleDependencyGraph.self,
-//            from: ModuleDependenciesInputs.mergeGraphInput2.data(using: .utf8)!)
-//
-//    var accumulatingModuleInfoMap: [ModuleDependencyId: ModuleInfo] = [:]
-//
-//    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph1,
-//                                                into: &accumulatingModuleInfoMap)
-//    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph2,
-//                                                into: &accumulatingModuleInfoMap)
-//
-//    // Ensure the dependencies of the diplicate clang "B" module are merged
-//    let clangIDs = accumulatingModuleInfoMap.keys.filter { $0.moduleName == "B" }
-//    XCTAssertTrue(clangIDs.count == 1)
-//    let clangBInfo = accumulatingModuleInfoMap[clangIDs[0]]!
-//    XCTAssertTrue(clangBInfo.directDependencies!.count == 2)
-//    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("D")))
-//    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("C")))
+    let moduleDependencyGraph1 =
+          try JSONDecoder().decode(
+            InterModuleDependencyGraph.self,
+            from: ModuleDependenciesInputs.mergeGraphInput1.data(using: .utf8)!)
+    let moduleDependencyGraph2 =
+          try JSONDecoder().decode(
+            InterModuleDependencyGraph.self,
+            from: ModuleDependenciesInputs.mergeGraphInput2.data(using: .utf8)!)
+
+    var accumulatingModuleInfoMap: [ModuleDependencyId: ModuleInfo] = [:]
+
+    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph1,
+                                                into: &accumulatingModuleInfoMap)
+    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph2,
+                                                into: &accumulatingModuleInfoMap)
+
+    // Ensure the dependencies of the diplicate clang "B" module are merged
+    let clangIDs = accumulatingModuleInfoMap.keys.filter { $0.moduleName == "B" }
+    XCTAssertTrue(clangIDs.count == 1)
+    let clangBInfo = accumulatingModuleInfoMap[clangIDs[0]]!
+    XCTAssertTrue(clangBInfo.directDependencies!.count == 2)
+    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("D")))
+    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("C")))
   }
 
   func testExplicitSwiftModuleMap() throws {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -20,8 +20,8 @@ import XCTest
 private func checkExplicitModuleBuildJob(job: Job,
                                          pcmArgs: [String],
                                          moduleId: ModuleDependencyId,
-                                         moduleDependencyGraph: InterModuleDependencyGraph) throws {
-  let moduleInfo = moduleDependencyGraph.modules[moduleId]!
+                                         dependencyOracle: InterModuleDependencyOracle) throws {
+  let moduleInfo = dependencyOracle.getModuleInfo(of: moduleId)!
   var downstreamPCMArgs = pcmArgs
   switch moduleInfo.details {
     case .swift(let swiftModuleDetails):
@@ -42,10 +42,6 @@ private func checkExplicitModuleBuildJob(job: Job,
         XCTAssertTrue(job.commandLine.filter {$0 == .flag("-candidate-module-file")}.count == compiledCandidateList.count)
       }
     case .clang(let clangModuleDetails):
-      guard case .swift = moduleDependencyGraph.mainModule.details else {
-        XCTFail("Main module does not have Swift details field")
-        return
-      }
       let moduleMapPath =
         TypedVirtualPath(file: try VirtualPath(path: clangModuleDetails.moduleMapPath),
                          type: .clangModuleMap)
@@ -62,7 +58,7 @@ private func checkExplicitModuleBuildJob(job: Job,
   XCTAssertTrue(job.commandLine.contains(.flag(String("-fno-implicit-modules"))))
   try checkExplicitModuleBuildJobDependencies(job: job, pcmArgs: downstreamPCMArgs,
                                               moduleInfo: moduleInfo,
-                                              moduleDependencyGraph: moduleDependencyGraph)
+                                              dependencyOracle: dependencyOracle)
 }
 
 /// Checks that the build job for the specified module contains the required options and inputs
@@ -70,10 +66,10 @@ private func checkExplicitModuleBuildJob(job: Job,
 private func checkExplicitModuleBuildJobDependencies(job: Job,
                                                      pcmArgs: [String],
                                                      moduleInfo : ModuleInfo,
-                                                     moduleDependencyGraph: InterModuleDependencyGraph
+                                                     dependencyOracle: InterModuleDependencyOracle
 ) throws {
   for dependencyId in moduleInfo.directDependencies! {
-    let dependencyInfo = moduleDependencyGraph.modules[dependencyId]!
+    let dependencyInfo = dependencyOracle.getModuleInfo(of: dependencyId)!
     switch dependencyInfo.details {
       case .swift(let swiftDetails):
         // Load the dependency JSON and verify this dependency was encoded correctly
@@ -137,8 +133,8 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
     // Ensure all transitive dependencies got added as well.
     for transitiveDependencyId in dependencyInfo.directDependencies! {
       try checkExplicitModuleBuildJobDependencies(job: job, pcmArgs: pcmArgs, 
-                                                  moduleInfo: moduleDependencyGraph.modules[transitiveDependencyId]!,
-                                                  moduleDependencyGraph: moduleDependencyGraph)
+                                                  moduleInfo: dependencyOracle.getModuleInfo(of: transitiveDependencyId)!,
+                                                  dependencyOracle: dependencyOracle)
 
     }
   }
@@ -163,8 +159,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
             try JSONDecoder().decode(
               InterModuleDependencyGraph.self,
               from: ModuleDependenciesInputs.fastDependencyScannerOutput.data(using: .utf8)!)
-      driver.explicitDependencyBuildPlanner = try ExplicitDependencyBuildPlanner(dependencyGraph: moduleDependencyGraph,
-                                                                         toolchain: driver.toolchain)
+      let dependencyOracle = InterModuleDependencyOracle()
+      try dependencyOracle.mergeModules(from: moduleDependencyGraph)
+      driver.explicitDependencyBuildPlanner =
+        try ExplicitDependencyBuildPlanner(mainModuleId:
+                                            .swift("test"),
+                                           dependencyOracle: dependencyOracle,
+                                           toolchain: driver.toolchain)
       let modulePrebuildJobs =
         try driver.explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
       XCTAssertEqual(modulePrebuildJobs.count, 4)
@@ -176,19 +177,19 @@ final class ExplicitModuleBuildTests: XCTestCase {
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgs)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs,
                                             moduleId: .clang("SwiftShims"),
-                                            moduleDependencyGraph: moduleDependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "c_simd", with: pcmArgs)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs,
                                             moduleId: .clang("c_simd"),
-                                            moduleDependencyGraph: moduleDependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(RelativePath("Swift.swiftmodule")):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs,
                                             moduleId: .swift("Swift"),
-                                            moduleDependencyGraph: moduleDependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(RelativePath("SwiftOnoneSupport.swiftmodule")):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs,
                                             moduleId: .swift("SwiftOnoneSupport"),
-                                            moduleDependencyGraph: moduleDependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           default:
             XCTFail("Unexpected module dependency build job output: \(job.outputs[0].file)")
         }
@@ -238,21 +239,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
         return false
       })
 
+      let dependencyOracle = InterModuleDependencyOracle()
+      try dependencyOracle.mergeModules(from: moduleDependencyGraph)
       driver.explicitDependencyBuildPlanner =
-        try ExplicitDependencyBuildPlanner(dependencyGraph: moduleDependencyGraph,
+        try ExplicitDependencyBuildPlanner(mainModuleId: .swift("A"),
+                                           dependencyOracle: dependencyOracle,
                                            toolchain: driver.toolchain)
       let modulePrebuildJobs =
         try driver.explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
-
-      // Verify that the dependency graph contains no placeholders.
-      let placeholdersInTheGraph = driver.interModuleDependencyGraph!.modules.keys
-        .filter {
-          if case .swiftPlaceholder(_) = $0 {
-            return true
-          } else {
-            return false
-          } }
-      XCTAssert(placeholdersInTheGraph.isEmpty)
 
       XCTAssertEqual(modulePrebuildJobs.count, 2)
       let mainModuleJob = try driver.emitModuleJob()
@@ -302,11 +296,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let jobs = try driver.planBuild()
       // Figure out which Triples to use.
-      let dependencyGraph = driver.explicitDependencyBuildPlanner!.dependencyGraph
-      guard case .swift(let mainModuleSwiftDetails) = dependencyGraph.mainModule.details else {
+      let dependencyOracle = driver.interModuleDependencyOracle
+      let mainModuleInfo =
+        dependencyOracle.getModuleInfo(of: .swift("testExplicitModuleBuildJobs"))!
+      guard case .swift(let mainModuleSwiftDetails) = mainModuleInfo.details else {
         XCTFail("Main module does not have Swift details field")
         return
       }
+
       let pcmArgsCurrent = mainModuleSwiftDetails.extraPcmArgs
       var pcmArgs9 = ["-Xcc","-target","-Xcc","x86_64-apple-macosx10.9"]
       if driver.targetTriple.isDarwin {
@@ -317,58 +314,54 @@ final class ExplicitModuleBuildTests: XCTestCase {
         switch (job.outputs[0].file) {
           case .relative(RelativePath("A.swiftmodule")):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .swift("A"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(RelativePath("E.swiftmodule")):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .swift("E"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(RelativePath("G.swiftmodule")):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .swift("G"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(RelativePath("Swift.swiftmodule")):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .swift("Swift"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(RelativePath("SwiftOnoneSupport.swiftmodule")):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .swift("SwiftOnoneSupport"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "A", with: pcmArgsCurrent)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .clang("A"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "B", with: pcmArgsCurrent)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .clang("B"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "C", with: pcmArgsCurrent)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .clang("C"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "G", with: pcmArgsCurrent)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .clang("G"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "G", with: pcmArgs9)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs9, moduleId: .clang("G"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           // Module X is a dependency from Clang module "G" discovered only via versioned PCM
           // re-scan. 
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "X", with: pcmArgsCurrent)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .clang("X"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "X", with: pcmArgs9)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs9, moduleId: .clang("X"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgs9)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs9, moduleId: .clang("SwiftShims"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .relative(try pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgsCurrent)):
             try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .clang("SwiftShims"),
-                                            moduleDependencyGraph: dependencyGraph)
+                                            dependencyOracle: dependencyOracle)
           case .temporary(RelativePath("testExplicitModuleBuildJobs.o")):
             XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
-            guard case .swift(let mainModuleSwiftDetails) = dependencyGraph.mainModule.details else {
-              XCTFail("Main module does not have Swift details field")
-              return
-            }
             let pcmArgs = mainModuleSwiftDetails.extraPcmArgs
             try checkExplicitModuleBuildJobDependencies(job: job, pcmArgs: pcmArgs,
-                                                        moduleInfo: dependencyGraph.mainModule,
-                                                        moduleDependencyGraph: dependencyGraph)
+                                                        moduleInfo: mainModuleInfo,
+                                                        dependencyOracle: dependencyOracle)
           case .relative(RelativePath("testExplicitModuleBuildJobs")):
             XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
             XCTAssertEqual(job.kind, .link)
@@ -417,29 +410,29 @@ final class ExplicitModuleBuildTests: XCTestCase {
   }
 
   func testDependencyGraphMerge() throws {
-    let moduleDependencyGraph1 =
-          try JSONDecoder().decode(
-            InterModuleDependencyGraph.self,
-            from: ModuleDependenciesInputs.mergeGraphInput1.data(using: .utf8)!)
-    let moduleDependencyGraph2 =
-          try JSONDecoder().decode(
-            InterModuleDependencyGraph.self,
-            from: ModuleDependenciesInputs.mergeGraphInput2.data(using: .utf8)!)
-
-    var accumulatingModuleInfoMap: [ModuleDependencyId: ModuleInfo] = [:]
-
-    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph1,
-                                                into: &accumulatingModuleInfoMap)
-    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph2,
-                                                into: &accumulatingModuleInfoMap)
-
-    // Ensure the dependencies of the diplicate clang "B" module are merged
-    let clangIDs = accumulatingModuleInfoMap.keys.filter { $0.moduleName == "B" }
-    XCTAssertTrue(clangIDs.count == 1)
-    let clangBInfo = accumulatingModuleInfoMap[clangIDs[0]]!
-    XCTAssertTrue(clangBInfo.directDependencies!.count == 2)
-    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("D")))
-    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("C")))
+//    let moduleDependencyGraph1 =
+//          try JSONDecoder().decode(
+//            InterModuleDependencyGraph.self,
+//            from: ModuleDependenciesInputs.mergeGraphInput1.data(using: .utf8)!)
+//    let moduleDependencyGraph2 =
+//          try JSONDecoder().decode(
+//            InterModuleDependencyGraph.self,
+//            from: ModuleDependenciesInputs.mergeGraphInput2.data(using: .utf8)!)
+//
+//    var accumulatingModuleInfoMap: [ModuleDependencyId: ModuleInfo] = [:]
+//
+//    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph1,
+//                                                into: &accumulatingModuleInfoMap)
+//    try InterModuleDependencyGraph.mergeModules(from: moduleDependencyGraph2,
+//                                                into: &accumulatingModuleInfoMap)
+//
+//    // Ensure the dependencies of the diplicate clang "B" module are merged
+//    let clangIDs = accumulatingModuleInfoMap.keys.filter { $0.moduleName == "B" }
+//    XCTAssertTrue(clangIDs.count == 1)
+//    let clangBInfo = accumulatingModuleInfoMap[clangIDs[0]]!
+//    XCTAssertTrue(clangBInfo.directDependencies!.count == 2)
+//    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("D")))
+//    XCTAssertTrue(clangBInfo.directDependencies!.contains(ModuleDependencyId.clang("C")))
   }
 
   func testExplicitSwiftModuleMap() throws {


### PR DESCRIPTION
This PR refactors the handling of inter-module dependencies to centralize their handling in a new, reference-type, oracle.

`InterModuleDependencyOracle` will now be responsible for responding to queries about dependencies of a given module.
The intent behind it is to abstract the actual mechanism used for tracking/computing/caching inter-module dependencies. A single oracle reference is intended to be passed around to multiple Driver invocations, corresponding to different targets, by build-system clients (e.g. SwiftPM), replacing today's use of `ModuleInfoMap`-based API, to communicate already-computed dependency-scan results.

As implemented, it is a simple store of `ModuleInfo` value objects, which a `Driver` invocation populates by invoking a `-scan-dependencies` job; not unlike passing around an accumulating `ModuleInfoMap`.
In the future, the oracle's internal implementation may be replaced with a direct dependency-scanner library access, without having to break the clients' API.

There will be a followup PR to cleanup some of the shims required to ensure that this does not break the API currently used by SwiftPM. 

Corresponding PR to adapt this API in SwiftPM: https://github.com/apple/swift-package-manager/pull/3042

Resolves rdar://71209183