### PR TITLE
Revert "Ensure temp dir is different between testIncremental and testIncrementalDiagnostics to see if that fixes the test breakage in CI"

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -341,12 +341,7 @@ final class IncrementalCompilationTests: XCTestCase {
   }
 
   override func setUp() {
-    // Prefix directory with test name to ensure directory name is unique when
-    // testing in parallel.
-    // name returns e.g. "[SwiftDriverTests.IncrementalCompilationTests testIncremental]
-    // but we just want "testIncremental"
-    let testName = name.split(separator: " ").last!.dropLast()
-    self.tempDir = try! withTemporaryDirectory(prefix: String(testName),  removeTreeOnDeinit: false) {$0}
+    self.tempDir = try! withTemporaryDirectory(removeTreeOnDeinit: false) {$0}
     try! localFileSystem.createDirectory(derivedDataPath)
     writeOutputFileMapData(module: module,
                            inputPaths: inputPathsAndContents.map {$0.0},
@@ -360,8 +355,11 @@ final class IncrementalCompilationTests: XCTestCase {
     }
   }
 
+  // FIXME: why does it fail on Linux in CI?
   func testIncrementalDiagnostics() throws {
+    #if !os(Linux)
     try testIncremental(checkDiagnostics: true)
+    #endif
   }
 
   func testIncremental() throws {


### PR DESCRIPTION
Reverts apple/swift-driver#374

This change caused failures in `swift` PR testing.
e.g. https://ci.swift.org/job/swift-PR-Linux-smoke-test/25956/console