### PR TITLE
Update option diagnostics to match c++ driver

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -175,7 +175,7 @@ extension Diagnostic.Message {
   static var warning_incremental_requires_build_record_entry: Diagnostic.Message {
     .warning(
       "ignoring -incremental; " +
-        "output file map has no master dependencies entry under \(FileType.swiftDeps)"
+        "output file map has no master dependencies entry (\"\(FileType.swiftDeps)\" under \"\")"
     )
   }
   fileprivate static func remark_incremental_compilation_disabled(because why: String) -> Diagnostic.Message {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -378,7 +378,7 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-gdwarf-types", "-debug-info-format=codeview") {
-      $1.expect(.error("argument 'codeview' is not allowed with '-gdwarf-types'"))
+      $1.expect(.error("argument '-debug-info-format=codeview' is not allowed with '-gdwarf-types'"))
     }
   }
 
@@ -423,7 +423,8 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(driver.moduleOutputInfo.name, "main")
     }
 
-    try assertNoDriverDiagnostics(args: "swift", "-repl") { driver in
+    try assertDriverDiagnostics(args: "swift", "-repl") { driver, verifier in
+      verifier.expect(.warning("unnecessary option '-repl'; this is the default for 'swift' with no input files"))
       XCTAssertNil(driver.moduleOutputInfo.output)
       XCTAssertEqual(driver.moduleOutputInfo.name, "REPL")
     }


### PR DESCRIPTION
Adds -repl warning
Rewords warning_incremental_requires_build_record_entry
Fix error_i_mode using potentially wrong driver kind
Fix error_argument_not_allowed_with not using '-debug-info-format='

Fixes Driver/options.swift (except for swift-driver doesn't allow integrated repl)