### PR TITLE
Serialize Fingerprint Blobs For External Dependencies

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -4,13 +4,17 @@ import Foundation
 /// A filename from another module
 /*@_spi(Testing)*/ public struct ExternalDependency: Hashable, Comparable, CustomStringConvertible {
   let fileName: String
+  let fingerprint: String?
+
+  /*@_spi(Testing)*/ public init(_ fileName: String, fingerprint: String? = nil) {
+    self.fileName = fileName
+    self.fingerprint = fingerprint
+  }
 
   var file: VirtualPath? {
     try? VirtualPath(path: fileName)
   }
-  /*@_spi(Testing)*/ public init(_ path: String) {
-    self.fileName = path
-  }
+
   public var description: String {
     fileName.description
   }

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -49,7 +49,7 @@ class DependencyGraphSerializationTests: XCTestCase {
       var commands: [LoadCommand]
 
       enum LoadCommand {
-        case load(index: Int, nodes: [MockDependencyKind: [String]])
+        case load(index: Int, nodes: [MockDependencyKind: [String]], fingerprint: String? = nil)
         case reload(index: Int, nodes: [MockDependencyKind: [String]], fingerprint: String? = nil)
       }
     }
@@ -212,6 +212,10 @@ class DependencyGraphSerializationTests: XCTestCase {
         .load(index: 6, nodes: [.nominal: ["C2->"]]),
         .reload(index: 0, nodes: [.nominal: ["A1@11", "A2@2"]])
       ]),
+      GraphFixture(commands: [
+        .load(index: 0, nodes: [.externalDepend: ["/foo->", "/bar->"]], fingerprint: "ABCDEFG"),
+        .reload(index: 0, nodes: [.externalDepend: ["/foo->", "/bar->"]], fingerprint: "HIJKLMNOP"),
+      ]),
     ]
 
     for fixture in fixtures {
@@ -219,8 +223,8 @@ class DependencyGraphSerializationTests: XCTestCase {
       let graph = ModuleDependencyGraph(mock: de)
       for loadCommand in fixture.commands {
         switch loadCommand {
-        case .load(index: let index, nodes: let nodes):
-          graph.simulateLoad(index, nodes, nil)
+        case .load(index: let index, nodes: let nodes, fingerprint: let fingerprint):
+          graph.simulateLoad(index, nodes, fingerprint)
         case .reload(index: let index, nodes: let nodes, fingerprint: let fingerprint):
           _ = graph.simulateReload(index, nodes, fingerprint)
         }


### PR DESCRIPTION
Now that external dependencies and incremental external dependencies are
one and the same, we need to serialize the fingerprints that may or may
not be attached to them.