### PR TITLE
[NFC] Encapsulate local outputFileMap to forestall bugs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -369,25 +369,27 @@ public struct Driver {
         guard let modTime = try? fileSystem
           .getFileInfo($0.file).modTime else { return nil }
         return ($0, modTime)
-    })
+      })
 
-    let outputFileMap: OutputFileMap?
-    // Initialize an empty output file map, which will be populated when we start creating jobs.
-    if let outputFileMapArg = parsedOptions.getLastArgument(.outputFileMap)?.asSingle {
-      do {
-        let path = try VirtualPath(path: outputFileMapArg)
-        outputFileMap = try .load(fileSystem: fileSystem, file: path, diagnosticEngine: diagnosticEngine)
-      } catch {
-        throw Error.unableToLoadOutputFileMap(outputFileMapArg)
+    do {
+      let outputFileMap: OutputFileMap?
+      // Initialize an empty output file map, which will be populated when we start creating jobs.
+      if let outputFileMapArg = parsedOptions.getLastArgument(.outputFileMap)?.asSingle {
+        do {
+          let path = try VirtualPath(path: outputFileMapArg)
+          outputFileMap = try .load(fileSystem: fileSystem, file: path, diagnosticEngine: diagnosticEngine)
+        } catch {
+          throw Error.unableToLoadOutputFileMap(outputFileMapArg)
+        }
+      } else {
+        outputFileMap = nil
       }
-    } else {
-      outputFileMap = nil
-    }
 
-    if let workingDirectory = self.workingDirectory {
-      self.outputFileMap = outputFileMap?.resolveRelativePaths(relativeTo: workingDirectory)
-    } else {
-      self.outputFileMap = outputFileMap
+      if let workingDirectory = self.workingDirectory {
+        self.outputFileMap = outputFileMap?.resolveRelativePaths(relativeTo: workingDirectory)
+      } else {
+        self.outputFileMap = outputFileMap
+      }
     }
 
     self.fileListThreshold = try Self.computeFileListThreshold(&self.parsedOptions, diagnosticsEngine: diagnosticsEngine)


### PR DESCRIPTION
Since the constructor uses a local `outputFileMap` that is different from `self.outputFileMap`, wrap the local in a block so later uses in this long method cannot accidentally use the wrong one.