### PR TITLE
[Explicit Module Builds] Use a stable hash to encode build arguments into PCM filenames

### DIFF
--- a/Sources/SwiftDriver/Explicit Module Builds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/ExplicitDependencyBuildPlanner.swift
@@ -449,9 +449,18 @@ extension ExplicitDependencyBuildPlanner {
   /// is to be constructed with.
   public static func targetEncodedClangModuleName(for moduleName: String,
                                                   pcmArgs: [String]) throws -> String {
-    var hasher = Hasher()
-    pcmArgs.forEach { hasher.combine($0) }
-    return moduleName + String(hasher.finalize())
+    let hashInput = pcmArgs.sorted().joined()
+    let hashedArguments: String
+    #if os(macOS)
+    if #available(macOS 10.15, iOS 13, *) {
+      hashedArguments = CryptoKitSHA256().hash(hashInput).hexadecimalRepresentation
+    } else {
+      hashedArguments = SHA256().hash(hashInput).hexadecimalRepresentation
+    }
+    #else
+    hashedArguments = SHA256().hash(hashInput).hexadecimalRepresentation
+    #endif
+    return moduleName + hashedArguments
   }
 }
 

--- a/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
+++ b/Sources/SwiftDriver/Explicit Module Builds/PlaceholderDependencyResolution.swift
@@ -101,16 +101,10 @@ fileprivate extension InterModuleDependencyGraph {
     // For all dependencies of this placeholder (direct and transitive), insert them
     // into this module's graph.
     //   - Swift dependencies are inserted as-is
-    //   - Clang dependencies, because PCM modules file names encode the specific pcmArguments
-    //     of their dependees, we cannot use pre-built files here because we do not always know
-    //     which target they corrspond to, nor do we have a way to map from a certain target to a
-    //     specific pcm file. Because of this, all PCM dependencies, direct and transitive, have to
-    //     be built for all modules. We merge moduleInfos of such dependencies with ones that are
-    //     already in the current graph, in order to obtain a super-set of their dependencies
-    //     at all possible PCMArgs variants.
-    // FIXME: Implement a stable hash for generated .pcm filenames in order to be able to re-use
-    // modules built by external dependencies here.
-
+    //   - Clang dependencies are inserted as-is, if a matching Clang module is already found
+    //     in this module's graph, we merge moduleInfos of the two modules, in order to obtain
+    //     a super-set of their dependencies at all possible PCMArgs variants.
+    //
     // The placeholder is resolved into a .swiftPrebuiltExternal module in the dependency graph.
     // The placeholder's corresponding module may appear in the externalModuleInfoMap as either
     // a .swift module or a .swiftPrebuiltExternal module if it had been resolved earlier

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -65,7 +65,15 @@ import SwiftOptions
       .map { $0.option.spelling }
       .sorted()
       .joined()
+    #if os(macOS)
+    if #available(macOS 10.15, iOS 13, *) {
+      return CryptoKitSHA256().hash(hashInput).hexadecimalRepresentation
+    } else {
+      return SHA256().hash(hashInput).hexadecimalRepresentation
+    }
+    #else
     return SHA256().hash(hashInput).hexadecimalRepresentation
+    #endif
   }
 
   /// Determine the input and output path for the build record


### PR DESCRIPTION
When generating build jobs for explicit module dependencies, we must distinguish multiple versions of the same Clang module/pcm by encoding the arguments used to build it (e.g. target triple) into the pcm filename.

So far, we have been using an unstable hash, which means that these filenames were not stable across invocations and were being needlessly re-built in some scenarios (e.g. many-target builds).

Switching to a stable hash (SHA256) ensures that the same Clang module, built with the same command line, will produce the same .pcm filename. This will allow the client build system (e.g. SwiftPM) to deduplicate identical compilation jobs because their output filenames will now also match.