### PR TITLE
Propagate Experimental Cross Module Incremental Build Flag

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -139,6 +139,18 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
     /// The `context` field corresponds to the mangled name of the type. The
     /// `name` field corresponds to the *unmangled* name of the member.
     case member(context: String, name: String)
+    /// A dependency that resides outside of the module being built, but which
+    /// has integrated dependency information in a format the driver
+    /// understands.
+    ///
+    /// These dependencies correspond to Swift modules that were built with
+    /// `-enable-experimental-cross-module-incremental-build`. These modules
+    /// contain a special section with swiftdeps information for the module
+    /// in it.
+    ///
+    /// The full path to the external dependency as seen by the frontend is
+    /// available from this node.
+    case incrementalExternalDependency(ExternalDependency)
 
     var externalDependency: ExternalDependency? {
       switch self {
@@ -164,6 +176,8 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
         return "module '\(externalDependency)'"
       case let .sourceFileProvide(name: name):
         return "source file \((try? VirtualPath(path: name).basename) ?? name)"
+      case let .incrementalExternalDependency(externalDependency):
+        return "incremental module '\(externalDependency)'"
       }
     }
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -202,7 +202,7 @@ extension ModuleDependencyGraph {
   }
 }
 fileprivate extension DependencyKey {
-  init(interfaceFor dep: ExternalDependency ) {
+  init(interfaceFor dep: ExternalDependency) {
     self.init(aspect: .interface, designator: .externalDepend(dep))
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -295,7 +295,9 @@ fileprivate extension DependencyKey.Designator {
     case 6:
       try mustBeEmpty(context)
       self = .sourceFileProvide(name: name)
-      
+    case 7:
+      try mustBeEmpty(context)
+      self = .incrementalExternalDependency(ExternalDependency(name))
     default: throw SourceFileDependencyGraph.ReadError.unknownKind
     }
   }

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -58,6 +58,10 @@ extension Driver {
 
     addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: true)
 
+    // Propagate cross-module incremental builds flag so dependency information
+    // shows up in swiftmodules.
+    try commandLine.appendLast(.enableExperimentalCrossModuleIncrementalBuild, from: &parsedOptions)
+
     commandLine.appendFlag(.o)
     commandLine.appendPath(moduleOutputInfo.output!.outputPath)
 

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -856,15 +856,20 @@ class ModuleDependencyGraphTests: XCTestCase {
 }
 
 enum MockDependencyKind {
-  case topLevel, dynamicLookup, externalDepend, sourceFileProvide,
-        nominal, potentialMember,
-        member
+  case topLevel
+  case dynamicLookup
+  case externalDepend
+  case sourceFileProvide
+  case nominal
+  case potentialMember
+  case member
+  case incrementalExternalDependency
 
   var singleNameIsContext: Bool? {
     switch self {
-      case .nominal, .potentialMember: return true
-      case .topLevel, .dynamicLookup, .externalDepend, .sourceFileProvide: return false
-      case .member: return nil
+    case .nominal, .potentialMember: return true
+    case .topLevel, .dynamicLookup, .externalDepend, .incrementalExternalDependency, .sourceFileProvide: return false
+    case .member: return nil
     }
   }
 }
@@ -1331,26 +1336,29 @@ fileprivate extension DependencyKey.Designator {
     }
     let (context: context, name: name) = contextAndName
     switch kind {
-      case .topLevel:
-        mustBeAbsent(context)
-        self = .topLevel(name: name!)
-      case .nominal:
-        mustBeAbsent(name)
-        self = .nominal(context: context!)
-      case .potentialMember:
-         mustBeAbsent(name)
-        self = .potentialMember(context: context!)
-      case .member:
-        self = .member(context: context!, name: name!)
-      case .dynamicLookup:
-         mustBeAbsent(context)
-        self = .dynamicLookup(name: name!)
-      case .externalDepend:
-         mustBeAbsent(context)
-        self = .externalDepend(ExternalDependency(name!))
-      case .sourceFileProvide:
-         mustBeAbsent(context)
-        self = .sourceFileProvide(name: name!)
+    case .topLevel:
+      mustBeAbsent(context)
+      self = .topLevel(name: name!)
+    case .nominal:
+      mustBeAbsent(name)
+      self = .nominal(context: context!)
+    case .potentialMember:
+      mustBeAbsent(name)
+      self = .potentialMember(context: context!)
+    case .member:
+      self = .member(context: context!, name: name!)
+    case .dynamicLookup:
+      mustBeAbsent(context)
+      self = .dynamicLookup(name: name!)
+    case .externalDepend:
+      mustBeAbsent(context)
+      self = .externalDepend(ExternalDependency(name!))
+    case .incrementalExternalDependency:
+      mustBeAbsent(context)
+      self = .incrementalExternalDependency(ExternalDependency(name!))
+    case .sourceFileProvide:
+      mustBeAbsent(context)
+      self = .sourceFileProvide(name: name!)
     }
   }
 }


### PR DESCRIPTION
Match the legacy driver and propagate this flag to the merge-modules job so embedded incremental information winds up in swift modules.

-------

Cross Module Incremental Builds Tasks

- [x] Teach the Driver to propagate the flag
- [ ] Integrate swiftdeps from swift modules
- [ ] Propagate bitstream writer infrastructure into Driver
- [ ] Write out the module dependency graph
- [ ] Integrate module dependency graph instead of swiftdeps for priors