### PR TITLE
[Incremental] Don't read swiftdeps of a new input or of a crashed compile.

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
@@ -69,6 +69,10 @@ public struct BuildRecord {
 
     var serializedName: String { rawValue }
   }
+
+  var allInputs: Set<VirtualPath> {
+    Set( inputInfos.map {$0.key} )
+  }
 }
 
 // MARK: - Reading the old map and deciding whether to use it

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -95,6 +95,7 @@ public class IncrementalCompilationState {
             ModuleDependencyGraph.buildInitialGraph(
               diagnosticEngine: diagnosticEngine,
               inputs: buildRecordInfo.compilationInputModificationDates.keys,
+              previousInputs: outOfDateBuildRecord.allInputs,
               outputFileMap: outputFileMap,
               parsedOptions: &parsedOptions,
               remarkDisabled: Diagnostic.Message.remark_incremental_compilation_disabled,

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -533,7 +533,9 @@ class ExecuteJobRule: LLBuildRule {
 #endif
         }
       }
-      context.addRuleBeyondMandatoryCompiles(finishedJob: job, result: result)
+      if case .terminated = result.exitStatus {
+        context.addRuleBeyondMandatoryCompiles(finishedJob: job, result: result)
+      }
 
       // Inform the delegate about job finishing.
       context.delegateQueue.async {


### PR DESCRIPTION
With the changes in the title, follows legacy behavior and passes `Driver/Dependencies/crash-added-fine.swift`