### PR TITLE
OutputFileMap: use .swift file path as the key for .o file when .bc file is an intermeidate output

### DIFF
--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -49,6 +49,19 @@ public struct OutputFileMap: Hashable, Codable {
     case .swiftDocumentation, .swiftSourceInfoFile:
       // Infer paths for these entities using .swiftmodule path.
       return entries[inputFile]?[.swiftModule]?.replacingExtension(with: outputType)
+
+    case .object:
+      // We may generate .o files from bitcode .bc files, but the output file map
+      // uses .swift file as the key for .o file paths. So we need to dig further.
+      let entry = entries.first {
+        return $0.value.contains { return $0.value == inputFile }
+      }
+      if let entry = entry {
+        if let path = entries[entry.key]?[outputType] {
+          return path
+        }
+      }
+      return nil
     default:
       return nil
     }


### PR DESCRIPTION
The build system always uses .swift file for all output kinds. This causes an issue when we are using
the .bc file path as the key to get the .o file path.

rdar://73358362