### PR TITLE
Remove @_spi's that were preventing compilation

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -195,7 +195,7 @@ public struct Driver {
   /// Info needed to write and maybe read the build record.
   /// Only present when the driver will be writing the record.
   /// Only used for reading when compiling incrementally.
-  @_spi(Testing) public let buildRecordInfo: BuildRecordInfo?
+  let buildRecordInfo: BuildRecordInfo?
 
   /// Code & data for incremental compilation. Nil if not running in incremental mode
   @_spi(Testing) public let incrementalCompilationState: IncrementalCompilationState?

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
@@ -163,7 +163,7 @@ extension BuildRecord {
     )
   }
 
-  @_spi(Testing) public func encode() throws -> String {
+   func encode() throws -> String {
       let pathsAndInfos = try inputInfos.map {
         input, inputInfo -> (String, InputInfo) in
         guard let path = input.absolutePath else {

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -16,7 +16,7 @@ import SwiftOptions
 
 /// Holds information required to read and write the build record (aka compilation record)
 /// This info is always written, but only read for incremental compilation.
-@_spi(Testing) public class BuildRecordInfo {
+ class BuildRecordInfo {
   let buildRecordPath: VirtualPath
   let fileSystem: FileSystem
   let argsHash: String

--- a/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
@@ -2,13 +2,13 @@
 import Foundation
 
 /// A filename from another module
-@_spi(Testing) public struct ExternalDependency: Hashable, CustomStringConvertible {
+struct ExternalDependency: Hashable, CustomStringConvertible {
   let fileName: String
 
   var file: VirtualPath? {
     try? VirtualPath(path: fileName)
   }
-  @_spi(Testing) public init(_ path: String) {
+  init(_ path: String) {
     self.fileName = path
   }
   public var description: String {
@@ -18,7 +18,7 @@ import Foundation
 
 
 
-@_spi(Testing) public struct DependencyKey: Hashable {
+public struct DependencyKey: Hashable {
   /// Instead of the status quo scheme of two kinds of "Depends", cascading and
   /// non-cascading this code represents each entity ("Provides" in the status
   /// quo), by a pair of nodes. One node represents the "implementation." If the
@@ -31,7 +31,7 @@ import Foundation
   /// implementations white. Each node holds an instance variable describing which
   /// aspect of the entity it represents.
 
-  @_spi(Testing) public enum DeclAspect {
+  enum DeclAspect {
     case interface, implementation
   }
 
@@ -39,7 +39,7 @@ import Foundation
   /// graph, splitting the current *member* into \ref member and \ref
   /// potentialMember and adding \ref sourceFileProvide.
   ///
-  @_spi(Testing) public enum Designator: Hashable {
+  enum Designator: Hashable {
     case
       topLevel(name: String),
       dynamicLookup(name: String),
@@ -60,13 +60,13 @@ import Foundation
       default:
         return nil}
     }
- }
+  }
 
-  @_spi(Testing) public let aspect: DeclAspect
-  @_spi(Testing) public let designator: Designator
+  let aspect: DeclAspect
+  let designator: Designator
 
 
-  @_spi(Testing) public init(
+  init(
     aspect: DeclAspect,
     designator: Designator)
   {
@@ -75,7 +75,7 @@ import Foundation
   }
 
 
-  @_spi(Testing) public var correspondingImplementation: Self {
+  var correspondingImplementation: Self {
     assert(aspect == .interface)
     return Self(aspect: .implementation, designator: designator)
   }

--- a/Sources/SwiftDriver/Incremental Compilation/DictionaryOfDictionaries.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/DictionaryOfDictionaries.swift
@@ -14,7 +14,7 @@
 /// It supports iterating over all 2nd-level pairs. See `subscript(key: OuterKey)`
 
 import Foundation
-@_spi(Testing) public struct DictionaryOfDictionaries<OuterKey: Hashable, InnerKey: Hashable, Value>: Collection {
+struct DictionaryOfDictionaries<OuterKey: Hashable, InnerKey: Hashable, Value>: Collection {
   public typealias InnerDict = [InnerKey: Value]
   public typealias OuterDict = [OuterKey: InnerDict]
   

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -49,7 +49,7 @@ public class IncrementalCompilationState {
 
 // MARK: - Creating IncrementalCompilationState if possible
   /// Return nil if not compiling incrementally
-  @_spi(Testing) public init?(
+  init?(
     buildRecordInfo: BuildRecordInfo?,
     compilerMode: CompilerMode,
     diagnosticEngine: DiagnosticsEngine,

--- a/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
@@ -14,8 +14,8 @@ import TSCBasic
 
 public struct InputInfo: Equatable {
 
-  @_spi(Testing) public let status: Status
-  @_spi(Testing) public let previousModTime: Date
+  let status: Status
+  let previousModTime: Date
 
   public init(status: Status, previousModTime: Date) {
     self.status = status

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Integrator.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Integrator.swift
@@ -17,12 +17,12 @@ extension ModuleDependencyGraph {
   // MARK: Integrator - state & creation
 
   /// Integrates a \c SourceFileDependencyGraph into a \c ModuleDependencyGraph
-  @_spi(Testing) public struct Integrator {
+  struct Integrator {
 
     // Shorthands
-    @_spi(Testing) public typealias Graph = ModuleDependencyGraph
+    typealias Graph = ModuleDependencyGraph
 
-    @_spi(Testing) public  typealias Changes = Set<Node>
+    typealias Changes = Set<Node>
 
     let source: SourceFileDependencyGraph
     let swiftDeps: SwiftDeps
@@ -55,7 +55,7 @@ extension ModuleDependencyGraph.Integrator {
     case notSwiftDeps
   }
   /// returns nil for error
-  @_spi(Testing) public static func integrate(
+  static func integrate(
     swiftDeps: Graph.SwiftDeps,
     into destination: Graph,
     diagnosticEngine: DiagnosticsEngine
@@ -76,7 +76,7 @@ extension ModuleDependencyGraph.Integrator {
   /// Integrate a SourceFileDepGraph into the receiver.
   /// Integration happens when the driver needs to read SourceFileDepGraph.
   /// Returns changed nodes
-  @_spi(Testing) public static func integrate(
+  static func integrate(
     from g: SourceFileDependencyGraph,
     swiftDeps: Graph.SwiftDeps,
     into destination: Graph

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
@@ -24,9 +24,9 @@ extension ModuleDependencyGraph {
   ///
   /// Use a class, not a struct because otherwise it would be duplicated for each thing it uses
 
-  @_spi(Testing) public final class Node {
+  final class Node {
 
-    @_spi(Testing) public typealias Graph = ModuleDependencyGraph
+    typealias Graph = ModuleDependencyGraph
 
     /// Def->use arcs go by DependencyKey. There may be >1 node for a given key.
     let dependencyKey: DependencyKey

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/NodeFinder.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/NodeFinder.swift
@@ -17,7 +17,7 @@ extension ModuleDependencyGraph {
   /// The core information for the ModuleDependencyGraph
   /// Isolate in a sub-structure in order to faciliate invariant maintainance
   struct NodeFinder {
-    @_spi(Testing) public typealias Graph = ModuleDependencyGraph
+    typealias Graph = ModuleDependencyGraph
     
     /// Maps swiftDeps files and DependencyKeys to Nodes
     fileprivate typealias NodeMap = TwoDMap<SwiftDeps?, DependencyKey, Node>

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
@@ -14,21 +14,21 @@ import TSCBasic
 
 // MARK: - SwiftDeps
 extension ModuleDependencyGraph {
-  @_spi(Testing) public struct SwiftDeps: Hashable, CustomStringConvertible {
+  struct SwiftDeps: Hashable, CustomStringConvertible {
 
     let file: VirtualPath
 
-    @_spi(Testing) public init?(_ typedFile: TypedVirtualPath) {
+    init?(_ typedFile: TypedVirtualPath) {
       guard typedFile.type == .swiftDeps else { return nil }
       self.init(typedFile.file)
     }
     init(_ file: VirtualPath) {
       self.file = file
     }
-    @_spi(Testing) public init(mock i: Int) {
+    init(mock i: Int) {
       self.file = try! VirtualPath(path: String(i))
     }
-    @_spi(Testing) public var mockID: Int {
+    var mockID: Int {
        Int(file.name)!
     }
     public var description: String {
@@ -39,10 +39,10 @@ extension ModuleDependencyGraph {
 
 // MARK: - testing
 extension ModuleDependencyGraph.SwiftDeps {
-  @_spi(Testing) public var sourceFileProvideNameForMockSwiftDeps: String {
+  var sourceFileProvideNameForMockSwiftDeps: String {
     file.name
   }
-  @_spi(Testing) public var interfaceHashForMockSwiftDeps: String {
+  var interfaceHashForMockSwiftDeps: String {
     file.name
   }
 }

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
@@ -15,13 +15,13 @@ import TSCBasic
 extension ModuleDependencyGraph {
 
 /// Trace dependencies through the graph
-  @_spi(Testing) public struct Tracer {
-    @_spi(Testing) public typealias Graph = ModuleDependencyGraph
+  struct Tracer {
+    typealias Graph = ModuleDependencyGraph
 
     let startingPoints: [Node]
     let graph: ModuleDependencyGraph
 
-    @_spi(Testing) public private(set) var tracedUses: [Node] = []
+    private(set) var tracedUses: [Node] = []
 
     /// Record the paths taking so that  -driver-show-incremental can explain why things are recompiled
     /// If tracing dependencies, holds a vector used to hold the current path
@@ -37,7 +37,7 @@ extension ModuleDependencyGraph.Tracer {
 
   /// Find all uses of `defs` that have not already been traced.
   /// (If already traced, jobs have already been scheduled.)
-  @_spi(Testing) public static func findPreviouslyUntracedUsesOf<Nodes: Sequence> (
+  static func findPreviouslyUntracedUsesOf<Nodes: Sequence> (
     defs: Nodes,
     in graph: ModuleDependencyGraph,
     diagnosticEngine: DiagnosticsEngine

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
@@ -16,24 +16,24 @@ import SwiftOptions
 
 // MARK: - ModuleDependencyGraph
 
-@_spi(Testing) public final class ModuleDependencyGraph {
+final class ModuleDependencyGraph {
   
-  internal var nodeFinder = NodeFinder()
+  var nodeFinder = NodeFinder()
   
   /// When integrating a change, want to find untraced nodes so we can kick off jobs that have not been
   /// kicked off yet
   private var tracedNodes = Set<Node>()
   
-  @_spi(Testing) public var sourceSwiftDepsMap = BidirectionalMap<TypedVirtualPath, SwiftDeps>()
+  private(set) var sourceSwiftDepsMap = BidirectionalMap<TypedVirtualPath, SwiftDeps>()
 
   // Supports requests from the driver to getExternalDependencies.
-  @_spi(Testing) public internal(set) var externalDependencies = Set<ExternalDependency>()
+  public internal(set) var externalDependencies = Set<ExternalDependency>()
   
   let verifyDependencyGraphAfterEveryImport: Bool
   let emitDependencyDotFileAfterEveryImport: Bool
   let reportIncrementalDecision: ((String, TypedVirtualPath?) -> Void)?
   
-  @_spi(Testing) public let diagnosticEngine: DiagnosticsEngine
+  private let diagnosticEngine: DiagnosticsEngine
   
   public init(
     diagnosticEngine: DiagnosticsEngine,
@@ -89,7 +89,7 @@ extension ModuleDependencyGraph {
 extension ModuleDependencyGraph {
   /// Find all the sources that depend on `sourceFile`. For some source files, these will be
   /// speculatively scheduled in the first wave.
-  @_spi(Testing) public func findDependentSourceFiles(
+  func findDependentSourceFiles(
     of sourceFile: TypedVirtualPath,
     _ reportIncrementalDecision: ((String, TypedVirtualPath?) -> Void)?
   ) -> [TypedVirtualPath] {
@@ -113,7 +113,7 @@ extension ModuleDependencyGraph {
 
   /// Find all the swiftDeps files that depend on `swiftDeps`.
   /// Really private, except for testing.
-  @_spi(Testing) public func findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(
+  func findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(
     _ swiftDeps: SwiftDeps
   ) -> Set<SwiftDeps> {
     let nodes = nodeFinder.findNodes(for: swiftDeps) ?? [:]
@@ -126,7 +126,7 @@ extension ModuleDependencyGraph {
   /// After `source` has been compiled, figure out what other source files need compiling.
   /// Used to schedule the 2nd wave.
   /// Return nil in case of an error.
-  @_spi(Testing) public func findSourcesToCompileAfterCompiling(
+  func findSourcesToCompileAfterCompiling(
     _ source: TypedVirtualPath
   ) -> [TypedVirtualPath]? {
     findSourcesToCompileAfterIntegrating( sourceSwiftDepsMap[source] )
@@ -152,7 +152,7 @@ extension ModuleDependencyGraph {
 // MARK: - Scheduling either wave
 extension ModuleDependencyGraph {
   /// Find all the swiftDeps affected when the nodes change.
-  @_spi(Testing) public func findSwiftDepsToRecompileWhenNodesChange<Nodes: Sequence>(
+  func findSwiftDepsToRecompileWhenNodesChange<Nodes: Sequence>(
     _ nodes: Nodes
   ) -> Set<SwiftDeps>
   where Nodes.Element == Node
@@ -165,7 +165,7 @@ extension ModuleDependencyGraph {
     return Set(affectedNodes.compactMap {$0.swiftDeps})
   }
 
-  @_spi(Testing) public  func forEachUntracedSwiftDepsDirectlyDependent(
+  func forEachUntracedSwiftDepsDirectlyDependent(
     on externalSwiftDeps: ExternalDependency,
     _ fn: (SwiftDeps) -> Void
   ) {
@@ -205,7 +205,7 @@ extension ModuleDependencyGraph {
 // MARK: - utilities for unit testing
 extension ModuleDependencyGraph {
   /// Testing only
-  @_spi(Testing) public func haveAnyNodesBeenTraversed(inMock i: Int) -> Bool {
+  func haveAnyNodesBeenTraversed(inMock i: Int) -> Bool {
     let swiftDeps = SwiftDeps(mock: i)
     // optimization
     if let fileNode = nodeFinder.findFileInterfaceNode(forMock: swiftDeps),

--- a/Sources/SwiftDriver/Incremental Compilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/Multidictionary.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Like a Dictionary, but can have >1 value per key (i.e., a multimap)
-@_spi(Testing) public struct Multidictionary<Key: Hashable, Value: Hashable>: Collection {
+struct Multidictionary<Key: Hashable, Value: Hashable>: Collection {
   public typealias OuterDict = [Key: Set<Value>]
   public typealias InnerSet = Set<Value>
   private var outerDict = OuterDict()

--- a/Sources/SwiftDriver/Incremental Compilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/SourceFileDependencyGraph.swift
@@ -12,7 +12,7 @@
 import Foundation
 import TSCUtility
 
-@_spi(Testing) public struct SourceFileDependencyGraph {
+struct SourceFileDependencyGraph {
   public static let sourceFileProvidesInterfaceSequenceNumber: Int = 0
   public static let sourceFileProvidesImplementationSequenceNumber: Int = 1
   
@@ -62,7 +62,7 @@ extension SourceFileDependencyGraph {
     public var defsIDependUpon: [Int]
     public var isProvides: Bool
     
-    @_spi(Testing) public init(
+    init(
       key: DependencyKey,
       fingerprint: String?,
       sequenceNumber: Int,
@@ -126,7 +126,7 @@ extension SourceFileDependencyGraph {
     return try self.init(pathString: path.pathString)
   }
   
-  @_spi(Testing) public init(nodesForTesting: [Node]) {
+  init(nodesForTesting: [Node]) {
     majorVersion = 0
     minorVersion = 0
     compilerVersionString = ""
@@ -134,13 +134,13 @@ extension SourceFileDependencyGraph {
   }
 
   // FIXME: This should accept a FileSystem parameter.
-  @_spi(Testing) public init(pathString: String) throws {
+  init(pathString: String) throws {
     let data = try Data(contentsOf: URL(fileURLWithPath: pathString))
     try self.init(data: data)
   }
 
-  @_spi(Testing) public init(data: Data,
-                             fromSwiftModule extractFromSwiftModule: Bool = false) throws {
+  init(data: Data,
+       fromSwiftModule extractFromSwiftModule: Bool = false) throws {
     struct Visitor: BitstreamVisitor {
       let extractFromSwiftModule: Bool
 

--- a/Sources/SwiftDriver/Incremental Compilation/TwoDMap.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/TwoDMap.swift
@@ -12,7 +12,7 @@
 
 
 /// A map with 2 keys that can iterate in a number of ways
-@_spi(Testing) public struct TwoDMap<Key1: Hashable, Key2: Hashable, Value: Equatable>: MutableCollection {
+struct TwoDMap<Key1: Hashable, Key2: Hashable, Value: Equatable>: MutableCollection {
 
   private var map1 = DictionaryOfDictionaries<Key1, Key2, Value>()
   private var map2 = DictionaryOfDictionaries<Key2, Key1, Value>()

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -16,7 +16,7 @@ import TSCBasic
 // argument input file to the linker.
 // FIXME: Also handle Cygwin and MinGW
 extension Driver {
-  @_spi(Testing) public var isAutolinkExtractJobNeeded: Bool {
+  var isAutolinkExtractJobNeeded: Bool {
     [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil
   }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 import TSCBasic
 
-@_spi(Testing) import SwiftDriver
+@testable import SwiftDriver
 
 final class NonincrementalCompilationTests: XCTestCase {
   func testBuildRecordReading() throws {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@_spi(Testing) import SwiftDriver
+@testable import SwiftDriver
 import TSCBasic
 
 class ModuleDependencyGraphTests: XCTestCase {
@@ -949,7 +949,7 @@ extension ModuleDependencyGraph {
   }
 
   /// Can return duplicates
-  private func findUntracedSwiftDepsDependent(
+  func findUntracedSwiftDepsDependent(
     on externalDependency: ExternalDependency
   ) -> [SwiftDeps] {
     var foundSwiftDeps = [SwiftDeps]()

--- a/Tests/SwiftDriverTests/TwoDMapTests.swift
+++ b/Tests/SwiftDriverTests/TwoDMapTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@_spi(Testing) import SwiftDriver
+@testable import SwiftDriver
 
 class TwoDMapTests: XCTestCase {
 


### PR DESCRIPTION
The latest Swift compiler is less tolerant of @_spi's than before. Remove the offenders.
rdar://71381579