### PR TITLE
[Incremental] Use same up-to-date test as legacy driver

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -272,14 +272,20 @@ extension IncrementalCompilationState {
       }
       let modDate = buildRecordInfo.compilationInputModificationDates[input]
         ?? Date.distantFuture
-      let previousCompilationStatus = outOfDateBuildRecord
-        .inputInfos[input.file]?.status ?? .newlyAdded
+      let inputInfo = outOfDateBuildRecord.inputInfos[input.file]
+      let previousCompilationStatus = inputInfo?.status ?? .newlyAdded
+      let previousModTime = inputInfo?.previousModTime
+
+      // Because legacy driver reads/writes dates wrt 1970,
+      // and because converting time intervals to/from Dates from 1970
+      // exceeds Double precision, must not compare dates directly
+      var datesMatch: Bool {
+        modDate.timeIntervalSince1970 == previousModTime?.timeIntervalSince1970
+      }
 
       switch previousCompilationStatus {
-      // Using outOfDateBuildRecord.inputInfos[input.file]?.previousModTime
-      // has some inaccuracy.
-      // Use outOfDateBuildRecord.buildTime instead
-      case .upToDate where modDate < outOfDateBuildRecord.buildTime:
+
+      case .upToDate where datesMatch:
         reportIncrementalDecision?("May skip current input:", input)
         return nil
 


### PR DESCRIPTION
Legacy driver insists that dates match exactly.  So do that here for compatibility. Required for some lit tests.