### PR TITLE
[Incremental] When tracing uses, include the implicit use of implementation when interface changes

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
@@ -94,8 +94,10 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   }
 
 
-  var correspondingImplementation: Self {
-    assert(aspect == .interface)
+var correspondingImplementation: Self? {
+    guard aspect == .interface  else {
+      return nil
+    }
     return Self(aspect: .implementation, designator: designator)
   }
 

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
@@ -83,7 +83,7 @@ extension ModuleDependencyGraph.Tracer {
     let pathLengthAfterArrival = traceArrival(at: definition);
     
     // If this use also provides something, follow it
-    graph.nodeFinder.forEachUse(of: definition.dependencyKey) { use, _ in
+    graph.nodeFinder.forEachUse(of: definition) { use, _ in
       findNextPreviouslyUntracedDependent(of: use)
     }
     traceDeparture(pathLengthAfterArrival);

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
@@ -171,7 +171,8 @@ extension ModuleDependencyGraph {
   ) {
     // These nodes will depend on the *interface* of the external Decl.
     let key = DependencyKey(interfaceFor: externalSwiftDeps)
-    nodeFinder.forEachUse(of: key) { use, useSwiftDeps in
+    let node = Node(key: key, fingerprint: nil, swiftDeps: nil)
+    nodeFinder.forEachUse(of: node) { use, useSwiftDeps in
       if isUntraced(use) {
         fn(useSwiftDeps)
       }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -136,11 +136,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
-    do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
-      XCTAssertEqual(1, swiftDeps.count)
-      XCTAssertTrue(swiftDeps.contains(0))
-    }
+
     XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
@@ -1058,8 +1054,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
     if case .sourceFileProvide = interfaceKey.designator, !allNodes.isEmpty {
       return getSourceFileNodePair()
     }
-    assert(interfaceKey.aspect == .interface)
-    let implementationKey = interfaceKey.correspondingImplementation
+    let implementationKey = try! XCTUnwrap(interfaceKey.correspondingImplementation)
     let nodePair = NodePair(
       interface: findExistingNodeOrCreateIfNew(interfaceKey, fingerprint,
                                                isProvides: true),


### PR DESCRIPTION
Dependency graphs contain an implicit link from a given interface to its implementation. Take that into account when tracing uses of defs.