### PR TITLE
Add Round-Trip Serialization For ModuleDependencyGraph

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": "main",
-          "revision": "c98cfc216d22798dce7ce7b9cc171565371e967e",
+          "revision": "395e7fb3d6149dc7a999342f23cfefa1ada56264",
           "version": null
         }
       },

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -26,9 +26,10 @@ import SwiftOptions
   
   private(set) var sourceSwiftDepsMap = BidirectionalMap<TypedVirtualPath, SwiftDeps>()
 
-  // Supports requests from the driver to getExternalDependencies.
+  // The set of paths to external dependencies discovered during the integration
+  // process.
   public internal(set) var externalDependencies = Set<ExternalDependency>()
-  
+
   let verifyDependencyGraphAfterEveryImport: Bool
   let emitDependencyDotFileAfterEveryImport: Bool
   let reporter: IncrementalCompilationState.Reporter?
@@ -39,8 +40,8 @@ import SwiftOptions
     diagnosticEngine: DiagnosticsEngine,
     reporter: IncrementalCompilationState.Reporter?,
     emitDependencyDotFileAfterEveryImport: Bool,
-    verifyDependencyGraphAfterEveryImport: Bool)
-  {
+    verifyDependencyGraphAfterEveryImport: Bool
+  ) {
     self.verifyDependencyGraphAfterEveryImport = verifyDependencyGraphAfterEveryImport
     self.emitDependencyDotFileAfterEveryImport = emitDependencyDotFileAfterEveryImport
     self.reporter = reporter
@@ -62,7 +63,7 @@ extension ModuleDependencyGraph {
     reporter: IncrementalCompilationState.Reporter?,
     fileSystem: FileSystem
   ) -> (ModuleDependencyGraph, inputsWithMalformedSwiftDeps: [(TypedVirtualPath, VirtualPath)])?
-  where Inputs.Element == TypedVirtualPath
+    where Inputs.Element == TypedVirtualPath
   {
     let emitOpt = Option.driverEmitFineGrainedDependencyDotFileAfterEveryImport
     let veriOpt = Option.driverVerifyFineGrainedDependencyGraphAfterEveryImport
@@ -72,10 +73,9 @@ extension ModuleDependencyGraph {
       emitDependencyDotFileAfterEveryImport: parsedOptions.contains(emitOpt),
       verifyDependencyGraphAfterEveryImport: parsedOptions.contains(veriOpt))
 
-    let inputsAndSwiftdeps = inputs.map {input in
-      (input, outputFileMap?.existingOutput( inputFile: input.file,
-                                             outputType: .swiftDeps)
-      )
+    let inputsAndSwiftdeps = inputs.map { input in
+      (input, outputFileMap?.existingOutput(inputFile: input.file,
+                                            outputType: .swiftDeps))
     }
     for isd in inputsAndSwiftdeps where isd.1 == nil {
       // The legacy driver fails silently here.
@@ -175,7 +175,6 @@ extension ModuleDependencyGraph {
                          fileSystem: fileSystem)
       .map {
         findSwiftDepsToRecompileWhenNodesChange($0)
-          .map {sourceSwiftDepsMap[$0]}
       }
   }
 }
@@ -186,7 +185,6 @@ extension ModuleDependencyGraph {
   /*@_spi(Testing)*/ public func findSwiftDepsToRecompileWhenNodesChange<Nodes: Sequence>(
     _ nodes: Nodes
   ) -> Set<SwiftDeps>
-  where Nodes.Element == Node
   {
     let affectedNodes = Tracer.findPreviouslyUntracedUsesOf(
       defs: nodes,
@@ -225,7 +223,6 @@ extension ModuleDependencyGraph {
     tracedNodes.insert(n)
   }
   func ensureGraphWillRetraceDependents<Nodes: Sequence>(of nodes: Nodes)
-  where Nodes.Element == Node
   {
     nodes.forEach { tracedNodes.remove($0) }
   }
@@ -262,3 +259,4 @@ extension ModuleDependencyGraph {
     fatalError("unimplmemented, writing dot file of dependency graph")
   }
 }
+

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -45,7 +45,7 @@ extension ModuleDependencyGraph {
     /// frontend creates an interface node,
     /// it adds a dependency to it from the implementation source file node (which
     /// has the intefaceHash as its fingerprint).
-    let fingerprint: String?
+    var fingerprint: String?
 
 
     /// The swiftDeps file that holds this entity iff the entities .swiftdeps is known.

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -40,7 +40,8 @@ extension ModuleDependencyGraph {
 // MARK: - finding
 
 extension ModuleDependencyGraph.NodeFinder {
-  func findFileInterfaceNode(forMock swiftDeps: ModuleDependencyGraph.SwiftDeps
+  func findFileInterfaceNode(
+    forMock swiftDeps: ModuleDependencyGraph.SwiftDeps
   ) -> Graph.Node?  {
     let fileKey = DependencyKey(fileKeyForMockSwiftDeps: swiftDeps)
     return findNode((swiftDeps, fileKey))
@@ -58,6 +59,16 @@ extension ModuleDependencyGraph.NodeFinder {
   }
   func findNodes(for key: DependencyKey) -> [Graph.SwiftDeps?: Graph.Node]? {
     nodeMap[key]
+  }
+
+  /// Calls the given closure on each node in this dependency graph.
+  ///
+  /// - Note: The order of iteration between successive runs of the driver is
+  ///         not guaranteed.
+  ///
+  /// - Parameter visit: The closure to call with each graph node.
+  func forEachNode(_ visit: (Graph.Node) -> Void) {
+    nodeMap.forEach { visit($1) }
   }
 
   /// Retrieves the set of uses corresponding to a given node.

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -19,7 +19,7 @@ class DependencyGraphSerializationTests: XCTestCase {
     let mockPath = AbsolutePath("/module-dependency-graph")
     let de = DiagnosticsEngine()
     let fs = InMemoryFileSystem()
-    graph.write(to: mockPath, on: fs)
+    graph.write(to: mockPath, on: fs, compilerVersion: "Swift 99")
 
     let deserializedGraph = try ModuleDependencyGraph.read(from: mockPath,
                                                            on: fs,

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -1,0 +1,226 @@
+//===----------- DependencyGraphSerializationTests.swift ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import SwiftDriver
+import TSCBasic
+
+class DependencyGraphSerializationTests: XCTestCase {
+  func roundTrip(_ graph: ModuleDependencyGraph) throws {
+    let mockPath = AbsolutePath("/module-dependency-graph")
+    let de = DiagnosticsEngine()
+    let fs = InMemoryFileSystem()
+    graph.write(to: mockPath, on: fs)
+
+    let deserializedGraph = try ModuleDependencyGraph.read(from: mockPath,
+                                                           on: fs,
+                                                           diagnosticEngine: de,
+                                                           reporter: nil)
+    var originalNodes = Set<ModuleDependencyGraph.Node>()
+    graph.nodeFinder.forEachNode {
+      originalNodes.insert($0)
+    }
+
+    var deserializedNodes = Set<ModuleDependencyGraph.Node>()
+    deserializedGraph.nodeFinder.forEachNode {
+      deserializedNodes.insert($0)
+    }
+
+    XCTAssertTrue(originalNodes == deserializedNodes,
+                  "Round trip failed! Symmetric difference - \(originalNodes.symmetricDifference(deserializedNodes))")
+  }
+
+  func testRoundTripFixtures() throws {
+    struct GraphFixture {
+      var commands: [LoadCommand]
+
+      enum LoadCommand {
+        case load(index: Int, nodes: [MockDependencyKind: [String]])
+        case reload(index: Int, nodes: [MockDependencyKind: [String]], fingerprint: String? = nil)
+      }
+    }
+    
+    let fixtures: [GraphFixture] = [
+      GraphFixture(commands: []),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.topLevel: ["a->", "b->"]]),
+        .load(index: 1, nodes: [.nominal: ["c->", "d->"]]),
+        .load(index: 2, nodes: [.topLevel: ["e", "f"]]),
+        .load(index: 3, nodes: [.nominal: ["g", "h"]]),
+        .load(index: 4, nodes: [.dynamicLookup: ["i", "j"]]),
+        .load(index: 5, nodes: [.dynamicLookup: ["k->", "l->"]]),
+        .load(index: 6, nodes: [.member: ["m,mm", "n,nn"]]),
+        .load(index: 7, nodes: [.member: ["o,oo->", "p,pp->"]]),
+        .load(index: 8, nodes: [.externalDepend: ["/foo->", "/bar->"]]),
+        .load(index: 9, nodes: [
+          .nominal: ["a", "b", "c->", "d->"],
+          .topLevel: ["b", "c", "d->", "a->"]
+        ])
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.topLevel: ["a0", "a->"]]),
+        .load(index: 1, nodes: [.topLevel: ["b0", "b->"]]),
+        .load(index: 2, nodes: [.topLevel: ["c0", "c->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a", "a->"]]),
+        .load(index: 1, nodes: [.topLevel: ["a", "b->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a->", "b"]]),
+        .load(index: 1, nodes: [.topLevel: ["b->", "a"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.member: ["a,aa"]]),
+        .load(index: 1, nodes: [.member: ["a,bb->"]]),
+        .load(index: 2, nodes: [.potentialMember: ["a"]]),
+        .load(index: 3, nodes: [.member: ["b,aa->"]]),
+        .load(index: 4, nodes: [.member: ["b,bb->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.topLevel: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.topLevel: ["x->", "b->", "z->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.topLevel: ["a->", "b->", "c->"]]),
+        .load(index: 1, nodes: [.topLevel: ["x", "b", "z"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.nominal: ["x->", "b->", "z->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a"], .topLevel: ["a"]]),
+        .load(index: 1, nodes: [.nominal: ["a->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a"], .topLevel: ["a"]]),
+        .load(index: 1, nodes: [.nominal: ["a->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a"]]),
+        .load(index: 1, nodes: [.nominal: ["a->"], .topLevel: ["a->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a"], .topLevel: ["a"]]),
+        .load(index: 1, nodes: [.nominal: ["a->"], .topLevel: ["a->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.dynamicLookup: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.dynamicLookup: ["x->", "b->", "z->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.member: ["a,aa", "b,bb", "c,cc"]]),
+        .load(index: 1, nodes: [.member: ["x,xx->", "b,bb->", "z,zz->"]])
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.nominal: ["x->", "b->", "z->"]]),
+        .load(index: 2, nodes: [.nominal: ["q->", "b->", "s->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.nominal: ["x->", "b->", "z->"]]),
+        .load(index: 2, nodes: [.nominal: ["q->", "r->", "c->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.nominal: ["x->", "b->", "z"]]),
+        .load(index: 2, nodes: [.nominal: ["z->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.nominal: ["x->", "b->", "#z"]]),
+        .load(index: 2, nodes: [.nominal: ["#z->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.topLevel: ["a", "b", "c"]]),
+        .load(index: 1, nodes: [.topLevel: ["x->", "#b->"], .nominal: ["z"]]),
+        .load(index: 2, nodes: [.nominal: ["z->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.topLevel: ["a", "b"]]),
+        .load(index: 1, nodes: [.topLevel: ["a->", "z"]]),
+        .load(index: 2, nodes: [.topLevel: ["z->"]]),
+        .load(index: 10, nodes: [.topLevel: ["y", "z", "q->"]]),
+        .load(index: 11, nodes: [.topLevel: ["y->"]]),
+        .load(index: 12, nodes: [.topLevel: ["q->", "q"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a"]]),
+        .load(index: 1, nodes: [.nominal: ["a->"]]),
+        .load(index: 2, nodes: [.nominal: ["b->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["a"]]),
+        .load(index: 1, nodes: [.nominal: ["a->"]]),
+        .load(index: 2, nodes: [.nominal: ["b->"]]),
+        .reload(index: 0, nodes: [.nominal: ["a", "b"]])
+      ]),
+      GraphFixture(commands: [
+        .reload(index: 1, nodes: [.nominal: ["b", "a->"]])
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["A1@1", "A2@2", "A1->"]]),
+        .load(index: 1, nodes: [.nominal: ["B1", "A1->"]]),
+        .load(index: 2, nodes: [.nominal: ["C1", "A2->"]]),
+        .load(index: 3, nodes: [.nominal: ["D1"]]),
+        .reload(index: 0, nodes: [.nominal: ["A1", "A2"]], fingerprint: "changed")
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["A"]]),
+        .load(index: 1, nodes: [.nominal: ["B", "C", "A->"]]),
+        .load(index: 2, nodes: [.nominal: ["B->"]]),
+        .load(index: 3, nodes: [.nominal: ["C->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["A"]]),
+        .load(index: 1, nodes: [.nominal: ["B", "C", "A->B"]]),
+        .load(index: 2, nodes: [.nominal: ["B->"]]),
+        .load(index: 3, nodes: [.nominal: ["C->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["A1@1", "A2@2"]]),
+        .load(index: 1, nodes: [.nominal: ["B1", "C1", "A1->"]]),
+        .load(index: 2, nodes: [.nominal: ["B1->"]]),
+        .load(index: 3, nodes: [.nominal: ["C1->"]]),
+        .load(index: 4, nodes: [.nominal: ["B2", "C2", "A2->"]]),
+        .load(index: 5, nodes: [.nominal: ["B2->"]]),
+        .load(index: 6, nodes: [.nominal: ["C2->"]]),
+      ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.nominal: ["A1@1", "A2@2"]]),
+        .load(index: 1, nodes: [.nominal: ["B1", "C1", "A1->B1"]]),
+        .load(index: 2, nodes: [.nominal: ["B1->"]]),
+        .load(index: 3, nodes: [.nominal: ["C1->"]]),
+        .load(index: 4, nodes: [.nominal: ["B2", "C2", "A2->B2"]]),
+        .load(index: 5, nodes: [.nominal: ["B2->"]]),
+        .load(index: 6, nodes: [.nominal: ["C2->"]]),
+        .reload(index: 0, nodes: [.nominal: ["A1@11", "A2@2"]])
+      ]),
+    ]
+
+    for fixture in fixtures {
+      let de = DiagnosticsEngine()
+      let graph = ModuleDependencyGraph(mock: de)
+      for loadCommand in fixture.commands {
+        switch loadCommand {
+        case .load(index: let index, nodes: let nodes):
+          graph.simulateLoad(index, nodes, nil)
+        case .reload(index: let index, nodes: let nodes, fingerprint: let fingerprint):
+          _ = graph.simulateReload(index, nodes, fingerprint)
+        }
+      }
+      try roundTrip(graph)
+    }
+  }
+}

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -227,9 +227,9 @@ final class NonincrementalCompilationTests: XCTestCase {
                    [0, 0])
     XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main  )]).status,
                    .upToDate)
-    XCTAssert(try! isCloseEnough( XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main  )])
-                                    .previousModTime.legacyDriverSecsAndNanos,
-                                  [1570083660, 0]))
+    XCTAssert(try! isCloseEnough(XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main  )])
+                                   .previousModTime.legacyDriverSecsAndNanos,
+                                 [1570083660, 0]))
 
     let outputString = try XCTUnwrap (buildRecord.encode(currentArgsHash: options,
                                                          diagnosticEngine: DiagnosticsEngine()))
@@ -743,7 +743,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
           "-module-name", "MagicKit",
           "-enable-experimental-cross-module-incremental-build",
           "-working-directory", path.pathString,
-          "-c", "-v",
+          "-c",
           magic.pathString,
         ])
         let jobs = try driver.planBuild()

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1314,7 +1314,8 @@ fileprivate extension DependencyKey {
 
 extension Job {
   init(_ dummyBaseName: String) {
-    let input = try! TypedVirtualPath(file: VirtualPath(path: dummyBaseName + ".swift"    ), type: .swift )
+    let input = try! TypedVirtualPath(file: VirtualPath(path: dummyBaseName + ".swift"),
+                                      type: .swift)
     try! self.init(moduleName: "nothing",
                    kind: .compile,
                    tool: VirtualPath(path: ""),


### PR DESCRIPTION
Use bitstream to read and write ModuleDependencyGraph instances out to
disk. The idea is that eventually the Driver can emit its dependency
graph as a supplemental output (possibly adjacent to the build record)
and recover the state it was last in by reading that file. This is as
opposed to the status quo where O(N) swiftdeps files are read and
integrated at startup. Whether this is a net win has yet to be seen.

Also, we're using bitstream because it's convenient. It would be prudent
to explore alternative serialization formats at some point.

rdar://73517080