### PR TITLE
Decode path fields in `InterModuleDependencyGraph` as VirtualPaths

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -75,24 +75,24 @@ extension ModuleDependencyId: Codable {
 
 /// Bridging header
 public struct BridgingHeader: Codable {
-  var path: String
-  var sourceFiles: [String]
+  var path: TextualVirtualPath
+  var sourceFiles: [TextualVirtualPath]
   var moduleDependencies: [String]
 }
 
 /// Details specific to Swift modules.
 public struct SwiftModuleDetails: Codable {
   /// The module interface from which this module was built, if any.
-  public var moduleInterfacePath: String?
+  public var moduleInterfacePath: TextualVirtualPath?
 
   /// The paths of potentially ready-to-use compiled modules for the interface.
-  public var compiledModuleCandidates: [String]?
+  public var compiledModuleCandidates: [TextualVirtualPath]?
 
   /// The bridging header, if any.
-  public var bridgingHeaderPath: String?
+  public var bridgingHeaderPath: TextualVirtualPath?
 
   /// The source files referenced by the bridging header.
-  public var bridgingSourceFiles: [String]? = []
+  public var bridgingSourceFiles: [TextualVirtualPath]? = []
 
   /// Options to the compile command
   public var commandLine: [String]? = []
@@ -109,37 +109,38 @@ public struct SwiftModuleDetails: Codable {
 /// Details specific to Swift placeholder dependencies.
 public struct SwiftPlaceholderModuleDetails: Codable {
   /// The path to the .swiftModuleDoc file.
-  var moduleDocPath: String?
+  var moduleDocPath: TextualVirtualPath?
 
   /// The path to the .swiftSourceInfo file.
-  var moduleSourceInfoPath: String?
+  var moduleSourceInfoPath: TextualVirtualPath?
 }
 
 /// Details specific to Swift externally-pre-built modules.
 public struct SwiftPrebuiltExternalModuleDetails: Codable {
   /// The path to the already-compiled module that must be used instead of
   /// generating a job to build this module.
-  public var compiledModulePath: String
+  public var compiledModulePath: TextualVirtualPath
 
   /// The path to the .swiftModuleDoc file.
-  public var moduleDocPath: String?
+  public var moduleDocPath: TextualVirtualPath?
 
   /// The path to the .swiftSourceInfo file.
-  public var moduleSourceInfoPath: String?
+  public var moduleSourceInfoPath: TextualVirtualPath?
 
-  public init(compiledModulePath: String,
-              moduleDocPath: String? = nil,
-              moduleSourceInfoPath: String? = nil) {
-    self.compiledModulePath = compiledModulePath
-    self.moduleDocPath = moduleDocPath
-    self.moduleSourceInfoPath = moduleSourceInfoPath
+  public init(compiledModulePath: VirtualPath,
+              moduleDocPath: VirtualPath? = nil,
+              moduleSourceInfoPath: VirtualPath? = nil) throws {
+    self.compiledModulePath = TextualVirtualPath(path: compiledModulePath)
+    self.moduleDocPath = moduleDocPath != nil ? TextualVirtualPath(path: moduleDocPath!) : nil
+    self.moduleSourceInfoPath =
+      moduleSourceInfoPath != nil ? TextualVirtualPath(path: moduleSourceInfoPath!) : nil
   }
 }
 
 /// Details specific to Clang modules.
 public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
-  public var moduleMapPath: String
+  public var moduleMapPath: TextualVirtualPath
 
   /// Set of PCM Arguments of depending modules which
   /// are covered by the directDependencies info of this module
@@ -151,7 +152,7 @@ public struct ClangModuleDetails: Codable {
   /// Options to the compile command
   public var commandLine: [String] = []
 
-  public init(moduleMapPath: String,
+  public init(moduleMapPath: TextualVirtualPath,
               dependenciesCapturedPCMArgs: Set<[String]>?,
               contextHash: String,
               commandLine: [String]) {
@@ -164,10 +165,10 @@ public struct ClangModuleDetails: Codable {
 
 public struct ModuleInfo: Codable {
   /// The path for the module.
-  public var modulePath: String
+  public var modulePath: TextualVirtualPath
 
   /// The source files used to build this module.
-  public var sourceFiles: [String]?
+  public var sourceFiles: [TextualVirtualPath]?
 
   /// The set of direct module dependencies of this module.
   public var directDependencies: [ModuleDependencyId]?
@@ -192,8 +193,8 @@ public struct ModuleInfo: Codable {
     case clang(ClangModuleDetails)
   }
 
-  public init(modulePath: String,
-              sourceFiles: [String]?,
+  public init(modulePath: TextualVirtualPath,
+              sourceFiles: [TextualVirtualPath]?,
               directDependencies: [ModuleDependencyId]?,
               details: Details) {
     self.modulePath = modulePath

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -62,7 +62,8 @@ extension Driver {
     for (moduleId, binaryModulePath) in externalTargetModulePathMap {
       placeholderArtifacts.append(
           SwiftModuleArtifactInfo(name: moduleId.moduleName,
-                                  modulePath: binaryModulePath.description))
+                                  modulePath: TextualVirtualPath(path:
+                                                    .absolute(binaryModulePath))))
     }
 
     // All other already-scanned Swift modules

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/PlaceholderDependencyResolution.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/PlaceholderDependencyResolution.swift
@@ -122,8 +122,8 @@ fileprivate extension InterModuleDependencyGraph {
     }
 
     let newExternalModuleDetails =
-      SwiftPrebuiltExternalModuleDetails(compiledModulePath: placeholderPath.description)
-    let newInfo = ModuleInfo(modulePath: placeholderPath.description,
+      try SwiftPrebuiltExternalModuleDetails(compiledModulePath: .absolute(placeholderPath))
+    let newInfo = ModuleInfo(modulePath: TextualVirtualPath(path: .absolute(placeholderPath)),
                              sourceFiles: [],
                              directDependencies: externalModuleInfo.directDependencies,
                              details: .swiftPrebuiltExternal(newExternalModuleDetails))

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
@@ -20,16 +20,16 @@ import Foundation
   /// The module's name
   public let moduleName: String
   /// The path for the module's .swiftmodule file
-  public let modulePath: String
+  public let modulePath: TextualVirtualPath
   /// The path for the module's .swiftdoc file
-  public let docPath: String?
+  public let docPath: TextualVirtualPath?
   /// The path for the module's .swiftsourceinfo file
-  public let sourceInfoPath: String?
+  public let sourceInfoPath: TextualVirtualPath?
   /// A flag to indicate whether this module is a framework
   public let isFramework: Bool
 
-  init(name: String, modulePath: String, docPath: String? = nil,
-       sourceInfoPath: String? = nil, isFramework: Bool = false) {
+  init(name: String, modulePath: TextualVirtualPath, docPath: TextualVirtualPath? = nil,
+       sourceInfoPath: TextualVirtualPath? = nil, isFramework: Bool = false) {
     self.moduleName = name
     self.modulePath = modulePath
     self.docPath = docPath
@@ -46,11 +46,11 @@ import Foundation
   /// The module's name
   public let moduleName: String
   /// The path for the module's .pcm file
-  public let modulePath: String
+  public let modulePath: TextualVirtualPath
   /// The path for this module's .modulemap file
-  public let moduleMapPath: String
+  public let moduleMapPath: TextualVirtualPath
 
-  init(name: String, modulePath: String, moduleMapPath: String) {
+  init(name: String, modulePath: TextualVirtualPath, moduleMapPath: TextualVirtualPath) {
     self.moduleName = name
     self.modulePath = modulePath
     self.moduleMapPath = moduleMapPath

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -512,12 +512,14 @@ extension Driver {
         let modulePath = moduleInfo.modulePath
         // Only update paths on modules which do not already specify a path beyond their module name
         // and a file extension.
-        if modulePath == moduleId.moduleName + ".swiftmodule" ||
-            modulePath == moduleId.moduleName + ".pcm" {
+        if modulePath.path.description == moduleId.moduleName + ".swiftmodule" ||
+            modulePath.path.description == moduleId.moduleName + ".pcm" {
           // Use VirtualPath to get the OS-specific path separators right.
           let modulePathInCache =
-            try VirtualPath(path: moduleCachePath!).appending(component: modulePath).description
-          dependencyGraph.modules[moduleId]!.modulePath = modulePathInCache
+            try VirtualPath(path: moduleCachePath!)
+              .appending(component: modulePath.path.description)
+          dependencyGraph.modules[moduleId]!.modulePath =
+            TextualVirtualPath(path: modulePathInCache)
         }
       }
     }

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -271,7 +271,7 @@ extension VirtualPath: Codable {
 }
 
 /// A wrapper for easier decoding of absolute or relative VirtualPaths from strings.
-@_spi(Testing) public struct TextualVirtualPath: Codable {
+public struct TextualVirtualPath: Codable, Hashable {
   public var path: VirtualPath
 
   public init(from decoder: Decoder) throws {
@@ -279,7 +279,7 @@ extension VirtualPath: Codable {
     path = try VirtualPath(path: container.decode(String.self))
   }
 
-  private init(path: VirtualPath) {
+  public init(path: VirtualPath) {
     self.path = path
   }
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -27,13 +27,13 @@ private func checkExplicitModuleBuildJob(job: Job,
     case .swift(let swiftModuleDetails):
       downstreamPCMArgs = swiftModuleDetails.extraPcmArgs
       let moduleInterfacePath =
-        TypedVirtualPath(file: try VirtualPath(path: swiftModuleDetails.moduleInterfacePath!),
+        TypedVirtualPath(file: swiftModuleDetails.moduleInterfacePath!.path,
                          type: .swiftInterface)
       XCTAssertEqual(job.kind, .emitModule)
       XCTAssertTrue(job.inputs.contains(moduleInterfacePath))
       if let compiledCandidateList = swiftModuleDetails.compiledModuleCandidates {
         for compiledCandidate in compiledCandidateList {
-          let candidatePath = try VirtualPath(path: compiledCandidate)
+          let candidatePath = compiledCandidate.path
           let typedCandidatePath = TypedVirtualPath(file: candidatePath,
                                                     type: .swiftModule)
           XCTAssertTrue(job.inputs.contains(typedCandidatePath))
@@ -43,7 +43,7 @@ private func checkExplicitModuleBuildJob(job: Job,
       }
     case .clang(let clangModuleDetails):
       let moduleMapPath =
-        TypedVirtualPath(file: try VirtualPath(path: clangModuleDetails.moduleMapPath),
+        TypedVirtualPath(file: clangModuleDetails.moduleMapPath.path,
                          type: .clangModuleMap)
       XCTAssertEqual(job.kind, .generatePCM)
       XCTAssertEqual(job.description, "Compiling Clang module \(moduleId.moduleName)")
@@ -109,7 +109,8 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
                                                       from: Data(contents.contents))
         let dependencyArtifacts =
           dependencyInfoList.first(where:{ $0.moduleName == dependencyId.moduleName })
-        XCTAssertEqual(dependencyArtifacts!.modulePath, prebuiltModuleDetails.compiledModulePath)
+        XCTAssertEqual(dependencyArtifacts!.modulePath,
+                       prebuiltModuleDetails.compiledModulePath)
       case .clang(let clangDependencyDetails):
         let clangDependencyModulePathString =
           try ExplicitDependencyBuildPlanner.targetEncodedClangModuleFilePath(
@@ -117,7 +118,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
         let clangDependencyModulePath =
           TypedVirtualPath(file: clangDependencyModulePathString, type: .pcm)
         let clangDependencyModuleMapPath =
-          TypedVirtualPath(file: try VirtualPath(path: clangDependencyDetails.moduleMapPath),
+          TypedVirtualPath(file: clangDependencyDetails.moduleMapPath.path,
                            type: .clangModuleMap)
 
         XCTAssertTrue(job.inputs.contains(clangDependencyModulePath))
@@ -125,7 +126,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
         XCTAssertTrue(job.commandLine.contains(
                         .flag(String("-fmodule-file=\(clangDependencyModulePathString)"))))
         XCTAssertTrue(job.commandLine.contains(
-                        .flag(String("-fmodule-map-file=\(clangDependencyDetails.moduleMapPath)"))))
+                        .flag(String("-fmodule-map-file=\(clangDependencyDetails.moduleMapPath.path.description)"))))
       case .swiftPlaceholder(_):
         XCTFail("Placeholder dependency found.")
     }
@@ -535,14 +536,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                              from: jsonExample.data(using: .utf8)!)
     XCTAssertEqual(moduleMap.count, 2)
     XCTAssertEqual(moduleMap[0].moduleName, "A")
-    XCTAssertEqual(moduleMap[0].modulePath, "A.swiftmodule")
-    XCTAssertEqual(moduleMap[0].docPath, "A.swiftdoc")
-    XCTAssertEqual(moduleMap[0].sourceInfoPath, "A.swiftsourceinfo")
+    XCTAssertEqual(moduleMap[0].modulePath.path.description, "A.swiftmodule")
+    XCTAssertEqual(moduleMap[0].docPath!.path.description, "A.swiftdoc")
+    XCTAssertEqual(moduleMap[0].sourceInfoPath!.path.description, "A.swiftsourceinfo")
     XCTAssertEqual(moduleMap[0].isFramework, true)
     XCTAssertEqual(moduleMap[1].moduleName, "B")
-    XCTAssertEqual(moduleMap[1].modulePath, "B.swiftmodule")
-    XCTAssertEqual(moduleMap[1].docPath, "B.swiftdoc")
-    XCTAssertEqual(moduleMap[1].sourceInfoPath, "B.swiftsourceinfo")
+    XCTAssertEqual(moduleMap[1].modulePath.path.description, "B.swiftmodule")
+    XCTAssertEqual(moduleMap[1].docPath!.path.description, "B.swiftdoc")
+    XCTAssertEqual(moduleMap[1].sourceInfoPath!.path.description, "B.swiftsourceinfo")
     XCTAssertEqual(moduleMap[1].isFramework, false)
   }
 }


### PR DESCRIPTION
In the process of generating explicit dependency jobs, we end up spending a lot of time constructing `VirtualPath` objects from strings contained in the dependency graph, (It involves querying whether or not this string constitutes an absolute path, and breaking it down into components) which all add up to a large amount of string manipulation.

Instead, decode these strings into `VirtualPath` values directly, using the `TextualVirtualPath` wrapper. 