### PR TITLE
[DNM] Audit of failing integration tests

### DIFF
--- a/test-fails.txt
+++ b/test-fails.txt
@@ -1,9 +1,5 @@
-Audit of Failing Driver Integration Tests
+Audit of Failing Driver Integration Tests (Errors may be out of date, but failures should be accurate to commit date)
 
-test/Interpreter
-  Swift(macosx-x86_64) :: Interpreter/vtables_multifile_testable.swift
-    Fatal error: multiple producers for output vtables_multifile_testable_helper.swiftmodule
-  
 validation-test/Driver:
   Swift(macosx-x86_64) :: Driver/Dependencies/rdar23148987.swift
     Required changes to test for spaces and json ordering. There is warning and skipped jobs aren't being skipped.
@@ -12,21 +8,7 @@ validation-test/Driver:
   Swift(macosx-x86_64) :: Driver/batch_mode_size_limit.swift
     -enable-only-one-dependency-file, Feature not brought to swift-driver on purpose: https://github.com/apple/swift-driver/pull/74
     
-test/Driver/Dependencies:
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-while-editing-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-fine.swift
-    Missing `Handled main.swift`
-    
-  Swift(macosx-x86_64) :: Driver/Dependencies/private-fine.swift
-    Missing `Handled a.swift`
-  
-  Swift(macosx-x86_64) :: Driver/Dependencies/fail-chained-fine.swift
-    Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Dependencies/Output/fail-chained-fine.swift.script: line 21: syntax error: unexpected end of file
-
 test/Driver:
-  Swift(macosx-x86_64) :: Driver/actions.swift
-    `3: link, {1, 1}, image` expected `3: link, {1, 2}, image`
-  
   Swift(macosx-x86_64) :: Driver/filelists.swift
     ValueError: '-filelist' is not in list
     
@@ -56,9 +38,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/driver-time-compilation.swift
     No output - Implementing would require rebuilding llvm::Timer
 
-  Swift(macosx-x86_64) :: Driver/batch_mode_with_WMO_or_index.swift
-    Test expects specific parameter ordering
-
   Swift(macosx-x86_64) :: Driver/static-archive.swift
   Swift(macosx-x86_64) :: Driver/link-time-opt.swift
   Swift(macosx-x86_64) :: Driver/verbose.swift
@@ -70,7 +49,6 @@ test/Driver:
     Windows
 
   Swift(macosx-x86_64) :: Driver/merge-module.swift
-  Swift(macosx-x86_64) :: Driver/batch_mode_aux_file_order.swift
   Swift(macosx-x86_64) :: Driver/bridging-pch.swift
     Temporary file name postfix (-######). swift-driver doesn't do this, c++ driver does, functionality comes from llvm.
 
@@ -109,9 +87,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/driver-use-frontend.swift
     swift-driver checks that frontend exists, c++ driver does not
 
-  Swift(macosx-x86_64) :: Driver/emit-module-from-sib.swift
-    Output is missing some types
-
   Swift(macosx-x86_64) :: Driver/options-interpreter.swift
     Input validation order difference. swift-driver does SDKROOT validation first, c++ driver does objc runtime library validation first.
     swift-driver needs sdk root early because it uses it to get target info.
@@ -121,3 +96,15 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/response-file.swift
     Temporary directory additional level, `TMPDIR` vs `TMPDIR/TemporaryDirectory.#####/`
+
+  Swift(macosx-x86_64) :: Driver/macabi-environment.swift
+  Swift(macosx-x86_64) :: Driver/sdk-version.swift
+    Missing: -target-sdk-version 10.15
+    Likely the cause: warning: Could not read SDKSettings.json for SDK at: SOURCE_DIR/test/Driver/Inputs/MacOSX10.15.versioned.sdk
+  
+  Swift(macosx-x86_64) :: Driver/sanitize_address_use_odr_indicator.swift
+    Missing: -sanitize-address-use-odr-indicator
+  
+  Swift(macosx-x86_64) :: Driver/sanitize_recover.swift
+    Missing: unsupported argument 'foo' to option '-sanitize-recover='
+    https://github.com/apple/swift-driver/pull/645

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -101,6 +101,7 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/sdk-version.swift
     Missing: -target-sdk-version 10.15
     Likely the cause: warning: Could not read SDKSettings.json for SDK at: SOURCE_DIR/test/Driver/Inputs/MacOSX10.15.versioned.sdk
+    https://github.com/apple/swift/pull/37338
   
   Swift(macosx-x86_64) :: Driver/sanitize_address_use_odr_indicator.swift
     Missing: -sanitize-address-use-odr-indicator

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -65,15 +65,14 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/parseable_output.swift
   Swift(macosx-x86_64) :: Driver/parseable_output_unicode.swift
     JSON formatting - Not simple fix, it's full JSON blobs being compared. Best option is probably parsing them in python or `REQUIRES: cplusplus_driver`.
-
-  Swift(macosx-x86_64) :: Driver/Dependencies/bindings-build-record.swift
-    Missing error: 'Disabling incremental build: could not read build record'
     
   Swift(macosx-x86_64) :: Driver/multi-threaded.swift
     Output file map isn't being respected
 
+  Swift(macosx-x86_64) :: Driver/emit-dependencies.swift
   Swift(macosx-x86_64) :: Driver/emit-module-summary.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/only-skip-once.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/embed-bitcode-parallel-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/whole-module-build-record.swift
     Exit Code non-zero (no output)
 
   Swift(macosx-x86_64) :: Driver/driver-time-compilation.swift
@@ -111,10 +110,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/working-directory.swift
   Swift(macosx-x86_64) :: Driver/options.swift
     Error about repl integrated repl being removed
-
-  Swift(macosx-x86_64) :: Driver/driver-compile.swift
-    Missing -emit-reference-dependencies-path
-    Fixed by: https://github.com/apple/swift-driver/pull/475
 
   Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output-fine.swift
   Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output_cancellation.swift

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -1,0 +1,181 @@
+Audit of Failing Driver Integration Tests
+
+validation-test/Driver:
+  Swift(macosx-x86_64) :: Driver/Dependencies/rdar23148987.swift
+    Required changes to test for spaces and json ordering. There is warning and skipped jobs aren't being skipped.
+  Swift(macosx-x86_64) :: Driver/Dependencies/rdar25405605.swift
+    Required changes to test for spaces and json ordering. Still failing.
+  Swift(macosx-x86_64) :: Driver/batch_mode_size_limit.swift
+    -enable-only-one-dependency-file, Feature not brought to swift-driver on purpose: https://github.com/apple/swift-driver/pull/74
+
+test/Driver:
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-provides-before-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/malformed-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-provides-after-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/private-after-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-external-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-parseable-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-while-editing-fine.swift
+  Swift(macosx-x86_64) :: Driver/filelists.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-parallel-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/mutual-interface-hash-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-depends-after-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/nominal-members-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-merge-module-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/malformed-but-valid-yaml-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/fail-simple-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-external-delete-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-depends-before-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/independent-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/embed-bitcode-parallel-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/file-added-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/private-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/independent-parseable-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/mutual-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/fail-new-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/fail-chained-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/check-interface-implementation-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/crash-simple-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/fail-with-bad-deps-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/fail-added-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-after-multiple-nominal-members-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-mutual-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-after-multiple-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/fail-interface-hash-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/crash-new-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/chained-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-after-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-swift-version-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/chained-after-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/crash-added-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/chained-additional-kinds-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/dependencies-preservation-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-arguments-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-conflicting-arguments-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-malformed-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-inputs-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/whole-module-build-record.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/independent-half-dirty-fine.swift
+  Swift(macosx-x86_64) :: Driver/bad_exec.swift
+    -print-frontend-info: https://github.com/apple/swift/pull/34405
+
+  Swift(macosx-x86_64) :: Driver/bindings.swift
+    Missing .swiftdeps
+
+  Swift(macosx-x86_64) :: Driver/parseable_output.swift
+  Swift(macosx-x86_64) :: Driver/parseable_output_unicode.swift
+    JSON formatting - Potentially just easy test fix
+
+  Swift(macosx-x86_64) :: Driver/Dependencies/bindings-build-record.swift
+  Swift(macosx-x86_64) :: Driver/working-directory.swift
+  Swift(macosx-x86_64) :: Driver/multi-threaded.swift
+    ./ path difference - Potentially easy test fix
+
+  Swift(macosx-x86_64) :: Driver/emit-module-summary.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/only-skip-once.swift
+    Exit Code non-zero (no output)
+
+  Swift(macosx-x86_64) :: Driver/driver-time-compilation.swift
+    No output - Implementing would require rebuilding llvm::Timer
+
+  Swift(macosx-x86_64) :: Driver/cross_module.swift
+    Looks like swift-driver bug that could be fixed
+
+  Swift(macosx-x86_64) :: Driver/tools_directory.swift
+  Swift(macosx-x86_64) :: Driver/batch_mode_with_WMO_or_index.swift
+    Test expects specific parameter ordering
+
+  Swift(macosx-x86_64) :: Driver/static-archive.swift
+  Swift(macosx-x86_64) :: Driver/link-time-opt.swift
+  Swift(macosx-x86_64) :: Driver/verbose.swift
+  Swift(macosx-x86_64) :: Driver/profiling.swift
+  Swift(macosx-x86_64) :: Driver/sanitizers.swift
+  Swift(macosx-x86_64) :: Driver/windows-libc-options.swift
+  Swift(macosx-x86_64) :: Driver/sanitize_scudo.swift
+    Windows
+
+  Swift(macosx-x86_64) :: Driver/merge-module.swift
+  Swift(macosx-x86_64) :: Driver/batch_mode_aux_file_order.swift
+    Temporary file name postfix (-######). swift-driver doesn't do this, c++ driver does, functionality comes from llvm.
+
+  Swift(macosx-x86_64) :: Driver/batch_mode_dependencies_make_wrong_order.swift
+  Swift(macosx-x86_64) :: Driver/advanced_output_file_map.swift
+  Swift(macosx-x86_64) :: Driver/supplementary-filelist-empty.swift
+    Unable to read file map
+
+  Swift(macosx-x86_64) :: Driver/bridging-pch.swift
+  Swift(macosx-x86_64) :: Driver/actions-dsym.swift
+  Swift(macosx-x86_64) :: Driver/actions.swift
+    -driver-print-actions bug
+
+  Swift(macosx-x86_64) :: Driver/options-repl.swift
+    Expecting an error about no input files, got error saying to use lldb repl
+
+  Swift(macosx-x86_64) :: Driver/options-repl-darwin.swift
+    Expecting integrated repl
+  
+  Swift(macosx-x86_64) :: Driver/sdk-apple.swift
+    Error about repl integrated repl being removed
+
+  Swift(macosx-x86_64) :: Driver/options.swift
+    Expected: error: unknown argument: '-crazy-option-that-does-not-exist'
+    Got:      error: option '-crazy-option-that-does-not-exist' is not supported by 'swift'; did you mean to use 'swiftc'?
+
+  Swift(macosx-x86_64) :: Driver/driver-compile.swift
+    Missing -emit-reference-dependencies-path
+
+  Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output-fine.swift
+  Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output_cancellation.swift
+  Swift(macosx-x86_64) :: Driver/batch_mode_bridging_pch.swift
+    Crash: Multiple jobs producing same output file
+
+  Swift(macosx-x86_64) :: Driver/android-link.swift
+    Target armv7-unknown-linux-androideabi vs armv7-none-linux-androidhf
+
+  Swift(macosx-x86_64) :: Driver/driver_migration.swift
+    Missing -emit-remap-file-path
+
+  Swift(macosx-x86_64) :: Driver/sdk.swift
+    Missing {{-syslibroot|--sysroot}}
+
+  Swift(macosx-x86_64) :: Driver/SourceRanges/range-incremental-no-build-record.swift
+    Same error messsage is worded differently
+  
+  Swift(macosx-x86_64) :: Driver/temp-files.swift
+    swift-driver has no -save-temps support
+
+  Swift(macosx-x86_64) :: Driver/batch_mode.swift
+    Linking failed
+
+  Swift(macosx-x86_64) :: Driver/autolink-force-load-no-comdat.swift
+    Different error than expected
+
+  Swift(macosx-x86_64) :: Driver/sanitize_coverage.swift
+    swift-driver missing parameter compatability checking
+
+  Swift(macosx-x86_64) :: Driver/embed-bitcode.swift
+  Swift(macosx-x86_64) :: Driver/modulewrap.swift
+    Missing -emit-module-path
+
+  Swift(macosx-x86_64) :: Driver/driver-use-frontend.swift
+    swift-driver checks that frontend exists, c++ driver does not
+
+  Swift(macosx-x86_64) :: Driver/continue-building-after-errors.swift
+    Found unexpected output
+
+  Swift(macosx-x86_64) :: Driver/emit-module-from-sib.swift
+    Output is missing some types
+
+  Swift(macosx-x86_64) :: Driver/help.swift
+    https://github.com/apple/swift-driver/pull/357
+
+  Swift(macosx-x86_64) :: Driver/options-interpreter.swift
+    Missing validation of SDKROOT
+
+  Swift(macosx-x86_64) :: Driver/pipe_round_robin.swift.gyb
+    name 'NumDriverPipeReads' is not defined
+
+  Swift(macosx-x86_64) :: Driver/response-file.swift
+    Potentially -debug-crash-immediately not being handled

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -82,7 +82,7 @@ test/Driver:
     No output - Implementing would require rebuilding llvm::Timer
 
   Swift(macosx-x86_64) :: Driver/cross_module.swift
-    Looks like swift-driver bug that could be fixed
+    Experimental feature not yet implemented in swift-driver
 
   Swift(macosx-x86_64) :: Driver/batch_mode_with_WMO_or_index.swift
     Test expects specific parameter ordering

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -149,10 +149,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/autolink-force-load-no-comdat.swift
     Different error than expected
 
-  Swift(macosx-x86_64) :: Driver/sanitize_coverage.swift
-    swift-driver missing parameter compatability checking
-    ^ https://github.com/apple/swift-driver/pull/369
-
   Swift(macosx-x86_64) :: Driver/embed-bitcode.swift
   Swift(macosx-x86_64) :: Driver/modulewrap.swift
     Missing -emit-module-path
@@ -162,6 +158,7 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/continue-building-after-errors.swift
     Found unexpected output
+    ^ https://github.com/apple/swift-driver/pull/371
 
   Swift(macosx-x86_64) :: Driver/emit-module-from-sib.swift
     Output is missing some types

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -28,7 +28,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/Dependencies/one-way-external-delete-fine.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/one-way-depends-before-fine.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/independent-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/embed-bitcode-parallel-fine.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/file-added-fine.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/private-fine.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/independent-parseable-fine.swift
@@ -56,7 +55,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-conflicting-arguments-fine.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-malformed-fine.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-inputs-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/whole-module-build-record.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/independent-half-dirty-fine.swift
   Swift(macosx-x86_64) :: Driver/bad_exec.swift
     -print-frontend-info: https://github.com/apple/swift/pull/34405
@@ -81,9 +79,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/driver-time-compilation.swift
     No output - Implementing would require rebuilding llvm::Timer
 
-  Swift(macosx-x86_64) :: Driver/cross_module.swift
-    Experimental feature not yet implemented in swift-driver
-
   Swift(macosx-x86_64) :: Driver/batch_mode_with_WMO_or_index.swift
     Test expects specific parameter ordering
 
@@ -104,7 +99,6 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/batch_mode_dependencies_make_wrong_order.swift
   Swift(macosx-x86_64) :: Driver/advanced_output_file_map.swift
-  Swift(macosx-x86_64) :: Driver/supplementary-filelist-empty.swift
     Unable to read file map
 
   Swift(macosx-x86_64) :: Driver/options-repl.swift
@@ -126,15 +120,8 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/batch_mode_bridging_pch.swift
     Crash: Multiple jobs producing same output file
 
-  Swift(macosx-x86_64) :: Driver/android-link.swift
-    Target armv7-unknown-linux-androideabi vs armv7-none-linux-androidhf
-    ^ https://github.com/apple/swift-driver/pull/370
-
   Swift(macosx-x86_64) :: Driver/driver_migration.swift
     Missing -emit-remap-file-path
-
-  Swift(macosx-x86_64) :: Driver/SourceRanges/range-incremental-no-build-record.swift
-    Same error messsage is worded differently
   
   Swift(macosx-x86_64) :: Driver/temp-files.swift
     swift-driver has no -save-temps support, and if an environment variable like `TMP` is set, swift-driver places temporary files in a subdirectory instead of immediately inside the specified one
@@ -146,15 +133,10 @@ test/Driver:
     Different error than expected
 
   Swift(macosx-x86_64) :: Driver/embed-bitcode.swift
-  Swift(macosx-x86_64) :: Driver/modulewrap.swift
-    Missing -emit-module-path
+    Different job order
 
   Swift(macosx-x86_64) :: Driver/driver-use-frontend.swift
     swift-driver checks that frontend exists, c++ driver does not
-
-  Swift(macosx-x86_64) :: Driver/continue-building-after-errors.swift
-    Found unexpected output
-    ^ https://github.com/apple/swift-driver/pull/371
 
   Swift(macosx-x86_64) :: Driver/emit-module-from-sib.swift
     Output is missing some types
@@ -168,3 +150,7 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/response-file.swift
     Temporary directory additional level, `TMPDIR` vs `TMPDIR/TemporaryDirectory.#####/`
+    
+  Swift(macosx-x86_64) :: Driver/help.swift
+    Expecting `SEE ALSO: swift build, swift run, swift package, swift test`
+    Broken with: https://github.com/apple/swift-driver/pull/433

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -104,6 +104,7 @@ test/Driver:
   
   Swift(macosx-x86_64) :: Driver/sanitize_address_use_odr_indicator.swift
     Missing: -sanitize-address-use-odr-indicator
+    https://github.com/apple/swift-driver/pull/647
   
   Swift(macosx-x86_64) :: Driver/sanitize_recover.swift
     Missing: unsupported argument 'foo' to option '-sanitize-recover='

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -11,8 +11,22 @@ validation-test/Driver:
     Required changes to test for spaces and json ordering. Still failing.
   Swift(macosx-x86_64) :: Driver/batch_mode_size_limit.swift
     -enable-only-one-dependency-file, Feature not brought to swift-driver on purpose: https://github.com/apple/swift-driver/pull/74
+    
+test/Driver/Dependencies:
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-while-editing-fine.swift
+  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-fine.swift
+    Missing `Handled main.swift`
+    
+  Swift(macosx-x86_64) :: Driver/Dependencies/private-fine.swift
+    Missing `Handled a.swift`
+  
+  Swift(macosx-x86_64) :: Driver/Dependencies/fail-chained-fine.swift
+    Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Dependencies/Output/fail-chained-fine.swift.script: line 21: syntax error: unexpected end of file
 
 test/Driver:
+  Swift(macosx-x86_64) :: Driver/actions.swift
+    `3: link, {1, 1}, image` expected `3: link, {1, 2}, image`
+  
   Swift(macosx-x86_64) :: Driver/filelists.swift
     ValueError: '-filelist' is not in list
     
@@ -20,9 +34,6 @@ test/Driver:
     Different error message
     Looking for: `unable to execute command`
     Found: `error: could not find executable for '/always/searching/never/finding'`
-    
-  Swift(macosx-x86_64) :: Driver/access-notes.swift
-    error: unknown argument: '-access-notes-path'
     
   Swift(macosx-x86_64) :: Driver/vfs.swift
     C++ driver tests checks that inputs exist, that's missing in swift-driver
@@ -40,8 +51,6 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/emit-dependencies.swift
   Swift(macosx-x86_64) :: Driver/emit-module-summary.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/embed-bitcode-parallel-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/whole-module-build-record.swift
     Exit Code non-zero (no output)
 
   Swift(macosx-x86_64) :: Driver/driver-time-compilation.swift

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -103,10 +103,6 @@ test/Driver:
     Likely the cause: warning: Could not read SDKSettings.json for SDK at: SOURCE_DIR/test/Driver/Inputs/MacOSX10.15.versioned.sdk
     https://github.com/apple/swift/pull/37338
   
-  Swift(macosx-x86_64) :: Driver/sanitize_address_use_odr_indicator.swift
-    Missing: -sanitize-address-use-odr-indicator
-    https://github.com/apple/swift-driver/pull/647
-  
   Swift(macosx-x86_64) :: Driver/sanitize_recover.swift
     Missing: unsupported argument 'foo' to option '-sanitize-recover='
     https://github.com/apple/swift-driver/pull/645

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -124,6 +124,7 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/options.swift
     Expected: error: unknown argument: '-crazy-option-that-does-not-exist'
     Got:      error: option '-crazy-option-that-does-not-exist' is not supported by 'swift'; did you mean to use 'swiftc'?
+    ^ should be fixed by https://github.com/apple/swift-driver/pull/366
 
   Swift(macosx-x86_64) :: Driver/driver-compile.swift
     Missing -emit-reference-dependencies-path

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -96,13 +96,7 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/response-file.swift
     Temporary directory additional level, `TMPDIR` vs `TMPDIR/TemporaryDirectory.#####/`
-
-  Swift(macosx-x86_64) :: Driver/macabi-environment.swift
-  Swift(macosx-x86_64) :: Driver/sdk-version.swift
-    Missing: -target-sdk-version 10.15
-    Likely the cause: warning: Could not read SDKSettings.json for SDK at: SOURCE_DIR/test/Driver/Inputs/MacOSX10.15.versioned.sdk
-    https://github.com/apple/swift/pull/37338
   
   Swift(macosx-x86_64) :: Driver/sanitize_recover.swift
     Missing: unsupported argument 'foo' to option '-sanitize-recover='
-    https://github.com/apple/swift-driver/pull/645
+    Fixed by, but error message was changed: https://github.com/apple/swift-driver/pull/645

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -175,7 +175,8 @@ test/Driver:
     https://github.com/apple/swift-driver/pull/357
 
   Swift(macosx-x86_64) :: Driver/options-interpreter.swift
-    Missing validation of SDKROOT
+    Input validation order difference. swift-driver does SDKROOT validation first, c++ driver does objc runtime library validation first.
+    swift-driver needs sdk root early because it uses it to get target info.
 
   Swift(macosx-x86_64) :: Driver/pipe_round_robin.swift.gyb
     name 'NumDriverPipeReads' is not defined

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -1,4 +1,4 @@
-Audit of Failing Driver Integration Tests (Errors may be out of date, but failures should be accurate to commit date)
+Audit of Failing Driver Integration Tests (Specific error reasons may be out of date, but which tests failed should be accurate to commit date)
 
 validation-test/Driver:
   Swift(macosx-x86_64) :: Driver/Dependencies/rdar23148987.swift

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -66,12 +66,13 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/parseable_output.swift
   Swift(macosx-x86_64) :: Driver/parseable_output_unicode.swift
-    JSON formatting - Potentially just easy test fix
+    JSON formatting - Not simple fix, it's full JSON blobs being compared. Best option is probably parsing them in python or `REQUIRES: cplusplus_driver`.
 
   Swift(macosx-x86_64) :: Driver/Dependencies/bindings-build-record.swift
-  Swift(macosx-x86_64) :: Driver/working-directory.swift
+    Missing error: 'Disabling incremental build: could not read build record'
+    
   Swift(macosx-x86_64) :: Driver/multi-threaded.swift
-    ./ path difference - Potentially easy test fix
+    Output file map isn't being respected
 
   Swift(macosx-x86_64) :: Driver/emit-module-summary.swift
   Swift(macosx-x86_64) :: Driver/Dependencies/only-skip-once.swift
@@ -117,6 +118,7 @@ test/Driver:
     Expecting integrated repl
   
   Swift(macosx-x86_64) :: Driver/sdk-apple.swift
+  Swift(macosx-x86_64) :: Driver/working-directory.swift
     Error about repl integrated repl being removed
 
   Swift(macosx-x86_64) :: Driver/options.swift

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -84,7 +84,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/cross_module.swift
     Looks like swift-driver bug that could be fixed
 
-  Swift(macosx-x86_64) :: Driver/tools_directory.swift
   Swift(macosx-x86_64) :: Driver/batch_mode_with_WMO_or_index.swift
     Test expects specific parameter ordering
 
@@ -95,6 +94,7 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/sanitizers.swift
   Swift(macosx-x86_64) :: Driver/windows-libc-options.swift
   Swift(macosx-x86_64) :: Driver/sanitize_scudo.swift
+  Swift(macosx-x86_64) :: Driver/sdk.swift
     Windows
 
   Swift(macosx-x86_64) :: Driver/merge-module.swift
@@ -119,12 +119,8 @@ test/Driver:
   
   Swift(macosx-x86_64) :: Driver/sdk-apple.swift
   Swift(macosx-x86_64) :: Driver/working-directory.swift
-    Error about repl integrated repl being removed
-
   Swift(macosx-x86_64) :: Driver/options.swift
-    Expected: error: unknown argument: '-crazy-option-that-does-not-exist'
-    Got:      error: option '-crazy-option-that-does-not-exist' is not supported by 'swift'; did you mean to use 'swiftc'?
-    ^ should be fixed by https://github.com/apple/swift-driver/pull/366
+    Error about repl integrated repl being removed
 
   Swift(macosx-x86_64) :: Driver/driver-compile.swift
     Missing -emit-reference-dependencies-path
@@ -139,9 +135,6 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/driver_migration.swift
     Missing -emit-remap-file-path
-
-  Swift(macosx-x86_64) :: Driver/sdk.swift
-    Missing {{-syslibroot|--sysroot}}
 
   Swift(macosx-x86_64) :: Driver/SourceRanges/range-incremental-no-build-record.swift
     Same error messsage is worded differently
@@ -170,9 +163,6 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/emit-module-from-sib.swift
     Output is missing some types
-
-  Swift(macosx-x86_64) :: Driver/help.swift
-    https://github.com/apple/swift-driver/pull/357
 
   Swift(macosx-x86_64) :: Driver/options-interpreter.swift
     Input validation order difference. swift-driver does SDKROOT validation first, c++ driver does objc runtime library validation first.

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -99,6 +99,7 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/merge-module.swift
   Swift(macosx-x86_64) :: Driver/batch_mode_aux_file_order.swift
+  Swift(macosx-x86_64) :: Driver/bridging-pch.swift
     Temporary file name postfix (-######). swift-driver doesn't do this, c++ driver does, functionality comes from llvm.
 
   Swift(macosx-x86_64) :: Driver/batch_mode_dependencies_make_wrong_order.swift
@@ -106,10 +107,10 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/supplementary-filelist-empty.swift
     Unable to read file map
 
-  Swift(macosx-x86_64) :: Driver/bridging-pch.swift
   Swift(macosx-x86_64) :: Driver/actions-dsym.swift
   Swift(macosx-x86_64) :: Driver/actions.swift
     -driver-print-actions bug
+    ^ https://github.com/apple/swift-driver/pull/372
 
   Swift(macosx-x86_64) :: Driver/options-repl.swift
     Expecting an error about no input files, got error saying to use lldb repl

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -1,5 +1,9 @@
 Audit of Failing Driver Integration Tests
 
+test/Interpreter
+  Swift(macosx-x86_64) :: Interpreter/vtables_multifile_testable.swift
+    Fatal error: multiple producers for output vtables_multifile_testable_helper.swiftmodule
+  
 validation-test/Driver:
   Swift(macosx-x86_64) :: Driver/Dependencies/rdar23148987.swift
     Required changes to test for spaces and json ordering. There is warning and skipped jobs aren't being skipped.
@@ -9,55 +13,20 @@ validation-test/Driver:
     -enable-only-one-dependency-file, Feature not brought to swift-driver on purpose: https://github.com/apple/swift-driver/pull/74
 
 test/Driver:
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-provides-before-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/malformed-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-provides-after-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/private-after-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-external-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-parseable-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-while-editing-fine.swift
   Swift(macosx-x86_64) :: Driver/filelists.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-parallel-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/mutual-interface-hash-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-depends-after-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/nominal-members-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-merge-module-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/malformed-but-valid-yaml-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/fail-simple-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-external-delete-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/one-way-depends-before-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/independent-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/file-added-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/private-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/independent-parseable-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/mutual-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/fail-new-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/fail-chained-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/check-interface-implementation-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/crash-simple-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/fail-with-bad-deps-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/fail-added-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-after-multiple-nominal-members-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-mutual-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-after-multiple-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/fail-interface-hash-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/crash-new-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/chained-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/chained-private-after-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-swift-version-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/chained-after-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/crash-added-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/chained-additional-kinds-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/dependencies-preservation-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-arguments-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-conflicting-arguments-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-malformed-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/driver-show-incremental-inputs-fine.swift
-  Swift(macosx-x86_64) :: Driver/Dependencies/independent-half-dirty-fine.swift
+    ValueError: '-filelist' is not in list
+    
   Swift(macosx-x86_64) :: Driver/bad_exec.swift
-    -print-frontend-info: https://github.com/apple/swift/pull/34405
+    Different error message
+    Looking for: `unable to execute command`
+    Found: `error: could not find executable for '/always/searching/never/finding'`
+    
+  Swift(macosx-x86_64) :: Driver/access-notes.swift
+    error: unknown argument: '-access-notes-path'
+    
+  Swift(macosx-x86_64) :: Driver/vfs.swift
+    C++ driver tests checks that inputs exist, that's missing in swift-driver
+    Missing error: no such file or directory: 'random.swift'
 
   Swift(macosx-x86_64) :: Driver/bindings.swift
     Missing .swiftdeps

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -132,6 +132,7 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/android-link.swift
     Target armv7-unknown-linux-androideabi vs armv7-none-linux-androidhf
+    ^ https://github.com/apple/swift-driver/pull/370
 
   Swift(macosx-x86_64) :: Driver/driver_migration.swift
     Missing -emit-remap-file-path
@@ -150,6 +151,7 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/sanitize_coverage.swift
     swift-driver missing parameter compatability checking
+    ^ https://github.com/apple/swift-driver/pull/369
 
   Swift(macosx-x86_64) :: Driver/embed-bitcode.swift
   Swift(macosx-x86_64) :: Driver/modulewrap.swift

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -80,7 +80,6 @@ test/Driver:
     No output - Implementing would require rebuilding llvm::Timer
 
   Swift(macosx-x86_64) :: Driver/batch_mode_with_WMO_or_index.swift
-  Swift(macosx-x86_64) :: Driver/driver_migration.swift
     Test expects specific parameter ordering
 
   Swift(macosx-x86_64) :: Driver/static-archive.swift
@@ -115,7 +114,7 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/driver-compile.swift
     Missing -emit-reference-dependencies-path
-    https://github.com/apple/swift-driver/pull/475 Fixes, but test expects temporary file name postfix
+    Fixed by: https://github.com/apple/swift-driver/pull/475
 
   Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output-fine.swift
   Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output_cancellation.swift
@@ -149,7 +148,3 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/response-file.swift
     Temporary directory additional level, `TMPDIR` vs `TMPDIR/TemporaryDirectory.#####/`
-    
-  Swift(macosx-x86_64) :: Driver/help.swift
-    Expecting `SEE ALSO: swift build, swift run, swift package, swift test`
-    Broken with: https://github.com/apple/swift-driver/pull/433

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -181,4 +181,4 @@ test/Driver:
     name 'NumDriverPipeReads' is not defined
 
   Swift(macosx-x86_64) :: Driver/response-file.swift
-    Potentially -debug-crash-immediately not being handled
+    Temporary directory additional level, `TMPDIR` vs `TMPDIR/TemporaryDirectory.#####/`

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -107,11 +107,6 @@ test/Driver:
   Swift(macosx-x86_64) :: Driver/supplementary-filelist-empty.swift
     Unable to read file map
 
-  Swift(macosx-x86_64) :: Driver/actions-dsym.swift
-  Swift(macosx-x86_64) :: Driver/actions.swift
-    -driver-print-actions bug
-    ^ https://github.com/apple/swift-driver/pull/372
-
   Swift(macosx-x86_64) :: Driver/options-repl.swift
     Expecting an error about no input files, got error saying to use lldb repl
 

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -142,10 +142,10 @@ test/Driver:
     Same error messsage is worded differently
   
   Swift(macosx-x86_64) :: Driver/temp-files.swift
-    swift-driver has no -save-temps support
+    swift-driver has no -save-temps support, and if an environment variable like `TMP` is set, swift-driver places temporary files in a subdirectory instead of immediately inside the specified one
 
   Swift(macosx-x86_64) :: Driver/batch_mode.swift
-    Linking failed
+    Linking failed (`-driver-skip-execution should prevent it from attempting the link in the first place, but isn't implemented yet`)
 
   Swift(macosx-x86_64) :: Driver/autolink-force-load-no-comdat.swift
     Different error than expected
@@ -169,7 +169,7 @@ test/Driver:
     swift-driver needs sdk root early because it uses it to get target info.
 
   Swift(macosx-x86_64) :: Driver/pipe_round_robin.swift.gyb
-    name 'NumDriverPipeReads' is not defined
+    name 'NumDriverPipeReads' is not defined (This test depends on the driver's performance counters, which aren't implemented yet)
 
   Swift(macosx-x86_64) :: Driver/response-file.swift
     Temporary directory additional level, `TMPDIR` vs `TMPDIR/TemporaryDirectory.#####/`

--- a/test-fails.txt
+++ b/test-fails.txt
@@ -80,6 +80,7 @@ test/Driver:
     No output - Implementing would require rebuilding llvm::Timer
 
   Swift(macosx-x86_64) :: Driver/batch_mode_with_WMO_or_index.swift
+  Swift(macosx-x86_64) :: Driver/driver_migration.swift
     Test expects specific parameter ordering
 
   Swift(macosx-x86_64) :: Driver/static-archive.swift
@@ -114,14 +115,12 @@ test/Driver:
 
   Swift(macosx-x86_64) :: Driver/driver-compile.swift
     Missing -emit-reference-dependencies-path
+    https://github.com/apple/swift-driver/pull/475 Fixes, but test expects temporary file name postfix
 
   Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output-fine.swift
   Swift(macosx-x86_64) :: Driver/batch_mode_parseable_output_cancellation.swift
   Swift(macosx-x86_64) :: Driver/batch_mode_bridging_pch.swift
     Crash: Multiple jobs producing same output file
-
-  Swift(macosx-x86_64) :: Driver/driver_migration.swift
-    Missing -emit-remap-file-path
   
   Swift(macosx-x86_64) :: Driver/temp-files.swift
     swift-driver has no -save-temps support, and if an environment variable like `TMP` is set, swift-driver places temporary files in a subdirectory instead of immediately inside the specified one


### PR DESCRIPTION
Started as an exploration of what to look into next, but figured it was worth doing this for all the currently failing tests and sharing for anyone else that might find it useful.

https://github.com/apple/swift/pull/34405 Will unblock most of the tests, but I assume that a lot of the dependencies tests will still fail after that.

There are 5 tests that looks like they could be fixed by updates to the tests (2 categories here):
- JSON formatting
  - (c++ `key: value`, swift-driver(JSONEncoder) `key : value`), can fix with `key{{ ?}}: value`
  - key/value pair ordering, can fix with `-DAG`
- Input file path -> output file path, swift-driver removes `./` when it's redundant. Can fix with `{{(\.\/)?}}`, tests that also support windows paths might need different regex.