### PR TITLE
Option parsing fixes when args have unexpected suffixes

### DIFF
--- a/Tests/SwiftOptionsTests/OptionParsingTests.swift
+++ b/Tests/SwiftOptionsTests/OptionParsingTests.swift
@@ -32,6 +32,15 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(error as? OptionParseError, .unknownOption(index: 0, argument: "-unrecognized"))
     }
 
+    // Ensure we check for an unexpected suffix on flags before checking if they are accepted by the current mode.
+    XCTAssertThrowsError(try options.parse(["-c-NOT"], for: .interactive)) { error in
+      XCTAssertEqual(error as? OptionParseError, .unknownOption(index: 0, argument: "-c-NOT"))
+    }
+
+    XCTAssertThrowsError(try options.parse(["-module-name-NOT", "foo"], for: .batch)) { error in
+      XCTAssertEqual(error as? OptionParseError, .unknownOption(index: 0, argument: "-module-name-NOT"))
+    }
+
     XCTAssertThrowsError(try options.parse(["-I"], for: .batch)) { error in
       XCTAssertEqual(error as? OptionParseError, .missingArgument(index: 0, argument: "-I"))
     }


### PR DESCRIPTION
1. If a flag has an unexpected suffix and is not supported by the current driver mode, diagnose it as an unsupported option instead of being available in another mode
2. Reject 'separate' options if they have an unexpected suffix