### PR TITLE
[Incremental] Honor -driver-always-rebuild-dependents

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/DependencyKey.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 /// A filename from another module
-struct ExternalDependency: Hashable, CustomStringConvertible {
+struct ExternalDependency: Hashable, Comparable, CustomStringConvertible {
   let fileName: String
 
   var file: VirtualPath? {
@@ -13,6 +13,10 @@ struct ExternalDependency: Hashable, CustomStringConvertible {
   }
   public var description: String {
     fileName.description
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.fileName < rhs.fileName
   }
 }
 
@@ -31,7 +35,7 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   /// implementations white. Each node holds an instance variable describing which
   /// aspect of the entity it represents.
 
-  enum DeclAspect {
+  enum DeclAspect: Comparable {
     case interface, implementation
   }
 
@@ -110,5 +114,17 @@ var correspondingImplementation: Self? {
     // This space reserved for future use.
     return true
   }
+}
+
+// MARK: - Comparing
+/// Needed to sort nodes to make tracing deterministic to test against emitted diagnostics
+extension DependencyKey: Comparable {
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.aspect != rhs.aspect ? lhs.aspect < rhs.aspect :
+      lhs.designator < rhs.designator
+  }
+}
+
+extension DependencyKey.Designator: Comparable {
 }
 

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Node.swift
@@ -80,6 +80,22 @@ extension ModuleDependencyGraph.Node: Equatable, Hashable {
   }
 }
 
+extension ModuleDependencyGraph.Node: Comparable {
+  static func < (lhs: ModuleDependencyGraph.Node, rhs: ModuleDependencyGraph.Node) -> Bool {
+    func lt<T: Comparable> (_ a: T?, _ b: T?) -> Bool {
+      switch (a, b) {
+      case let (x?, y?): return x < y
+      case (nil, nil): return false
+      case (nil, _?): return true
+      case (_?, nil): return false
+      }
+    }
+    return lhs.dependencyKey != rhs.dependencyKey ? lhs.dependencyKey < rhs.dependencyKey :
+      lhs.swiftDeps != rhs.swiftDeps ? lt(lhs.swiftDeps, rhs.swiftDeps)
+      : lt(lhs.fingerprint, rhs.fingerprint)
+  }
+}
+
 
 extension ModuleDependencyGraph.Node: CustomStringConvertible {
   public var description: String {

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/NodeFinder.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/NodeFinder.swift
@@ -71,6 +71,14 @@ extension ModuleDependencyGraph.NodeFinder {
       .map(fnVerifyingSwiftDeps)
   }
 
+  func forEachUseInOrder(of def: Graph.Node, _ fn: (Graph.Node, Graph.SwiftDeps) -> Void) {
+    var uses = [(Graph.Node, Graph.SwiftDeps)]()
+    forEachUse(of: def) {
+      uses.append(($0, $1))
+    }
+    uses.sorted {$0.0 < $1.0} .forEach { fn($0.0, $0.1) }
+  }
+
   func mappings(of n: Graph.Node) -> [(Graph.SwiftDeps?, DependencyKey)]
   {
     nodeMap.compactMap {

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/SwiftDeps.swift
@@ -46,3 +46,9 @@ extension ModuleDependencyGraph.SwiftDeps {
     file.name
   }
 }
+// MARK: - comparing
+extension ModuleDependencyGraph.SwiftDeps: Comparable {
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.file.name < rhs.file.name
+  }
+}

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph Parts/Tracer.swift
@@ -57,7 +57,8 @@ extension ModuleDependencyGraph.Tracer {
   where Nodes.Element == ModuleDependencyGraph.Node
   {
     self.graph = graph
-    self.startingPoints = Array(defs)
+    // Sort so "Tracing" diagnostics are deterministically ordered
+    self.startingPoints = defs.sorted()
     self.currentPathIfTracing = graph.reportIncrementalDecision != nil ? [] : nil
     self.diagnosticEngine = diagnosticEngine
   }
@@ -83,7 +84,7 @@ extension ModuleDependencyGraph.Tracer {
     let pathLengthAfterArrival = traceArrival(at: definition);
     
     // If this use also provides something, follow it
-    graph.nodeFinder.forEachUse(of: definition) { use, _ in
+    graph.nodeFinder.forEachUseInOrder(of: definition) { use, _ in
       findNextPreviouslyUntracedDependent(of: use)
     }
     traceDeparture(pathLengthAfterArrival);

--- a/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/ModuleDependencyGraph.swift
@@ -194,7 +194,7 @@ extension ModuleDependencyGraph {
     // These nodes will depend on the *interface* of the external Decl.
     let key = DependencyKey(interfaceFor: externalSwiftDeps)
     let node = Node(key: key, fingerprint: nil, swiftDeps: nil)
-    nodeFinder.forEachUse(of: node) { use, useSwiftDeps in
+    nodeFinder.forEachUseInOrder(of: node) { use, useSwiftDeps in
       if isUntraced(use) {
         fn(useSwiftDeps)
       }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -507,6 +507,7 @@ final class IncrementalCompilationTests: XCTestCase {
       ],
       whenAutolinking: autolinkLifecycleExpectations)
   }
+
   func tryTouchingMainAlwaysRebuildDependents(_ checkDiagnostics: Bool) {
     touch("main")
     let extraArgument = "-driver-always-rebuild-dependents"
@@ -536,7 +537,6 @@ final class IncrementalCompilationTests: XCTestCase {
       ],
       whenAutolinking: autolinkLifecycleExpectations)
   }
-
 
   func touch(_ name: String) {
     print("*** touching \(name) ***", to: &stderrStream); stderrStream.flush()


### PR DESCRIPTION
In order to pass legacy tests, honor -driver-always-rebuild-dependents