### PR TITLE
[Incremental] Fix race on `finishedJobResults`

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -36,8 +36,9 @@ struct ToolExecutionDelegate: JobExecutionDelegate {
   public let showJobLifecycle: Bool
   public let diagnosticEngine: DiagnosticsEngine
 
-
   public func jobStarted(job: Job, arguments: [String], pid: Int) {
+    buildRecordInfo?.jobStarted(job: job, arguments: arguments, pid: pid)
+
     if showJobLifecycle {
       diagnosticEngine.emit(.remark_job_lifecycle("Starting", job))
     }


### PR DESCRIPTION
The build engine can exit before all jobs have registered their results in `finishedJobResults`. Then when the build record is written, the read of these results races with the writes. Protect these with a semaphore.