### PR TITLE
Add test for date accuracy.

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -369,8 +369,8 @@ final class IncrementalCompilationTests: XCTestCase {
   /// Ensure that the mod date of the input comes back exactly the same via the build-record.
   /// Otherwise the up-to-date calculation in `IncrementalCompilationState` will fail.
   func testBuildRecordDateAccuracy() throws {
+    tryInitial(false)
     (1...10).forEach { n in
-      tryInitial(false)
       tryNoChange(true)
     }
   }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -366,6 +366,16 @@ final class IncrementalCompilationTests: XCTestCase {
     try testIncremental(checkDiagnostics: false)
   }
 
+  /// Ensure that the mod date of the input comes back exactly the same via the build-record.
+  /// Otherwise the up-to-date calculation in `IncrementalCompilationState` will fail.
+  func testBuildRecordDateAccuracy() throws {
+    (1...10) .forEach { n in
+      tryInitial(false)
+      tryNoChange(true)
+    }
+  }
+
+
 
   func testIncremental(checkDiagnostics: Bool) throws {
     tryInitial(checkDiagnostics)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -369,7 +369,7 @@ final class IncrementalCompilationTests: XCTestCase {
   /// Ensure that the mod date of the input comes back exactly the same via the build-record.
   /// Otherwise the up-to-date calculation in `IncrementalCompilationState` will fail.
   func testBuildRecordDateAccuracy() throws {
-    (1...10) .forEach { n in
+    (1...10).forEach { n in
       tryInitial(false)
       tryNoChange(true)
     }


### PR DESCRIPTION
Required because legacy driver does an exact check of input mod time vs time reconstructed from build record.