### PR TITLE
[Incremental] Honor -driver-use-frontend-path

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2055,6 +2055,9 @@ extension Driver {
     } else {
       swiftCompilerPrefixArgs = []
     }
+    var hasFrontendBeenRedirectedForTesting: Bool {
+      return !swiftCompilerPrefixArgs.isEmpty
+    }
 
     // Find the SDK, if any.
     let sdkPath: VirtualPath? = Self.computeSDKPath(
@@ -2063,8 +2066,11 @@ extension Driver {
       diagnosticsEngine: diagnosticsEngine, env: env)
 
     // Query the frontend for target information.
+    // If there's a dummy frontend, don't query it.
     do {
-      var info = try executor.execute(
+      var info = hasFrontendBeenRedirectedForTesting
+        ? FrontendTargetInfo.dummyForTesting(toolchain)
+        : try executor.execute(
         job: toolchain.printTargetInfoJob(
           target: explicitTarget, targetVariant: explicitTargetVariant,
           sdkPath: sdkPath, resourceDirPath: resourceDirPath,

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -95,6 +95,17 @@ extension SwiftVersion: Codable {
     /// Whether the Swift libraries need to be referenced in their system
     /// location (/usr/lib/swift) via rpath.
     let librariesRequireRPath: Bool
+
+    static func dummyForTesting(_ toolchain: Toolchain) -> Self {
+      let dummyForTestingTriple = Triple.dummyForTesting(toolchain)
+      return Self(
+        triple: dummyForTestingTriple,
+        unversionedTriple: dummyForTestingTriple,
+        moduleTriple: dummyForTestingTriple,
+        swiftRuntimeCompatibilityVersion: nil,
+        compatibilityLibraries: [],
+        librariesRequireRPath: false)
+    }
   }
 
   @_spi(Testing) public struct Paths: Codable {
@@ -103,12 +114,25 @@ extension SwiftVersion: Codable {
     public let runtimeLibraryPaths: [TextualVirtualPath]
     public let runtimeLibraryImportPaths: [TextualVirtualPath]
     public let runtimeResourcePath: TextualVirtualPath
+
+    static let dummyForTesting = Paths(
+      sdkPath: nil,
+      runtimeLibraryPaths: [],
+      runtimeLibraryImportPaths: [],
+      runtimeResourcePath: .dummyForTesting)
   }
 
   var compilerVersion: String
   var target: Target
   var targetVariant: Target?
   let paths: Paths
+
+  static func dummyForTesting(_ toolchain: Toolchain) -> Self {
+    Self(compilerVersion: "dummy",
+         target: .dummyForTesting(toolchain),
+         targetVariant: nil,
+         paths: .dummyForTesting)
+  }
 }
 
 // Make members of `FrontendTargetInfo.Paths` accessible on `FrontendTargetInfo`.

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -32,6 +32,8 @@ import SwiftOptions
   // An externally provided path from where we should find tools like ld
   public let toolDirectory: AbsolutePath?
 
+  public let dummyForTestingObjectFormat = Triple.ObjectFormat.macho
+
   public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, toolDirectory: AbsolutePath? = nil) {
     self.env = env
     self.executor = executor

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -26,6 +26,8 @@ import TSCBasic
 
   public let toolDirectory: AbsolutePath?
 
+  public let dummyForTestingObjectFormat = Triple.ObjectFormat.elf
+
   public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, toolDirectory: AbsolutePath? = nil) {
     self.env = env
     self.executor = executor

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -90,6 +90,8 @@ public enum Tool: Hashable {
     inputs: inout [TypedVirtualPath],
     frontendTargetInfo: FrontendTargetInfo
   ) throws
+
+  var dummyForTestingObjectFormat: Triple.ObjectFormat {get}
 }
 
 extension Toolchain {

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -47,6 +47,8 @@ import SwiftOptions
 
   public let toolDirectory: AbsolutePath?
 
+  public let dummyForTestingObjectFormat = Triple.ObjectFormat.wasm
+
   public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, toolDirectory: AbsolutePath? = nil) {
     self.env = env
     self.executor = executor

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -176,6 +176,20 @@ public struct Triple {
                                              os: parsedOS?.value)
     }
   }
+
+  private init(dummyForTesting toolchain: Toolchain) {
+    self.triple = ""
+    self.arch = nil
+    self.subArch = nil
+    self.vendor = nil
+    self.os = nil
+    self.environment = nil
+    self.objectFormat = toolchain.dummyForTestingObjectFormat
+  }
+
+  static func dummyForTesting(_ toolchain: Toolchain) -> Self {
+    Self(dummyForTesting: toolchain)
+  }
 }
 
 extension Triple: Codable {

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -271,6 +271,12 @@ extension VirtualPath: Codable {
     path = try VirtualPath(path: container.decode(String.self))
   }
 
+  private init(path: VirtualPath) {
+    self.path = path
+  }
+
+  static let dummyForTesting = Self(path: try! .init(path: ""))
+
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     switch path {


### PR DESCRIPTION
In order to use legacy lit dependency tests, the driver must honor `-driver-use-fronttend-path`. In that use-case, there is no point in querying the frontend for target info, so add a computation for dummy values for this.