### PR TITLE
[Explicit Modules] Support using -experimental-explicit-module-build with immediate mode

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -598,7 +598,10 @@ extension Driver {
       return ([try replJob()], nil)
 
     case .immediate:
-      return ([try interpretJob(inputs: inputFiles)], nil)
+      var jobs: [Job] = []
+      try addPrecompileModuleDependenciesJobs(addJob: { jobs.append($0) })
+      jobs.append(try interpretJob(inputs: inputFiles))
+      return (jobs, nil)
 
     case .standardCompile, .batchCompile, .singleCompile:
       return try planStandardCompile()

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4209,7 +4209,7 @@ func assertString(
                 """, file: file, line: line)
 }
 
-fileprivate extension Array where Element: Equatable {
+extension Array where Element: Equatable {
   /// Returns true if the receiver contains the given elements as a subsequence
   /// (i.e., all elements are present, contiguous, and in the same order).
   ///


### PR DESCRIPTION
For example, `swift -experimental-explicit-module-build hello.swift` will now prebuild module dependencies, and then run the interpret job in-place at the end. On its own this isn't that useful, but I'm using it to explore the idea of `@package` imports in scripts a bit more, and I think the generalization here is pretty harmless

