### PR TITLE
Delete temporaries after running unless -save-temps is passed

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4244,9 +4244,7 @@ extension Array where Element: Equatable {
   }
 }
 
-fileprivate extension Array
-where Element == Job
-{
+extension Array where Element == Job {
   // Utility to drop autolink-extract jobs, which helps avoid introducing
   // platform-specific conditionals in tests unrelated to autolinking.
   func removingAutolinkExtractJobs() -> Self {


### PR DESCRIPTION
Unlike the old driver, all of the temporaries are created in a subdirectory, so we can just delete that instead of tracking each temporary file individually. We should also save temps if any of the jobs signals - I left that as a todo in this PR because it will require a bit more refactoring to make that information available to the driver.