### PR TITLE
Ensure REPL arguments are processed by the ArgsResolver

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -67,10 +67,15 @@ public final class ArgsResolver {
       return try lock.withLock {
         return try unsafeResolve(path: path)
       }
+
     case .responseFilePath(let path):
       return "@\(try resolve(.path(path)))"
+
     case let .joinedOptionAndPath(option, path):
       return option + (try resolve(.path(path)))
+
+    case let .squashedArgumentList(option: option, args: args):
+      return try option + args.map{ try resolve($0) }.joined(separator: " ")
     }
   }
 

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -162,7 +162,8 @@ extension Array where Element == Job.ArgTemplate {
   }
 
   /// A shell-escaped string representation of the arguments, as they would appear on the command line.
-  public var joinedArguments: String {
+  /// Note: does not resolve arguments.
+  public var joinedUnresolvedArguments: String {
     return self.map {
       switch $0 {
         case .flag(let string):
@@ -173,6 +174,8 @@ extension Array where Element == Job.ArgTemplate {
         return "@\(path.name.spm_shellEscaped())"
       case let .joinedOptionAndPath(option, path):
         return option.spm_shellEscaped() + path.name.spm_shellEscaped()
+      case let .squashedArgumentList(option, args):
+        return (option + args.joinedUnresolvedArguments).spm_shellEscaped()
       }
     }.joined(separator: " ")
   }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -49,6 +49,9 @@ public struct Job: Codable, Equatable, Hashable {
 
     /// Represents a joined option+path combo.
     case joinedOptionAndPath(String, VirtualPath)
+
+    /// Represents a list of arguments squashed together and passed as a single argument.
+    case squashedArgumentList(option: String, args: [ArgTemplate])
   }
 
   /// The Swift module this job involves.
@@ -234,10 +237,14 @@ extension Job.Kind {
 
 extension Job.ArgTemplate: Codable {
   private enum CodingKeys: String, CodingKey {
-    case flag, path, responseFilePath, joinedOptionAndPath
+    case flag, path, responseFilePath, joinedOptionAndPath, squashedArgumentList
 
     enum JoinedOptionAndPathCodingKeys: String, CodingKey {
       case option, path
+    }
+
+    enum SquashedArgumentListCodingKeys: String, CodingKey {
+      case option, args
     }
   }
 
@@ -259,6 +266,12 @@ extension Job.ArgTemplate: Codable {
         forKey: .joinedOptionAndPath)
       try keyedContainer.encode(option, forKey: .option)
       try keyedContainer.encode(path, forKey: .path)
+    case .squashedArgumentList(option: let option, args: let args):
+      var keyedContainer = container.nestedContainer(
+        keyedBy: CodingKeys.SquashedArgumentListCodingKeys.self,
+        forKey: .squashedArgumentList)
+      try keyedContainer.encode(option, forKey: .option)
+      try keyedContainer.encode(args, forKey: .args)
     }
   }
 
@@ -286,6 +299,12 @@ extension Job.ArgTemplate: Codable {
         forKey: .joinedOptionAndPath)
       self = .joinedOptionAndPath(try keyedValues.decode(String.self, forKey: .option),
                                   try keyedValues.decode(VirtualPath.self, forKey: .path))
+    case .squashedArgumentList:
+      let keyedValues = try values.nestedContainer(
+        keyedBy: CodingKeys.SquashedArgumentListCodingKeys.self,
+        forKey: .squashedArgumentList)
+      self = .squashedArgumentList(option: try keyedValues.decode(String.self, forKey: .option),
+                                   args: try keyedValues.decode([Job.ArgTemplate].self, forKey: .args))
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -22,12 +22,12 @@ extension Driver {
     try commandLine.appendAll(.l, .framework, .L, from: &parsedOptions)
 
     // Squash important frontend options into a single argument for LLDB.
-    let lldbArg = "--repl=\(commandLine.joinedArguments)"
+    let lldbCommandLine: [Job.ArgTemplate] = [.squashedArgumentList(option: "--repl=", args: commandLine)]
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .repl,
       tool: .absolute(try toolchain.getToolPath(.lldb)),
-      commandLine: [Job.ArgTemplate.flag(lldbArg)],
+      commandLine: lldbCommandLine,
       inputs: inputs,
       primaryInputs: [],
       outputs: [],

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -86,7 +86,7 @@ public final class SwiftDriverExecutor: DriverExecutor {
 
     if usedResponseFile {
       // Print the response file arguments as a comment.
-      result += " # \(job.commandLine.joinedArguments)"
+      result += " # \(job.commandLine.joinedUnresolvedArguments)"
     }
 
     if !job.extraEnvironment.isEmpty {

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -82,7 +82,7 @@ public final class SwiftDriverExecutor: DriverExecutor {
 
   public func description(of job: Job, forceResponseFiles: Bool) throws -> String {
     let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, forceResponseFiles: forceResponseFiles)
-    var result = args.joined(separator: " ")
+    var result = args.map { $0.spm_shellEscaped() }.joined(separator: " ")
 
     if usedResponseFile {
       // Print the response file arguments as a comment.

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -330,6 +330,18 @@ final class JobExecutorTests: XCTestCase {
     }
   }
 
+  func testResolveSquashedArgs() throws {
+    try withTemporaryDirectory { path in
+      let resolver = try ArgsResolver(fileSystem: localFileSystem, temporaryDirectory: .absolute(path))
+      let tmpPath = VirtualPath.temporaryWithKnownContents(.init("one.txt"), "hello, world!".data(using: .utf8)!)
+      let tmpPath2 = VirtualPath.temporaryWithKnownContents(.init("two.txt"), "goodbye!".data(using: .utf8)!)
+      let resolvedCommandLine = try resolver.resolve(
+        .squashedArgumentList(option: "--opt=", args: [.path(tmpPath), .path(tmpPath2)]))
+      XCTAssertEqual(resolvedCommandLine, "--opt=\(path.appending(component: "one.txt").pathString) \(path.appending(component: "two.txt").pathString)")
+      XCTAssertEqual(resolvedCommandLine.spm_shellEscaped(), "'--opt=\(path.appending(component: "one.txt").pathString) \(path.appending(component: "two.txt").pathString)'")
+    }
+  }
+
   func testSaveTemps() throws {
     do {
       try withTemporaryDirectory { path in

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -289,6 +289,21 @@ final class JobExecutorTests: XCTestCase {
     }
   }
 
+  func testShellEscapingArgsInJobDescription() throws {
+    let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
+                                           processSet: ProcessSet(),
+                                           fileSystem: localFileSystem,
+                                           env: [:])
+    let job = Job(moduleName: "Module",
+                  kind: .compile,
+                  tool: .absolute(.init("/path/to/the tool")),
+                  commandLine: [.path(.absolute(.init("/with space"))),
+                                .path(.absolute(.init("/withoutspace")))],
+                  inputs: [], primaryInputs: [], outputs: [])
+    XCTAssertEqual(try executor.description(of: job, forceResponseFiles: false),
+                   "'/path/to/the tool' '/with space' /withoutspace")
+  }
+
   func testInputModifiedDuringMultiJobBuild() throws {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "main.swift")


### PR DESCRIPTION
Introduce a new Job.ArgTemplate case which represents "squashed" arguments, so we can represent the structure of LLDB's --repl= argument and resolve the args which will be used to configure the frontend before concatenating them. The old behavior wasn't causing too many problems in practice, but this should make it easier to eventually launch the REPL as the last step in a multi-job build plan.

Also, this PR shell escapes arguments when printing jobs with -###, matching the behavior of the old driver