### PR TITLE
Handle -continue-building-after-errors and add mechanism for stopping build on failure

### DIFF
--- a/Sources/SwiftDriver/Driver/CompilerMode.swift
+++ b/Sources/SwiftDriver/Driver/CompilerMode.swift
@@ -80,6 +80,15 @@ extension CompilerMode {
     }
   }
 
+  var isBatchCompile: Bool {
+    switch self {
+    case .batchCompile:
+      return true
+    case .singleCompile, .standardCompile, .compilePCM, .immediate, .repl:
+      return false
+    }
+  }
+
   // Whether this compilation mode supports the use of bridging pre-compiled
   // headers.
   public var supportsBridgingPCH: Bool {

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -27,6 +27,7 @@ public protocol DriverExecutor {
   func execute(workload: DriverExecutorWorkload,
                delegate: JobExecutionDelegate,
                numParallelJobs: Int,
+               continueBuildingAfterErrors: Bool,
                forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath: Date]
   ) throws
@@ -35,6 +36,7 @@ public protocol DriverExecutor {
   func execute(jobs: [Job],
                delegate: JobExecutionDelegate,
                numParallelJobs: Int,
+               continueBuildingAfterErrors: Bool,
                forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath: Date]
   ) throws
@@ -92,6 +94,7 @@ extension DriverExecutor {
     jobs: [Job],
     delegate: JobExecutionDelegate,
     numParallelJobs: Int,
+    continueBuildingAfterErrors: Bool,
     forceResponseFiles: Bool,
     recordedInputModificationDates: [TypedVirtualPath: Date]
   ) throws {
@@ -99,6 +102,7 @@ extension DriverExecutor {
       workload: .all(jobs),
       delegate: delegate,
       numParallelJobs: numParallelJobs,
+      continueBuildingAfterErrors: continueBuildingAfterErrors,
       forceResponseFiles: forceResponseFiles,
       recordedInputModificationDates: recordedInputModificationDates)
   }

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -60,6 +60,7 @@ public final class SwiftDriverExecutor: DriverExecutor {
   public func execute(workload: DriverExecutorWorkload,
                       delegate: JobExecutionDelegate,
                       numParallelJobs: Int = 1,
+                      continueBuildingAfterErrors: Bool,
                       forceResponseFiles: Bool = false,
                       recordedInputModificationDates: [TypedVirtualPath: Date] = [:]
   ) throws {
@@ -69,6 +70,7 @@ public final class SwiftDriverExecutor: DriverExecutor {
       executorDelegate: delegate,
       diagnosticsEngine: diagnosticsEngine,
       numParallelJobs: numParallelJobs,
+      continueBuildingAfterErrors: continueBuildingAfterErrors,
       processSet: processSet,
       forceResponseFiles: forceResponseFiles,
       recordedInputModificationDates: recordedInputModificationDates)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1466,6 +1466,11 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testBatchModeContinueAfterErrors() throws {
+    let driver = try Driver(args: ["swiftc", "foo1.swift", "bar1.swift", "-enable-batch-mode"])
+    XCTAssert(driver.continueBuildingAfterErrors)
+  }
+
   func testSingleThreadedWholeModuleOptimizationCompiles() throws {
     var driver1 = try Driver(args: ["swiftc", "-whole-module-optimization", "foo.swift", "bar.swift", "-module-name", "Test", "-target", "x86_64-apple-macosx10.15", "-emit-module-interface", "-emit-objc-header-path", "Test-Swift.h", "-emit-private-module-interface-path", "Test.private.swiftinterface"])
     let plannedJobs = try driver1.planBuild()
@@ -2861,6 +2866,7 @@ final class SwiftDriverTests: XCTestCase {
         func execute(workload: DriverExecutorWorkload,
                      delegate: JobExecutionDelegate,
                      numParallelJobs: Int,
+                     continueBuildingAfterErrors: Bool,
                      forceResponseFiles: Bool,
                      recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
           fatalError()


### PR DESCRIPTION
Fixes Driver/continue-building-after-errors.swift

Long term we probably want to add more to llbuildSwift, so that we can cancel the build there instead of going through all the jobs. We could suspend the jobQueue so it doesn't start anymore. It also feels like llbuild should have a mechanism for throttling parallel builds, so maybe with that the queue could be replaced.