### PR TITLE
Rework printActions to be more like how the actions are created

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -291,16 +291,20 @@ extension Driver {
       inputs.append(TypedVirtualPath(file: moduleOutputInfo.output!.outputPath, type: .swiftModule))
     }
 
+    var displayInputs = primaryInputs
+
     // Bridging header is needed for compiling these .swift sources.
     if let pchPath = bridgingPrecompiledHeader {
-      inputs.append(TypedVirtualPath(file: pchPath, type: .pch))
+      let pchInput = TypedVirtualPath(file: pchPath, type: .pch)
+      inputs.append(pchInput)
+      displayInputs.append(pchInput)
     }
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .compile,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,
-      displayInputs: primaryInputs,
+      displayInputs: displayInputs,
       inputs: inputs,
       primaryInputs: primaryInputs,
       outputs: outputs,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -259,7 +259,7 @@ extension Driver {
         diagnosticEngine.emit(.error_unexpected_input_file(input.file))
       }
 
-    case .swiftModule, .swiftDocumentation:
+    case .swiftModule:
       if moduleOutputInfo.output != nil && linkerOutputType == nil {
         // When generating a .swiftmodule as a top-level output (as opposed
         // to, for example, linking an image), treat .swiftmodule files as
@@ -347,7 +347,10 @@ extension Driver {
       addJob(wrapJob)
       wrapJob.outputs.forEach(addLinkerInput)
     } else {
-      mergeJob.outputs.forEach(addLinkerInput)
+      let mergeModuleOutputs = mergeJob.outputs.filter { $0.type == .swiftModule }
+      assert(mergeModuleOutputs.count == 1,
+             "Merge module job should only have one swiftmodule output")
+      addLinkerInput(mergeModuleOutputs[0])
     }
   }
 


### PR DESCRIPTION
Fixes:
Driver/actions.swift
Driver/actions-dsym.swift
Driver/bridging-pch.swift now fails on the output not having -* at the end.

Also fix issue where linker was being passed swiftmoduledoc and swiftsourceinfo files. (As far as I can tell they were ignored)