### PR TITLE
[Incremental] Allow build record to reside at a relative path

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -435,6 +435,7 @@ public struct Driver {
     self.buildRecordInfo = BuildRecordInfo(
       actualSwiftVersion: self.frontendTargetInfo.compilerVersion,
       compilerOutputType: compilerOutputType,
+      workingDirectory: self.workingDirectory ?? fileSystem.currentWorkingDirectory,
       diagnosticEngine: diagnosticEngine,
       fileSystem: fileSystem,
       moduleOutputInfo: moduleOutputInfo,

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -246,10 +246,3 @@ extension String {
     return self + "." + ext
   }
 }
-
-extension VirtualPath {
-  fileprivate func resolvedRelativePath(base: AbsolutePath) -> VirtualPath {
-    guard case let .relative(relPath) = self else { return self }
-    return .absolute(.init(base, relPath))
-  }
-}

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -96,7 +96,9 @@ import SwiftOptions
       diagnosticEngine.emit(.warning_incremental_requires_build_record_entry)
       return nil
     }
-    return partialBuildRecordPath.resolveRelativePath(workingDirectory)
+    return workingDirectory
+      .map(partialBuildRecordPath.resolvedRelativePath(base:))
+      ?? partialBuildRecordPath
   }
 
   /// Write out the build record.
@@ -175,15 +177,6 @@ import SwiftOptions
     // REDUNDANT?
     if let _ = finishedJobResults.updateValue(result, forKey: job) {
       fatalError("job finished twice?!")
-    }
-  }
-}
-
-extension VirtualPath {
-  fileprivate func resolveRelativePath(_ workingDirectory: AbsolutePath?) -> VirtualPath {
-    switch (workingDirectory, self) {
-    case let (wd?, .relative(relPath)): return .absolute(.init(wd, relPath))
-    default: return self
     }
   }
 }

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -346,6 +346,14 @@ extension VirtualPath {
   }
 }
 
+extension VirtualPath {
+  /// Resolve a relative path into an absolute one, if possible.
+  public func resolvedRelativePath(base: AbsolutePath) -> VirtualPath {
+    guard case let .relative(relPath) = self else { return self }
+    return .absolute(.init(base, relPath))
+  }
+}
+
 private extension String {
   func withoutExt(_ ext: String?) -> String {
     if let ext = ext {


### PR DESCRIPTION
Allow build record to reside at a relative path on the way to making legacy lit tests work.