### PR TITLE
Match the legacy driver's output file map behavior when there are no outputs

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -130,9 +130,14 @@ public final class ArgsResolver {
       // and the frontend (llvm) only seems to support implicit block format.
       try fileSystem.writeFileContents(absPath) { out in
         for (input, map) in outputFileMap.entries {
-          out <<< quoteAndEscape(path: input) <<< ":\n"
-          for (type, output) in map {
-            out <<< "  " <<< type.name <<< ": " <<< quoteAndEscape(path: output) <<< "\n"
+          out <<< quoteAndEscape(path: input) <<< ":"
+          if map.isEmpty {
+            out <<< " {}\n"
+          } else {
+            out <<< "\n"
+            for (type, output) in map {
+              out <<< "  " <<< type.name <<< ": " <<< quoteAndEscape(path: output) <<< "\n"
+            }
           }
         }
       }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4146,6 +4146,55 @@ final class SwiftDriverTests: XCTestCase {
       }
       XCTAssertEqual(inputs, [.temporary(RelativePath("a.o")), .temporary(RelativePath("b.o")), .temporary(RelativePath("c.o"))])
     }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-typecheck", "a.swift", "b.swift", "-driver-filelist-threshold=0"])
+      let plannedJobs = try driver.planBuild()
+
+      let jobA = plannedJobs[0]
+      let flagA = jobA.commandLine.firstIndex(of: .flag("-supplementary-output-file-map"))!
+      let fileListArgumentA = jobA.commandLine[jobA.commandLine.index(after: flagA)]
+      guard case let .path(.fileList(_, fileListA)) = fileListArgumentA else {
+        XCTFail("Argument wasn't a filelist")
+        return
+      }
+      guard case let .outputFileMap(mapA) = fileListA else {
+        XCTFail("FileList wasn't OutputFileMap")
+        return
+      }
+      XCTAssertEqual(mapA.entries, [.relative(.init("a.swift")): [:]])
+
+      let jobB = plannedJobs[1]
+      let flagB = jobB.commandLine.firstIndex(of: .flag("-supplementary-output-file-map"))!
+      let fileListArgumentB = jobB.commandLine[jobB.commandLine.index(after: flagB)]
+      guard case let .path(.fileList(_, fileListB)) = fileListArgumentB else {
+        XCTFail("Argument wasn't a filelist")
+        return
+      }
+      guard case let .outputFileMap(mapB) = fileListB else {
+        XCTFail("FileList wasn't OutputFileMap")
+        return
+      }
+      XCTAssertEqual(mapB.entries, [.relative(.init("b.swift")): [:]])
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-typecheck", "-wmo", "a.swift", "b.swift", "-driver-filelist-threshold=0"])
+      let plannedJobs = try driver.planBuild()
+
+      let jobA = plannedJobs[0]
+      let flagA = jobA.commandLine.firstIndex(of: .flag("-supplementary-output-file-map"))!
+      let fileListArgumentA = jobA.commandLine[jobA.commandLine.index(after: flagA)]
+      guard case let .path(.fileList(_, fileListA)) = fileListArgumentA else {
+        XCTFail("Argument wasn't a filelist")
+        return
+      }
+      guard case let .outputFileMap(mapA) = fileListA else {
+        XCTFail("FileList wasn't OutputFileMap")
+        return
+      }
+      XCTAssertEqual(mapA.entries, [.relative(.init("a.swift")): [:]])
+    }
   }
 }
 


### PR DESCRIPTION
- Adjust the supplementary output file map calculation to better match the C++ driver's WMO behavior
- Always include either primary inputs or the first input in the supplementary output file map, even if there aren't any corresponding outputs

Fixes Driver/supplementary-filelist-empty.swift and Driver/modulewrap.swift