### PR TITLE
[DNM Incremental] Start of cross-module incrementality

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -176,14 +176,14 @@ final class BuildRecordInfo {
     do {
       contents = try fileSystem.readFileContents(buildRecordPath).cString
      } catch {
-      reporter?.report("Incremental compilation could not read build record at \(buildRecordPath)")
+      reporter?.report("Incremental compilation could not read build record at ", buildRecordPath)
       reporter?.reportDisablingIncrementalBuild("could not read build record")
       return nil
     }
     func failedToReadOutOfDateMap(_ reason: String? = nil) {
       let why = "malformed build record file\(reason.map {" " + $0} ?? "")"
       reporter?.report(
-        "Incremental compilation has been disabled due to \(why) '\(buildRecordPath)'")
+        "Incremental compilation has been disabled due to \(why)", buildRecordPath)
       reporter?.reportDisablingIncrementalBuild(why)
     }
     guard let outOfDateBuildRecord = BuildRecord(contents: contents,

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -152,10 +152,12 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
     /// available from this node.
     case incrementalExternalDependency(ExternalDependency)
 
-    var externalDependency: ExternalDependency? {
+    var externalDependency: (ExternalDependency, isIncremental: Bool)? {
       switch self {
       case let .externalDepend(externalDependency):
-        return externalDependency
+        return (externalDependency, isIncremental: false)
+      case let .incrementalExternalDependency(externalDependency):
+        return (externalDependency, isIncremental: true)
       default:
         return nil}
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -410,17 +410,16 @@ extension IncrementalCompilationState {
  ) -> [TypedVirtualPath] {
     var externalDependencySources = Set<ModuleDependencyGraph.DependencySource>()
     for extDep in moduleDependencyGraph.externalDependencies {
-      let extModTime = extDep.file.flatMap {
-        try? fileSystem.getFileInfo($0).modTime}
+      let extModTime = extDep.file.flatMap {try? fileSystem.getFileInfo($0).modTime}
         ?? Date.distantFuture
       if extModTime >= buildTime {
         for dependent in moduleDependencyGraph.untracedDependents(of: extDep) {
           guard let dependencySource = dependent.dependencySource else {
-            fatalError("Dependent \(dependent) does not have dependencies source file!")
+            fatalError("Dependent \(dependent) does not have dependencies file!")
           }
           reporter?.report(
             "Queuing because of external dependency on newer \(extDep.file?.basename ?? "extDep?")",
-            path: TypedVirtualPath(file: dependencySource.file, type: .swiftDeps))
+            path: dependencySource.typedFile)
           externalDependencySources.insert(dependencySource)
         }
       }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -443,7 +443,7 @@ extension IncrementalCompilationState {
             fatalError("Dependent \(dependent) does not have dependencies file!")
           }
           reporter?.report(
-            "Queuing because of external dependency on newer \(extDep.file?.basename ?? "extDep?")",
+            "Queuing because of \(forIncrementalExternalDependencies ? "incremental " : "")external dependency on newer \(extDep.file?.basename ?? "extDep?")",
             path: dependencySource.typedFile)
           externalDependencySources.insert(dependencySource)
         }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -13,6 +13,9 @@ import TSCBasic
 import Foundation
 import SwiftOptions
 public class IncrementalCompilationState {
+  /// Whether cross-module incrementality is enabled
+  private let isCrossModuleIncrementalBuildEnabled: Bool
+
   /// The oracle for deciding what depends on what. Applies to this whole module.
   private let moduleDependencyGraph: ModuleDependencyGraph
 
@@ -56,6 +59,11 @@ public class IncrementalCompilationState {
       self.reporter = nil
     }
 
+    self.isCrossModuleIncrementalBuildEnabled =
+      driver.parsedOptions.contains(.enableExperimentalCrossModuleIncrementalBuild)
+    reporter?.report(
+      "\(self.isCrossModuleIncrementalBuildEnabled ? "Enabling" : "Disabling") incremental cross-module building")
+
 
     guard let (outputFileMap, buildRecordInfo, outOfDateBuildRecord)
             = try driver.getBuildInfo(self.reporter)
@@ -66,13 +74,12 @@ public class IncrementalCompilationState {
     guard let (
       moduleDependencyGraph,
       inputsHavingMalformedDependencySources: inputsHavingMalformedDependencySources
-    ) =
-            Self.computeModuleDependencyGraph(
-              buildRecordInfo,
-              outOfDateBuildRecord,
-              outputFileMap,
-              &driver,
-              self.reporter)
+    ) = Self.computeModuleDependencyGraph(
+      buildRecordInfo,
+      outOfDateBuildRecord,
+      outputFileMap,
+      &driver,
+      self.reporter)
     else {
       return nil
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -176,7 +176,6 @@ extension ModuleDependencyGraph {
   ) -> Integrator.Results? {
     guard let file = incrementalExternalDependency.file
      else {
-      #warning("right?")
       diagnosticEngine.emit(warning: "Cannot get file for externalDependency \(incrementalExternalDependency.fileName)")
       return nil
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -180,7 +180,7 @@ extension ModuleDependencyGraph {
       return nil
     }
     let dependencySource = DependencySource(TypedVirtualPath(file: file, type: .swiftModule))
-    reporter?.report("integrating incrementalExperimentalDependency", path: dependencySource.typedFile)
+    reporter?.report("integrating incrementalExperimentalDependency", dependencySource.typedFile)
     let results = Integrator.integrate(
       dependencySource: dependencySource,
       into: graph,
@@ -213,7 +213,7 @@ extension ModuleDependencyGraph {
     return allDependencySourcesToRecompile.map {
       let dependentSource = inputDependencySourceMap[$0]
       self.reporter?.report(
-        "Found dependent of \(sourceFile.file.basename):", path: dependentSource)
+        "Found dependent of \(sourceFile.file.basename):", dependentSource)
       return dependentSource
     }
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -95,7 +95,9 @@ extension ModuleDependencyGraph {
       else {
         return nil
       }
-      let dependencySource = DependencySource(swiftDepsFile)
+      assert(swiftDepsFile.extension == FileType.swiftDeps.rawValue)
+      let typedSwiftDepsFile = TypedVirtualPath(file: swiftDepsFile, type: .swiftDeps)
+      let dependencySource = DependencySource(typedSwiftDepsFile)
       graph.inputDependencySourceMap[input] = dependencySource
       guard previousInputs.contains(input.file)
       else {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -219,6 +219,8 @@ extension ModuleDependencyGraph.Integrator {
         .contains(externalDependency)
       guard !isKnown else {return}
       if !isIncremental {
+        destination.reporter?.report("found externalDependency",
+                                     externalDependency.file)
         // no integration to do for these, so just remember them here
         destination.externalDependencies.insert(externalDependency)
       }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -24,9 +24,14 @@ extension ModuleDependencyGraph {
 
     /*@_spi(Testing)*/ public typealias Changes = Set<Node>
 
+    /// the graph to be integrated
     let source: SourceFileDependencyGraph
+
+    /// the source (file) of the graph to be integrated
     let dependencySource: DependencySource
-    let destination: ModuleDependencyGraph
+
+    /// the graph to be integrated into
+     let destination: ModuleDependencyGraph
 
     /// When done, changedNodes contains a set of nodes that changed as a result of this integration.
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -22,7 +22,12 @@ extension ModuleDependencyGraph {
     // Shorthands
     /*@_spi(Testing)*/ public typealias Graph = ModuleDependencyGraph
 
-    /*@_spi(Testing)*/ public typealias Changes = Set<Node>
+    /*@_spi(Testing)*/
+    public struct Results {
+      var changedNodes = Set<Node>()
+      var discoveredIncrementalExternalDependencies = Set<ExternalDependency>()
+    }
+    public private(set) var results = Results()
 
     /// the graph to be integrated
     let source: SourceFileDependencyGraph
@@ -31,11 +36,9 @@ extension ModuleDependencyGraph {
     let dependencySource: DependencySource
 
     /// the graph to be integrated into
-     let destination: ModuleDependencyGraph
+    let destination: ModuleDependencyGraph
 
-    /// When done, changedNodes contains a set of nodes that changed as a result of this integration.
-
-    var changedNodes = Changes()
+    let isCrossModuleIncrementalBuildEnabled: Bool
 
     /// Starts with all nodes in dependencySource. Nodes that persist will be removed.
     /// After integration is complete, contains the nodes that have disappeared.
@@ -43,11 +46,13 @@ extension ModuleDependencyGraph {
 
     init(source: SourceFileDependencyGraph,
          dependencySource: DependencySource,
-         destination: ModuleDependencyGraph)
+         destination: ModuleDependencyGraph,
+         isCrossModuleIncrementalBuildEnabled: Bool)
     {
       self.source = source
       self.dependencySource = dependencySource
       self.destination = destination
+      self.isCrossModuleIncrementalBuildEnabled = isCrossModuleIncrementalBuildEnabled
       self.disappearedNodes = destination.nodeFinder.findNodes(for: dependencySource)
         ?? [:]
     }
@@ -60,11 +65,12 @@ extension ModuleDependencyGraph.Integrator {
   static func integrate(
     dependencySource: Graph.DependencySource,
     into destination: Graph,
-    input: TypedVirtualPath,
+    input: TypedVirtualPath?, // just for reporting
     reporter: IncrementalCompilationState.Reporter?,
     diagnosticEngine: DiagnosticsEngine,
-    fileSystem: FileSystem
-  ) -> Changes? {
+    fileSystem: FileSystem,
+    isCrossModuleIncrementalBuildEnabled: Bool
+  ) -> Results? {
     guard let sfdg = try? SourceFileDependencyGraph.read(
             from: dependencySource, on: fileSystem)
     else {
@@ -73,7 +79,8 @@ extension ModuleDependencyGraph.Integrator {
     }
     return integrate(from: sfdg,
                      dependencySource: dependencySource,
-                     into: destination)
+                     into: destination,
+                     isCrossModuleIncrementalBuildEnabled: isCrossModuleIncrementalBuildEnabled)
   }
 }
 // MARK: - integrate a graph
@@ -85,11 +92,13 @@ extension ModuleDependencyGraph.Integrator {
   /*@_spi(Testing)*/ public static func integrate(
     from g: SourceFileDependencyGraph,
     dependencySource: Graph.DependencySource,
-    into destination: Graph
-  ) ->  Changes {
+    into destination: Graph,
+    isCrossModuleIncrementalBuildEnabled: Bool
+  ) ->  Results {
     var integrator = Self(source: g,
                           dependencySource: dependencySource,
-                          destination: destination)
+                          destination: destination,
+                          isCrossModuleIncrementalBuildEnabled: isCrossModuleIncrementalBuildEnabled)
     integrator.integrate()
 
     if destination.verifyDependencyGraphAfterEveryImport {
@@ -98,20 +107,20 @@ extension ModuleDependencyGraph.Integrator {
     if destination.emitDependencyDotFileAfterEveryImport {
       destination.emitDotFile(g, dependencySource)
     }
-    return integrator.changedNodes
+    return integrator.results
   }
 
   private mutating func integrate() {
     integrateEachSourceNode()
     handleDisappearedNodes()
-    destination.ensureGraphWillRetraceDependents(of: changedNodes)
+    destination.ensureGraphWillRetraceDependents(of: results.changedNodes)
   }
   private mutating func integrateEachSourceNode() {
     source.forEachNode { integrate(oneNode: $0) }
   }
   private mutating func handleDisappearedNodes() {
     for (_, node) in disappearedNodes {
-      changedNodes.insert(node)
+      results.changedNodes.insert(node)
       destination.nodeFinder.remove(node)
     }
   }
@@ -149,7 +158,7 @@ extension ModuleDependencyGraph.Integrator {
     // Node was and still is. Do not remove it.
     disappearedNodes.removeValue(forKey: matchHere.dependencyKey)
     if matchHere.fingerprint != integrand.fingerprint {
-      changedNodes.insert(matchHere)
+      results.changedNodes.insert(matchHere)
     }
     return matchHere
   }
@@ -169,7 +178,7 @@ extension ModuleDependencyGraph.Integrator {
       .replace(expat,
                newDependencySource: dependencySource,
                newFingerprint: integrand.fingerprint)
-    changedNodes.insert(integratedNode)
+    results.changedNodes.insert(integratedNode)
     return integratedNode
   }
 
@@ -184,7 +193,7 @@ extension ModuleDependencyGraph.Integrator {
       dependencySource: dependencySource)
     let oldNode = destination.nodeFinder.insert(newNode)
     assert(oldNode == nil, "Should be new!")
-    changedNodes.insert(newNode)
+    results.changedNodes.insert(newNode)
     return newNode
   }
 
@@ -198,11 +207,42 @@ extension ModuleDependencyGraph.Integrator {
     source.forEachDefDependedUpon(by: sourceFileUseNode) { def in
       let isNewUse = destination.nodeFinder.record(def: def.key,
                                                    use: moduleUseNode)
-      if let externalDependency = def.key.designator.externalDependency,
-         isNewUse {
-        destination.externalDependencies.insert(externalDependency)
-        changedNodes.insert(moduleUseNode)
+      guard isNewUse else { return }
+      guard let (externalDependency, isIncremental: isIncremental) =
+              def.key.designator.externalDependency
+      else {
+        return
       }
+      let isKnown = (isIncremental
+                      ? destination.incrementalExternalDependencies
+                      : destination.externalDependencies)
+        .contains(externalDependency)
+      guard !isKnown else {return}
+      if !isIncremental {
+        // no integration to do for these, so just remember them here
+        destination.externalDependencies.insert(externalDependency)
+      }
+      else if !isCrossModuleIncrementalBuildEnabled {
+        destination.reporter?.report(
+          "found incremntalExternalDependency but treating as non-incremental",
+          path: externalDependency.file.map{ TypedVirtualPath(file: $0, type: .swiftModule)})
+        // treat like nonincremental
+        let key = DependencyKey(
+          aspect: .interface,
+          designator: .externalDepend(externalDependency))
+        let isNewUse = destination.nodeFinder.record(def: key, use: moduleUseNode)
+        if !isNewUse {
+          destination.externalDependencies.insert(externalDependency)
+          results.changedNodes.insert(moduleUseNode)
+        }
+      }
+      else {
+        destination.reporter?.report(
+          "found incremntalExternalDependency",
+          path: externalDependency.file.map{ TypedVirtualPath(file: $0, type: .swiftModule)})
+        results.discoveredIncrementalExternalDependencies.insert(externalDependency)
+      }
+      results.changedNodes.insert(moduleUseNode)
     }
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -74,7 +74,7 @@ extension ModuleDependencyGraph.Integrator {
     guard let sfdg = try? SourceFileDependencyGraph.read(
             from: dependencySource, on: fileSystem)
     else {
-      reporter?.report("Could not read \(dependencySource)", path: input)
+      reporter?.report("Could not read \(dependencySource)", input)
       return nil
     }
     return integrate(from: sfdg,
@@ -224,8 +224,8 @@ extension ModuleDependencyGraph.Integrator {
       }
       else if !isCrossModuleIncrementalBuildEnabled {
         destination.reporter?.report(
-          "found incremntalExternalDependency but treating as non-incremental",
-          path: externalDependency.file.map{ TypedVirtualPath(file: $0, type: .swiftModule)})
+          "found incrementalExternalDependency but treating as non-incremental",
+          externalDependency.file)
         // treat like nonincremental
         let key = DependencyKey(
           aspect: .interface,
@@ -237,9 +237,8 @@ extension ModuleDependencyGraph.Integrator {
         }
       }
       else {
-        destination.reporter?.report(
-          "found incremntalExternalDependency",
-          path: externalDependency.file.map{ TypedVirtualPath(file: $0, type: .swiftModule)})
+        destination.reporter?.report( "found incrementalExternalDependency",
+                                      externalDependency.file)
         results.discoveredIncrementalExternalDependencies.insert(externalDependency)
       }
       results.changedNodes.insert(moduleUseNode)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -130,8 +130,7 @@ extension ModuleDependencyGraph.Tracer {
               .map { "\(node.dependencyKey) in \($0.file.basename)"}
           }
           .joined(separator: " -> ")
-      ].joined(separator: " "),
-      path: nil
+      ].joined(separator: " ")
     )
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -117,10 +117,10 @@ extension SourceFileDependencyGraph {
   }
 
   static func read(
-    from swiftDeps: ModuleDependencyGraph.DependencySource,
+    from dependencySource: ModuleDependencyGraph.DependencySource,
     on fileSystem: FileSystem
   ) throws -> Self {
-    try self.init(contentsOf: swiftDeps.file, on: fileSystem)
+    try self.init(contentsOf: dependencySource.typedFile, on: fileSystem)
   }
   
   /*@_spi(Testing)*/ public init(nodesForTesting: [Node]) {
@@ -131,11 +131,11 @@ extension SourceFileDependencyGraph {
   }
 
   /*@_spi(Testing)*/ public init(
-    contentsOf path: VirtualPath,
+    contentsOf path: TypedVirtualPath,
     on filesystem: FileSystem
   ) throws {
-    let data = try filesystem.readFileContents(path)
-    try self.init(data: data)
+    let data = try filesystem.readFileContents(path.file)
+    try self.init(data: data, fromSwiftModule: path.type == .swiftModule)
   }
 
   /*@_spi(Testing)*/ public init(

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -24,7 +24,8 @@ class DependencyGraphSerializationTests: XCTestCase {
     let deserializedGraph = try ModuleDependencyGraph.read(from: mockPath,
                                                            on: fs,
                                                            diagnosticEngine: de,
-                                                           reporter: nil)
+                                                           reporter: nil,
+                                                           isCrossModuleIncrementalBuildEnabled: false)
     var originalNodes = Set<ModuleDependencyGraph.Node>()
     graph.nodeFinder.forEachNode {
       originalNodes.insert($0)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -454,6 +454,8 @@ final class IncrementalCompilationTests: XCTestCase {
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
         "Disabling incremental cross-module building",
+        "Incremental compilation: found externalDependency",
+        "Incremental compilation: found externalDependency",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
@@ -470,6 +472,8 @@ final class IncrementalCompilationTests: XCTestCase {
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
         "Disabling incremental cross-module building",
+        "Incremental compilation: found externalDependency",
+        "Incremental compilation: found externalDependency",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: other.o <= other.swift}",
@@ -495,6 +499,8 @@ final class IncrementalCompilationTests: XCTestCase {
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
         "Disabling incremental cross-module building",
+        "Incremental compilation: found externalDependency",
+        "Incremental compilation: found externalDependency",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -521,6 +527,8 @@ final class IncrementalCompilationTests: XCTestCase {
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
         "Disabling incremental cross-module building",
+        "Incremental compilation: found externalDependency",
+        "Incremental compilation: found externalDependency",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -556,6 +564,8 @@ final class IncrementalCompilationTests: XCTestCase {
       extraArguments: [extraArgument],
       expectingRemarks: [
         "Disabling incremental cross-module building",
+        "Incremental compilation: found externalDependency",
+        "Incremental compilation: found externalDependency",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
         "Incremental compilation: scheduling dependents of main.swift; -driver-always-rebuild-dependents",

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -431,6 +431,7 @@ final class IncrementalCompilationTests: XCTestCase {
         // Leave off the part after the colon because it varies on Linux:
         // MacOS: The operation could not be completed. (TSCBasic.FileSystemError error 3.).
         // Linux: The operation couldn’t be completed. (TSCBasic.FileSystemError error 3.)
+        "Disabling incremental cross-module building",
         "Incremental compilation: Incremental compilation could not read build record at",
         "Incremental compilation: Disabling incremental build: could not read build record",
         "Found 2 batchable jobs",
@@ -450,6 +451,7 @@ final class IncrementalCompilationTests: XCTestCase {
       "no-change",
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
+        "Disabling incremental cross-module building",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
@@ -465,6 +467,7 @@ final class IncrementalCompilationTests: XCTestCase {
       "non-propagating",
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
+        "Disabling incremental cross-module building",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: other.o <= other.swift}",
@@ -489,6 +492,7 @@ final class IncrementalCompilationTests: XCTestCase {
       "non-propagating, both touched",
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
+        "Disabling incremental cross-module building",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -514,6 +518,7 @@ final class IncrementalCompilationTests: XCTestCase {
       "propagating into 2nd wave",
       checkDiagnostics: checkDiagnostics,
       expectingRemarks: [
+        "Disabling incremental cross-module building",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -548,6 +553,7 @@ final class IncrementalCompilationTests: XCTestCase {
       checkDiagnostics: checkDiagnostics,
       extraArguments: [extraArgument],
       expectingRemarks: [
+        "Disabling incremental cross-module building",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
         "Incremental compilation: scheduling dependents of main.swift; -driver-always-rebuild-dependents",

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -68,7 +68,8 @@ final class NonincrementalCompilationTests: XCTestCase {
     let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
                                                          for: "main.swiftdeps"))
     let graph = try SourceFileDependencyGraph(
-      contentsOf: VirtualPath.absolute(absolutePath),
+      contentsOf: TypedVirtualPath(file: VirtualPath.absolute(absolutePath),
+                                   type: .swiftDeps),
       on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)
@@ -113,7 +114,8 @@ final class NonincrementalCompilationTests: XCTestCase {
     let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
                                                          for: "hello.swiftdeps"))
     let graph = try SourceFileDependencyGraph(
-      contentsOf: VirtualPath.absolute(absolutePath),
+      contentsOf: TypedVirtualPath(file: VirtualPath.absolute(absolutePath),
+                                   type: .swiftDeps),
       on: localFileSystem)
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -752,7 +752,7 @@ class ModuleDependencyGraphTests: XCTestCase {
 
   func testLoadPassesWithFingerprint() {
     let graph = ModuleDependencyGraph(mock: de)
-    _ = graph.getChangesForSimulatedLoad(0, [.nominal: ["A@1"]])
+    _ = graph.getChangesForSimulatedLoad(0, [MockDependencyKind.nominal: ["A@1"]])
   }
 
   func testUseFingerprints() {
@@ -883,6 +883,7 @@ extension ModuleDependencyGraph {
     self.init(
       diagnosticEngine: diagnosticEngine,
       reporter: nil,
+      isCrossModuleIncrementalBuildEnabled: false,
       emitDependencyDotFileAfterEveryImport: false,
       verifyDependencyGraphAfterEveryImport: true)
   }
@@ -908,15 +909,15 @@ extension ModuleDependencyGraph {
                       hadCompilationError: Bool = false)
   -> [Int]
   {
-    let changedNodes = getChangesForSimulatedLoad(
+    let results = getChangesForSimulatedLoad(
       swiftDepsIndex,
       dependencyDescriptions,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError)
 
-      return findSwiftDepsToRecompileWhenNodesChange(changedNodes)
-        .map { $0.mockID }
+    return findSwiftDepsToRecompileWhenNodesChange(results.changedNodes)
+      .map { $0.mockID }
   }
 
 
@@ -926,7 +927,7 @@ extension ModuleDependencyGraph {
     _ interfaceHashIfPresent: String? = nil,
     includePrivateDeps: Bool = true,
     hadCompilationError: Bool = false)
-  -> Integrator.Changes
+  -> Integrator.Results
   {
     let dependencySource = DependencySource(mock: swiftDepsIndex)
     let interfaceHash =
@@ -942,7 +943,8 @@ extension ModuleDependencyGraph {
     return Integrator.integrate(
       from: sfdg,
       dependencySource: dependencySource,
-      into: self)
+      into: self,
+      isCrossModuleIncrementalBuildEnabled: false)
   }
 
   func findUntracedSwiftDepsDependent(onExternal s: String) -> [Int] {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -946,16 +946,17 @@ extension ModuleDependencyGraph {
   }
 
   func findUntracedSwiftDepsDependent(onExternal s: String) -> [Int] {
-    findUntracedSwiftDepsDependent(on: s.asExternal)
+    findUntracedSwiftDepsDependent(on: s.asExternal, isIncremental: false)
       .map { $0.mockID }
   }
 
   /// Can return duplicates
   func findUntracedSwiftDepsDependent(
-    on externalDependency: ExternalDependency
+    on externalDependency: ExternalDependency,
+    isIncremental: Bool
   ) -> [DependencySource] {
     var foundSources = [DependencySource]()
-    for dependent in self.untracedDependents(of: externalDependency) {
+    for dependent in self.untracedDependents(of: externalDependency, isIncremental: isIncremental) {
       let dependencySource = dependent.dependencySource!
       foundSources.append(dependencySource)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive


### PR DESCRIPTION
Integrates incrementalExternalDependencies.

Unimplemented/Broken:
Does not write ModuleDepGraph or try to read it instead of swiftDeps. Probably doesn't do the right thing if it did read ModuleDepGraph.
- For instance: how to handle deleted imports

Does not do the right thing when importing a module with incrementalExternalDependencies when running with -enable-incremental-cross-module-etc turned off.

Implemented:
Reads incrementalExternalDependencies and integrates the contents of the swiftmodule files, running to a fixpoint.
Causes anything depended upon them to be marked as dirty, since right now there is no prior ModuleDepGraph.