### PR TITLE
Make disabling incremental build message same as in legacy driver.

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -146,7 +146,7 @@ import SwiftOptions
       outOfDateBuildRecord  = try BuildRecord(contents: contents)
     }
     catch {
-      failed("incremental compilation could not read build record at \(buildRecordPath): \(error.localizedDescription).")
+      failed("could not read build record at \(buildRecordPath): \(error.localizedDescription).")
       return nil
     }
     guard actualSwiftVersion == outOfDateBuildRecord.swiftVersion else {

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -179,7 +179,7 @@ extension Diagnostic.Message {
     )
   }
   fileprivate static func remark_incremental_compilation_disabled(because why: String) -> Diagnostic.Message {
-    .remark("Incremental compilation has been disabled, because \(why)")
+    .remark("Disabling incremental build: \(why)")
   }
   fileprivate static func remark_incremental_compilation(because why: String) -> Diagnostic.Message {
     .remark("Incremental compilation: \(why)")

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -386,7 +386,7 @@ final class IncrementalCompilationTests: XCTestCase {
         // Leave off the part after the colon because it varies on Linux:
         // MacOS: The operation could not be completed. (TSCBasic.FileSystemError error 3.).
         // Linux: The operation couldn’t be completed. (TSCBasic.FileSystemError error 3.)
-        "Incremental compilation has been disabled, because incremental compilation could not read build record",
+        "Disabling incremental build: could not read build record at",
         "Found 2 batchable jobs",
         "Forming into 1 batch",
         "Adding {compile: main.swift} to batch 0",


### PR DESCRIPTION
Make disabling incremental build message same as in legacy driver.
Towards getting legacy driver lit tests to run.