### PR TITLE
Revert "[Incremental] Enable testBatchModeContinueAfterErrors & skip frontend query even if no extra arguments to -driver-use-frontend-path"

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2061,10 +2061,8 @@ extension Driver {
                                        toolDirectory: toolDir)
 
     // Find the Swift compiler executable.
-    let hasFrontendBeenRedirectedForTesting: Bool
     let swiftCompilerPrefixArgs: [String]
     if let frontendPath = parsedOptions.getLastArgument(.driverUseFrontendPath){
-      hasFrontendBeenRedirectedForTesting = true
       var frontendCommandLine =
         frontendPath.asSingle.split(separator: ";").map { String($0) }
       if frontendCommandLine.isEmpty {
@@ -2077,8 +2075,10 @@ extension Driver {
         swiftCompilerPrefixArgs = frontendCommandLine
       }
     } else {
-      hasFrontendBeenRedirectedForTesting = false
       swiftCompilerPrefixArgs = []
+    }
+    var hasFrontendBeenRedirectedForTesting: Bool {
+      return !swiftCompilerPrefixArgs.isEmpty
     }
 
     // Find the SDK, if any.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1472,6 +1472,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testBatchModeContinueAfterErrors() throws {
+    throw XCTSkip("This test requires the fix to honoring -driver-use-frontend-path")
     struct MockExecutor: DriverExecutor {
       let resolver = try! ArgsResolver(fileSystem: localFileSystem)
 


### PR DESCRIPTION
Reverts apple/swift-driver#393

This change causes a failure in SwiftPM unit-tests:
```
Test Case '-[BuildTests.BuildPlanTests testExplicitSwiftPackageBuild]' started.
/Volumes/Data/GHWorkspace1/swift-driver/Sources/SwiftDriver/Execution/DriverExecutor.swift:91: error: -[BuildTests.BuildPlanTests testExplicitSwiftPackageBuild] : failed: caught error: "jobFailedWithNonzeroExitCode(1, "<unknown>:0: error: unsupported target architecture: \'\'\n<unknown>:0: error: unsupported target OS: \'\'\n")"
Test Case '-[BuildTests.BuildPlanTests testExplicitSwiftPackageBuild]' failed (0.208 seconds).
```