### PR TITLE
Add arguments when creating Driver for tests so that tests can run

### DIFF
--- a/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
+++ b/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
@@ -41,7 +41,7 @@ private func augment(args: [String]) throws -> [String] {
   var augmentedArgs = args
 
   // Color codes in diagnostics cause mismatches
-  if !args.contains("-color-diagnostics") {
+  if !args.contains("-color-diagnostics") && !args.contains("-no-color-diagnostics") {
     augmentedArgs.insert("-no-color-diagnostics", at: extraArgsIndex)
   }
 

--- a/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
+++ b/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
@@ -37,11 +37,13 @@ extension Driver {
 }
 
 private func augment(args: [String]) throws -> [String] {
+  let extraArgsIndex = 1
   var augmentedArgs = args
-  let extraArgsIndex = args.firstIndex(of: "--") ?? args.endIndex
 
   // Color codes in diagnostics cause mismatches
-  augmentedArgs.insert("-no-color-diagnostics", at: extraArgsIndex)
+  if !args.contains("-color-diagnostics") {
+    augmentedArgs.insert("-no-color-diagnostics", at: extraArgsIndex)
+  }
 
   // The frontend fails to load the standard library because it cannot
   // find it relative to the execution path used by the Swift Driver.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -81,7 +81,9 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertNoThrow(try Driver(args: ["swift", ".foo"]))
     XCTAssertNoThrow(try Driver(args: ["swift", "/foo"]))
 
-    XCTAssertThrowsError(try Driver(args: ["swift", "foo"]))
+    XCTAssertThrowsError(try Driver(args: ["swift", "foo",
+                                            "-no-color-diagnostics",
+                                            "-sdk", "foo"]))
   }
 
   func testDriverKindParsing() throws {
@@ -3507,7 +3509,8 @@ final class SwiftDriverTests: XCTestCase {
 
   func testIndexFilePathHandling() throws {
     do {
-      var driver = try Driver(args: ["swiftc", "-index-file", "-index-file-path",
+      var driver = try Driver(args: ["swiftc", "-module-name", "mod",
+                                     "-index-file", "-index-file-path",
                                      "bar.swift", "foo.swift", "bar.swift", "baz.swift"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)


### PR DESCRIPTION
Ensure the diagnostics are not colored, and that the frontend jobs can find the sdk.