### PR TITLE
[Incremental] Mimic legacy for testing, can omit argsHash from build record and it still matches.

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
@@ -77,11 +77,12 @@ public struct BuildRecord {
 
 // MARK: - Reading the old map and deciding whether to use it
 public extension BuildRecord {
-  init(contents: String) throws {
+  init(contents: String, defaultArgsHash: String? = nil) throws {
     guard let sections = try Parser(yaml: contents, resolver: .basic, encoding: .utf8)
       .singleRoot()?.mapping
       else { throw SimpleErrors.couldNotDecodeBuildRecord }
-    var argsHash, swiftVersion: String?
+    var argsHash: String? = defaultArgsHash
+    var swiftVersion: String?
     var buildTime: Date?
     var inputInfos: [VirtualPath: InputInfo]?
     for (key, value) in sections {

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecord.swift
@@ -83,7 +83,8 @@ public extension BuildRecord {
       else { throw SimpleErrors.couldNotDecodeBuildRecord }
     var argsHash: String? = defaultArgsHash
     var swiftVersion: String?
-    var buildTime: Date?
+    // Legacy driver does not disable incremental if no buildTime field.
+    var buildTime: Date = .distantPast
     var inputInfos: [VirtualPath: InputInfo]?
     for (key, value) in sections {
       guard let k = key.string else { throw SimpleErrors.sectionNameNotString }

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -152,12 +152,14 @@ struct JobResult {
 // TODO: Incremental too many names, buildRecord BuildRecord outofdatemap
   func populateOutOfDateBuildRecord(
     inputFiles: [TypedVirtualPath],
+    defaultArgsHash: String?,
     failed: (String) -> Void
   ) -> BuildRecord? {
     let outOfDateBuildRecord: BuildRecord
     do {
       let contents = try fileSystem.readFileContents(buildRecordPath).cString
-      outOfDateBuildRecord  = try BuildRecord(contents: contents)
+      outOfDateBuildRecord  = try BuildRecord(contents: contents,
+                                              defaultArgsHash: defaultArgsHash)
     }
     catch {
       failed("could not read build record at \(buildRecordPath): \(error.localizedDescription).")

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -74,10 +74,15 @@ public class IncrementalCompilationState {
       return nil
     }
 
+    // Mimic the legacy driver for testing ease: If no `argsHash` section,
+    // record still matches.
+    let defaultArgsHash = buildRecordInfo.argsHash
+
     // FIXME: This should work without an output file map. We should have
     // another way to specify a build record and where to put intermediates.
     guard let outOfDateBuildRecord = buildRecordInfo.populateOutOfDateBuildRecord(
             inputFiles: inputFiles,
+            defaultArgsHash: defaultArgsHash,
             failed: {
               diagnosticEngine.emit(
                 .remark_incremental_compilation_disabled(because: $0))

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -37,6 +37,31 @@ final class NonincrementalCompilationTests: XCTestCase {
                        ])
   }
 
+  func testBuildRecordWithoutOptionsReading() throws {
+    let hash = "abbbfbcaf36b93e58efaadd8271ff142"
+    let buildRecord = try! BuildRecord(
+      contents: Inputs.buildRecordWithoutOptions,
+      defaultArgsHash: hash)
+    XCTAssertEqual(buildRecord.swiftVersion,
+                   "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)")
+    XCTAssertEqual(buildRecord.argsHash, hash)
+
+    try XCTAssertEqual(buildRecord.buildTime,
+                       Date(legacyDriverSecsAndNanos: [1570318779, 32358000]))
+    try XCTAssertEqual(buildRecord.inputInfos,
+                       [
+                        VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"):
+                          InputInfo(status: .needsCascadingBuild,
+                                    previousModTime: Date(legacyDriverSecsAndNanos: [1570318778, 0])),
+                        VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"):
+                          InputInfo(status: .upToDate,
+                                    previousModTime: Date(legacyDriverSecsAndNanos: [1570083660, 0])),
+                        VirtualPath(path: "/Volumes/gazorp.swift"):
+                          InputInfo(status: .needsNonCascadingBuild,
+                                    previousModTime:  Date(legacyDriverSecsAndNanos: [0, 0]))
+                       ])
+  }
+
   func testReadBinarySourceFileDependencyGraph() throws {
     let packageRootPath = URL(fileURLWithPath: #file).pathComponents
       .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()

--- a/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
@@ -24,6 +24,16 @@ enum Inputs {
           "/Volumes/gazorp.swift": !private [0,0]
     """
   }
+  static var buildRecordWithoutOptions: String {
+    """
+        version: "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
+        build_time: [1570318779, 32358000]
+        inputs:
+          "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift": !dirty [1570318778, 0]
+          "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift": [1570083660, 0]
+          "/Volumes/gazorp.swift": !private [0,0]
+    """
+  }
   static var fineGrainedSourceFileDependencyGraph: String {
     """
     # Fine-grained v0


### PR DESCRIPTION
Legacy test driver-show-incremental-arguments-fine.swift requires this.
Same applies to build date.