### PR TITLE
[Incremental] Preserve old build record in order to pass dependencies-preservation-file.swift

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -157,7 +157,7 @@ struct JobResult {
   /// Added for the sake of compatibility with the legacy driver.
   private func preservePreviousBuildRecord(_ oldPath: AbsolutePath) {
     let newPath = oldPath.withTilde()
-    try! fileSystem.move(from: oldPath, to: newPath)
+    try? fileSystem.move(from: oldPath, to: newPath)
   }
 
 


### PR DESCRIPTION
Pull over a feature from the legacy driver: Preserve old build record in order to pass dependencies-preservation-file.swift.