### PR TITLE
Exit with 0 when swift-driver invocation is interrupted

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -23,6 +23,10 @@ do {
   let processSet = ProcessSet()
   intHandler = try InterruptHandler {
     processSet.terminate()
+    // If the swift-driver invocation is interrupted by the build system,
+    // returning non-zero value emits red-herring error messages in the build logs.
+    // So we exit with 0 here.
+    exit(0)
   }
 
   if ProcessEnv.vars["SWIFT_ENABLE_EXPLICIT_MODULE"] != nil {


### PR DESCRIPTION
The build system may interrupt swift-driver invocation if some errors are hit in other targets.
If these interrupted swift-driver processes return a non-zero value, the build
log will show a bunch of red-herring error-messages.

rdar://73456559