### PR TITLE
Migrate to TSC versions of some Absolute/RelativePath APIs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "main",
-          "revision": "5b5421a12fea9c5ec63fd9a797c05f7aebd8142b",
+          "revision": "eb56a00ed9dfd62c2ce4ec86183ff0bc0afda997",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": "main",
-          "revision": "99ae28c10aaf9009d87445d780197d85bc09f0b3",
+          "revision": "c98cfc216d22798dce7ce7b9cc171565371e967e",
           "version": null
         }
       },

--- a/Sources/SwiftDriver/Utilities/RelativePathAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/RelativePathAdditions.swift
@@ -12,17 +12,6 @@
 import TSCBasic
 
 extension RelativePath {
-  /// Retrieve the basename of the relative path without the extension.
-  ///
-  /// FIXME: Probably belongs in TSC
-  var basenameWithoutExt: String {
-    if let ext = self.extension {
-      return String(basename.dropLast(ext.count + 1))
-    }
-
-    return basename
-  }
-
   /// Retrieve the basename of the relative path without any extensions,
   /// even if there are several, and without any leading dots. Roughly
   /// equivalent to the regex `/[^.]+/`.

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -162,13 +162,21 @@ public enum VirtualPath: Hashable {
   }
 
   public func appending(components: String...) -> VirtualPath {
-    // FIXME: TSC should add non-variadic overloads of appending(components:)
-    // so we can forward arguments here instead of appending components one-by-one.
-    var result = self
-    components.forEach {
-      result = result.appending(component: $0)
+    switch self {
+    case .absolute(let path):
+      return .absolute(path.appending(components: components))
+    case .relative(let path):
+      return .relative(path.appending(components: components))
+    case .temporary(let path):
+      return .temporary(path.appending(components: components))
+    case let .temporaryWithKnownContents(path, contents):
+      return .temporaryWithKnownContents(path.appending(components: components), contents)
+    case .fileList(let path, let content):
+      return .fileList(path.appending(components: components), content)
+    case .standardInput, .standardOutput:
+      assertionFailure("Can't append path component to standard in/out")
+      return self
     }
-    return result
   }
 
   /// Returns the virtual path with an additional suffix appended to base name.


### PR DESCRIPTION
This PR just resolves a couple of FIXMEs after I added some AbsolutePath/RelativePath utilities to TSC in https://github.com/apple/swift-tools-support-core/pull/173