### PR TITLE
[Incremental] Properly detect the testing case when honoring -driver-use-frontend-path

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2075,7 +2075,9 @@ extension Driver {
         let frontendPath = try AbsolutePath(validating: frontendPathString)
         toolchain.overrideToolPath(.swiftCompiler, path: frontendPath)
         swiftCompilerPrefixArgs = frontendCommandLine
-        hasFrontendBeenRedirectedForTesting = FileType.isFrontendExtensionForTesting(frontendPath.extension)
+        // The tests in Driver/Dependencies redirect the frontend to a python
+        // script, so don't ask the frontend for target info in that case.
+        hasFrontendBeenRedirectedForTesting = frontendPath.basename == "Python"
       }
     } else {
       swiftCompilerPrefixArgs = []

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -79,8 +79,7 @@ extension Driver {
     case .swift, .image, .dSYM, .dependencies, .autolink, .swiftDocumentation, .swiftInterface,
          .privateSwiftInterface, .swiftSourceInfoFile, .diagnostics, .objcHeader, .swiftDeps,
          .remap, .tbd, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
-         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies,
-         .python, nil:
+         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies, nil:
       return false
     }
   }
@@ -358,8 +357,7 @@ extension FileType {
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
          .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
-         .privateSwiftInterface, .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts,
-         .python:
+         .privateSwiftInterface, .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts:
       fatalError("Output type can never be a primary output")
     }
   }

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -130,9 +130,6 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
 
   /// Clang Module Map
   case clangModuleMap = "modulemap"
-
-  /// Python script (used for tests)
-  case python = "py"
 }
 
 extension FileType: CustomStringConvertible {
@@ -140,7 +137,7 @@ extension FileType: CustomStringConvertible {
     switch self {
     case .swift, .sil, .sib, .image, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile, .assembly,
-         .remap, .tbd, .pcm, .pch, .clangModuleMap, .python:
+         .remap, .tbd, .pcm, .pch, .clangModuleMap:
       return rawValue
     case .object:
       return "object"
@@ -214,8 +211,7 @@ extension FileType {
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
          .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
          .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile, .jsonDependencies,
-         .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies,
-         .python:
+         .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies:
       return false
     }
   }
@@ -306,8 +302,6 @@ extension FileType {
       return "bitstream-opt-record"
     case .diagnostics:
       return "diagnostics"
-    case .python:
-      return "python"
     }
   }
 }
@@ -319,7 +313,7 @@ extension FileType {
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
          .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface,
          .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts,
-         .jsonClangDependencies, .python:
+         .jsonClangDependencies:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -339,13 +333,8 @@ extension FileType {
          .swiftSourceInfoFile, .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap,
          .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord,
          .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies, .clangModuleMap,
-         .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies, .python:
+         .jsonTargetInfo, .jsonSwiftArtifacts, .jsonClangDependencies:
       return false
     }
   }
-
-  static func isFrontendExtensionForTesting(_ extension: String?) -> Bool {
-    python.rawValue == `extension`
-  }
-
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1495,7 +1495,8 @@ final class SwiftDriverTests: XCTestCase {
        }
     }
 
-    let driver = try Driver(args: ["swiftc", "foo1.swift", "bar1.swift", "-enable-batch-mode", "-driver-use-frontend-path", "/dummy.py"], executor: MockExecutor())
+    var driver = try Driver(args: ["swiftc", "foo1.swift", "bar1.swift", "-enable-batch-mode", "-driver-use-frontend-path", "/Python"], executor: MockExecutor())
+    try! driver.run(jobs: [])
   }
 
   func testSingleThreadedWholeModuleOptimizationCompiles() throws {


### PR DESCRIPTION
Turns out the tests invoke `Python` as the command, so test for that. No need to add .py to file types.