### PR TITLE
Install swift-help for integration tests. Suppress .noDriver options from being emitted by swift-help.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1048,7 +1048,7 @@ extension Driver {
     // Some output flags affect the compiler mode.
     if let outputOption = parsedOptions.getLast(in: .modes) {
       switch outputOption.option {
-      case .emitPch, .emitImportedModules:
+      case .emitImportedModules:
         return .singleCompile
 
       case .repl, .lldbRepl:
@@ -1090,8 +1090,6 @@ extension Driver {
       parsedOptions.eraseArgument(.indexFile)
       parsedOptions.eraseArgument(.indexFilePath)
       parsedOptions.eraseArgument(.indexStorePath)
-      parsedOptions.eraseArgument(.indexIgnoreStdlib)
-      parsedOptions.eraseArgument(.indexSystemModules)
       parsedOptions.eraseArgument(.indexIgnoreSystemModules)
       return .standardCompile
     }
@@ -1230,9 +1228,6 @@ extension Driver {
 
       case .dumpAst:
         compilerOutputType = .ast
-
-      case .emitPch:
-        compilerOutputType = .pch
 
       case .emitPcm:
         compilerOutputType = .pcm

--- a/Sources/SwiftOptions/Option.swift
+++ b/Sources/SwiftOptions/Option.swift
@@ -135,9 +135,9 @@ extension Option {
   public func isAccepted(by driverKind: DriverKind) -> Bool {
     switch driverKind {
     case .batch:
-      return !attributes.contains(.noBatch)
+      return attributes.isDisjoint(with: [.noDriver, .noBatch])
     case .interactive:
-      return !attributes.contains(.noInteractive)
+      return attributes.isDisjoint(with: [.noDriver, .noInteractive])
     }
   }
 }

--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -38,7 +38,8 @@ extension OptionTable {
   public func parse(_ arguments: [String],
                     for driverKind: DriverKind) throws -> ParsedOptions {
     var trie = PrefixTrie<Option>()
-    for opt in options {
+    // Add all options, ignoring the .noDriver ones
+    for opt in options where !opt.attributes.contains(.noDriver) {
       trie[opt.spelling] = opt
     }
 

--- a/Sources/SwiftOptions/OptionTable.swift
+++ b/Sources/SwiftOptions/OptionTable.swift
@@ -37,6 +37,7 @@ extension OptionTable {
 
     for option in options {
       if option.isAlias { continue }
+      if option.attributes.contains(.noDriver) { continue }
       if option.isHelpHidden && !includeHidden { continue }
       guard option.isAccepted(by: driverKind) else { continue }
       guard let helpText = option.helpText else { continue }

--- a/Sources/SwiftOptions/OptionTable.swift
+++ b/Sources/SwiftOptions/OptionTable.swift
@@ -37,7 +37,6 @@ extension OptionTable {
 
     for option in options {
       if option.isAlias { continue }
-      if option.attributes.contains(.noDriver) { continue }
       if option.isHelpHidden && !includeHidden { continue }
       guard option.isAccepted(by: driverKind) else { continue }
       guard let helpText = option.helpText else { continue }

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -34,17 +34,21 @@ func makeDriverSymlinks(
   try makeDirectories(tempBinDir)
 
   let swift = tempBinDir.appending(component: "swift")
-  try createSymlink(swift, pointingAt: driver, relative: false)
+  try localFileSystem.createSymbolicLink(swift, pointingAt: driver, relative: false)
 
   let swiftc = tempBinDir.appending(components: "swiftc")
-  try createSymlink(swiftc, pointingAt: driver, relative: false)
+  try localFileSystem.createSymbolicLink(swiftc, pointingAt: driver, relative: false)
+
+  let swiftHelp = binDir.appending(component: "swift-help")
+  let swiftHelpSimlink = tempBinDir.appending(component: "swift-help")
+  try localFileSystem.createSymbolicLink(swiftHelpSimlink, pointingAt: swiftHelp, relative: false)
 
   // If we've been given a build dir, link in its lib folder so we can find its
   // resource directory.
   if let swiftBuildDir = swiftBuildDir {
     let libDir = swiftBuildDir.appending(component: "lib")
     let tempLibDir = tempDir.appending(component: "lib" )
-    try createSymlink(tempLibDir, pointingAt: libDir, relative: false)
+    try localFileSystem.createSymbolicLink(tempLibDir, pointingAt: libDir, relative: false)
   }
 
   return (swift: swift, swiftc: swiftc)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1558,7 +1558,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testMergeModulesOnly() throws {
     do {
-      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module", "-disable-bridging-pch", "-import-objc-header", "TestInputHeader.h", "-emit-dependencies", "-emit-module-doc-path", "/foo/bar/Test.swiftdoc", "-emit-module-source-info-path", "/foo/bar/Test.swiftsourceinfo"])
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module", "-disable-bridging-pch", "-import-objc-header", "TestInputHeader.h", "-emit-dependencies", "-emit-module-source-info-path", "/foo/bar/Test.swiftsourceinfo"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertEqual(plannedJobs[0].outputs.count, 4)
@@ -1578,7 +1578,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(plannedJobs[2].tool.name.contains("swift"))
       XCTAssertEqual(plannedJobs[2].outputs.count, 3)
       XCTAssertEqual(plannedJobs[2].outputs[0].file, .relative(RelativePath("Test.swiftmodule")))
-      XCTAssertEqual(plannedJobs[2].outputs[1].file, .absolute(AbsolutePath("/foo/bar/Test.swiftdoc")))
+      XCTAssertEqual(plannedJobs[2].outputs[1].file, .relative(RelativePath("Test.swiftdoc")))
       XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(AbsolutePath("/foo/bar/Test.swiftsourceinfo")))
       XCTAssert(plannedJobs[2].commandLine.contains(.flag("-import-objc-header")))
     }
@@ -1608,7 +1608,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // Make sure the swiftdoc path is correct for an inferred module
-      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-doc", "-emit-module"])
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertTrue(plannedJobs[2].tool.name.contains("swift"))
@@ -2714,7 +2714,6 @@ final class SwiftDriverTests: XCTestCase {
                                        "foo.swift",
                                        "-index-file-path", "foo.swift",
                                        "-index-store-path", "store/path",
-                                       "-index-ignore-stdlib", "-index-system-modules",
                                        "-index-ignore-system-modules"]) {
       $1.expect(.warning("ignoring '-index-file' because '-dump-ast' was also specified"))
       let jobs = try $0.planBuild()
@@ -3805,15 +3804,6 @@ final class SwiftDriverTests: XCTestCase {
   }
   
   func testSourceInfoFileEmitOption() throws {
-    do {
-      var driver = try Driver(args: ["swiftc", "-emit-module-source-info", "foo.swift"])
-      let plannedJobs = try driver.planBuild()
-      let compileJob = plannedJobs[0]
-      XCTAssertTrue(compileJob.commandLine.contains(.flag("-emit-module-source-info-path")))
-      XCTAssertEqual(compileJob.outputs.count, 2)
-      XCTAssertEqual(compileJob.outputs[0].file, .temporary(RelativePath("foo.o")))
-      XCTAssertEqual(compileJob.outputs[1].file, .temporary(RelativePath("foo.swiftsourceinfo")))
-    }
     // implicit
     do {
       var driver = try Driver(args: ["swiftc", "-emit-module", "foo.swift"])


### PR DESCRIPTION
Fixes: Driver/help.swift

Also replaces deprecated `createSymlink` calls with `localFileSystem.createSymbolicLink`