### PR TITLE
Clean Up The Module Dependency Graph Format A Bit

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -267,6 +267,7 @@ extension ModuleDependencyGraph {
 // MARK: - Serialization
 
 extension ModuleDependencyGraph {
+  /// The leading signature of this file format.
   fileprivate static let signature = "DDEP"
 
   fileprivate enum RecordID: UInt64 {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -280,6 +280,22 @@ extension ModuleDependencyGraph {
     case metadata           = 1
     case moduleDepGraphNode = 2
     case identifierNode     = 3
+
+    /// The human-readable name of this record.
+    ///
+    /// This data is emitted into the block info field for each record so tools
+    /// like llvm-bcanalyzer can be used to more effectively debug serialized
+    /// dependency graphs.
+    var humanReadableName: String {
+      switch self {
+      case .metadata:
+        return "METADATA"
+      case .moduleDepGraphNode:
+        return "MODULE_DEP_GRAPH_NODE"
+      case .identifierNode:
+        return "IDENTIFIER_NODE"
+      }
+    }
   }
 
   fileprivate enum ReadError: Error {
@@ -501,19 +517,19 @@ extension ModuleDependencyGraph {
       }
     }
 
-    private func emitRecordID(_ id: RecordID, named name: String) {
+    private func emitRecordID(_ id: RecordID) {
       self.stream.writeRecord(Bitstream.BlockInfoCode.setRecordName) {
         $0.append(id)
-        $0.append(name)
+        $0.append(id.humanReadableName)
       }
     }
 
     private func writeBlockInfoBlock() {
       self.stream.writeBlockInfoBlock {
         self.emitBlockID(.firstApplicationID, "RECORD_BLOCK")
-        self.emitRecordID(.metadata, named: "METADATA")
-        self.emitRecordID(.moduleDepGraphNode, named: "MODULE_DEP_GRAPH_NODE")
-        self.emitRecordID(.identifierNode, named: "IDENTIFIER_NODE")
+        self.emitRecordID(.metadata)
+        self.emitRecordID(.moduleDepGraphNode)
+        self.emitRecordID(.identifierNode)
       }
     }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -45,7 +45,7 @@ extension ModuleDependencyGraph {
     /// frontend creates an interface node,
     /// it adds a dependency to it from the implementation source file node (which
     /// has the intefaceHash as its fingerprint).
-    var fingerprint: String?
+    let fingerprint: String?
 
 
     /// The swiftDeps file that holds this entity iff the entities .swiftdeps is known.


### PR DESCRIPTION
- Squash Fingerprint data into the end of a node record as a trailing blob.
- Restore the immutable `fingerprint` member
- Document, clean up, and formalize more serialization infrastructure.