### PR TITLE
[ExplicitModule] when using driver as an executable, differentiate PCM dependency names for each target

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -104,6 +104,9 @@ public struct Driver {
   /// it should be identical to the real environment.
   public let env: [String: String]
 
+  /// Whether we are using the driver as the integrated driver via libSwiftDriver
+  public let integratedDriver: Bool
+
   /// The file system which we should interact with.
   let fileSystem: FileSystem
 
@@ -322,6 +325,7 @@ public struct Driver {
     diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
     fileSystem: FileSystem = localFileSystem,
     executor: DriverExecutor,
+    integratedDriver: Bool = true,
     // FIXME: Duplication with externalBuildArtifacts and externalTargetModulePathMap
     // is a temporary backwards-compatibility shim to help transition SwiftPM to the new API
     externalBuildArtifacts: ExternalBuildArtifacts? = nil,
@@ -330,6 +334,7 @@ public struct Driver {
   ) throws {
     self.env = env
     self.fileSystem = fileSystem
+    self.integratedDriver = integratedDriver
 
     self.diagnosticEngine = diagnosticsEngine
     self.executor = executor

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -460,7 +460,9 @@ extension Driver {
     // Plan build jobs for all direct and transitive module dependencies of the current target
     explicitDependencyBuildPlanner =
       try ExplicitDependencyBuildPlanner(dependencyGraph: dependencyGraph,
-                                         toolchain: toolchain)
+                                         toolchain: toolchain,
+                                         integratedDriver: integratedDriver,
+                                         mainModuleName: moduleOutputInfo.name)
     return try explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
   }
 

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -51,7 +51,8 @@ do {
                                          env: ProcessEnv.vars)
   var driver = try Driver(args: arguments,
                           diagnosticsEngine: diagnosticsEngine,
-                          executor: executor)
+                          executor: executor,
+                          integratedDriver: false)
   // FIXME: The following check should be at the end of Driver.init, but current
   // usage of the DiagnosticVerifier in tests makes this difficult.
   guard !driver.diagnosticEngine.hasErrors else { throw Diagnostics.fatalError }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -113,7 +113,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
       case .clang(let clangDependencyDetails):
         let clangDependencyModulePathString =
           try ExplicitDependencyBuildPlanner.targetEncodedClangModuleFilePath(
-          for: dependencyInfo, pcmArgs: pcmArgs)
+          for: dependencyInfo, hashParts: pcmArgs)
         let clangDependencyModulePath =
           TypedVirtualPath(file: clangDependencyModulePathString, type: .pcm)
         let clangDependencyModuleMapPath =
@@ -144,7 +144,7 @@ private func pcmArgsEncodedRelativeModulePath(for moduleName: String, with pcmAr
 ) throws -> RelativePath {
   return RelativePath(
     try ExplicitDependencyBuildPlanner.targetEncodedClangModuleName(for: moduleName,
-                                                                pcmArgs: pcmArgs) + ".pcm")
+                                                                hashParts: pcmArgs) + ".pcm")
 }
 
 /// Test that for the given JSON module dependency graph, valid jobs are generated


### PR DESCRIPTION
We need this to enable explicit modules in the driver-as-executable mode. For instance,
we have two Swift targets A and B, where A depends on X.pcm which in turn depends on Y.pcm, and
B only depends on Y.pcm. In the driver-as-executable mode, the build system isn't aware
of the shared dependency of Y.pcm so it will be generated multiple times. If all these Y.pcm
share the same name, X.pcm may fail to be loaded because its dependency Y.pcm could have a changed mod time.

We only differentiate these PCM names in the non-integrated mode due to the lacking of
inter-module planning.

rdar://72830153