### PR TITLE
[Incremental] Handle relative paths when writing build record. (and a typo fix)

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
@@ -166,10 +166,7 @@ extension BuildRecord {
    func encode() throws -> String {
       let pathsAndInfos = try inputInfos.map {
         input, inputInfo -> (String, InputInfo) in
-        guard let path = input.absolutePath else {
-          throw Errors.notAbsolutePath(input)
-        }
-        return (path.pathString, inputInfo)
+        return (input.name, inputInfo)
       }
       let inputInfosNode = Yams.Node(
         pathsAndInfos

--- a/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
@@ -65,7 +65,7 @@ extension InputInfo.Status {
   }
 
   /// Construct a status to write at the end of the compilation.
-  /// The status will be read for the nextr driver invocaiton and will control the scheduling of that job.
+  /// The status will be read for the next driver invocation and will control the scheduling of that job.
   /// `upToDate` means only that the file was up to date when the build record was written.
   init( wasSkipped: Bool?, jobResult: ProcessResult? ) {
     if let exitStatus = jobResult?.exitStatus,


### PR DESCRIPTION
Handle relative paths when writing build record. (and a typo fix). Needed for legacy lit tests.