### PR TITLE
[Incremental] Add sdk arguments to incremental tests

### DIFF
--- a/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
+++ b/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
@@ -46,7 +46,7 @@ private let cachedSDKPath = Result<String, Error> {
     return pathFromEnv
   }
   #if !os(macOS)
-  return .Failure(XCTSkip("xcrun only available on macOS"))
+  throw XCTSkip("xcrun only available on macOS")
   #endif
   let process = Process(arguments: ["xcrun", "-sdk", "macosx", "--show-sdk-path"])
   try process.launch()

--- a/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
+++ b/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
@@ -45,6 +45,9 @@ private let cachedSDKPath = Result<String, Error> {
   if let pathFromEnv = ProcessEnv.vars["SDKROOT"] {
     return pathFromEnv
   }
+  #if !os(macOS)
+  return .Failure(XCTSkip("xcrun only available on macOS"))
+  #endif
   let process = Process(arguments: ["xcrun", "-sdk", "macosx", "--show-sdk-path"])
   try process.launch()
   let result = try process.waitUntilExit()

--- a/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
+++ b/Tests/SwiftDriverTests/Helpers/DriverExtensions.swift
@@ -13,6 +13,8 @@
 import SwiftDriver
 import SwiftDriverExecution
 import TSCBasic
+import Foundation
+import XCTest
 
 extension Driver {
   /// Initializer which creates an executor suitable for use in tests.
@@ -32,4 +34,26 @@ extension Driver {
                   fileSystem: fileSystem,
                   executor: executor)
   }
+
+  // For tests that need to set the sdk path:
+  static func sdkArgumentsForTesting() throws -> [String] {
+    ["-sdk", try cachedSDKPath.get()]
+  }
+}
+
+private let cachedSDKPath = Result<String, Error> {
+  if let pathFromEnv = ProcessEnv.vars["SDKROOT"] {
+    return pathFromEnv
+  }
+  let process = Process(arguments: ["xcrun", "-sdk", "macosx", "--show-sdk-path"])
+  try process.launch()
+  let result = try process.waitUntilExit()
+  guard result.exitStatus == .terminated(code: EXIT_SUCCESS) else {
+    enum XCRunFailure: LocalizedError {
+      case xcrunFailure
+    }
+    throw XCRunFailure.xcrunFailure
+  }
+  return try XCTUnwrap(String(bytes: try result.output.get(), encoding: .utf8))
+    .spm_chomp()
 }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -609,7 +609,7 @@ final class IncrementalCompilationTests: XCTestCase {
       try? driver.run(jobs: jobs)
     }
 
-    let allArgs = args + extraArguments
+    let allArgs = try args + extraArguments + Driver.sdkArgumentsForTesting()
     if checkDiagnostics {
       try assertDriverDiagnostics(args: allArgs) {driver, verifier in
         verifier.forbidUnexpected(.error, .warning, .note, .remark, .ignored)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -394,7 +394,7 @@ final class IncrementalCompilationTests: XCTestCase {
   // FIXME: Expect failure in Linux in CI just as testIncrementalDiagnostics
   func testAlwaysRebuildDependents() throws {
     #if !os(Linux)
-    tryInitial(true)
+    try tryInitial(true)
     tryTouchingMainAlwaysRebuildDependents(true)
     #endif
   }
@@ -406,14 +406,14 @@ final class IncrementalCompilationTests: XCTestCase {
   /// Ensure that the mod date of the input comes back exactly the same via the build-record.
   /// Otherwise the up-to-date calculation in `IncrementalCompilationState` will fail.
   func testBuildRecordDateAccuracy() throws {
-    tryInitial(false)
+    try tryInitial(false)
     (1...10).forEach { n in
       tryNoChange(true)
     }
   }
 
   func testIncremental(checkDiagnostics: Bool) throws {
-    tryInitial(checkDiagnostics)
+    try tryInitial(checkDiagnostics)
     #if true // sometimes want to skip for debugging
     tryNoChange(checkDiagnostics)
     tryTouchingOther(checkDiagnostics)
@@ -423,8 +423,8 @@ final class IncrementalCompilationTests: XCTestCase {
   }
 
 
-  func tryInitial(_ checkDiagnostics: Bool) {
-    try! doABuild(
+  func tryInitial(_ checkDiagnostics: Bool) throws {
+    try doABuild(
       "initial",
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [


### PR DESCRIPTION
The latest Swift makes tests fail because it cannot load libraries. Point the frontend to the sdk for the incremental tests. Add an affordance to do so. More tests will probably need to use this affordance in the future.