### PR TITLE
Set up a client-side C library to talk with C APIs exposed from the compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.15.1)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
-project(SwiftDriver LANGUAGES Swift)
+project(SwiftDriver LANGUAGES Swift C)
 
 set(SWIFT_VERSION 5)
 set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})
@@ -18,6 +18,9 @@ if(CMAKE_VERSION VERSION_LESS 3.16)
     add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-swift-version$<SEMICOLON>${SWIFT_VERSION}>)
     set(CMAKE_LINK_LIBRARY_FLAG "-l")
 endif()
+
+# ensure Swift compiler can find _CSwiftDriver
+add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-I$<SEMICOLON>${CMAKE_CURRENT_SOURCE_DIR}/Sources/_CSwiftDriver/include>)
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 

--- a/Package.swift
+++ b/Package.swift
@@ -36,10 +36,12 @@ let package = Package(
       targets: ["SwiftDriverExecution"]),
   ],
   targets: [
+    .target(name: "_CSwiftDriver"),
+
     /// The driver library.
     .target(
       name: "SwiftDriver",
-      dependencies: ["SwiftOptions", "SwiftToolsSupport-auto", "Yams"]),
+      dependencies: ["SwiftOptions", "SwiftToolsSupport-auto", "Yams", "_CSwiftDriver"]),
 
     /// The execution library.
     .target(

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -99,7 +99,8 @@ target_link_libraries(SwiftDriver PUBLIC
   SwiftOptions)
 target_link_libraries(SwiftDriver PRIVATE
   CYaml
-  Yams)
+  Yams
+  CSwiftDriver)
 
 set_property(GLOBAL APPEND PROPERTY SWIFTDRIVER_EXPORTS SwiftDriver)
 

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -13,6 +13,7 @@ import TSCBasic
 import TSCUtility
 import Foundation
 import SwiftOptions
+@_implementationOnly import _CSwiftDriver
 
 /// The Swift driver.
 public struct Driver {

--- a/Sources/_CSwiftDriver/CMakeLists.txt
+++ b/Sources/_CSwiftDriver/CMakeLists.txt
@@ -1,14 +1,10 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_subdirectory(_CSwiftDriver)
-add_subdirectory(SwiftOptions)
-add_subdirectory(SwiftDriver)
-add_subdirectory(SwiftDriverExecution)
-add_subdirectory(swift-driver)
-add_subdirectory(swift-help)
+add_library(CSwiftDriver STATIC
+  _CSwiftDriverImpl.c)

--- a/Sources/_CSwiftDriver/_CSwiftDriverImpl.c
+++ b/Sources/_CSwiftDriver/_CSwiftDriverImpl.c
@@ -1,0 +1,1 @@
+// This file is here to prevent the package manager from warning about a target with no sources.

--- a/Sources/_CSwiftDriver/include/_CSwiftDriver.h
+++ b/Sources/_CSwiftDriver/include/_CSwiftDriver.h
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+void dummyfunction();

--- a/Sources/_CSwiftDriver/include/module.modulemap
+++ b/Sources/_CSwiftDriver/include/module.modulemap
@@ -1,0 +1,4 @@
+module _CSwiftDriver {
+    umbrella "."
+    export *
+}


### PR DESCRIPTION
We could use functions like dlopen and dlsym in this client-side library to talk with
compiler-side C APIs.