### PR TITLE
Ensure temp dir is different between testIncremental and testIncrementalDiagnostics to see if that fixes the test breakage in CI

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -358,10 +358,8 @@ final class IncrementalCompilationTests: XCTestCase {
 
   // FIXME: why does it fail on Linux in CI?
   func testIncrementalDiagnostics() throws {
-    #if !os(Linux)
     prepare()
     try testIncremental(checkDiagnostics: true)
-    #endif
   }
 
   func testIncremental() throws {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -289,7 +289,7 @@ final class NonincrementalCompilationTests: XCTestCase {
 
 final class IncrementalCompilationTests: XCTestCase {
 
-  var tempDir: AbsolutePath = AbsolutePath("/tmp")
+  let tempDir: AbsolutePath
 
   let module = "theModule"
   var OFM: AbsolutePath {
@@ -336,17 +336,19 @@ final class IncrementalCompilationTests: XCTestCase {
     ]
     + inputPathsAndContents.map {$0.0.pathString} .sorted()
   }
+
+  override init(selector: Selector) {
+    // Prefix directory with test name to ensure directory name is unique when
+    // testing in parallel.
+    self.tempDir = try! withTemporaryDirectory(prefix: selector.description,  removeTreeOnDeinit: false) {$0}
+    super.init(selector: selector)
+  }
+
   deinit {
     try? localFileSystem.removeFileTree(tempDir)
   }
 
   override func setUp() {
-    // Prefix directory with test name to ensure directory name is unique when
-    // testing in parallel.
-    // name returns e.g. "[SwiftDriverTests.IncrementalCompilationTests testIncremental]
-    // but we just want "testIncremental"
-    let testName = name.split(separator: " ").last!.dropLast()
-    self.tempDir = try! withTemporaryDirectory(prefix: String(testName),  removeTreeOnDeinit: false) {$0}
     try! localFileSystem.createDirectory(derivedDataPath)
     writeOutputFileMapData(module: module,
                            inputPaths: inputPathsAndContents.map {$0.0},

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -289,7 +289,7 @@ final class NonincrementalCompilationTests: XCTestCase {
 
 final class IncrementalCompilationTests: XCTestCase {
 
-  let tempDir: AbsolutePath
+  var tempDir: AbsolutePath = AbsolutePath("/tmp")
 
   let module = "theModule"
   var OFM: AbsolutePath {
@@ -336,19 +336,17 @@ final class IncrementalCompilationTests: XCTestCase {
     ]
     + inputPathsAndContents.map {$0.0.pathString} .sorted()
   }
-
-  override init(selector: Selector) {
-    // Prefix directory with test name to ensure directory name is unique when
-    // testing in parallel.
-    self.tempDir = try! withTemporaryDirectory(prefix: selector.description,  removeTreeOnDeinit: false) {$0}
-    super.init(selector: selector)
-  }
-
   deinit {
     try? localFileSystem.removeFileTree(tempDir)
   }
 
   override func setUp() {
+    // Prefix directory with test name to ensure directory name is unique when
+    // testing in parallel.
+    // name returns e.g. "[SwiftDriverTests.IncrementalCompilationTests testIncremental]
+    // but we just want "testIncremental"
+    let testName = name.split(separator: " ").last!.dropLast()
+    self.tempDir = try! withTemporaryDirectory(prefix: String(testName),  removeTreeOnDeinit: false) {$0}
     try! localFileSystem.createDirectory(derivedDataPath)
     writeOutputFileMapData(module: module,
                            inputPaths: inputPathsAndContents.map {$0.0},

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -340,8 +340,9 @@ final class IncrementalCompilationTests: XCTestCase {
     try? localFileSystem.removeFileTree(tempDir)
   }
 
-  override func setUp() {
-    self.tempDir = try! withTemporaryDirectory(removeTreeOnDeinit: false) {$0}
+  func prepare(line: Int = #line) {
+    // ensure tempDir is unique by using line prefix
+    self.tempDir = try! withTemporaryDirectory(prefix: line.description, removeTreeOnDeinit: false) {$0}
     try! localFileSystem.createDirectory(derivedDataPath)
     writeOutputFileMapData(module: module,
                            inputPaths: inputPathsAndContents.map {$0.0},
@@ -358,11 +359,13 @@ final class IncrementalCompilationTests: XCTestCase {
   // FIXME: why does it fail on Linux in CI?
   func testIncrementalDiagnostics() throws {
     #if !os(Linux)
+    prepare()
     try testIncremental(checkDiagnostics: true)
     #endif
   }
 
   func testIncremental() throws {
+    prepare()
     try testIncremental(checkDiagnostics: false)
   }
 
@@ -553,6 +556,7 @@ final class IncrementalCompilationTests: XCTestCase {
   /// autolink job.
   /// Much of the code below is taking from testLinking(), but uses the output file map code here.
   func testAutolinkOutputPath() {
+    prepare()
     var env = ProcessEnv.vars
     env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"


### PR DESCRIPTION
Best theory to explain a mysterious test failure on CI Linux. Land it and if test starts failing, disable the test again.