### PR TITLE
[Incremental] Bring swift-driver into correspondence with legacy driver.

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -102,6 +102,20 @@ struct ToolExecutionDelegate: JobExecutionDelegate {
     }
   }
 
+  public func jobSkipped(job: Job) {
+    if showJobLifecycle {
+      diagnosticEngine.emit(.remark_job_lifecycle("Skipped", job))
+    }
+    switch mode {
+    case .regular, .verbose:
+      break
+    case .parsableOutput:
+      let skippedMessage = SkippedMessage(inputs: job.displayInputs.map{ $0.file.name })
+      let message = ParsableMessage(name: job.kind.rawValue, kind: .skipped(skippedMessage))
+      emit(message)
+    }
+  }
+
   private func emit(_ message: ParsableMessage) {
     // FIXME: Do we need to do error handling here? Can this even fail?
     guard let json = try? message.toJSON() else { return }

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -137,4 +137,7 @@ public protocol JobExecutionDelegate {
   
   /// Called when a job finished.
   func jobFinished(job: Job, result: ProcessResult, pid: Int)
+
+  /// Called when a job is skipped.
+  func jobSkipped(job: Job)
 }

--- a/Sources/SwiftDriver/Execution/ParsableOutput.swift
+++ b/Sources/SwiftDriver/Execution/ParsableOutput.swift
@@ -17,7 +17,7 @@ import Foundation
     case began(BeganMessage)
     case finished(FinishedMessage)
     case signalled(SignalledMessage)
-    case skipped
+    case skipped(SkippedMessage)
   }
 
   public let name: String
@@ -76,6 +76,18 @@ import Foundation
     case outputs
     case commandExecutable = "command_executable"
     case commandArguments = "command_arguments"
+  }
+}
+
+@_spi(Testing) public struct SkippedMessage: Encodable {
+  public let inputs: [String]
+
+  public init( inputs: [String] ) {
+    self.inputs = inputs
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case inputs
   }
 }
 
@@ -144,8 +156,10 @@ import Foundation
     case .signalled(let msg):
       try container.encode("signalled", forKey: .kind)
       try msg.encode(to: encoder)
-    case .skipped:
-      break
+    case .skipped(let msg):
+      try container.encode("skipped", forKey: .kind)
+      try msg.encode(to: encoder)
+
     }
   }
 }

--- a/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/BuildRecordInfo.swift
@@ -181,10 +181,9 @@ struct JobResult {
     else {
       return nil
     }
-    guard actualSwiftVersion == outOfDateBuildRecord.swiftVersion ||
-            actualSwiftVersion == FrontendTargetInfo.dummyVersion
+    guard actualSwiftVersion == outOfDateBuildRecord.swiftVersion
     else {
-      let why = "compiler version mismatch. Compiling with \(actualSwiftVersion), previously with \(outOfDateBuildRecord.swiftVersion)"
+      let why = "compiler version mismatch. Compiling with: \(actualSwiftVersion). Previously compiled with: \(outOfDateBuildRecord.swiftVersion)"
       // mimic legacy
       reportIncrementalCompilationHasBeenDisabled("due to a " + why)
       reportDisablingIncrementalBuild(why)

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -314,7 +314,7 @@ extension IncrementalCompilationState {
     alwaysRebuildDependents: Bool,
     reportIncrementalDecision: ((String, TypedVirtualPath?) -> Void)?
   ) -> Set<TypedVirtualPath> {
-    let changedInputs: [(TypedVirtualPath, InputInfo.Status)] =
+    let changedInputs: [(TypedVirtualPath, InputInfo.Status, datesMatch: Bool)] =
       computeChangedInputs(
         groups: allGroups,
         buildRecordInfo: buildRecordInfo,
@@ -353,6 +353,7 @@ extension IncrementalCompilationState {
     let speculativeInputs = computeSpeculativeInputs(
       changedInputs: changedInputs,
       externalDependents: externalDependents,
+      inputsMissingOutputs: Set(inputsMissingOutputs),
       moduleDependencyGraph: moduleDependencyGraph,
       alwaysRebuildDependents: alwaysRebuildDependents,
       reportIncrementalDecision: reportIncrementalDecision)
@@ -383,7 +384,7 @@ extension IncrementalCompilationState {
     outOfDateBuildRecord: BuildRecord,
     fileSystem: FileSystem,
     reportIncrementalDecision: ((String, TypedVirtualPath?) -> Void)?
-   ) -> [(TypedVirtualPath, InputInfo.Status)] {
+  ) -> [(TypedVirtualPath, InputInfo.Status, datesMatch: Bool)] {
     groups.compactMap { group in
       let input = group.primaryInput
       let modDate = buildRecordInfo.compilationInputModificationDates[input]
@@ -414,7 +415,7 @@ extension IncrementalCompilationState {
       case .needsNonCascadingBuild:
         reportIncrementalDecision?("Scheduling noncascading build", input)
       }
-      return (input, previousCompilationStatus)
+      return (input, previousCompilationStatus, datesMatch)
     }
   }
 
@@ -450,35 +451,43 @@ extension IncrementalCompilationState {
   /// TODO: something better, e.g. return nothing here, but process changed swiftDeps
   /// before the whole frontend job finished.
   private static func computeSpeculativeInputs(
-    changedInputs: [(TypedVirtualPath, InputInfo.Status)],
+    changedInputs: [(TypedVirtualPath, InputInfo.Status, datesMatch: Bool)],
     externalDependents: [TypedVirtualPath],
+    inputsMissingOutputs: Set<TypedVirtualPath>,
     moduleDependencyGraph: ModuleDependencyGraph,
     alwaysRebuildDependents: Bool,
     reportIncrementalDecision: ((String, TypedVirtualPath?) -> Void)?
     ) -> Set<TypedVirtualPath> {
     // Collect the files that will be compiled whose dependents should be schedule
-    let cascadingChangedInputs: [TypedVirtualPath] = changedInputs.compactMap { input, status in
+    let cascadingChangedInputs: [TypedVirtualPath] = changedInputs.compactMap {
+      input, status, datesMatch in
       let basename = input.file.basename
-      switch (status, alwaysRebuildDependents) {
+      switch (status, alwaysRebuildDependents,
+              datesMatch && !inputsMissingOutputs.contains(input)) {
 
-       case (_, true):
+       case (_, true, false):
         reportIncrementalDecision?(
           "scheduling dependents of \(basename); -driver-always-rebuild-dependents", nil)
         return input
-      case (.needsCascadingBuild, false):
+      case(_, true, true):
+        reportIncrementalDecision?(
+          "not scheduling dependents of \(basename) despite -driver-always-rebuild-dependents because is up to date", nil)
+        return nil
+
+      case (.needsCascadingBuild, false, _):
         reportIncrementalDecision?(
           "scheduling dependents of \(basename); needed cascading build", nil)
         return input
 
-      case (.upToDate, false): // was up to date, but changed
+      case (.upToDate, false, _): // was up to date, but changed
         reportIncrementalDecision?(
           "not scheduling dependents of \(basename); unknown changes", nil)
         return nil
-       case (.newlyAdded, false):
+       case (.newlyAdded, false, _):
         reportIncrementalDecision?(
           "not scheduling dependents of \(basename): no entry in build record or dependency graph", nil)
         return nil
-      case (.needsNonCascadingBuild, false):
+      case (.needsNonCascadingBuild, false, _):
         reportIncrementalDecision?(
           "not scheduling dependents of \(basename): does not need cascading build", nil)
         return nil

--- a/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/Incremental Compilation/IncrementalCompilationState.swift
@@ -597,5 +597,10 @@ extension IncrementalCompilationState {
   var skippedCompilationInputs: Set<TypedVirtualPath> {
     Set(skippedCompileGroups.keys)
   }
+  public var skippedJobs: [Job] {
+    skippedCompileGroups.values
+      .sorted {$0.primaryInput.file.name < $1.primaryInput.file.name}
+      .flatMap {$0.allJobs()}
+  }
 }
 

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -217,9 +217,14 @@ extension Driver {
     try commandLine.appendLast(.saveOptimizationRecordEQ, from: &parsedOptions)
     try commandLine.appendLast(.saveOptimizationRecordPasses, from: &parsedOptions)
 
+    let inputsGeneratingCodeCount = primaryInputs.isEmpty
+      ? inputs.count
+      : primaryInputs.count
+
     outputs += try addFrontendSupplementaryOutputArguments(
       commandLine: &commandLine,
       primaryInputs: primaryInputs,
+      inputsGeneratingCodeCount: inputsGeneratingCodeCount,
       inputOutputMap: inputOutputMap,
       includeModuleTracePath: emitModuleTrace)
 

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -249,6 +249,7 @@ extension Driver {
 
   mutating func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate],
                                                         primaryInputs: [TypedVirtualPath],
+                                                        inputsGeneratingCodeCount: Int,
                                                         inputOutputMap: [TypedVirtualPath: TypedVirtualPath],
                                                         includeModuleTracePath: Bool) throws -> [TypedVirtualPath] {
     var flaggedInputOutputPairs: [(flag: String, input: TypedVirtualPath?, output: TypedVirtualPath)] = []
@@ -378,10 +379,7 @@ extension Driver {
                                       output: TypedVirtualPath(file: tracePath, type: .moduleTrace)))
     }
 
-    // This calculation treats all the files in a WMO compile as a single input
-    let allInputsCount = max(primaryInputs.count, 1)
-    // Question: outputs.count > fileListThreshold makes sense, but c++ does the following:
-    if allInputsCount * FileType.allCases.count > fileListThreshold {
+    if inputsGeneratingCodeCount * FileType.allCases.count > fileListThreshold {
       var entries = [VirtualPath: [FileType: VirtualPath]]()
       for input in primaryInputs {
         if let output = inputOutputMap[input] {

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -95,17 +95,6 @@ extension SwiftVersion: Codable {
     /// Whether the Swift libraries need to be referenced in their system
     /// location (/usr/lib/swift) via rpath.
     let librariesRequireRPath: Bool
-
-    static func dummyForTesting(_ toolchain: Toolchain) -> Self {
-      let dummyForTestingTriple = Triple.dummyForTesting(toolchain)
-      return Self(
-        triple: dummyForTestingTriple,
-        unversionedTriple: dummyForTestingTriple,
-        moduleTriple: dummyForTestingTriple,
-        swiftRuntimeCompatibilityVersion: nil,
-        compatibilityLibraries: [],
-        librariesRequireRPath: false)
-    }
   }
 
   @_spi(Testing) public struct Paths: Codable {
@@ -114,27 +103,12 @@ extension SwiftVersion: Codable {
     public let runtimeLibraryPaths: [TextualVirtualPath]
     public let runtimeLibraryImportPaths: [TextualVirtualPath]
     public let runtimeResourcePath: TextualVirtualPath
-
-    static let dummyForTesting = Paths(
-      sdkPath: nil,
-      runtimeLibraryPaths: [],
-      runtimeLibraryImportPaths: [],
-      runtimeResourcePath: .dummyForTesting)
   }
 
   var compilerVersion: String
   var target: Target
   var targetVariant: Target?
   let paths: Paths
-
-  static let dummyVersion = "dummy"
-
-  static func dummyForTesting(_ toolchain: Toolchain) -> Self {
-    Self(compilerVersion: Self.dummyVersion,
-         target: .dummyForTesting(toolchain),
-         targetVariant: nil,
-         paths: .dummyForTesting)
-  }
 }
 
 // Make members of `FrontendTargetInfo.Paths` accessible on `FrontendTargetInfo`.

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -176,20 +176,6 @@ public struct Triple {
                                              os: parsedOS?.value)
     }
   }
-
-  private init(dummyForTesting toolchain: Toolchain) {
-    self.triple = ""
-    self.arch = nil
-    self.subArch = nil
-    self.vendor = nil
-    self.os = nil
-    self.environment = nil
-    self.objectFormat = toolchain.dummyForTestingObjectFormat
-  }
-
-  static func dummyForTesting(_ toolchain: Toolchain) -> Self {
-    Self(dummyForTesting: toolchain)
-  }
 }
 
 extension Triple: Codable {

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -283,8 +283,6 @@ extension VirtualPath: Codable {
     self.path = path
   }
 
-  static let dummyForTesting = Self(path: try! .init(path: ""))
-
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     switch path {

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -247,6 +247,12 @@ public final class MultiJobExecutor {
         break
       }
     }
+
+    fileprivate func reportSkippedJobs() {
+      for job in incrementalCompilationState?.skippedJobs ?? [] {
+        executorDelegate.jobSkipped(job: job)
+      }
+    }
   }
 
   /// The work to be done.
@@ -306,6 +312,8 @@ public final class MultiJobExecutor {
     let engine = LLBuildEngine(delegate: delegate)
 
     let result = try engine.build(key: ExecuteAllJobsRule.RuleKey())
+
+    context.reportSkippedJobs()
 
     // Throw the stub error the build didn't finish successfully.
     if !result.success {

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -197,7 +197,7 @@ public final class MultiJobExecutor {
     ) {
       for output in job.outputs {
         if let otherJobIndex = producerMap.updateValue(index, forKey: output.file) {
-          fatalError("multiple producers for output \(output): \(job) & \(knownJobs[otherJobIndex])")
+          fatalError("multiple producers for output \(output.file): \(job) & \(knownJobs[otherJobIndex])")
         }
         producerMap[output.file] = index
       }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -455,6 +455,8 @@ final class IncrementalCompilationTests: XCTestCase {
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
         "Incremental compilation: Skipping input:  {compile: other.o <= other.swift}",
+        "Skipped Compiling main.swift",
+        "Skipped Compiling other.swift",
       ],
       whenAutolinking: [])
   }
@@ -477,6 +479,7 @@ final class IncrementalCompilationTests: XCTestCase {
         "Finished Compiling other.swift",
         "Starting Linking theModule",
         "Finished Linking theModule",
+        "Skipped Compiling main.swift",
     ],
     whenAutolinking: autolinkLifecycleExpectations)
   }

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -51,6 +51,8 @@ class JobCollectingDelegate: JobExecutionDelegate {
   func jobStarted(job: Job, arguments: [String], pid: Int) {
     started.append(job)
   }
+
+  func jobSkipped(job: Job) {}
 }
 
 extension DarwinToolchain {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1471,34 +1471,6 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
-  func testBatchModeContinueAfterErrors() throws {
-    struct MockExecutor: DriverExecutor {
-      let resolver = try! ArgsResolver(fileSystem: localFileSystem)
-
-      struct ShouldNeverGetHere: LocalizedError {}
-
-      func execute(job: Job, forceResponseFiles: Bool, recordedInputModificationDates: [TypedVirtualPath : Date]) throws -> ProcessResult {
-        throw ShouldNeverGetHere()
-      }
-      func execute(workload: DriverExecutorWorkload,
-                   delegate: JobExecutionDelegate,
-                   numParallelJobs: Int,
-                   forceResponseFiles: Bool,
-                   recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
-        XCTAssert(workload.continueBuildingAfterErrors)
-      }
-      func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
-        throw ShouldNeverGetHere()
-      }
-      func description(of job: Job, forceResponseFiles: Bool) throws -> String {
-        throw ShouldNeverGetHere()
-       }
-    }
-
-    var driver = try Driver(args: ["swiftc", "foo1.swift", "bar1.swift", "-enable-batch-mode", "-driver-use-frontend-path", "/Python"], executor: MockExecutor())
-    try! driver.run(jobs: [])
-  }
-
   func testSingleThreadedWholeModuleOptimizationCompiles() throws {
     var driver1 = try Driver(args: ["swiftc", "-whole-module-optimization", "foo.swift", "bar.swift", "-module-name", "Test", "-target", "x86_64-apple-macosx10.15", "-emit-module-interface", "-emit-objc-header-path", "Test-Swift.h", "-emit-private-module-interface-path", "Test.private.swiftinterface"])
     let plannedJobs = try driver1.planBuild()


### PR DESCRIPTION
With these changes, all 50 test in `Driver/Dependencies` run (assuming https://github.com/apple/swift/pull/35171 ).
See the individual commits for the details.

rdar://71869951
rdar://71870416
rdar://72508507