### PR TITLE
[Incremental] Enable testBatchModeContinueAfterErrors & skip frontend query even if no extra arguments to -driver-use-frontend-path

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2061,8 +2061,10 @@ extension Driver {
                                        toolDirectory: toolDir)
 
     // Find the Swift compiler executable.
+    let hasFrontendBeenRedirectedForTesting: Bool
     let swiftCompilerPrefixArgs: [String]
     if let frontendPath = parsedOptions.getLastArgument(.driverUseFrontendPath){
+      hasFrontendBeenRedirectedForTesting = true
       var frontendCommandLine =
         frontendPath.asSingle.split(separator: ";").map { String($0) }
       if frontendCommandLine.isEmpty {
@@ -2075,10 +2077,8 @@ extension Driver {
         swiftCompilerPrefixArgs = frontendCommandLine
       }
     } else {
+      hasFrontendBeenRedirectedForTesting = false
       swiftCompilerPrefixArgs = []
-    }
-    var hasFrontendBeenRedirectedForTesting: Bool {
-      return !swiftCompilerPrefixArgs.isEmpty
     }
 
     // Find the SDK, if any.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1472,7 +1472,6 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testBatchModeContinueAfterErrors() throws {
-    throw XCTSkip("This test requires the fix to honoring -driver-use-frontend-path")
     struct MockExecutor: DriverExecutor {
       let resolver = try! ArgsResolver(fileSystem: localFileSystem)
 


### PR DESCRIPTION
Enable testBatchModeContinueAfterErrors & skip frontend query even if no extra arguments to -driver-use-frontend-path.
This test uncovered a bug, so add the test and and the fix.
Could not enable the test earlier because it depended on another PR.