### PR TITLE
[Incremental] Refactor & enhance dependency trace printing.

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
@@ -18,7 +18,7 @@ struct ExternalDependency: Hashable, CustomStringConvertible {
 
 
 
-public struct DependencyKey: Hashable {
+public struct DependencyKey: Hashable, CustomStringConvertible {
   /// Instead of the status quo scheme of two kinds of "Depends", cascading and
   /// non-cascading this code represents each entity ("Provides" in the status
   /// quo), by a pair of nodes. One node represents the "implementation." If the
@@ -39,7 +39,7 @@ public struct DependencyKey: Hashable {
   /// graph, splitting the current *member* into \ref member and \ref
   /// potentialMember and adding \ref sourceFileProvide.
   ///
-  enum Designator: Hashable {
+  enum Designator: Hashable, CustomStringConvertible {
     case
       topLevel(name: String),
       dynamicLookup(name: String),
@@ -60,6 +60,25 @@ public struct DependencyKey: Hashable {
       default:
         return nil}
     }
+
+    public var description: String {
+      switch self {
+      case let .topLevel(name: name):
+        return "top-level name \(name)"
+      case let .nominal(context: context):
+        return "type \(context)"
+      case let .potentialMember(context: context):
+        return "potential members of \(context)"
+      case let .member(context: context, name: name):
+        return "member \(name) of \(context)"
+      case let .dynamicLookup(name: name):
+        return "AnyObject member \(name)"
+      case let .externalDepend(externalDependency):
+        return "module \(externalDependency)"
+      case let .sourceFileProvide(name: name):
+        return (try? VirtualPath(path: name).basename) ?? name
+      }
+    }
   }
 
   let aspect: DeclAspect
@@ -78,6 +97,10 @@ public struct DependencyKey: Hashable {
   var correspondingImplementation: Self {
     assert(aspect == .interface)
     return Self(aspect: .implementation, designator: designator)
+  }
+
+  public var description: String {
+    "\(aspect) of \(designator)"
   }
 
   @discardableResult

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
@@ -123,38 +123,11 @@ extension ModuleDependencyGraph.Tracer {
           .compactMap { node in
             node.swiftDeps
               .flatMap {graph.sourceSwiftDepsMap[$0] }
-              .map (node.dependencyKey.descriptionForPath(from:))
+              .map { "\(node.dependencyKey) from: \($0.file.basename)"}
           }
           .joined(separator: " -> ")
       ].joined(separator: " "),
       nil
     )
-  }
-}
-
-fileprivate extension DependencyKey {
-  func descriptionForPath(from sourceFile: TypedVirtualPath) -> String {
-    "\(aspect) of \(designator.descriptionForPath(from: sourceFile))"
-  }
-}
-
-fileprivate extension DependencyKey.Designator {
-  func descriptionForPath(from sourceFile: TypedVirtualPath) -> String {
-    switch self {
-    case let .topLevel(name: name):
-      return "top-level name \(name)"
-    case let .nominal(context: context):
-      return "type \(context)"
-    case let .potentialMember(context: context):
-      return "potential members of \(context)"
-    case let .member(context: context, name: name):
-      return "member \(name) of \(context)"
-    case let .dynamicLookup(name: name):
-      return "AnyObject member \(name)"
-    case let .externalDepend(externalDependency):
-      return "module \(externalDependency)"
-    case let .sourceFileProvide(name: name):
-      return (try? VirtualPath(path: name).basename) ?? name
-    }
   }
 }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -478,7 +478,7 @@ final class IncrementalCompilationTests: XCTestCase {
         "Forming batch job from 1 constituents: main.swift",
         "Incremental compilation: Queuing Compiling main.swift",
         "Starting Compiling main.swift",
-        "Incremental compilation: Traced: interface of main.swiftdeps -> interface of top-level name foo -> implementation of other.swiftdeps",
+        "Incremental compilation: Traced: interface of main.swiftdeps from: main.swift -> interface of top-level name foo from: main.swift -> implementation of other.swiftdeps from: other.swift",
         "Incremental compilation: Queuing because of dependencies discovered later: {compile: other.o <= other.swift}",
         "Incremental compilation: Scheduling discovered {compile: other.o <= other.swift}",
         "Finished Compiling main.swift",


### PR DESCRIPTION
Move print code for dependency keys that was only used for trace printing, to `DependencyKey.description`.

Include the containing file when printing out a node.