### PR TITLE
[NFC] Simplify Parts of the Change Computation's Interface

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -140,7 +140,7 @@ public class IncrementalCompilationState {
                mandatoryJobsInOrder: [Job])
   {
     let compileGroups =
-      Dictionary( uniqueKeysWithValues:
+      Dictionary(uniqueKeysWithValues:
                     jobsInPhases.compileGroups.map {($0.primaryInput, $0)} )
 
      let skippedInputs = Self.computeSkippedCompilationInputs(
@@ -407,11 +407,14 @@ extension IncrementalCompilationState {
         try? fileSystem.getFileInfo($0).modTime}
         ?? Date.distantFuture
       if extModTime >= buildTime {
-        for (_, dependent) in moduleDependencyGraph.untracedDependents(of: extDep) {
+        for dependent in moduleDependencyGraph.untracedDependents(of: extDep) {
+          guard let swiftDeps = dependent.swiftDeps else {
+            fatalError("Dependent \(dependent) does not have swiftdeps file!")
+          }
           reporter?.report(
             "Queuing because of external dependency on newer \(extDep.file?.basename ?? "extDep?")",
-            path: TypedVirtualPath(file: dependent.file, type: .swiftDeps))
-          externallyDependentSwiftDeps.insert(dependent)
+            path: TypedVirtualPath(file: swiftDeps.file, type: .swiftDeps))
+          externallyDependentSwiftDeps.insert(swiftDeps)
         }
       }
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -407,11 +407,11 @@ extension IncrementalCompilationState {
         try? fileSystem.getFileInfo($0).modTime}
         ?? Date.distantFuture
       if extModTime >= buildTime {
-        moduleDependencyGraph.forEachUntracedSwiftDepsDirectlyDependent(on: extDep) {
+        for (_, dependent) in moduleDependencyGraph.untracedDependents(of: extDep) {
           reporter?.report(
             "Queuing because of external dependency on newer \(extDep.file?.basename ?? "extDep?")",
-            path: TypedVirtualPath(file: $0.file, type: .swiftDeps))
-          externallyDependentSwiftDeps.insert($0)
+            path: TypedVirtualPath(file: dependent.file, type: .swiftDeps))
+          externallyDependentSwiftDeps.insert(dependent)
         }
       }
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
@@ -12,9 +12,17 @@
 import Foundation
 import TSCBasic
 
+/// Contains information about the current status of an input to the incremental
+/// build.
+///
+/// This is as opposed to information derived from the build record, which
+/// from our perspective only records informatiuon about inputs that were known
+/// to the driver in the past.
 /*@_spi(Testing)*/ public struct InputInfo: Equatable {
 
+  /// The current status of the input file.
   /*@_spi(Testing)*/ public let status: Status
+  /// The last known modification time of this input.
   /*@_spi(Testing)*/ public let previousModTime: Date
 
   /*@_spi(Testing)*/ public init(status: Status, previousModTime: Date) {
@@ -24,11 +32,24 @@ import TSCBasic
 }
 
 /*@_spi(Testing)*/ public extension InputInfo {
+  /// The status of an input known to the driver. These are used to affect
+  /// the scheduling decisions made during an incremental build.
+  ///
+  /// - Note: The order of cases matters. They are ordered from least to
+  ///         greatest impact on the incremental build schedule.
   enum Status: Equatable {
-    case upToDate,
-         needsCascadingBuild,
-         needsNonCascadingBuild,
-         newlyAdded
+    /// The input to this job is up to date.
+    case upToDate
+    /// The input to this job has changed in a way that requires this job to
+    /// be rerun, but not in such a way that it requires a cascading rebuild.
+    case needsNonCascadingBuild
+    /// The input to this job has changed in a way that requires this job to
+    /// be rerun, and in such a way that all jobs dependent upon this one
+    /// must be scheduled as well.
+    case needsCascadingBuild
+    /// The input to this job was not known to the driver when it was last
+    /// run.
+    case newlyAdded
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -192,13 +192,13 @@ extension ModuleDependencyGraph {
 
   /*@_spi(Testing)*/ public func untracedDependents(
     of externalSwiftDeps: ExternalDependency
-  ) -> [(ModuleDependencyGraph.Node, ModuleDependencyGraph.SwiftDeps)] {
+  ) -> [ModuleDependencyGraph.Node] {
     // These nodes will depend on the *interface* of the external Decl.
     let key = DependencyKey(interfaceFor: externalSwiftDeps)
     let node = Node(key: key, fingerprint: nil, swiftDeps: nil)
     return nodeFinder
       .orderedUses(of: node)
-      .filter({ use, _ in isUntraced(use) })
+      .filter({ use in isUntraced(use) })
   }
 }
 fileprivate extension DependencyKey {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -190,18 +190,15 @@ extension ModuleDependencyGraph {
     return Set(affectedNodes.compactMap {$0.swiftDeps})
   }
 
-  /*@_spi(Testing)*/ public func forEachUntracedSwiftDepsDirectlyDependent(
-    on externalSwiftDeps: ExternalDependency,
-    _ fn: (SwiftDeps) -> Void
-  ) {
+  /*@_spi(Testing)*/ public func untracedDependents(
+    of externalSwiftDeps: ExternalDependency
+  ) -> [(ModuleDependencyGraph.Node, ModuleDependencyGraph.SwiftDeps)] {
     // These nodes will depend on the *interface* of the external Decl.
     let key = DependencyKey(interfaceFor: externalSwiftDeps)
     let node = Node(key: key, fingerprint: nil, swiftDeps: nil)
-    nodeFinder.forEachUseInOrder(of: node) { use, useSwiftDeps in
-      if isUntraced(use) {
-        fn(useSwiftDeps)
-      }
-    }
+    return nodeFinder
+      .orderedUses(of: node)
+      .filter({ use, _ in isUntraced(use) })
   }
 }
 fileprivate extension DependencyKey {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -84,7 +84,7 @@ extension ModuleDependencyGraph.Tracer {
     let pathLengthAfterArrival = traceArrival(at: definition);
     
     // If this use also provides something, follow it
-    for (use, _) in graph.nodeFinder.orderedUses(of: definition) {
+    for use in graph.nodeFinder.orderedUses(of: definition) {
       findNextPreviouslyUntracedDependent(of: use)
     }
     traceDeparture(pathLengthAfterArrival);

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -84,7 +84,7 @@ extension ModuleDependencyGraph.Tracer {
     let pathLengthAfterArrival = traceArrival(at: definition);
     
     // If this use also provides something, follow it
-    graph.nodeFinder.forEachUseInOrder(of: definition) { use, _ in
+    for (use, _) in graph.nodeFinder.orderedUses(of: definition) {
       findNextPreviouslyUntracedDependent(of: use)
     }
     traceDeparture(pathLengthAfterArrival);

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -57,6 +57,10 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection {
   public subscript(key: Key) -> (key: Key, values: Set<Value>)? {
     outerDict[key].map { (key: key, values: $0) }
   }
+
+  public subscript(key: Key, default defaultValues: @autoclosure () -> Set<Value>) -> (key: Key, values: Set<Value>) {
+    self[key] ?? (key: key, values: defaultValues())
+  }
   
   public func keysContainingValue(_ v: Value) -> [Key] {
     outerDict.compactMap { (k, vs) in vs.contains(v) ? k : nil }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -949,15 +949,14 @@ extension ModuleDependencyGraph {
     on externalDependency: ExternalDependency
   ) -> [SwiftDeps] {
     var foundSwiftDeps = [SwiftDeps]()
-    forEachUntracedSwiftDepsDirectlyDependent(on: externalDependency) {
-      swiftDeps in
+    for (_, swiftDeps) in self.untracedDependents(of: externalDependency) {
       foundSwiftDeps.append(swiftDeps)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive
       // Don't return job twice.
-      for marked in findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(swiftDeps)
-      where marked != swiftDeps {
-        foundSwiftDeps.append(marked)
-      }
+      let filesToRebuild =
+        findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(swiftDeps)
+        .filter({ marked in marked != swiftDeps })
+      foundSwiftDeps.append(contentsOf: filesToRebuild)
     }
     return foundSwiftDeps;
   }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import SwiftDriver
+@testable import SwiftDriver
 import TSCBasic
 
 class ModuleDependencyGraphTests: XCTestCase {
@@ -949,7 +949,8 @@ extension ModuleDependencyGraph {
     on externalDependency: ExternalDependency
   ) -> [SwiftDeps] {
     var foundSwiftDeps = [SwiftDeps]()
-    for (_, swiftDeps) in self.untracedDependents(of: externalDependency) {
+    for dependent in self.untracedDependents(of: externalDependency) {
+      let swiftDeps = dependent.swiftDeps!
       foundSwiftDeps.append(swiftDeps)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive
       // Don't return job twice.


### PR DESCRIPTION
- Add a new type representing changed inputs
- Break down the `forEach`-style APIs into explicit sequences and clean up their call sites.
- Break down the karnaugh map in `computeSpeculativeInputs`