### PR TITLE
[Incremental] Rename "SwiftDeps" etc. to "DependencySource"

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(SwiftDriver
   "IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/Node.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift"
-  "IncrementalCompilation/ModuleDependencyGraphParts/SwiftDeps.swift"
+  "IncrementalCompilation/ModuleDependencyGraphParts/DependenciesSource.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift"
   "IncrementalCompilation/BidirectionalMap.swift"
   "IncrementalCompilation/BuildRecord.swift"

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(SwiftDriver
   "IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/Node.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift"
-  "IncrementalCompilation/ModuleDependencyGraphParts/DependenciesSource.swift"
+  "IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift"
   "IncrementalCompilation/BidirectionalMap.swift"
   "IncrementalCompilation/BuildRecord.swift"

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -63,8 +63,10 @@ public class IncrementalCompilationState {
       return nil
     }
 
-    guard let (moduleDependencyGraph,
-               inputsHavingMalformedDependenciesSources: inputsHavingMalformedDependenciesSources) =
+    guard let (
+      moduleDependencyGraph,
+      inputsHavingMalformedDependenciesSources: inputsHavingMalformedDependenciesSources
+    ) =
             Self.computeModuleDependencyGraph(
               buildRecordInfo,
               outOfDateBuildRecord,
@@ -99,19 +101,23 @@ public class IncrementalCompilationState {
     _ driver: inout Driver,
     _ reporter: Reporter?
   )
-  -> (ModuleDependencyGraph, inputsHavingMalformedDependenciesSources: [TypedVirtualPath])?
+  -> (ModuleDependencyGraph,
+      inputsHavingMalformedDependenciesSources: [TypedVirtualPath])?
   {
     let diagnosticEngine = driver.diagnosticEngine
-    guard let (moduleDependencyGraph, inputsAndMalformedDependenciesSources: inputsAndMalformedDependenciesSources) =
-            ModuleDependencyGraph.buildInitialGraph(
-              diagnosticEngine: diagnosticEngine,
-              inputs: buildRecordInfo.compilationInputModificationDates.keys,
-              previousInputs: outOfDateBuildRecord.allInputs,
-              outputFileMap: outputFileMap,
-              parsedOptions: &driver.parsedOptions,
-              remarkDisabled: Diagnostic.Message.remark_incremental_compilation_has_been_disabled,
-              reporter: reporter,
-              fileSystem: driver.fileSystem)
+    guard let (
+      moduleDependencyGraph,
+      inputsAndMalformedDependenciesSources: inputsAndMalformedDependenciesSources
+    ) =
+    ModuleDependencyGraph.buildInitialGraph(
+      diagnosticEngine: diagnosticEngine,
+      inputs: buildRecordInfo.compilationInputModificationDates.keys,
+      previousInputs: outOfDateBuildRecord.allInputs,
+      outputFileMap: outputFileMap,
+      parsedOptions: &driver.parsedOptions,
+      remarkDisabled: Diagnostic.Message.remark_incremental_compilation_has_been_disabled,
+      reporter: reporter,
+      fileSystem: driver.fileSystem)
     else {
       return nil
     }
@@ -436,10 +442,11 @@ extension IncrementalCompilationState {
     alwaysRebuildDependents: Bool,
     reporter: IncrementalCompilationState.Reporter?
   ) -> Set<TypedVirtualPath> {
-    let cascadingChangedInputs = Self.computeCascadingChangedInputs(from: changedInputs,
-                                                                    inputsMissingOutputs: inputsMissingOutputs,
-                                                                    alwaysRebuildDependents: alwaysRebuildDependents,
-                                                                    reporter: reporter)
+    let cascadingChangedInputs = Self.computeCascadingChangedInputs(
+      from: changedInputs,
+      inputsMissingOutputs: inputsMissingOutputs,
+      alwaysRebuildDependents: alwaysRebuildDependents,
+      reporter: reporter)
     let cascadingExternalDependents = alwaysRebuildDependents ? externalDependents : []
     // Collect the dependent files to speculatively schedule
     var dependentFiles = Set<TypedVirtualPath>()

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -64,7 +64,10 @@ extension ModuleDependencyGraph {
     remarkDisabled: (String) -> Diagnostic.Message,
     reporter: IncrementalCompilationState.Reporter?,
     fileSystem: FileSystem
-  ) -> (ModuleDependencyGraph, inputsAndMalformedDependenciesSources: [(TypedVirtualPath, VirtualPath)])?
+  ) -> (
+    ModuleDependencyGraph,
+    inputsAndMalformedDependenciesSources: [(TypedVirtualPath, VirtualPath)]
+  )?
     where Inputs.Element == TypedVirtualPath
   {
     let emitOpt = Option.driverEmitFineGrainedDependencyDotFileAfterEveryImport
@@ -258,7 +261,8 @@ extension ModuleDependencyGraph {
 }
 // MARK: - debugging
 extension ModuleDependencyGraph {
-  func emitDotFile(_ g: SourceFileDependencyGraph, _ dependenciesSource: DependenciesSource) {
+  func emitDotFile(_ g: SourceFileDependencyGraph,
+                   _ dependenciesSource: DependenciesSource) {
     // TODO: Incremental emitDotFIle
     fatalError("unimplmemented, writing dot file of dependency graph")
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -15,7 +15,8 @@ import TSCBasic
 // MARK: - DependencySource
 extension ModuleDependencyGraph {
   /// Points to the source of dependencies, i.e. the file read to obtain the information.
-  /*@_spi(Testing)*/ public struct DependenciesSource: Hashable, CustomStringConvertible {
+  /*@_spi(Testing)*/
+  public struct DependenciesSource: Hashable, CustomStringConvertible {
 
     let file: VirtualPath
     #warning("if generalize, fix IncrementalCompilationState.swift:417")
@@ -41,10 +42,12 @@ extension ModuleDependencyGraph {
 
 // MARK: - testing
 extension ModuleDependencyGraph.DependenciesSource {
-  /*@_spi(Testing)*/ public var sourceFileProvideNameForMockDependenciesSource: String {
+  /*@_spi(Testing)*/
+  public var sourceFileProvideNameForMockDependenciesSource: String {
     file.name
   }
-  /*@_spi(Testing)*/ public var interfaceHashForMockDependenciesSource: String {
+  /*@_spi(Testing)*/
+  public var interfaceHashForMockDependenciesSource: String {
     file.name
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -12,11 +12,13 @@
 import Foundation
 import TSCBasic
 
-// MARK: - SwiftDeps
+// MARK: - DependencySource
 extension ModuleDependencyGraph {
-  /*@_spi(Testing)*/ public struct SwiftDeps: Hashable, CustomStringConvertible {
+  /// Points to the source of dependencies, i.e. the file read to obtain the information.
+  /*@_spi(Testing)*/ public struct DependenciesSource: Hashable, CustomStringConvertible {
 
     let file: VirtualPath
+    #warning("if generalize, fix IncrementalCompilationState.swift:417")
 
     init?(_ typedFile: TypedVirtualPath) {
       guard typedFile.type == .swiftDeps else { return nil }
@@ -38,16 +40,16 @@ extension ModuleDependencyGraph {
 }
 
 // MARK: - testing
-extension ModuleDependencyGraph.SwiftDeps {
-  /*@_spi(Testing)*/ public var sourceFileProvideNameForMockSwiftDeps: String {
+extension ModuleDependencyGraph.DependenciesSource {
+  /*@_spi(Testing)*/ public var sourceFileProvideNameForMockDependenciesSource: String {
     file.name
   }
-  /*@_spi(Testing)*/ public var interfaceHashForMockSwiftDeps: String {
+  /*@_spi(Testing)*/ public var interfaceHashForMockDependenciesSource: String {
     file.name
   }
 }
 // MARK: - comparing
-extension ModuleDependencyGraph.SwiftDeps: Comparable {
+extension ModuleDependencyGraph.DependenciesSource: Comparable {
   public static func < (lhs: Self, rhs: Self) -> Bool {
     lhs.file.name < rhs.file.name
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -16,7 +16,7 @@ import TSCBasic
 extension ModuleDependencyGraph {
   /// Points to the source of dependencies, i.e. the file read to obtain the information.
   /*@_spi(Testing)*/
-  public struct DependenciesSource: Hashable, CustomStringConvertible {
+  public struct DependencySource: Hashable, CustomStringConvertible {
 
     let file: VirtualPath
     #warning("if generalize, fix IncrementalCompilationState.swift:417")
@@ -41,18 +41,18 @@ extension ModuleDependencyGraph {
 }
 
 // MARK: - testing
-extension ModuleDependencyGraph.DependenciesSource {
+extension ModuleDependencyGraph.DependencySource {
   /*@_spi(Testing)*/
-  public var sourceFileProvideNameForMockDependenciesSource: String {
+  public var sourceFileProvideNameForMockDependencySource: String {
     file.name
   }
   /*@_spi(Testing)*/
-  public var interfaceHashForMockDependenciesSource: String {
+  public var interfaceHashForMockDependencySource: String {
     file.name
   }
 }
 // MARK: - comparing
-extension ModuleDependencyGraph.DependenciesSource: Comparable {
+extension ModuleDependencyGraph.DependencySource: Comparable {
   public static func < (lhs: Self, rhs: Self) -> Bool {
     lhs.file.name < rhs.file.name
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -25,38 +25,35 @@ extension ModuleDependencyGraph {
     /*@_spi(Testing)*/ public typealias Changes = Set<Node>
 
     let source: SourceFileDependencyGraph
-    let swiftDeps: SwiftDeps
+    let dependenciesSource: DependenciesSource
     let destination: ModuleDependencyGraph
 
     /// When done, changedNodes contains a set of nodes that changed as a result of this integration.
 
     var changedNodes = Changes()
 
-    /// Starts with all nodes in swiftDeps. Nodes that persist will be removed.
+    /// Starts with all nodes in dependenciesSource. Nodes that persist will be removed.
     /// After integration is complete, contains the nodes that have disappeared.
     var disappearedNodes = [DependencyKey: Graph.Node]()
 
     init(source: SourceFileDependencyGraph,
-         swiftDeps: SwiftDeps,
+         dependenciesSource: DependenciesSource,
          destination: ModuleDependencyGraph)
     {
       self.source = source
-      self.swiftDeps = swiftDeps
+      self.dependenciesSource = dependenciesSource
       self.destination = destination
-      self.disappearedNodes = destination.nodeFinder.findNodes(for: swiftDeps)
+      self.disappearedNodes = destination.nodeFinder.findNodes(for: dependenciesSource)
         ?? [:]
     }
   }
 }
 
-// MARK: - integrate a swiftDeps file
+// MARK: - integrate a file containing dependency information
 extension ModuleDependencyGraph.Integrator {
-  private enum IntegrateError: Error {
-    case notSwiftDeps
-  }
   /// returns nil for error
   static func integrate(
-    swiftDeps: Graph.SwiftDeps,
+    dependenciesSource: Graph.DependenciesSource,
     into destination: Graph,
     input: TypedVirtualPath,
     reporter: IncrementalCompilationState.Reporter?,
@@ -64,13 +61,13 @@ extension ModuleDependencyGraph.Integrator {
     fileSystem: FileSystem
   ) -> Changes? {
     guard let sfdg = try? SourceFileDependencyGraph.read(
-            from: swiftDeps, on: fileSystem)
+            from: dependenciesSource, on: fileSystem)
     else {
-      reporter?.report("Could not read \(swiftDeps)", path: input)
+      reporter?.report("Could not read \(dependenciesSource)", path: input)
       return nil
     }
     return integrate(from: sfdg,
-                     swiftDeps: swiftDeps,
+                     dependenciesSource: dependenciesSource,
                      into: destination)
   }
 }
@@ -82,11 +79,11 @@ extension ModuleDependencyGraph.Integrator {
   /// Returns changed nodes
   /*@_spi(Testing)*/ public static func integrate(
     from g: SourceFileDependencyGraph,
-    swiftDeps: Graph.SwiftDeps,
+    dependenciesSource: Graph.DependenciesSource,
     into destination: Graph
   ) ->  Changes {
     var integrator = Self(source: g,
-                          swiftDeps: swiftDeps,
+                          dependenciesSource: dependenciesSource,
                           destination: destination)
     integrator.integrate()
 
@@ -94,7 +91,7 @@ extension ModuleDependencyGraph.Integrator {
       integrator.verifyAfterImporting()
     }
     if destination.emitDependencyDotFileAfterEveryImport {
-      destination.emitDotFile(g, swiftDeps)
+      destination.emitDotFile(g, dependenciesSource)
     }
     return integrator.changedNodes
   }
@@ -134,16 +131,16 @@ extension ModuleDependencyGraph.Integrator {
     recordDefsForThisUse(integrand, integratedNode)
   }
 
-  /// If there is already a node in the graph for this swiftDeps, merge the integrand into that,
+  /// If there is already a node in the graph for this dependenciesSource, merge the integrand into that,
   /// and return the merged node. Remember that the merged node has changed if it has.
   private mutating func integrateWithNodeHere(
     _ integrand: SourceFileDependencyGraph.Node,
-    _ nodesMatchingKey: [Graph.SwiftDeps?: Graph.Node]
+    _ nodesMatchingKey: [Graph.DependenciesSource?: Graph.Node]
   ) -> Graph.Node? {
-    guard let matchHere = nodesMatchingKey[swiftDeps] else {
+    guard let matchHere = nodesMatchingKey[dependenciesSource] else {
       return nil
     }
-    assert(matchHere.swiftDeps == swiftDeps)
+    assert(matchHere.dependenciesSource == dependenciesSource)
     // Node was and still is. Do not remove it.
     disappearedNodes.removeValue(forKey: matchHere.dependencyKey)
     if matchHere.fingerprint != integrand.fingerprint {
@@ -152,11 +149,11 @@ extension ModuleDependencyGraph.Integrator {
     return matchHere
   }
 
-  /// If there is an expat node with this key, replace it with a ndoe for this swiftDeps
+  /// If there is an expat node with this key, replace it with a ndoe for this dependenciesSource
   /// and return the replacement. Remember that the replace has changed.
   private mutating func integrateWithExpat(
     _ integrand: SourceFileDependencyGraph.Node,
-    _ nodesMatchingKey: [Graph.SwiftDeps?: Graph.Node]
+    _ nodesMatchingKey: [Graph.DependenciesSource?: Graph.Node]
   ) -> Graph.Node? {
     guard let expat = nodesMatchingKey[nil] else {
       return nil
@@ -165,7 +162,7 @@ extension ModuleDependencyGraph.Integrator {
            "If an expat exists, then must not be any matches in other files")
     let integratedNode = destination.nodeFinder
       .replace(expat,
-               newSwiftDeps: swiftDeps,
+               newDependenciesSource: dependenciesSource,
                newFingerprint: integrand.fingerprint)
     changedNodes.insert(integratedNode)
     return integratedNode
@@ -179,7 +176,7 @@ extension ModuleDependencyGraph.Integrator {
     let newNode = Graph.Node(
       key: integrand.key,
       fingerprint: integrand.fingerprint,
-      swiftDeps: swiftDeps)
+      dependenciesSource: dependenciesSource)
     let oldNode = destination.nodeFinder.insert(newNode)
     assert(oldNode == nil, "Should be new!")
     changedNodes.insert(newNode)
@@ -209,10 +206,10 @@ extension ModuleDependencyGraph.Integrator {
 extension ModuleDependencyGraph.Integrator {
   @discardableResult
   func verifyAfterImporting() -> Bool {
-    guard let nodesInFile = destination.nodeFinder.findNodes(for: swiftDeps),
+    guard let nodesInFile = destination.nodeFinder.findNodes(for: dependenciesSource),
           !nodesInFile.isEmpty
     else {
-      fatalError("Just imported \(swiftDeps), should have nodes")
+      fatalError("Just imported \(dependenciesSource), should have nodes")
     }
     return destination.verifyGraph()
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -25,25 +25,25 @@ extension ModuleDependencyGraph {
     /*@_spi(Testing)*/ public typealias Changes = Set<Node>
 
     let source: SourceFileDependencyGraph
-    let dependenciesSource: DependenciesSource
+    let dependencySource: DependencySource
     let destination: ModuleDependencyGraph
 
     /// When done, changedNodes contains a set of nodes that changed as a result of this integration.
 
     var changedNodes = Changes()
 
-    /// Starts with all nodes in dependenciesSource. Nodes that persist will be removed.
+    /// Starts with all nodes in dependencySource. Nodes that persist will be removed.
     /// After integration is complete, contains the nodes that have disappeared.
     var disappearedNodes = [DependencyKey: Graph.Node]()
 
     init(source: SourceFileDependencyGraph,
-         dependenciesSource: DependenciesSource,
+         dependencySource: DependencySource,
          destination: ModuleDependencyGraph)
     {
       self.source = source
-      self.dependenciesSource = dependenciesSource
+      self.dependencySource = dependencySource
       self.destination = destination
-      self.disappearedNodes = destination.nodeFinder.findNodes(for: dependenciesSource)
+      self.disappearedNodes = destination.nodeFinder.findNodes(for: dependencySource)
         ?? [:]
     }
   }
@@ -53,7 +53,7 @@ extension ModuleDependencyGraph {
 extension ModuleDependencyGraph.Integrator {
   /// returns nil for error
   static func integrate(
-    dependenciesSource: Graph.DependenciesSource,
+    dependencySource: Graph.DependencySource,
     into destination: Graph,
     input: TypedVirtualPath,
     reporter: IncrementalCompilationState.Reporter?,
@@ -61,13 +61,13 @@ extension ModuleDependencyGraph.Integrator {
     fileSystem: FileSystem
   ) -> Changes? {
     guard let sfdg = try? SourceFileDependencyGraph.read(
-            from: dependenciesSource, on: fileSystem)
+            from: dependencySource, on: fileSystem)
     else {
-      reporter?.report("Could not read \(dependenciesSource)", path: input)
+      reporter?.report("Could not read \(dependencySource)", path: input)
       return nil
     }
     return integrate(from: sfdg,
-                     dependenciesSource: dependenciesSource,
+                     dependencySource: dependencySource,
                      into: destination)
   }
 }
@@ -79,11 +79,11 @@ extension ModuleDependencyGraph.Integrator {
   /// Returns changed nodes
   /*@_spi(Testing)*/ public static func integrate(
     from g: SourceFileDependencyGraph,
-    dependenciesSource: Graph.DependenciesSource,
+    dependencySource: Graph.DependencySource,
     into destination: Graph
   ) ->  Changes {
     var integrator = Self(source: g,
-                          dependenciesSource: dependenciesSource,
+                          dependencySource: dependencySource,
                           destination: destination)
     integrator.integrate()
 
@@ -91,7 +91,7 @@ extension ModuleDependencyGraph.Integrator {
       integrator.verifyAfterImporting()
     }
     if destination.emitDependencyDotFileAfterEveryImport {
-      destination.emitDotFile(g, dependenciesSource)
+      destination.emitDotFile(g, dependencySource)
     }
     return integrator.changedNodes
   }
@@ -131,16 +131,16 @@ extension ModuleDependencyGraph.Integrator {
     recordDefsForThisUse(integrand, integratedNode)
   }
 
-  /// If there is already a node in the graph for this dependenciesSource, merge the integrand into that,
+  /// If there is already a node in the graph for this dependencySource, merge the integrand into that,
   /// and return the merged node. Remember that the merged node has changed if it has.
   private mutating func integrateWithNodeHere(
     _ integrand: SourceFileDependencyGraph.Node,
-    _ nodesMatchingKey: [Graph.DependenciesSource?: Graph.Node]
+    _ nodesMatchingKey: [Graph.DependencySource?: Graph.Node]
   ) -> Graph.Node? {
-    guard let matchHere = nodesMatchingKey[dependenciesSource] else {
+    guard let matchHere = nodesMatchingKey[dependencySource] else {
       return nil
     }
-    assert(matchHere.dependenciesSource == dependenciesSource)
+    assert(matchHere.dependencySource == dependencySource)
     // Node was and still is. Do not remove it.
     disappearedNodes.removeValue(forKey: matchHere.dependencyKey)
     if matchHere.fingerprint != integrand.fingerprint {
@@ -149,11 +149,11 @@ extension ModuleDependencyGraph.Integrator {
     return matchHere
   }
 
-  /// If there is an expat node with this key, replace it with a ndoe for this dependenciesSource
+  /// If there is an expat node with this key, replace it with a ndoe for this dependencySource
   /// and return the replacement. Remember that the replace has changed.
   private mutating func integrateWithExpat(
     _ integrand: SourceFileDependencyGraph.Node,
-    _ nodesMatchingKey: [Graph.DependenciesSource?: Graph.Node]
+    _ nodesMatchingKey: [Graph.DependencySource?: Graph.Node]
   ) -> Graph.Node? {
     guard let expat = nodesMatchingKey[nil] else {
       return nil
@@ -162,7 +162,7 @@ extension ModuleDependencyGraph.Integrator {
            "If an expat exists, then must not be any matches in other files")
     let integratedNode = destination.nodeFinder
       .replace(expat,
-               newDependenciesSource: dependenciesSource,
+               newDependencySource: dependencySource,
                newFingerprint: integrand.fingerprint)
     changedNodes.insert(integratedNode)
     return integratedNode
@@ -176,7 +176,7 @@ extension ModuleDependencyGraph.Integrator {
     let newNode = Graph.Node(
       key: integrand.key,
       fingerprint: integrand.fingerprint,
-      dependenciesSource: dependenciesSource)
+      dependencySource: dependencySource)
     let oldNode = destination.nodeFinder.insert(newNode)
     assert(oldNode == nil, "Should be new!")
     changedNodes.insert(newNode)
@@ -206,10 +206,10 @@ extension ModuleDependencyGraph.Integrator {
 extension ModuleDependencyGraph.Integrator {
   @discardableResult
   func verifyAfterImporting() -> Bool {
-    guard let nodesInFile = destination.nodeFinder.findNodes(for: dependenciesSource),
+    guard let nodesInFile = destination.nodeFinder.findNodes(for: dependencySource),
           !nodesInFile.isEmpty
     else {
-      fatalError("Just imported \(dependenciesSource), should have nodes")
+      fatalError("Just imported \(dependencySource), should have nodes")
     }
     return destination.verifyGraph()
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -17,8 +17,8 @@ extension ModuleDependencyGraph {
   
   /// A node in the per-module (i.e. the driver) dependency graph
   /// Each node represents a `Decl` from the frontend.
-  /// If a file references a `Decl` we haven't seen yet, the node's `swiftDeps` will be nil, otherwise
-  /// it will hold the name of the swiftdeps file from which the node was read.
+  /// If a file references a `Decl` we haven't seen yet, the node's `dependenciesSource` will be nil, otherwise
+  /// it will hold the name of the dependenciesSource file from which the node was read.
   /// A dependency is represented by an arc, in the `usesByDefs` map.
   /// (Cargo-culted and modified from the legacy driver.)
   ///
@@ -48,21 +48,21 @@ extension ModuleDependencyGraph {
     let fingerprint: String?
 
 
-    /// The swiftDeps file that holds this entity iff the entities .swiftdeps is known.
+    /// The dependenciesSource file that holds this entity iff the entities .swiftdeps (or in future, .swiftmodule) is known.
     /// If more than one source file has the same DependencyKey, then there
     /// will be one node for each in the driver, distinguished by this field.
     /// Nodes can move from file to file when the driver reads the result of a
     /// compilation.
     /// Nil represents a node with no known residance
-    let swiftDeps: SwiftDeps?
-    var isExpat: Bool { swiftDeps == nil }
+    let dependenciesSource: DependenciesSource?
+    var isExpat: Bool { dependenciesSource == nil }
 
-    /// This swiftDeps is the file where the swiftDeps was read, not necessarily anything in the
+    /// This dependenciesSource is the file where the swiftDeps, etc. was read, not necessarily anything in the
     /// SourceFileDependencyGraph or the DependencyKeys
-    init(key: DependencyKey, fingerprint: String?, swiftDeps: SwiftDeps?) {
+    init(key: DependencyKey, fingerprint: String?, dependenciesSource: DependenciesSource?) {
       self.dependencyKey = key
       self.fingerprint = fingerprint
-      self.swiftDeps = swiftDeps
+      self.dependenciesSource = dependenciesSource
     }
   }
 }
@@ -70,13 +70,13 @@ extension ModuleDependencyGraph {
 extension ModuleDependencyGraph.Node: Equatable, Hashable {
   public static func == (lhs: Graph.Node, rhs: Graph.Node) -> Bool {
     lhs.dependencyKey == rhs.dependencyKey && lhs.fingerprint == rhs.fingerprint
-      && lhs.swiftDeps == rhs.swiftDeps
+      && lhs.dependenciesSource == rhs.dependenciesSource
   }
   
   public func hash(into hasher: inout Hasher) {
     hasher.combine(dependencyKey)
     hasher.combine(fingerprint)
-    hasher.combine(swiftDeps)
+    hasher.combine(dependenciesSource)
   }
 }
 
@@ -91,7 +91,7 @@ extension ModuleDependencyGraph.Node: Comparable {
       }
     }
     return lhs.dependencyKey != rhs.dependencyKey ? lhs.dependencyKey < rhs.dependencyKey :
-      lhs.swiftDeps != rhs.swiftDeps ? lt(lhs.swiftDeps, rhs.swiftDeps)
+      lhs.dependenciesSource != rhs.dependenciesSource ? lt(lhs.dependenciesSource, rhs.dependenciesSource)
       : lt(lhs.fingerprint, rhs.fingerprint)
   }
 }
@@ -99,7 +99,7 @@ extension ModuleDependencyGraph.Node: Comparable {
 
 extension ModuleDependencyGraph.Node: CustomStringConvertible {
   public var description: String {
-    "\(dependencyKey) \( swiftDeps.map { "in \($0.description)" } ?? "<expat>" )"
+    "\(dependencyKey) \( dependenciesSource.map { "in \($0.description)" } ?? "<expat>" )"
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -17,8 +17,8 @@ extension ModuleDependencyGraph {
   
   /// A node in the per-module (i.e. the driver) dependency graph
   /// Each node represents a `Decl` from the frontend.
-  /// If a file references a `Decl` we haven't seen yet, the node's `dependenciesSource` will be nil,
-  /// otherwise it will hold the name of the dependenciesSource file from which the node was read.
+  /// If a file references a `Decl` we haven't seen yet, the node's `dependencySource` will be nil,
+  /// otherwise it will hold the name of the dependencySource file from which the node was read.
   /// A dependency is represented by an arc, in the `usesByDefs` map.
   /// (Cargo-culted and modified from the legacy driver.)
   ///
@@ -48,22 +48,22 @@ extension ModuleDependencyGraph {
     let fingerprint: String?
 
 
-    /// The dependenciesSource file that holds this entity iff the entities .swiftdeps (or in future, .swiftmodule) is known.
+    /// The dependencySource file that holds this entity iff the entities .swiftdeps (or in future, .swiftmodule) is known.
     /// If more than one source file has the same DependencyKey, then there
     /// will be one node for each in the driver, distinguished by this field.
     /// Nodes can move from file to file when the driver reads the result of a
     /// compilation.
     /// Nil represents a node with no known residance
-    let dependenciesSource: DependenciesSource?
-    var isExpat: Bool { dependenciesSource == nil }
+    let dependencySource: DependencySource?
+    var isExpat: Bool { dependencySource == nil }
 
-    /// This dependenciesSource is the file where the swiftDeps, etc. was read, not necessarily anything in the
+    /// This dependencySource is the file where the swiftDeps, etc. was read, not necessarily anything in the
     /// SourceFileDependencyGraph or the DependencyKeys
     init(key: DependencyKey, fingerprint: String?,
-         dependenciesSource: DependenciesSource?) {
+         dependencySource: DependencySource?) {
       self.dependencyKey = key
       self.fingerprint = fingerprint
-      self.dependenciesSource = dependenciesSource
+      self.dependencySource = dependencySource
     }
   }
 }
@@ -71,13 +71,13 @@ extension ModuleDependencyGraph {
 extension ModuleDependencyGraph.Node: Equatable, Hashable {
   public static func == (lhs: Graph.Node, rhs: Graph.Node) -> Bool {
     lhs.dependencyKey == rhs.dependencyKey && lhs.fingerprint == rhs.fingerprint
-      && lhs.dependenciesSource == rhs.dependenciesSource
+      && lhs.dependencySource == rhs.dependencySource
   }
   
   public func hash(into hasher: inout Hasher) {
     hasher.combine(dependencyKey)
     hasher.combine(fingerprint)
-    hasher.combine(dependenciesSource)
+    hasher.combine(dependencySource)
   }
 }
 
@@ -92,8 +92,8 @@ extension ModuleDependencyGraph.Node: Comparable {
       }
     }
     return lhs.dependencyKey != rhs.dependencyKey ? lhs.dependencyKey < rhs.dependencyKey :
-      lhs.dependenciesSource != rhs.dependenciesSource
-        ? lt(lhs.dependenciesSource, rhs.dependenciesSource)
+      lhs.dependencySource != rhs.dependencySource
+        ? lt(lhs.dependencySource, rhs.dependencySource)
         : lt(lhs.fingerprint, rhs.fingerprint)
   }
 }
@@ -101,7 +101,7 @@ extension ModuleDependencyGraph.Node: Comparable {
 
 extension ModuleDependencyGraph.Node: CustomStringConvertible {
   public var description: String {
-    "\(dependencyKey) \( dependenciesSource.map { "in \($0.description)" } ?? "<expat>" )"
+    "\(dependencyKey) \( dependencySource.map { "in \($0.description)" } ?? "<expat>" )"
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -17,8 +17,8 @@ extension ModuleDependencyGraph {
   
   /// A node in the per-module (i.e. the driver) dependency graph
   /// Each node represents a `Decl` from the frontend.
-  /// If a file references a `Decl` we haven't seen yet, the node's `dependenciesSource` will be nil, otherwise
-  /// it will hold the name of the dependenciesSource file from which the node was read.
+  /// If a file references a `Decl` we haven't seen yet, the node's `dependenciesSource` will be nil,
+  /// otherwise it will hold the name of the dependenciesSource file from which the node was read.
   /// A dependency is represented by an arc, in the `usesByDefs` map.
   /// (Cargo-culted and modified from the legacy driver.)
   ///
@@ -59,7 +59,8 @@ extension ModuleDependencyGraph {
 
     /// This dependenciesSource is the file where the swiftDeps, etc. was read, not necessarily anything in the
     /// SourceFileDependencyGraph or the DependencyKeys
-    init(key: DependencyKey, fingerprint: String?, dependenciesSource: DependenciesSource?) {
+    init(key: DependencyKey, fingerprint: String?,
+         dependenciesSource: DependenciesSource?) {
       self.dependencyKey = key
       self.fingerprint = fingerprint
       self.dependenciesSource = dependenciesSource
@@ -91,8 +92,9 @@ extension ModuleDependencyGraph.Node: Comparable {
       }
     }
     return lhs.dependencyKey != rhs.dependencyKey ? lhs.dependencyKey < rhs.dependencyKey :
-      lhs.dependenciesSource != rhs.dependenciesSource ? lt(lhs.dependenciesSource, rhs.dependenciesSource)
-      : lt(lhs.fingerprint, rhs.fingerprint)
+      lhs.dependenciesSource != rhs.dependenciesSource
+        ? lt(lhs.dependenciesSource, rhs.dependenciesSource)
+        : lt(lhs.fingerprint, rhs.fingerprint)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -19,8 +19,8 @@ extension ModuleDependencyGraph {
   struct NodeFinder {
     typealias Graph = ModuleDependencyGraph
     
-    /// Maps swiftDeps files and DependencyKeys to Nodes
-    fileprivate typealias NodeMap = TwoDMap<SwiftDeps?, DependencyKey, Node>
+    /// Maps dependenciesSource files and DependencyKeys to Nodes
+    fileprivate typealias NodeMap = TwoDMap<DependenciesSource?, DependencyKey, Node>
     fileprivate var nodeMap = NodeMap()
     
     /// Since dependency keys use baseNames, they are coarser than individual
@@ -41,23 +41,23 @@ extension ModuleDependencyGraph {
 
 extension ModuleDependencyGraph.NodeFinder {
   func findFileInterfaceNode(
-    forMock swiftDeps: ModuleDependencyGraph.SwiftDeps
+    forMock dependenciesSource: ModuleDependencyGraph.DependenciesSource
   ) -> Graph.Node?  {
-    let fileKey = DependencyKey(fileKeyForMockSwiftDeps: swiftDeps)
-    return findNode((swiftDeps, fileKey))
+    let fileKey = DependencyKey(fileKeyForMockDependenciesSource: dependenciesSource)
+    return findNode((dependenciesSource, fileKey))
   }
-  func findNode(_ mapKey: (Graph.SwiftDeps?, DependencyKey)) -> Graph.Node? {
+  func findNode(_ mapKey: (Graph.DependenciesSource?, DependencyKey)) -> Graph.Node? {
     nodeMap[mapKey]
   }
   func findCorrespondingImplementation(of n: Graph.Node) -> Graph.Node? {
     n.dependencyKey.correspondingImplementation
-      .flatMap {findNode((n.swiftDeps, $0))}
+      .flatMap {findNode((n.dependenciesSource, $0))}
   }
   
-  func findNodes(for swiftDeps: Graph.SwiftDeps?) -> [DependencyKey: Graph.Node]? {
-    nodeMap[swiftDeps]
+  func findNodes(for dependenciesSource: Graph.DependenciesSource?) -> [DependencyKey: Graph.Node]? {
+    nodeMap[dependenciesSource]
   }
-  func findNodes(for key: DependencyKey) -> [Graph.SwiftDeps?: Graph.Node]? {
+  func findNodes(for key: DependencyKey) -> [Graph.DependenciesSource?: Graph.Node]? {
     nodeMap[key]
   }
 
@@ -104,9 +104,9 @@ extension ModuleDependencyGraph.NodeFinder {
     return self.uses(of: def).sorted()
   }
 
-  func mappings(of n: Graph.Node) -> [(Graph.SwiftDeps?, DependencyKey)] {
+  func mappings(of n: Graph.Node) -> [(Graph.DependenciesSource?, DependencyKey)] {
     nodeMap.compactMap { k, _ in
-      guard k.0 == n.swiftDeps && k.1 == n.dependencyKey else {
+      guard k.0 == n.dependenciesSource && k.1 == n.dependencyKey else {
         return nil
       }
       return k
@@ -119,8 +119,8 @@ extension ModuleDependencyGraph.NodeFinder {
 }
 
 fileprivate extension ModuleDependencyGraph.Node {
-  var mapKey: (Graph.SwiftDeps?, DependencyKey) {
-    return (swiftDeps, dependencyKey)
+  var mapKey: (Graph.DependenciesSource?, DependencyKey) {
+    return (dependenciesSource, dependencyKey)
   }
 }
 
@@ -172,12 +172,12 @@ extension ModuleDependencyGraph.NodeFinder {
   ///
   /// Now that nodes are immutable, this function needs to replace the node
   mutating func replace(_ original: Graph.Node,
-                        newSwiftDeps: Graph.SwiftDeps,
+                        newDependenciesSource: Graph.DependenciesSource,
                         newFingerprint: String?
   ) -> Graph.Node {
     let replacement = Graph.Node(key: original.dependencyKey,
                                  fingerprint: newFingerprint,
-                                 swiftDeps: newSwiftDeps)
+                                 dependenciesSource: newDependenciesSource)
     usesByDef.replace(original, with: replacement, forKey: original.dependencyKey)
     nodeMap.removeValue(forKey: original.mapKey)
     nodeMap.updateValue(replacement, forKey: replacement.mapKey)
@@ -234,14 +234,14 @@ extension ModuleDependencyGraph.NodeFinder {
 // MARK: - key helpers
 
 fileprivate extension DependencyKey {
-  init(fileKeyForMockSwiftDeps swiftDeps: ModuleDependencyGraph.SwiftDeps) {
+  init(fileKeyForMockDependenciesSource dependenciesSource: ModuleDependencyGraph.DependenciesSource) {
     self.init(aspect: .interface,
               designator:
-                .sourceFileProvide(name: swiftDeps.sourceFileProvidesNameForMocking)
+                .sourceFileProvide(name: dependenciesSource.sourceFileProvidesNameForMocking)
     )
   }
 }
-fileprivate extension ModuleDependencyGraph.SwiftDeps {
+fileprivate extension ModuleDependencyGraph.DependenciesSource {
   var sourceFileProvidesNameForMocking: String {
     // Only when mocking are these two guaranteed to be the same
     file.name

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -54,7 +54,8 @@ extension ModuleDependencyGraph.NodeFinder {
       .flatMap {findNode((n.dependenciesSource, $0))}
   }
   
-  func findNodes(for dependenciesSource: Graph.DependenciesSource?) -> [DependencyKey: Graph.Node]? {
+  func findNodes(for dependenciesSource: Graph.DependenciesSource?)
+  -> [DependencyKey: Graph.Node]? {
     nodeMap[dependenciesSource]
   }
   func findNodes(for key: DependencyKey) -> [Graph.DependenciesSource?: Graph.Node]? {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -116,7 +116,7 @@ extension ModuleDependencyGraph.Tracer {
 
 
   private func printPath(_ path: [Graph.Node]) {
-    guard path.first?.dependenciesSource != path.last?.dependenciesSource
+    guard path.first?.dependencySource != path.last?.dependencySource
     else {
       return
     }
@@ -125,8 +125,8 @@ extension ModuleDependencyGraph.Tracer {
         "Traced:",
         path
           .compactMap { node in
-            node.dependenciesSource
-              .flatMap {graph.inputDependenciesSourceMap[$0] }
+            node.dependencySource
+              .flatMap {graph.inputDependencySourceMap[$0] }
               .map { "\(node.dependencyKey) in \($0.file.basename)"}
           }
           .joined(separator: " -> ")

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -116,7 +116,10 @@ extension ModuleDependencyGraph.Tracer {
 
 
   private func printPath(_ path: [Graph.Node]) {
-    guard path.first?.dependenciesSource != path.last?.dependenciesSource else {return}
+    guard path.first?.dependenciesSource != path.last?.dependenciesSource
+    else {
+      return
+    }
     graph.reporter?.report(
       [
         "Traced:",

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -116,14 +116,14 @@ extension ModuleDependencyGraph.Tracer {
 
 
   private func printPath(_ path: [Graph.Node]) {
-    guard path.first?.swiftDeps != path.last?.swiftDeps else {return}
+    guard path.first?.dependenciesSource != path.last?.dependenciesSource else {return}
     graph.reporter?.report(
       [
         "Traced:",
         path
           .compactMap { node in
-            node.swiftDeps
-              .flatMap {graph.sourceSwiftDepsMap[$0] }
+            node.dependenciesSource
+              .flatMap {graph.inputDependenciesSourceMap[$0] }
               .map { "\(node.dependencyKey) in \($0.file.basename)"}
           }
           .joined(separator: " -> ")

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -1,4 +1,4 @@
-//===------- SourceFileDependencyGraph.swift - Read swiftdeps files -------===//
+//===---SourceFileDependencyGraph.swift - Read swiftdeps or swiftmodule files ---===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -117,7 +117,7 @@ extension SourceFileDependencyGraph {
   }
 
   static func read(
-    from swiftDeps: ModuleDependencyGraph.SwiftDeps,
+    from swiftDeps: ModuleDependencyGraph.DependenciesSource,
     on fileSystem: FileSystem
   ) throws -> Self {
     try self.init(contentsOf: swiftDeps.file, on: fileSystem)

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -117,7 +117,7 @@ extension SourceFileDependencyGraph {
   }
 
   static func read(
-    from swiftDeps: ModuleDependencyGraph.DependenciesSource,
+    from swiftDeps: ModuleDependencyGraph.DependencySource,
     on fileSystem: FileSystem
   ) throws -> Self {
     try self.init(contentsOf: swiftDeps.file, on: fileSystem)

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -39,7 +39,7 @@ class DependencyGraphSerializationTests: XCTestCase {
                   "Round trip failed! Symmetric difference - \(originalNodes.symmetricDifference(deserializedNodes))")
 
     XCTAssertEqual(graph.nodeFinder.usesByDef, deserializedGraph.nodeFinder.usesByDef)
-    XCTAssertEqual(graph.sourceSwiftDepsMap, deserializedGraph.sourceSwiftDepsMap)
+    XCTAssertEqual(graph.inputDependenciesSourceMap, deserializedGraph.inputDependenciesSourceMap)
     XCTAssertEqual(graph.externalDependencies, deserializedGraph.externalDependencies)
   }
 

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -39,7 +39,7 @@ class DependencyGraphSerializationTests: XCTestCase {
                   "Round trip failed! Symmetric difference - \(originalNodes.symmetricDifference(deserializedNodes))")
 
     XCTAssertEqual(graph.nodeFinder.usesByDef, deserializedGraph.nodeFinder.usesByDef)
-    XCTAssertEqual(graph.inputDependenciesSourceMap, deserializedGraph.inputDependenciesSourceMap)
+    XCTAssertEqual(graph.inputDependencySourceMap, deserializedGraph.inputDependencySourceMap)
     XCTAssertEqual(graph.externalDependencies, deserializedGraph.externalDependencies)
   }
 

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -44,23 +44,23 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.topLevel: ["b0", "b->"]])
     graph.simulateLoad(2, [.topLevel: ["c0", "c->"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
     // Mark 0 again -- should be no change.
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(2).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(2).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(1).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -72,7 +72,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.nominal: ["a", "a->"]])
     graph.simulateLoad(1, [.topLevel: ["a", "b->"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -83,7 +83,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.nominal: ["a->", "b"]])
     graph.simulateLoad(1, [.topLevel: ["b->", "a"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(1).count)
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -97,7 +97,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(3, [.member: ["b,aa->"]])
     graph.simulateLoad(4, [.member: ["b,bb->"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -111,14 +111,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad(1, [.topLevel: ["x->", "b->", "z->"]])
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -130,14 +130,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.topLevel: ["x", "b", "z"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(1)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -149,14 +149,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -168,14 +168,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["a->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -188,14 +188,14 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.nominal: ["a->"], .topLevel: ["a->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -209,15 +209,15 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.nominal: ["a->"], .topLevel: ["a->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    let _ = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    let _ = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -229,14 +229,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1,
                        [.dynamicLookup: ["x->", "b->", "z->"]])
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -249,14 +249,14 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.member: ["x,xx->", "b,bb->", "z,zz->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -269,7 +269,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["q->", "b->", "s->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -278,7 +278,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -292,7 +292,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["q->", "r->", "c->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -301,7 +301,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -315,7 +315,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -324,7 +324,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -338,7 +338,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["#z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -347,7 +347,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -361,7 +361,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -381,7 +381,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(12, [.topLevel: ["q->", "q"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2)) //?????
@@ -394,7 +394,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 12))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(10)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(10)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(10))
       XCTAssertTrue(swiftDeps.contains(11))
@@ -416,7 +416,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -442,7 +442,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -467,7 +467,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["a->"]])
     graph.simulateLoad(2, [.nominal: ["b->"]])
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(1)
       XCTAssertEqual(1, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -495,7 +495,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(1)
       XCTAssertEqual(1, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -524,7 +524,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.topLevel: ["x->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -534,7 +534,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(0, swiftDeps.count)
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
@@ -552,7 +552,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -580,7 +580,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
       XCTAssertTrue(swiftDeps.contains(1))
@@ -709,7 +709,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.topLevel: ["a", "b->"]])
     graph.simulateLoad(1, [.topLevel: ["a->", "b"]])
 
-    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
     XCTAssertTrue(swiftDeps.contains(1))
   }
 
@@ -721,7 +721,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B1->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(1)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
       XCTAssertTrue(swiftDeps.contains(1))
@@ -785,7 +785,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B->"]])
     graph.simulateLoad(3, [.nominal: ["C->"]])
 
-    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
     XCTAssertTrue(swiftDeps.contains(0))
     XCTAssertTrue(swiftDeps.contains(1))
     XCTAssertTrue(swiftDeps.contains(2))
@@ -802,7 +802,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B->"]])
     graph.simulateLoad(3, [.nominal: ["C->"]])
 
-    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependencySourceChanges(0)
     XCTAssertTrue(swiftDeps.contains(0))
     XCTAssertTrue(swiftDeps.contains(1))
     XCTAssertTrue(swiftDeps.contains(2))
@@ -928,20 +928,20 @@ extension ModuleDependencyGraph {
     hadCompilationError: Bool = false)
   -> Integrator.Changes
   {
-    let dependenciesSource = DependenciesSource(mock: swiftDepsIndex)
+    let dependencySource = DependencySource(mock: swiftDepsIndex)
     let interfaceHash =
-      interfaceHashIfPresent ?? dependenciesSource.interfaceHashForMockDependenciesSource
+      interfaceHashIfPresent ?? dependencySource.interfaceHashForMockDependencySource
 
     let sfdg = SourceFileDependencyGraphMocker.mock(
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError,
-      dependenciesSource: dependenciesSource,
+      dependencySource: dependencySource,
       interfaceHash: interfaceHash,
       dependencyDescriptions)
 
     return Integrator.integrate(
       from: sfdg,
-      dependenciesSource: dependenciesSource,
+      dependencySource: dependencySource,
       into: self)
   }
 
@@ -953,24 +953,24 @@ extension ModuleDependencyGraph {
   /// Can return duplicates
   func findUntracedSwiftDepsDependent(
     on externalDependency: ExternalDependency
-  ) -> [DependenciesSource] {
-    var foundSources = [DependenciesSource]()
+  ) -> [DependencySource] {
+    var foundSources = [DependencySource]()
     for dependent in self.untracedDependents(of: externalDependency) {
-      let dependenciesSource = dependent.dependenciesSource!
-      foundSources.append(dependenciesSource)
+      let dependencySource = dependent.dependencySource!
+      foundSources.append(dependencySource)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive
       // Don't return job twice.
       let filesToRebuild =
-        findSwiftDepsToRecompileWhenDependenciesSourceChanges(dependenciesSource)
-        .filter({ marked in marked != dependenciesSource })
+        findSwiftDepsToRecompileWhenDependencySourceChanges(dependencySource)
+        .filter({ marked in marked != dependencySource })
       foundSources.append(contentsOf: filesToRebuild)
     }
     return foundSources
   }
 
 
-  func findSwiftDepsToRecompileWhenDependenciesSourceChanges(_ i: Int) -> [Int] {
-    findSwiftDepsToRecompileWhenDependenciesSourceChanges(DependenciesSource(mock: i))
+  func findSwiftDepsToRecompileWhenDependencySourceChanges(_ i: Int) -> [Int] {
+    findSwiftDepsToRecompileWhenDependencySourceChanges(DependencySource(mock: i))
       .map { $0.mockID }
   }
 }
@@ -1006,7 +1006,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
 
   private let includePrivateDeps: Bool
   private let hadCompilationError: Bool
-  private let dependenciesSource: ModuleDependencyGraph.DependenciesSource
+  private let dependencySource: ModuleDependencyGraph.DependencySource
   private let interfaceHash: String
   private let dependencyDescriptions: [(MockDependencyKind, String)]
 
@@ -1017,7 +1017,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
   static func mock(
     includePrivateDeps: Bool,
     hadCompilationError: Bool,
-    dependenciesSource: ModuleDependencyGraph.DependenciesSource,
+    dependencySource: ModuleDependencyGraph.DependencySource,
     interfaceHash: String,
     _ dependencyDescriptions: [MockDependencyKind: [String]]
   ) -> SourceFileDependencyGraph
@@ -1025,7 +1025,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
     var m = Self.init(
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError,
-      dependenciesSource: dependenciesSource,
+      dependencySource: dependencySource,
       interfaceHash: interfaceHash,
       dependencyDescriptions:
         dependencyDescriptions.flatMap { (kind, descs) in descs.map {(kind, $0)}}
@@ -1048,7 +1048,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
 
   private mutating func addSourceFileNodesToGraph() {
     sourceFileNodePair = findExistingNodePairOrCreateAndAddIfNew(
-      DependencyKey.createKeyForWholeSourceFile(.interface, dependenciesSource),
+      DependencyKey.createKeyForWholeSourceFile(.interface, dependencySource),
       interfaceHash);
   }
 
@@ -1162,7 +1162,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
             s,
             kind,
             includePrivateDeps: includePrivateDeps,
-            dependenciesSource: dependenciesSource)
+            dependencySource: dependencySource)
     else { return }
     let defNode = findExistingNodeOrCreateIfNew(defAndUseKeys.def, nil, isProvides: false)
 
@@ -1219,7 +1219,7 @@ fileprivate extension DependencyKey {
     _ s: String,
     _ kind: MockDependencyKind,
     includePrivateDeps: Bool,
-    dependenciesSource: ModuleDependencyGraph.DependenciesSource
+    dependencySource: ModuleDependencyGraph.DependencySource
   ) -> (def: Self, use: Self)? {
     let noncascadingPrefix = "#"
     let privateHolderPrefix = "~"
@@ -1241,13 +1241,13 @@ fileprivate extension DependencyKey {
             use: computeUseKey(defUseStrings.use,
                                isCascadingUse: isCascadingUse,
                                includePrivateDeps: includePrivateDeps,
-                               dependenciesSource: dependenciesSource))
+                               dependencySource: dependencySource))
   }
 
   static func computeUseKey(
     _ s: String, isCascadingUse: Bool,
     includePrivateDeps: Bool,
-    dependenciesSource: ModuleDependencyGraph.DependenciesSource
+    dependencySource: ModuleDependencyGraph.DependencySource
   ) -> Self {
     // For now, in unit tests, mock uses are always nominal
     let aspectOfUse: DeclAspect = isCascadingUse ? .interface : .implementation
@@ -1259,7 +1259,7 @@ fileprivate extension DependencyKey {
       aspect: aspectOfUse,
       designator: Designator(kind: .sourceFileProvide,
                              (context: "",
-                              name: dependenciesSource.sourceFileProvideNameForMockDependenciesSource)))
+                              name: dependencySource.sourceFileProvideNameForMockDependencySource)))
   }
 }
 
@@ -1309,11 +1309,11 @@ fileprivate extension SourceFileDependencyGraph.Node {
 fileprivate extension DependencyKey {
   static func createKeyForWholeSourceFile(
     _ aspect: DeclAspect,
-    _ dependenciesSource: ModuleDependencyGraph.DependenciesSource
+    _ dependencySource: ModuleDependencyGraph.DependencySource
   ) -> Self {
     return Self(aspect: aspect,
                 designator: Designator(kind: .sourceFileProvide,
-                                       dependenciesSource.sourceFileProvideNameForMockDependenciesSource
+                                       dependencySource.sourceFileProvideNameForMockDependencySource
                                         .parseContextAndName(.sourceFileProvide)))
   }
 }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -44,23 +44,23 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.topLevel: ["b0", "b->"]])
     graph.simulateLoad(2, [.topLevel: ["c0", "c->"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
     // Mark 0 again -- should be no change.
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(2).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(2).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(1).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -72,7 +72,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.nominal: ["a", "a->"]])
     graph.simulateLoad(1, [.topLevel: ["a", "b->"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -83,7 +83,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.nominal: ["a->", "b"]])
     graph.simulateLoad(1, [.topLevel: ["b->", "a"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(1).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1).count)
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -97,7 +97,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(3, [.member: ["b,aa->"]])
     graph.simulateLoad(4, [.member: ["b,bb->"]])
 
-    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(1, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -111,14 +111,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad(1, [.topLevel: ["x->", "b->", "z->"]])
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -130,14 +130,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.topLevel: ["x", "b", "z"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -149,14 +149,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -168,14 +168,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["a->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -188,14 +188,14 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.nominal: ["a->"], .topLevel: ["a->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -209,15 +209,15 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.nominal: ["a->"], .topLevel: ["a->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    let _ = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    let _ = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -229,14 +229,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1,
                        [.dynamicLookup: ["x->", "b->", "z->"]])
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -249,14 +249,14 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.member: ["x,xx->", "b,bb->", "z,zz->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -269,7 +269,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["q->", "b->", "s->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -278,7 +278,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -292,7 +292,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["q->", "r->", "c->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -301,7 +301,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -315,7 +315,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -324,7 +324,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -338,7 +338,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["#z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -347,7 +347,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0).count)
+    XCTAssertEqual(0, graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -361,7 +361,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["z->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -381,7 +381,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(12, [.topLevel: ["q->", "q"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2)) //?????
@@ -394,7 +394,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 12))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(10)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(10)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(10))
       XCTAssertTrue(swiftDeps.contains(11))
@@ -416,7 +416,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -442,7 +442,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -467,7 +467,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["a->"]])
     graph.simulateLoad(2, [.nominal: ["b->"]])
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
       XCTAssertEqual(1, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -495,7 +495,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
       XCTAssertEqual(1, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -524,7 +524,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.topLevel: ["x->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -534,7 +534,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(0, swiftDeps.count)
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
@@ -552,7 +552,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -580,7 +580,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
       XCTAssertTrue(swiftDeps.contains(1))
@@ -709,7 +709,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.topLevel: ["a", "b->"]])
     graph.simulateLoad(1, [.topLevel: ["a->", "b"]])
 
-    let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
     XCTAssertTrue(swiftDeps.contains(1))
   }
 
@@ -721,7 +721,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B1->"]])
 
     do {
-      let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(1)
+      let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(1)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
       XCTAssertTrue(swiftDeps.contains(1))
@@ -785,7 +785,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B->"]])
     graph.simulateLoad(3, [.nominal: ["C->"]])
 
-    let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
     XCTAssertTrue(swiftDeps.contains(0))
     XCTAssertTrue(swiftDeps.contains(1))
     XCTAssertTrue(swiftDeps.contains(2))
@@ -802,7 +802,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B->"]])
     graph.simulateLoad(3, [.nominal: ["C->"]])
 
-    let swiftDeps = graph.findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(0)
+    let swiftDeps = graph.findSwiftDepsToRecompileWhenDependenciesSourceChanges(0)
     XCTAssertTrue(swiftDeps.contains(0))
     XCTAssertTrue(swiftDeps.contains(1))
     XCTAssertTrue(swiftDeps.contains(2))
@@ -928,19 +928,19 @@ extension ModuleDependencyGraph {
     hadCompilationError: Bool = false)
   -> Integrator.Changes
   {
-    let swiftDeps = SwiftDeps(mock: swiftDepsIndex)
-    let interfaceHash = interfaceHashIfPresent ?? swiftDeps.interfaceHashForMockSwiftDeps
+    let dependenciesSource = DependenciesSource(mock: swiftDepsIndex)
+    let interfaceHash = interfaceHashIfPresent ?? dependenciesSource.interfaceHashForMockDependenciesSource
 
     let sfdg = SourceFileDependencyGraphMocker.mock(
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError,
-      swiftDeps: swiftDeps,
+      dependenciesSource: dependenciesSource,
       interfaceHash: interfaceHash,
       dependencyDescriptions)
 
     return Integrator.integrate(
       from: sfdg,
-      swiftDeps: swiftDeps,
+      dependenciesSource: dependenciesSource,
       into: self)
   }
 
@@ -952,24 +952,24 @@ extension ModuleDependencyGraph {
   /// Can return duplicates
   func findUntracedSwiftDepsDependent(
     on externalDependency: ExternalDependency
-  ) -> [SwiftDeps] {
-    var foundSwiftDeps = [SwiftDeps]()
+  ) -> [DependenciesSource] {
+    var foundSources = [DependenciesSource]()
     for dependent in self.untracedDependents(of: externalDependency) {
-      let swiftDeps = dependent.swiftDeps!
-      foundSwiftDeps.append(swiftDeps)
+      let dependenciesSource = dependent.dependenciesSource!
+      foundSources.append(dependenciesSource)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive
       // Don't return job twice.
       let filesToRebuild =
-        findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(swiftDeps)
-        .filter({ marked in marked != swiftDeps })
-      foundSwiftDeps.append(contentsOf: filesToRebuild)
+        findSwiftDepsToRecompileWhenDependenciesSourceChanges(dependenciesSource)
+        .filter({ marked in marked != dependenciesSource })
+      foundSources.append(contentsOf: filesToRebuild)
     }
-    return foundSwiftDeps;
+    return foundSources
   }
 
 
-  func findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(_ i: Int) -> [Int] {
-    findSwiftDepsToRecompileWhenWholeSwiftDepsChanges(SwiftDeps(mock: i))
+  func findSwiftDepsToRecompileWhenDependenciesSourceChanges(_ i: Int) -> [Int] {
+    findSwiftDepsToRecompileWhenDependenciesSourceChanges(DependenciesSource(mock: i))
       .map { $0.mockID }
   }
 }
@@ -1005,7 +1005,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
 
   private let includePrivateDeps: Bool
   private let hadCompilationError: Bool
-  private let swiftDeps: ModuleDependencyGraph.SwiftDeps
+  private let dependenciesSource: ModuleDependencyGraph.DependenciesSource
   private let interfaceHash: String
   private let dependencyDescriptions: [(MockDependencyKind, String)]
 
@@ -1016,7 +1016,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
   static func mock(
     includePrivateDeps: Bool,
     hadCompilationError: Bool,
-    swiftDeps: ModuleDependencyGraph.SwiftDeps,
+    dependenciesSource: ModuleDependencyGraph.DependenciesSource,
     interfaceHash: String,
     _ dependencyDescriptions: [MockDependencyKind: [String]]
   ) -> SourceFileDependencyGraph
@@ -1024,7 +1024,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
     var m = Self.init(
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError,
-      swiftDeps: swiftDeps,
+      dependenciesSource: dependenciesSource,
       interfaceHash: interfaceHash,
       dependencyDescriptions:
         dependencyDescriptions.flatMap { (kind, descs) in descs.map {(kind, $0)}}
@@ -1047,7 +1047,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
 
   private mutating func addSourceFileNodesToGraph() {
     sourceFileNodePair = findExistingNodePairOrCreateAndAddIfNew(
-      DependencyKey.createKeyForWholeSourceFile(.interface, swiftDeps),
+      DependencyKey.createKeyForWholeSourceFile(.interface, dependenciesSource),
       interfaceHash);
   }
 
@@ -1160,7 +1160,7 @@ fileprivate struct SourceFileDependencyGraphMocker {
     guard let defAndUseKeys = DependencyKey.parseAUsedDecl(s,
                                                            kind,
                                                            includePrivateDeps: includePrivateDeps,
-                                                           swiftDeps: swiftDeps)
+                                                           dependenciesSource: dependenciesSource)
     else { return }
     let defNode = findExistingNodeOrCreateIfNew(defAndUseKeys.def, nil, isProvides: false)
 
@@ -1216,7 +1216,7 @@ fileprivate extension DependencyKey {
   static func parseAUsedDecl(_ s: String,
                              _ kind: MockDependencyKind,
                              includePrivateDeps: Bool,
-                             swiftDeps: ModuleDependencyGraph.SwiftDeps
+                             dependenciesSource: ModuleDependencyGraph.DependenciesSource
   ) -> (def: Self, use: Self)? {
     let noncascadingPrefix = "#"
     let privateHolderPrefix = "~"
@@ -1238,12 +1238,12 @@ fileprivate extension DependencyKey {
             use: computeUseKey(defUseStrings.use,
                                isCascadingUse: isCascadingUse,
                                includePrivateDeps: includePrivateDeps,
-                               swiftDeps: swiftDeps))
+                               dependenciesSource: dependenciesSource))
   }
 
   static func computeUseKey(_ s: String, isCascadingUse: Bool,
                             includePrivateDeps: Bool,
-                            swiftDeps: ModuleDependencyGraph.SwiftDeps
+                            dependenciesSource: ModuleDependencyGraph.DependenciesSource
   ) -> Self {
     // For now, in unit tests, mock uses are always nominal
     let aspectOfUse: DeclAspect = isCascadingUse ? .interface : .implementation
@@ -1253,7 +1253,7 @@ fileprivate extension DependencyKey {
     }
     return Self(aspect: aspectOfUse,
                 designator: Designator(kind: .sourceFileProvide,
-                                       (context: "", name: swiftDeps.sourceFileProvideNameForMockSwiftDeps)))
+                                       (context: "", name: dependenciesSource.sourceFileProvideNameForMockDependenciesSource)))
   }
 }
 
@@ -1303,11 +1303,11 @@ fileprivate extension SourceFileDependencyGraph.Node {
 fileprivate extension DependencyKey {
   static func createKeyForWholeSourceFile(
     _ aspect: DeclAspect,
-    _ swiftDeps: ModuleDependencyGraph.SwiftDeps
+    _ dependenciesSource: ModuleDependencyGraph.DependenciesSource
   ) -> Self {
     return Self(aspect: aspect,
                 designator: Designator(kind: .sourceFileProvide,
-                                       swiftDeps.sourceFileProvideNameForMockSwiftDeps
+                                       dependenciesSource.sourceFileProvideNameForMockDependenciesSource
                                         .parseContextAndName(.sourceFileProvide)))
   }
 }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -929,7 +929,8 @@ extension ModuleDependencyGraph {
   -> Integrator.Changes
   {
     let dependenciesSource = DependenciesSource(mock: swiftDepsIndex)
-    let interfaceHash = interfaceHashIfPresent ?? dependenciesSource.interfaceHashForMockDependenciesSource
+    let interfaceHash =
+      interfaceHashIfPresent ?? dependenciesSource.interfaceHashForMockDependenciesSource
 
     let sfdg = SourceFileDependencyGraphMocker.mock(
       includePrivateDeps: includePrivateDeps,
@@ -1157,10 +1158,11 @@ fileprivate struct SourceFileDependencyGraphMocker {
   }
 
   private mutating func addAUsedDecl(_ kind: MockDependencyKind, _ s: String) {
-    guard let defAndUseKeys = DependencyKey.parseAUsedDecl(s,
-                                                           kind,
-                                                           includePrivateDeps: includePrivateDeps,
-                                                           dependenciesSource: dependenciesSource)
+    guard let defAndUseKeys = DependencyKey.parseAUsedDecl(
+            s,
+            kind,
+            includePrivateDeps: includePrivateDeps,
+            dependenciesSource: dependenciesSource)
     else { return }
     let defNode = findExistingNodeOrCreateIfNew(defAndUseKeys.def, nil, isProvides: false)
 
@@ -1213,10 +1215,11 @@ fileprivate extension DependencyKey {
                 designator: Designator(kind: kind, String(sss).parseContextAndName(kind)))
   }
 
-  static func parseAUsedDecl(_ s: String,
-                             _ kind: MockDependencyKind,
-                             includePrivateDeps: Bool,
-                             dependenciesSource: ModuleDependencyGraph.DependenciesSource
+  static func parseAUsedDecl(
+    _ s: String,
+    _ kind: MockDependencyKind,
+    includePrivateDeps: Bool,
+    dependenciesSource: ModuleDependencyGraph.DependenciesSource
   ) -> (def: Self, use: Self)? {
     let noncascadingPrefix = "#"
     let privateHolderPrefix = "~"
@@ -1241,9 +1244,10 @@ fileprivate extension DependencyKey {
                                dependenciesSource: dependenciesSource))
   }
 
-  static func computeUseKey(_ s: String, isCascadingUse: Bool,
-                            includePrivateDeps: Bool,
-                            dependenciesSource: ModuleDependencyGraph.DependenciesSource
+  static func computeUseKey(
+    _ s: String, isCascadingUse: Bool,
+    includePrivateDeps: Bool,
+    dependenciesSource: ModuleDependencyGraph.DependenciesSource
   ) -> Self {
     // For now, in unit tests, mock uses are always nominal
     let aspectOfUse: DeclAspect = isCascadingUse ? .interface : .implementation
@@ -1251,9 +1255,11 @@ fileprivate extension DependencyKey {
       let kindOfUse = MockDependencyKind.nominal
       return parseADefinedDecl(s, kindOfUse, aspectOfUse, includePrivateDeps: includePrivateDeps)!
     }
-    return Self(aspect: aspectOfUse,
-                designator: Designator(kind: .sourceFileProvide,
-                                       (context: "", name: dependenciesSource.sourceFileProvideNameForMockDependenciesSource)))
+    return Self(
+      aspect: aspectOfUse,
+      designator: Designator(kind: .sourceFileProvide,
+                             (context: "",
+                              name: dependenciesSource.sourceFileProvideNameForMockDependenciesSource)))
   }
 }
 


### PR DESCRIPTION
In order to implement cross-module incrementality, the SwiftDeps type needs to also represent a swiftSourceFile file, so the name is how wrong.