### PR TITLE
[NFC] Plumb Through Explicit FileSystem to the Integrator

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -110,7 +110,8 @@ public class IncrementalCompilationState {
               outputFileMap: outputFileMap,
               parsedOptions: &driver.parsedOptions,
               remarkDisabled: Diagnostic.Message.remark_incremental_compilation_has_been_disabled,
-              reporter: reporter)
+              reporter: reporter,
+              fileSystem: driver.fileSystem)
     else {
       return nil
     }
@@ -550,7 +551,7 @@ extension IncrementalCompilationState {
       Set(
         job.primaryInputs.flatMap {
           input -> [TypedVirtualPath] in
-          if let found = moduleDependencyGraph.findSourcesToCompileAfterCompiling(input) {
+          if let found = moduleDependencyGraph.findSourcesToCompileAfterCompiling(input, on: self.driver.fileSystem) {
             return found
           }
           self.reporter?.report("Failed to read some swiftdeps; compiling everything", path: input)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -60,10 +60,11 @@ extension ModuleDependencyGraph.Integrator {
     into destination: Graph,
     input: TypedVirtualPath,
     reporter: IncrementalCompilationState.Reporter?,
-    diagnosticEngine: DiagnosticsEngine
+    diagnosticEngine: DiagnosticsEngine,
+    fileSystem: FileSystem
   ) -> Changes? {
     guard let sfdg = try? SourceFileDependencyGraph.read(
-            from: swiftDeps)
+            from: swiftDeps, on: fileSystem)
     else {
       reporter?.report("Could not read \(swiftDeps)", path: input)
       return nil

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -251,7 +251,14 @@ extension SourceFileDependencyGraph {
     }
 
     var visitor = Visitor(extractFromSwiftModule: extractFromSwiftModule)
-    try Bitcode.read(stream: Data(data.contents), using: &visitor)
+    try data.contents.withUnsafeBytes { buf in
+      // SAFETY: The bitcode reader does not mutate the data stream we give it.
+      // FIXME: Let's avoid this altogether and traffic in ByteString/[UInt8]
+      // if possible. There's no real reason to use `Data` in this API.
+      let baseAddr = UnsafeMutableRawPointer(mutating: buf.baseAddress!)
+      let data = Data(bytesNoCopy: baseAddr, count: buf.count, deallocator: .none)
+      try Bitcode.read(stream: data, using: &visitor)
+    }
     guard let major = visitor.majorVersion,
           let minor = visitor.minorVersion,
           let versionString = visitor.compilerVersionString else {

--- a/Tests/SwiftDriverTests/Helpers/Fixture.swift
+++ b/Tests/SwiftDriverTests/Helpers/Fixture.swift
@@ -1,0 +1,49 @@
+//===-------- DriverExtensions.swift - Driver Testing Extensions ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCBasic
+
+/// Contains helpers for retrieving paths to fixtures under the
+/// repo-local `TestInputs` directory.
+enum Fixture {
+  /// Form a path to a file residing in the test fixtures directory under the
+  /// root of this package.
+  /// - Parameters:
+  ///   - file: The name of the fixture file to search for.
+  ///   - relativePath: The relative path of the subdirectory under
+  ///                   `<package-root>/TestInputs`
+  ///   - fileSystem: The filesystem on which to search.
+  /// - Returns: A path to the fixture file if the resulting path exists on the
+  ///            given file system. Else, returns `nil`.
+  static func fixturePath(
+    at relativePath: RelativePath,
+    for file: String,
+    on fileSystem: FileSystem = localFileSystem
+  ) -> AbsolutePath? {
+    let packageRootPath = AbsolutePath(#file)
+      .parentDirectory
+      .parentDirectory
+      .parentDirectory
+      .parentDirectory
+    let fixturePath = packageRootPath
+      .appending(component: "TestInputs")
+      .appending(relativePath)
+      .appending(component: file)
+
+    // Check that the fixture is really there.
+    guard fileSystem.exists(fixturePath) else {
+      return nil
+    }
+
+    return fixturePath
+  }
+}

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -68,7 +68,9 @@ final class NonincrementalCompilationTests: XCTestCase {
     let packageRootPath = URL(fileURLWithPath: #file).pathComponents
       .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
     let testInputPath = packageRootPath + "/TestInputs/Incremental/main.swiftdeps"
-    let graph = try SourceFileDependencyGraph(pathString: String(testInputPath))
+    let absolutePath = try AbsolutePath(validating: String(testInputPath))
+    let graph = try SourceFileDependencyGraph(contentsOf: absolutePath,
+                                              on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)
     XCTAssertEqual(graph.compilerVersionString, "Swift version 5.3-dev (LLVM f516ac602c, Swift c39f31febd)")
@@ -112,7 +114,9 @@ final class NonincrementalCompilationTests: XCTestCase {
     let packageRootPath = URL(fileURLWithPath: #file).pathComponents
       .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
     let testInputPath = packageRootPath + "/TestInputs/Incremental/hello.swiftdeps"
-    let graph = try SourceFileDependencyGraph(pathString: String(testInputPath))
+    let absolutePath = try AbsolutePath(validating: String(testInputPath))
+    let graph = try SourceFileDependencyGraph(contentsOf: absolutePath,
+                                              on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)
     XCTAssertEqual(graph.compilerVersionString, "Swift version 5.3-dev (LLVM 4510748e505acd4, Swift 9f07d884c97eaf4)")
@@ -163,7 +167,8 @@ final class NonincrementalCompilationTests: XCTestCase {
     let packageRootPath = URL(fileURLWithPath: #file).pathComponents
       .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
     let testInputPath = packageRootPath + "/TestInputs/Incremental/hello.swiftmodule"
-    let data = try Data(contentsOf: URL(fileURLWithPath: String(testInputPath)))
+    let absolutePath = try AbsolutePath(validating: String(testInputPath))
+    let data = try localFileSystem.readFileContents(absolutePath)
     let graph = try SourceFileDependencyGraph(data: data, fromSwiftModule: true)
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -65,10 +65,8 @@ final class NonincrementalCompilationTests: XCTestCase {
   }
 
   func testReadBinarySourceFileDependencyGraph() throws {
-    let packageRootPath = URL(fileURLWithPath: #file).pathComponents
-      .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
-    let testInputPath = packageRootPath + "/TestInputs/Incremental/main.swiftdeps"
-    let absolutePath = try AbsolutePath(validating: String(testInputPath))
+    let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
+                                                         for: "main.swiftdeps"))
     let graph = try SourceFileDependencyGraph(contentsOf: absolutePath,
                                               on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
@@ -111,10 +109,8 @@ final class NonincrementalCompilationTests: XCTestCase {
   }
 
   func testReadComplexSourceFileDependencyGraph() throws {
-    let packageRootPath = URL(fileURLWithPath: #file).pathComponents
-      .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
-    let testInputPath = packageRootPath + "/TestInputs/Incremental/hello.swiftdeps"
-    let absolutePath = try AbsolutePath(validating: String(testInputPath))
+    let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
+                                                         for: "hello.swiftdeps"))
     let graph = try SourceFileDependencyGraph(contentsOf: absolutePath,
                                               on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
@@ -164,10 +160,8 @@ final class NonincrementalCompilationTests: XCTestCase {
   }
 
   func testExtractSourceFileDependencyGraphFromSwiftModule() throws {
-    let packageRootPath = URL(fileURLWithPath: #file).pathComponents
-      .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
-    let testInputPath = packageRootPath + "/TestInputs/Incremental/hello.swiftmodule"
-    let absolutePath = try AbsolutePath(validating: String(testInputPath))
+    let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
+                                                         for: "hello.swiftmodule"))
     let data = try localFileSystem.readFileContents(absolutePath)
     let graph = try SourceFileDependencyGraph(data: data, fromSwiftModule: true)
     XCTAssertEqual(graph.majorVersion, 1)
@@ -783,7 +777,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
 
-      let data = try Data(contentsOf: path.appending(component: "main.swiftdeps").asURL)
+      let data = try localFileSystem.readFileContents(path.appending(component: "main.swiftdeps"))
       let graph = try SourceFileDependencyGraph(data: data, fromSwiftModule: false)
       XCTAssertEqual(graph.majorVersion, 1)
       XCTAssertEqual(graph.minorVersion, 0)

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1034,7 +1034,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
 
   private mutating func mock() -> SourceFileDependencyGraph {
     buildNodes()
-    return SourceFileDependencyGraph(nodesForTesting: allNodes )
+    return SourceFileDependencyGraph(nodesForTesting: allNodes)
   }
 
   private mutating func buildNodes() {


### PR DESCRIPTION
This should make tests that build virtual file systems easier to write in the future. While I'm here, sequester some hacks for computing paths into the test fixtures directory.