### PR TITLE
Comment out `@testable` and `@_spi`

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
@@ -161,7 +161,7 @@ extension BuildRecord {
     )
   }
 
-   func encode() throws -> String {
+  /*@_spi(Testing)*/ public func encode() throws -> String {
       let pathsAndInfos = inputInfos.map {
         input, inputInfo -> (String, InputInfo) in
         return (input.name, inputInfo)

--- a/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
@@ -2,13 +2,13 @@
 import Foundation
 
 /// A filename from another module
-struct ExternalDependency: Hashable, Comparable, CustomStringConvertible {
+/*@_spi(Testing)*/ public struct ExternalDependency: Hashable, Comparable, CustomStringConvertible {
   let fileName: String
 
   var file: VirtualPath? {
     try? VirtualPath(path: fileName)
   }
-  init(_ path: String) {
+  /*@_spi(Testing)*/ public init(_ path: String) {
     self.fileName = path
   }
   public var description: String {
@@ -35,7 +35,7 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   /// implementations white. Each node holds an instance variable describing which
   /// aspect of the entity it represents.
 
-  enum DeclAspect: Comparable {
+  /*@_spi(Testing)*/ public enum DeclAspect: Comparable {
     case interface, implementation
   }
 
@@ -43,7 +43,7 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   /// graph, splitting the current *member* into \ref member and \ref
   /// potentialMember and adding \ref sourceFileProvide.
   ///
-  enum Designator: Hashable, CustomStringConvertible {
+  /*@_spi(Testing)*/ public enum Designator: Hashable, CustomStringConvertible {
     case
       topLevel(name: String),
       dynamicLookup(name: String),
@@ -85,11 +85,11 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
     }
   }
 
-  let aspect: DeclAspect
-  let designator: Designator
+  /*@_spi(Testing)*/ public let aspect: DeclAspect
+  /*@_spi(Testing)*/ public let designator: Designator
 
 
-  init(
+  /*@_spi(Testing)*/ public init(
     aspect: DeclAspect,
     designator: Designator)
   {
@@ -98,7 +98,7 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   }
 
 
-var correspondingImplementation: Self? {
+  /*@_spi(Testing)*/ public var correspondingImplementation: Self? {
     guard aspect == .interface  else {
       return nil
     }

--- a/Sources/SwiftDriver/Incremental Compilation/DictionaryOfDictionaries.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/DictionaryOfDictionaries.swift
@@ -14,7 +14,7 @@
 /// It supports iterating over all 2nd-level pairs. See `subscript(key: OuterKey)`
 
 import Foundation
-struct DictionaryOfDictionaries<OuterKey: Hashable, InnerKey: Hashable, Value>: Collection {
+public struct DictionaryOfDictionaries<OuterKey: Hashable, InnerKey: Hashable, Value>: Collection {
   public typealias InnerDict = [InnerKey: Value]
   public typealias OuterDict = [OuterKey: InnerDict]
   

--- a/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
@@ -12,18 +12,18 @@
 import Foundation
 import TSCBasic
 
-/*@_spi(Testing)*/ public  struct InputInfo: Equatable {
+/*@_spi(Testing)*/ public struct InputInfo: Equatable {
 
   /*@_spi(Testing)*/ public let status: Status
   /*@_spi(Testing)*/ public let previousModTime: Date
 
-  /*@_spi(Testing)*/ public  init(status: Status, previousModTime: Date) {
+  /*@_spi(Testing)*/ public init(status: Status, previousModTime: Date) {
     self.status = status
     self.previousModTime = previousModTime
   }
 }
 
-/*@_spi(Testing)*/ public  extension InputInfo {
+/*@_spi(Testing)*/ public extension InputInfo {
   enum Status: Equatable {
     case upToDate,
          needsCascadingBuild,

--- a/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/InputInfo.swift
@@ -12,18 +12,18 @@
 import Foundation
 import TSCBasic
 
-public struct InputInfo: Equatable {
+/*@_spi(Testing)*/ public  struct InputInfo: Equatable {
 
-  let status: Status
-  let previousModTime: Date
+  /*@_spi(Testing)*/ public let status: Status
+  /*@_spi(Testing)*/ public let previousModTime: Date
 
-  public init(status: Status, previousModTime: Date) {
+  /*@_spi(Testing)*/ public  init(status: Status, previousModTime: Date) {
     self.status = status
     self.previousModTime = previousModTime
   }
 }
 
-public extension InputInfo {
+/*@_spi(Testing)*/ public  extension InputInfo {
   enum Status: Equatable {
     case upToDate,
          needsCascadingBuild,

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Integrator.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Integrator.swift
@@ -17,12 +17,12 @@ extension ModuleDependencyGraph {
   // MARK: Integrator - state & creation
 
   /// Integrates a \c SourceFileDependencyGraph into a \c ModuleDependencyGraph
-  struct Integrator {
+  /*@_spi(Testing)*/ public struct Integrator {
 
     // Shorthands
-    typealias Graph = ModuleDependencyGraph
+    /*@_spi(Testing)*/ public typealias Graph = ModuleDependencyGraph
 
-    typealias Changes = Set<Node>
+    /*@_spi(Testing)*/ public typealias Changes = Set<Node>
 
     let source: SourceFileDependencyGraph
     let swiftDeps: SwiftDeps
@@ -79,7 +79,7 @@ extension ModuleDependencyGraph.Integrator {
   /// Integrate a SourceFileDepGraph into the receiver.
   /// Integration happens when the driver needs to read SourceFileDepGraph.
   /// Returns changed nodes
-  static func integrate(
+  /*@_spi(Testing)*/ public static func integrate(
     from g: SourceFileDependencyGraph,
     swiftDeps: Graph.SwiftDeps,
     into destination: Graph

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
@@ -24,9 +24,9 @@ extension ModuleDependencyGraph {
   ///
   /// Use a class, not a struct because otherwise it would be duplicated for each thing it uses
 
-  final class Node {
+  /*@_spi(Testing)*/ public final class Node {
 
-    typealias Graph = ModuleDependencyGraph
+    /*@_spi(Testing)*/ public typealias Graph = ModuleDependencyGraph
 
     /// Def->use arcs go by DependencyKey. There may be >1 node for a given key.
     let dependencyKey: DependencyKey

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
@@ -81,7 +81,7 @@ extension ModuleDependencyGraph.Node: Equatable, Hashable {
 }
 
 extension ModuleDependencyGraph.Node: Comparable {
-  static func < (lhs: ModuleDependencyGraph.Node, rhs: ModuleDependencyGraph.Node) -> Bool {
+  public static func < (lhs: ModuleDependencyGraph.Node, rhs: ModuleDependencyGraph.Node) -> Bool {
     func lt<T: Comparable> (_ a: T?, _ b: T?) -> Bool {
       switch (a, b) {
       case let (x?, y?): return x < y

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
@@ -14,7 +14,7 @@ import TSCBasic
 
 // MARK: - SwiftDeps
 extension ModuleDependencyGraph {
-  struct SwiftDeps: Hashable, CustomStringConvertible {
+  /*@_spi(Testing)*/ public struct SwiftDeps: Hashable, CustomStringConvertible {
 
     let file: VirtualPath
 
@@ -25,10 +25,10 @@ extension ModuleDependencyGraph {
     init(_ file: VirtualPath) {
       self.file = file
     }
-    init(mock i: Int) {
+    /*@_spi(Testing)*/ public init(mock i: Int) {
       self.file = try! VirtualPath(path: String(i))
     }
-    var mockID: Int {
+    /*@_spi(Testing)*/ public var mockID: Int {
        Int(file.name)!
     }
     public var description: String {
@@ -39,10 +39,10 @@ extension ModuleDependencyGraph {
 
 // MARK: - testing
 extension ModuleDependencyGraph.SwiftDeps {
-  var sourceFileProvideNameForMockSwiftDeps: String {
+  /*@_spi(Testing)*/ public var sourceFileProvideNameForMockSwiftDeps: String {
     file.name
   }
-  var interfaceHashForMockSwiftDeps: String {
+  /*@_spi(Testing)*/ public var interfaceHashForMockSwiftDeps: String {
     file.name
   }
 }

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
@@ -48,7 +48,7 @@ extension ModuleDependencyGraph.SwiftDeps {
 }
 // MARK: - comparing
 extension ModuleDependencyGraph.SwiftDeps: Comparable {
-  static func < (lhs: Self, rhs: Self) -> Bool {
+  public static func < (lhs: Self, rhs: Self) -> Bool {
     lhs.file.name < rhs.file.name
   }
 }

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
@@ -16,7 +16,7 @@ import SwiftOptions
 
 // MARK: - ModuleDependencyGraph
 
-final class ModuleDependencyGraph {
+/*@_spi(Testing)*/ public final class ModuleDependencyGraph {
   
   var nodeFinder = NodeFinder()
   
@@ -127,7 +127,7 @@ extension ModuleDependencyGraph {
 
   /// Find all the swiftDeps files that depend on `swiftDeps`.
   /// Really private, except for testing.
-  func findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(
+  /*@_spi(Testing)*/ public func findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(
     _ swiftDeps: SwiftDeps
   ) -> Set<SwiftDeps> {
     let nodes = nodeFinder.findNodes(for: swiftDeps) ?? [:]
@@ -174,7 +174,7 @@ extension ModuleDependencyGraph {
 // MARK: - Scheduling either wave
 extension ModuleDependencyGraph {
   /// Find all the swiftDeps affected when the nodes change.
-  func findSwiftDepsToRecompileWhenNodesChange<Nodes: Sequence>(
+  /*@_spi(Testing)*/ public func findSwiftDepsToRecompileWhenNodesChange<Nodes: Sequence>(
     _ nodes: Nodes
   ) -> Set<SwiftDeps>
   where Nodes.Element == Node
@@ -187,7 +187,7 @@ extension ModuleDependencyGraph {
     return Set(affectedNodes.compactMap {$0.swiftDeps})
   }
 
-  func forEachUntracedSwiftDepsDirectlyDependent(
+  /*@_spi(Testing)*/ public func forEachUntracedSwiftDepsDirectlyDependent(
     on externalSwiftDeps: ExternalDependency,
     _ fn: (SwiftDeps) -> Void
   ) {
@@ -228,7 +228,7 @@ extension ModuleDependencyGraph {
 // MARK: - utilities for unit testing
 extension ModuleDependencyGraph {
   /// Testing only
-  func haveAnyNodesBeenTraversed(inMock i: Int) -> Bool {
+  /*@_spi(Testing)*/ public func haveAnyNodesBeenTraversed(inMock i: Int) -> Bool {
     let swiftDeps = SwiftDeps(mock: i)
     // optimization
     if let fileNode = nodeFinder.findFileInterfaceNode(forMock: swiftDeps),

--- a/Sources/SwiftDriver/Incremental Compilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/SourceFileDependencyGraph.swift
@@ -12,7 +12,7 @@
 import Foundation
 import TSCUtility
 
-struct SourceFileDependencyGraph {
+/*@_spi(Testing)*/ public struct SourceFileDependencyGraph {
   public static let sourceFileProvidesInterfaceSequenceNumber: Int = 0
   public static let sourceFileProvidesImplementationSequenceNumber: Int = 1
   
@@ -62,7 +62,7 @@ extension SourceFileDependencyGraph {
     public var defsIDependUpon: [Int]
     public var isProvides: Bool
     
-    init(
+    /*@_spi(Testing)*/ public init(
       key: DependencyKey,
       fingerprint: String?,
       sequenceNumber: Int,
@@ -121,7 +121,7 @@ extension SourceFileDependencyGraph {
     try self.init(pathString: swiftDeps.file.name)
   }
   
-  init(nodesForTesting: [Node]) {
+  /*@_spi(Testing)*/ public init(nodesForTesting: [Node]) {
     majorVersion = 0
     minorVersion = 0
     compilerVersionString = ""
@@ -129,12 +129,12 @@ extension SourceFileDependencyGraph {
   }
 
   // FIXME: This should accept a FileSystem parameter.
-  init(pathString: String) throws {
+  /*@_spi(Testing)*/ public init(pathString: String) throws {
     let data = try Data(contentsOf: URL(fileURLWithPath: pathString))
     try self.init(data: data)
   }
 
-  init(data: Data,
+  /*@_spi(Testing)*/ public init(data: Data,
        fromSwiftModule extractFromSwiftModule: Bool = false) throws {
     struct Visitor: BitstreamVisitor {
       let extractFromSwiftModule: Bool

--- a/Sources/SwiftDriver/Incremental Compilation/TwoDMap.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/TwoDMap.swift
@@ -12,7 +12,7 @@
 
 
 /// A map with 2 keys that can iterate in a number of ways
-struct TwoDMap<Key1: Hashable, Key2: Hashable, Value: Equatable>: MutableCollection {
+public struct TwoDMap<Key1: Hashable, Key2: Hashable, Value: Equatable>: MutableCollection {
 
   private var map1 = DictionaryOfDictionaries<Key1, Key2, Value>()
   private var map2 = DictionaryOfDictionaries<Key2, Key1, Value>()

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -16,7 +16,7 @@ import TSCBasic
 // argument input file to the linker.
 // FIXME: Also handle Cygwin and MinGW
 extension Driver {
-  var isAutolinkExtractJobNeeded: Bool {
+  /*@_spi(Testing)*/ public var isAutolinkExtractJobNeeded: Bool {
     [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil
   }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 import TSCBasic
 
-/*@testable*/ import SwiftDriver
+import SwiftDriver
 
 final class NonincrementalCompilationTests: XCTestCase {
   func testBuildRecordReading() throws {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -12,7 +12,7 @@
 import XCTest
 import TSCBasic
 
-@testable import SwiftDriver
+/*@testable*/ import SwiftDriver
 
 final class NonincrementalCompilationTests: XCTestCase {
   func testBuildRecordReading() throws {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import SwiftDriver
+/*@testable*/ import SwiftDriver
 import TSCBasic
 
 class ModuleDependencyGraphTests: XCTestCase {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-/*@testable*/ import SwiftDriver
+import SwiftDriver
 import TSCBasic
 
 class ModuleDependencyGraphTests: XCTestCase {

--- a/Tests/SwiftDriverTests/TwoDMapTests.swift
+++ b/Tests/SwiftDriverTests/TwoDMapTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import SwiftDriver
+/*@testable*/ import SwiftDriver
 
 class TwoDMapTests: XCTestCase {
 

--- a/Tests/SwiftDriverTests/TwoDMapTests.swift
+++ b/Tests/SwiftDriverTests/TwoDMapTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-/*@testable*/ import SwiftDriver
+import SwiftDriver
 
 class TwoDMapTests: XCTestCase {
 

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -492,8 +492,6 @@ def build_swift_driver_using_cmake(args, target, swiftc_exec, build_dir, base_cm
         '-DTSC_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-tools-support-core'), 'cmake/modules'),
         '-DYams_DIR=' + os.path.join(os.path.join(dependencies_dir, 'yams'), 'cmake/modules'),
         '-DArgumentParser_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-argument-parser'), 'cmake/modules')]
-  #FIXME: Building with testing enable to allow @testable import of SwiftDriver
-  driver_swift_flags.append('-enable-testing')
   driver_cmake_flags = base_cmake_flags + flags
   cmake_build(args, swiftc_exec, driver_cmake_flags, driver_swift_flags,
               driver_source_dir, driver_build_dir)


### PR DESCRIPTION
For now, comment out testable and _spi, which makes it easier to try the driver out with various versions of the compiler.
Someday, we can either uncomment the @spi's, or we can move components into sub-modules. What do you think?