### PR TITLE
build: swap compiler search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.15.1)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
-project(SwiftDriver LANGUAGES Swift C)
+project(SwiftDriver LANGUAGES C Swift)
 
 set(SWIFT_VERSION 5)
 set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})


### PR DESCRIPTION
Swap the toolchain search order.  This ensures that the correct linker setup is done on WIndows.  For some reason, the Swift search first will potentially pick up MinGW if the tools are in the path.