### PR TITLE
Add support for the -update-code flag used to run the migrator

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1335,10 +1335,6 @@ extension Driver {
       case .indexFile:
         compilerOutputType = .indexData
 
-      case .updateCode:
-        compilerOutputType = .remap
-        linkerOutputType = nil
-
       case .parse, .resolveImports, .typecheck, .dumpParse, .emitSyntax,
            .printAst, .dumpTypeRefinementContexts, .dumpScopeMaps,
            .dumpInterfaceHash, .dumpTypeInfo, .verifyDebugInfo:

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -17,6 +17,10 @@ extension Diagnostic.Message {
     .error("-static may not be used with -emit-executable")
   }
 
+  static func error_update_code_not_supported(in mode: CompilerMode) -> Diagnostic.Message {
+    .error("using '-update-code' in \(mode) mode is not supported")
+  }
+
   static func error_option_missing_required_argument(option: Option, requiredArg: String) -> Diagnostic.Message {
     .error("option '\(option.spelling)' is missing a required argument (\(requiredArg))")
   }


### PR DESCRIPTION
This doesn't pass the corresponding lit test yet because the flags are in a different order, but everything else seems to match.

It's worth pointing out that I deleted the `-update-code` check in `determinePrimaryOutputs` because the condition would never be met (-update-code isn't in the modes option group and the same problem occurs in the old driver). This seems consistent with the intent of the original driver's implementation which treats the migration as a parallel output to the compile, but might be worth double checking for correctness because I don't think the migrator is used much outside of Xcode.

Also, please feel free to ignore this until after the holidays! I'm just posting it early to run CI tests