### PR TITLE
[Incremental] Another attempt to get the driver to honor -driver-use-frontend-path

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2062,23 +2062,24 @@ extension Driver {
 
     // Find the Swift compiler executable.
     let swiftCompilerPrefixArgs: [String]
+    let hasFrontendBeenRedirectedForTesting: Bool
     if let frontendPath = parsedOptions.getLastArgument(.driverUseFrontendPath){
       var frontendCommandLine =
         frontendPath.asSingle.split(separator: ";").map { String($0) }
       if frontendCommandLine.isEmpty {
         diagnosticsEngine.emit(.error_no_swift_frontend)
         swiftCompilerPrefixArgs = []
+        hasFrontendBeenRedirectedForTesting = false
       } else {
-        let frontendPath = frontendCommandLine.removeFirst()
-        toolchain.overrideToolPath(
-          .swiftCompiler, path: try AbsolutePath(validating: frontendPath))
+        let frontendPathString = frontendCommandLine.removeFirst()
+        let frontendPath = try AbsolutePath(validating: frontendPathString)
+        toolchain.overrideToolPath(.swiftCompiler, path: frontendPath)
         swiftCompilerPrefixArgs = frontendCommandLine
+        hasFrontendBeenRedirectedForTesting = FileType.isFrontendExtensionForTesting(frontendPath.extension)
       }
     } else {
       swiftCompilerPrefixArgs = []
-    }
-    var hasFrontendBeenRedirectedForTesting: Bool {
-      return !swiftCompilerPrefixArgs.isEmpty
+      hasFrontendBeenRedirectedForTesting = false
     }
 
     // Find the SDK, if any.

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -77,7 +77,8 @@ extension Driver {
     case .swift, .image, .dSYM, .dependencies, .autolink, .swiftDocumentation, .swiftInterface,
          .privateSwiftInterface, .swiftSourceInfoFile, .diagnostics, .objcHeader, .swiftDeps,
          .remap, .tbd, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
-         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies, nil:
+         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies,
+         .python, nil:
       return false
     }
   }
@@ -355,7 +356,8 @@ extension FileType {
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
          .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
-         .privateSwiftInterface, .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts:
+         .privateSwiftInterface, .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts,
+         .python:
       fatalError("Output type can never be a primary output")
     }
   }

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -130,6 +130,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
 
   /// Clang Module Map
   case clangModuleMap = "modulemap"
+
+  /// Python script (used for tests)
+  case python = "py"
 }
 
 extension FileType: CustomStringConvertible {
@@ -137,7 +140,7 @@ extension FileType: CustomStringConvertible {
     switch self {
     case .swift, .sil, .sib, .image, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile, .assembly,
-         .remap, .tbd, .pcm, .pch, .clangModuleMap:
+         .remap, .tbd, .pcm, .pch, .clangModuleMap, .python:
       return rawValue
     case .object:
       return "object"
@@ -211,7 +214,8 @@ extension FileType {
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
          .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
          .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile, .jsonDependencies,
-         .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies:
+         .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies,
+         .python:
       return false
     }
   }
@@ -302,6 +306,8 @@ extension FileType {
       return "bitstream-opt-record"
     case .diagnostics:
       return "diagnostics"
+    case .python:
+      return "python"
     }
   }
 }
@@ -313,7 +319,7 @@ extension FileType {
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
          .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface,
          .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts,
-         .jsonClangDependencies:
+         .jsonClangDependencies, .python:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -333,8 +339,13 @@ extension FileType {
          .swiftSourceInfoFile, .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap,
          .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord,
          .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies, .clangModuleMap,
-         .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies:
+         .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies, .python:
       return false
     }
   }
+
+  static func isFrontendExtensionForTesting(_ extension: String?) -> Bool {
+    python.rawValue == `extension`
+  }
+
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1472,7 +1472,6 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testBatchModeContinueAfterErrors() throws {
-    throw XCTSkip("This test requires the fix to honoring -driver-use-frontend-path")
     struct MockExecutor: DriverExecutor {
       let resolver = try! ArgsResolver(fileSystem: localFileSystem)
 
@@ -1496,7 +1495,7 @@ final class SwiftDriverTests: XCTestCase {
        }
     }
 
-    let driver = try Driver(args: ["swiftc", "foo1.swift", "bar1.swift", "-enable-batch-mode", "-driver-use-frontend-path", "/bin/echo"], executor: MockExecutor())
+    let driver = try Driver(args: ["swiftc", "foo1.swift", "bar1.swift", "-enable-batch-mode", "-driver-use-frontend-path", "/dummy.py"], executor: MockExecutor())
   }
 
   func testSingleThreadedWholeModuleOptimizationCompiles() throws {


### PR DESCRIPTION
This one only subverts the frontend target check if the new frontend path is a Python script. That way, the option still should work with swiftpm. Don't merge until the swiftpm unit tests pass with this.