### PR TITLE
[5.4] Switch branch-based dependencies from `main` to `release/5.4`.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,7 +14,7 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "main",
+          "branch": "release/5.4",
           "revision": "eb56a00ed9dfd62c2ce4ec86183ff0bc0afda997",
           "version": null
         }
@@ -23,8 +23,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "main",
-          "revision": "c98cfc216d22798dce7ce7b9cc171565371e967e",
+          "branch": "release/5.4",
+          "revision": "35f9f3aa38111cf7f10143f3da2341cc605d0baa",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("main")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("release/5.4")),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools
@@ -96,7 +96,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("release/5.4")),
     .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "4.0.0")),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate


### PR DESCRIPTION
In the `release/5.4` branch, also switch the branch-based dependencies to the `release/5.4` branch.