### PR TITLE
Allow argsHash to be nil when testing. Use dummy value for compilerVersion when testing.

### DIFF
--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -73,16 +73,10 @@ public class IncrementalCompilationState {
       diagnosticEngine.emit(.warning_incremental_requires_output_file_map)
       return nil
     }
-
-    // Mimic the legacy driver for testing ease: If no `argsHash` section,
-    // record still matches.
-    let defaultArgsHash = buildRecordInfo.argsHash
-
     // FIXME: This should work without an output file map. We should have
     // another way to specify a build record and where to put intermediates.
     guard let outOfDateBuildRecord = buildRecordInfo.populateOutOfDateBuildRecord(
             inputFiles: inputFiles,
-            defaultArgsHash: defaultArgsHash,
             failed: {
               diagnosticEngine.emit(
                 .remark_incremental_compilation_disabled(because: $0))

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -127,8 +127,10 @@ extension SwiftVersion: Codable {
   var targetVariant: Target?
   let paths: Paths
 
+  static let dummyVersion = "dummy"
+
   static func dummyForTesting(_ toolchain: Toolchain) -> Self {
-    Self(compilerVersion: "dummy",
+    Self(compilerVersion: Self.dummyVersion,
          target: .dummyForTesting(toolchain),
          targetVariant: nil,
          paths: .dummyForTesting)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -38,13 +38,11 @@ final class NonincrementalCompilationTests: XCTestCase {
   }
 
   func testBuildRecordWithoutOptionsReading() throws {
-    let hash = "abbbfbcaf36b93e58efaadd8271ff142"
     let buildRecord = try! BuildRecord(
-      contents: Inputs.buildRecordWithoutOptions,
-      defaultArgsHash: hash)
+      contents: Inputs.buildRecordWithoutOptions)
     XCTAssertEqual(buildRecord.swiftVersion,
                    "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)")
-    XCTAssertEqual(buildRecord.argsHash, hash)
+    XCTAssertEqual(buildRecord.argsHash, nil)
 
     try XCTAssertEqual(buildRecord.buildTime,
                        Date(legacyDriverSecsAndNanos: [1570318779, 32358000]))
@@ -230,7 +228,7 @@ final class NonincrementalCompilationTests: XCTestCase {
                                     .previousModTime.legacyDriverSecsAndNanos,
                                   [1570083660, 0]))
 
-    let outputString = try buildRecord.encode()
+    let outputString = try buildRecord.encode(currentArgsHash: options)
     XCTAssertEqual(inputString, outputString)
   }
   /// The date conversions are not exact


### PR DESCRIPTION
Although both are transmitted through the build record, they are different:
- argsHash for the current run can be determined, but not easily consed up in a test
- compilerVersion cannot be determined (when the frontend path is set to Python for testing), but the tests have no trouble finding one.

So, just as the legacy driver does, allow the "options" field to be omitted from the incoming build record without triggering a mismatch.

And when testing, let the driver set the compilerVersion to a dummy value, which can be recognized when testing.