### PR TITLE
Remove redundant clang '-target' flag from Unix Toolchain

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -61,11 +61,6 @@ extension GenericUnixToolchain {
       commandLine.appendFlag("-shared")
       fallthrough
     case .executable:
-      if !targetTriple.triple.isEmpty {
-        commandLine.appendFlag("-target")
-        commandLine.appendFlag(targetTriple.triple)
-      }
-
         // Select the linker to use.
       var linker: String?
       if let arg = parsedOptions.getLastArgument(.useLd) {


### PR DESCRIPTION
This is a port of the change to the C++ Driver from apple/swift#34978 to Swift.

All the tests in this repo passed with this pull when run on linux x86_64. I don't know if this Driver is periodically run against the upstream testsuite, in which case the upstream pull will have to be merged first.

@cltnschlosser, this pull invalidates much of #370, maybe you can repurpose that by reworking the tests and adding the Android sanitizer change.