### PR TITLE
Improve support for subcommands help in swift-help

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,7 @@ let package = Package(
     /// The help executable.
     .target(
       name: "swift-help",
-      dependencies: ["SwiftOptions", "ArgumentParser"]),
+      dependencies: ["SwiftOptions", "ArgumentParser", "SwiftToolsSupport-auto"]),
 
     /// The `makeOptions` utility (for importing option definitions).
     .target(

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -555,7 +555,7 @@ extension Driver {
     }
 
     if parsedOptions.contains(.help) || parsedOptions.contains(.helpHidden) {
-      var commandLine: [Job.ArgTemplate] = [.flag("-tool=\(driverKind.rawValue)")]
+      var commandLine: [Job.ArgTemplate] = [.flag(driverKind.rawValue)]
       if parsedOptions.contains(.helpHidden) {
         commandLine.append(.flag("-show-hidden"))
       }

--- a/Sources/SwiftOptions/DriverKind.swift
+++ b/Sources/SwiftOptions/DriverKind.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Describes which mode the driver is in.
-public enum DriverKind: String {
+public enum DriverKind: String, CaseIterable {
   case interactive = "swift"
   case batch = "swiftc"
 }
@@ -23,21 +23,6 @@ extension DriverKind {
       return "swift"
     case .batch:
       return "swiftc"
-    }
-  }
-
-  public var seeAlsoHelpMessage: String? {
-    switch self {
-    case .interactive:
-      return """
-             SEE ALSO - PACKAGE MANAGER COMMANDS:
-                     "swift build" Build sources into binary products
-                     "swift package" Perform operations on Swift packages
-                     "swift run" Build and run an executable product
-                     "swift test" Build and run tests
-             """
-    case .batch:
-      return "SEE ALSO: swift build, swift run, swift package, swift test"
     }
   }
 }

--- a/Sources/SwiftOptions/OptionTable.swift
+++ b/Sources/SwiftOptions/OptionTable.swift
@@ -72,8 +72,5 @@ extension OptionTable {
         print("  \(leftPadding) \(helpText)")
       }
     }
-    if let seeAlsoMessage = driverKind.seeAlsoHelpMessage {
-      print("\n\(seeAlsoMessage)")
-    }
   }
 }

--- a/Sources/swift-help/CMakeLists.txt
+++ b/Sources/swift-help/CMakeLists.txt
@@ -10,5 +10,6 @@ add_executable(swift-help
   main.swift)
 target_link_libraries(swift-help PUBLIC
   SwiftOptions
-  ArgumentParser)
+  ArgumentParser
+  TSCBasic)
 

--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -10,14 +10,52 @@
 //
 //===----------------------------------------------------------------------===//
 import SwiftOptions
+import TSCBasic
 import ArgumentParser
 
-extension DriverKind: ExpressibleByArgument {}
+enum HelpTopic: ExpressibleByArgument, CustomStringConvertible {
+  case driver(DriverKind)
+  case subcommand(Subcommand)
+
+  init?(argument topicName: String) {
+    if let kind = DriverKind(rawValue: topicName) {
+      self = .driver(kind)
+    } else if let subcommand = Subcommand(rawValue: topicName) {
+      self = .subcommand(subcommand)
+    } else {
+      return nil
+    }
+  }
+
+  var description: String {
+    switch self {
+    case .driver(let kind):
+      return kind.rawValue
+    case .subcommand(let command):
+      return command.rawValue
+    }
+  }
+}
+
+enum Subcommand: String, CaseIterable {
+  case build, package, run, test
+
+  var description: String {
+    switch self {
+    case .build:
+      return "SwiftPM - Build sources into binary products"
+    case .package:
+      return "SwiftPM - Perform operations on Swift packages"
+    case .run:
+      return "SwiftPM - Build and run an executable product"
+    case .test:
+      return "SwiftPM - Build and run tests"
+    }
+  }
+}
 
 struct SwiftHelp: ParsableCommand {
-  @ArgumentParser.Option(name: .customLong("tool", withSingleDash: true),
-                         help: "The tool to list options of")
-  var tool: DriverKind = .interactive
+  @Argument var topic: HelpTopic = .driver(.interactive)
 
   @Flag(name: .customLong("show-hidden", withSingleDash: true),
         help: "List hidden (unsupported) options")
@@ -25,7 +63,34 @@ struct SwiftHelp: ParsableCommand {
 
   func run() throws {
     let driverOptionTable = OptionTable()
-    driverOptionTable.printHelp(driverKind: tool, includeHidden: showHidden)
+    switch topic {
+    case .driver(let kind):
+      driverOptionTable.printHelp(driverKind: kind, includeHidden: showHidden)
+      print("\nSUBCOMMANDS (swift <subcommand> [arguments]):")
+      let maxSubcommandNameLength = Subcommand.allCases.map(\.rawValue.count).max()!
+      for subcommand in Subcommand.allCases {
+        let padding = String(repeating: " ", count: maxSubcommandNameLength - subcommand.rawValue.count)
+        print("  \(subcommand.rawValue):\(padding) \(subcommand.description)")
+      }
+      print("\n  Use \"swift help <subcommand>\" for more information about a subcommand")
+
+    case .subcommand(let subcommand):
+      // Try to find the subcommand adjacent to the help tool.
+      // If we didn't find the tool there, let the OS search for it.
+      let execName = "swift-\(subcommand)"
+      let subcommandPath = Process.findExecutable(
+        CommandLine.arguments[0])?
+        .parentDirectory
+        .appending(component: execName)
+        ?? Process.findExecutable(execName)
+
+      guard let path = subcommandPath, localFileSystem.isExecutableFile(subcommandPath!) else {
+        fatalError("cannot find subcommand executable '\(execName)'")
+      }
+
+      // Execute the subcommand with --help.
+      try exec(path: path.pathString, args: [execName, "--help"])
+    }
   }
 }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -201,7 +201,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(helpJob.kind == .help)
       XCTAssertTrue(helpJob.requiresInPlaceExecution)
       XCTAssertTrue(helpJob.tool.name.hasSuffix("swift-help"))
-      let expected: [Job.ArgTemplate] = [.flag("-tool=swift")]
+      let expected: [Job.ArgTemplate] = [.flag("swift")]
       XCTAssertEqual(helpJob.commandLine, expected)
     }
 
@@ -213,7 +213,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(helpJob.kind == .help)
       XCTAssertTrue(helpJob.requiresInPlaceExecution)
       XCTAssertTrue(helpJob.tool.name.hasSuffix("swift-help"))
-      let expected: [Job.ArgTemplate] = [.flag("-tool=swiftc"), .flag("-show-hidden")]
+      let expected: [Job.ArgTemplate] = [.flag("swiftc"), .flag("-show-hidden")]
       XCTAssertEqual(helpJob.commandLine, expected)
     }
   }


### PR DESCRIPTION
This PR has a couple of changes to the help tool:
- The subcommand listings are reformatted a bit, and I added a note to "Use "swift help subcommand" for more information about a subcommand". This is inspired by Go's help page, which also supports more general help topics. I think we could do something similar in a follow-up to add the kind of driver documentation requested in https://bugs.swift.org/browse/SR-7704.
- "swift help build/test/package/run" now forward to the help pages for each subcommand