### PR TITLE
[Incremental] Write build record even if error.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -859,12 +859,14 @@ extension Driver {
                            recordedInputModificationDates: recordedInputModificationDates)
       return
     }
-
-    try performTheBuild(allJobs: jobs, forceResponseFiles: forceResponseFiles)
-
-    buildRecordInfo?.writeBuildRecord(
-      jobs,
-      incrementalCompilationState?.skippedCompilationInputs)
+    do {
+      defer {
+        buildRecordInfo?.writeBuildRecord(
+          jobs,
+          incrementalCompilationState?.skippedCompilationInputs)
+      }
+      try performTheBuild(allJobs: jobs, forceResponseFiles: forceResponseFiles)
+    }
 
     // If requested, warn for options that weren't used by the driver after the build is finished.
     if parsedOptions.hasArgument(.driverWarnUnusedOptions) {


### PR DESCRIPTION
For the sake of compatibility with legacy driver, and better incremental builds, write the build record even if there was an error.