### PR TITLE
[Incremental] Accept VirtualPath for reading a SourceFileDependencyGraph so the lit tests work.

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -120,8 +120,7 @@ extension SourceFileDependencyGraph {
     from swiftDeps: ModuleDependencyGraph.SwiftDeps,
     on fileSystem: FileSystem
   ) throws -> Self {
-    try self.init(contentsOf: swiftDeps.file.absolutePath!,
-                  on: fileSystem)
+    try self.init(contentsOf: swiftDeps.file, on: fileSystem)
   }
   
   /*@_spi(Testing)*/ public init(nodesForTesting: [Node]) {
@@ -132,7 +131,7 @@ extension SourceFileDependencyGraph {
   }
 
   /*@_spi(Testing)*/ public init(
-    contentsOf path: AbsolutePath,
+    contentsOf path: VirtualPath,
     on filesystem: FileSystem
   ) throws {
     let data = try filesystem.readFileContents(path)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -67,8 +67,9 @@ final class NonincrementalCompilationTests: XCTestCase {
   func testReadBinarySourceFileDependencyGraph() throws {
     let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
                                                          for: "main.swiftdeps"))
-    let graph = try SourceFileDependencyGraph(contentsOf: absolutePath,
-                                              on: localFileSystem)
+    let graph = try SourceFileDependencyGraph(
+      contentsOf: VirtualPath.absolute(absolutePath),
+      on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)
     XCTAssertEqual(graph.compilerVersionString, "Swift version 5.3-dev (LLVM f516ac602c, Swift c39f31febd)")
@@ -111,8 +112,9 @@ final class NonincrementalCompilationTests: XCTestCase {
   func testReadComplexSourceFileDependencyGraph() throws {
     let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
                                                          for: "hello.swiftdeps"))
-    let graph = try SourceFileDependencyGraph(contentsOf: absolutePath,
-                                              on: localFileSystem)
+    let graph = try SourceFileDependencyGraph(
+      contentsOf: VirtualPath.absolute(absolutePath),
+      on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)
     XCTAssertEqual(graph.compilerVersionString, "Swift version 5.3-dev (LLVM 4510748e505acd4, Swift 9f07d884c97eaf4)")


### PR DESCRIPTION
Lit tests use relative paths.