### PR TITLE
[Incremental] fix-path-in-guard-not-usable

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -655,12 +655,12 @@ extension IncrementalCompilationState {
     ///   - message: The message to emit in the remark.
     ///   - path: If non-nil, the path of some file. If the output for an incremental job, will print out the
     ///           source and object files.
-    func report(_ message: String, _ path: TypedVirtualPath?) {
-       guard let path = path,
+    func report(_ message: String, _ pathIfPresent: TypedVirtualPath?) {
+       guard let path = pathIfPresent,
             let outputFileMap = outputFileMap,
             let input = path.type == .swift ? path.file : outputFileMap.getInput(outputFile: path.file)
       else {
-        report(message, path?.file)
+        report(message, pathIfPresent?.file)
         return
       }
       let output = outputFileMap.getOutput(inputFile: path.file, outputType: .object)


### PR DESCRIPTION
At some point, the compiler decided to make an unexpected choice: ```
<path is defined>
guard if let path = path, ...
else {
  <use path>
}
<use path>
```
the `path` in the else used to be bound to the definition before the guard, but now this code won't compile.
So rename things.

rdar://problem/73984428