### PR TITLE
Revert "Ensure REPL arguments are processed by the ArgsResolver"

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -67,15 +67,10 @@ public final class ArgsResolver {
       return try lock.withLock {
         return try unsafeResolve(path: path)
       }
-
     case .responseFilePath(let path):
       return "@\(try resolve(.path(path)))"
-
     case let .joinedOptionAndPath(option, path):
       return option + (try resolve(.path(path)))
-
-    case let .squashedArgumentList(option: option, args: args):
-      return try option + args.map{ try resolve($0) }.joined(separator: " ")
     }
   }
 

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -162,8 +162,7 @@ extension Array where Element == Job.ArgTemplate {
   }
 
   /// A shell-escaped string representation of the arguments, as they would appear on the command line.
-  /// Note: does not resolve arguments.
-  public var joinedUnresolvedArguments: String {
+  public var joinedArguments: String {
     return self.map {
       switch $0 {
         case .flag(let string):
@@ -174,8 +173,6 @@ extension Array where Element == Job.ArgTemplate {
         return "@\(path.name.spm_shellEscaped())"
       case let .joinedOptionAndPath(option, path):
         return option.spm_shellEscaped() + path.name.spm_shellEscaped()
-      case let .squashedArgumentList(option, args):
-        return (option + args.joinedUnresolvedArguments).spm_shellEscaped()
       }
     }.joined(separator: " ")
   }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -49,9 +49,6 @@ public struct Job: Codable, Equatable, Hashable {
 
     /// Represents a joined option+path combo.
     case joinedOptionAndPath(String, VirtualPath)
-
-    /// Represents a list of arguments squashed together and passed as a single argument.
-    case squashedArgumentList(option: String, args: [ArgTemplate])
   }
 
   /// The Swift module this job involves.
@@ -237,14 +234,10 @@ extension Job.Kind {
 
 extension Job.ArgTemplate: Codable {
   private enum CodingKeys: String, CodingKey {
-    case flag, path, responseFilePath, joinedOptionAndPath, squashedArgumentList
+    case flag, path, responseFilePath, joinedOptionAndPath
 
     enum JoinedOptionAndPathCodingKeys: String, CodingKey {
       case option, path
-    }
-
-    enum SquashedArgumentListCodingKeys: String, CodingKey {
-      case option, args
     }
   }
 
@@ -266,12 +259,6 @@ extension Job.ArgTemplate: Codable {
         forKey: .joinedOptionAndPath)
       try keyedContainer.encode(option, forKey: .option)
       try keyedContainer.encode(path, forKey: .path)
-    case .squashedArgumentList(option: let option, args: let args):
-      var keyedContainer = container.nestedContainer(
-        keyedBy: CodingKeys.SquashedArgumentListCodingKeys.self,
-        forKey: .squashedArgumentList)
-      try keyedContainer.encode(option, forKey: .option)
-      try keyedContainer.encode(args, forKey: .args)
     }
   }
 
@@ -299,12 +286,6 @@ extension Job.ArgTemplate: Codable {
         forKey: .joinedOptionAndPath)
       self = .joinedOptionAndPath(try keyedValues.decode(String.self, forKey: .option),
                                   try keyedValues.decode(VirtualPath.self, forKey: .path))
-    case .squashedArgumentList:
-      let keyedValues = try values.nestedContainer(
-        keyedBy: CodingKeys.SquashedArgumentListCodingKeys.self,
-        forKey: .squashedArgumentList)
-      self = .squashedArgumentList(option: try keyedValues.decode(String.self, forKey: .option),
-                                   args: try keyedValues.decode([Job.ArgTemplate].self, forKey: .args))
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -22,12 +22,12 @@ extension Driver {
     try commandLine.appendAll(.l, .framework, .L, from: &parsedOptions)
 
     // Squash important frontend options into a single argument for LLDB.
-    let lldbCommandLine: [Job.ArgTemplate] = [.squashedArgumentList(option: "--repl=", args: commandLine)]
+    let lldbArg = "--repl=\(commandLine.joinedArguments)"
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .repl,
       tool: .absolute(try toolchain.getToolPath(.lldb)),
-      commandLine: lldbCommandLine,
+      commandLine: [Job.ArgTemplate.flag(lldbArg)],
       inputs: inputs,
       primaryInputs: [],
       outputs: [],

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -82,11 +82,11 @@ public final class SwiftDriverExecutor: DriverExecutor {
 
   public func description(of job: Job, forceResponseFiles: Bool) throws -> String {
     let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, forceResponseFiles: forceResponseFiles)
-    var result = args.map { $0.spm_shellEscaped() }.joined(separator: " ")
+    var result = args.joined(separator: " ")
 
     if usedResponseFile {
       // Print the response file arguments as a comment.
-      result += " # \(job.commandLine.joinedUnresolvedArguments)"
+      result += " # \(job.commandLine.joinedArguments)"
     }
 
     if !job.extraEnvironment.isEmpty {


### PR DESCRIPTION
Reverts apple/swift-driver#451

This breaks SwiftPM:
https://ci.swift.org/job/swift-package-manager-self-hosted-Linux-smoke-test/1489/