### PR TITLE
[Incremental] Move subtraction to outer function to cope with multiple input jobs.

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -565,6 +565,7 @@ extension IncrementalCompilationState {
           return Array(skippedCompileGroups.keys)
         }
       )
+      .subtracting(job.primaryInputs) // have already compiled these
     )
     .sorted {$0.file.name < $1.file.name}
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -160,6 +160,7 @@ extension ModuleDependencyGraph {
   /// After a compile job has finished, read its swiftDeps file and return the source files needing
   /// recompilation.
   /// Return nil in case of an error.
+  /// May return a source that has already been compiled.
   private func findSourcesToCompileAfterIntegrating(
     input: TypedVirtualPath,
     swiftDeps: SwiftDeps,
@@ -172,7 +173,6 @@ extension ModuleDependencyGraph {
                          diagnosticEngine: diagnosticEngine)
       .map {
         findSwiftDepsToRecompileWhenNodesChange($0)
-          .subtracting([swiftDeps])
           .map {sourceSwiftDepsMap[$0]}
       }
   }


### PR DESCRIPTION
Fix assertion failure by moving subtraction of already-compiled inputs to the calling function so that if job compiling x.swift requires y.swift be compiled, and job compiling y.swift requires x.swift be compiled, x.swift and y.swift are subtracted out from jobs needing to be compiled. The bug shows up when testing with -j1.