### PR TITLE
Read and Write The Driver's Dependency Graph For Cross-Module Builds

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -206,15 +206,15 @@ public struct Driver {
   ///
   /// FIXME: This is a little ridiculous. We could probably just replace the
   /// build record outright with a serialized format.
-  var driverDependencyGraphPath: AbsolutePath? {
-    guard
-      let recordInfo = self.buildRecordInfo,
-      let recordPath = recordInfo.buildRecordPath.absolutePath
-    else {
+  var driverDependencyGraphPath: VirtualPath? {
+    guard let recordInfo = self.buildRecordInfo else {
       return nil
     }
-    let filename = recordPath.basenameWithoutExt
-    return recordPath.parentDirectory.appending(component: filename + ".priors")
+    let filename = recordInfo.buildRecordPath.basenameWithoutExt
+    return recordInfo
+      .buildRecordPath
+      .parentDirectory
+      .appending(component: filename + ".priors")
   }
   
   /// Code & data for incremental compilation. Nil if not running in incremental mode.

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -201,6 +201,22 @@ public struct Driver {
   /// Only used for reading when compiling incrementally.
   let buildRecordInfo: BuildRecordInfo?
 
+  /// A build-record-relative path to the location of a serialized copy of the
+  /// driver's dependency graph.
+  ///
+  /// FIXME: This is a little ridiculous. We could probably just replace the
+  /// build record outright with a serialized format.
+  var driverDependencyGraphPath: AbsolutePath? {
+    guard
+      let recordInfo = self.buildRecordInfo,
+      let recordPath = recordInfo.buildRecordPath.absolutePath
+    else {
+      return nil
+    }
+    let filename = recordPath.basenameWithoutExt
+    return recordPath.parentDirectory.appending(component: filename + ".priors")
+  }
+  
   /// Code & data for incremental compilation. Nil if not running in incremental mode.
   /// Set during planning because needs the jobs to look at outputs.
   @_spi(Testing) public private(set) var incrementalCompilationState: IncrementalCompilationState? = nil
@@ -910,6 +926,7 @@ extension Driver {
     if !childJobs.isEmpty {
       do {
         defer {
+          self.incrementalCompilationState?.writeDependencyGraph()
           buildRecordInfo?.writeBuildRecord(
             jobs,
             incrementalCompilationState?.skippedCompilationInputs)

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -18,7 +18,7 @@ import SwiftOptions
 /// compilation record).
 ///
 /// This info is always written, but only read for incremental compilation.
-final class BuildRecordInfo {
+@_spi(Testing) public final class BuildRecordInfo {
   /// A pair of a `Job` and the `ProcessResult` corresponding to the outcome of
   /// its execution during this compilation session.
   struct JobResult {
@@ -122,16 +122,19 @@ final class BuildRecordInfo {
   }
 
   /// Write out the build record.
-  /// `Jobs` must include all of the compilation jobs.
-  /// `Inputs` will hold all the primary inputs that were not compiled because of incremental compilation
-  func writeBuildRecord(_ jobs: [Job], _ skippedInputs: Set<TypedVirtualPath>? ) {
+  ///
+  /// - Parameters:
+  ///   - jobs: All compilation jobs formed during this build.
+  ///   - skippedInputs: All primary inputs that were not compiled because the
+  ///                    incremental build plan determined they could be
+  ///                    skipped.
+  func writeBuildRecord(_ jobs: [Job], _ skippedInputs: Set<TypedVirtualPath>?) {
     guard let absPath = buildRecordPath.absolutePath else {
       diagnosticEngine.emit(
         .warning_could_not_write_build_record_not_absolutePath(buildRecordPath))
       return
     }
     preservePreviousBuildRecord(absPath)
-    
 
     let buildRecord = self.confinementQueue.sync {
       BuildRecord(
@@ -155,7 +158,7 @@ final class BuildRecordInfo {
     } catch {
       diagnosticEngine.emit(.warning_could_not_write_build_record(absPath))
     }
- }
+  }
 
   /// Before writing to the dependencies file path, preserve any previous file
   /// that may have been there. No error handling -- this is just a nicety, it

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -457,7 +457,7 @@ extension ModuleDependencyGraph {
   /// - Throws: An error describing any failures to read the graph from the given file.
   /// - Returns: A fully deserialized ModuleDependencyGraph.
   static func read(
-    from path: AbsolutePath,
+    from path: VirtualPath,
     on fileSystem: FileSystem,
     diagnosticEngine: DiagnosticsEngine,
     reporter: IncrementalCompilationState.Reporter?,
@@ -648,7 +648,7 @@ extension ModuleDependencyGraph {
   ///   - compilerVersion: A string containing version information for the
   ///                      driver used to create this file.
   func write(
-    to path: AbsolutePath,
+    to path: VirtualPath,
     on fileSystem: FileSystem,
     compilerVersion: String
   ) {
@@ -1038,7 +1038,7 @@ fileprivate extension DependencyKey.Designator {
 
 extension Diagnostic.Message {
   fileprivate static func error_could_not_write_dep_graph(
-    to path: AbsolutePath
+    to path: VirtualPath
   ) -> Diagnostic.Message {
     .error("could not write driver dependency graph to \(path)")
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -56,6 +56,37 @@ import SwiftOptions
 
 // MARK: - initial build only
 extension ModuleDependencyGraph {
+  /// Builds an empty `ModuleDependencyGraph` for a compilation with the
+  /// given input files.
+  static func buildEmptyGraph<Inputs: Sequence>(
+    for inputFiles: Inputs,
+    diagnosticEngine: DiagnosticsEngine,
+    outputFileMap: OutputFileMap,
+    options: IncrementalCompilationState.Options,
+    reporter: IncrementalCompilationState.Reporter?,
+    filesystem: FileSystem
+  ) -> ModuleDependencyGraph
+    where Inputs.Element == TypedVirtualPath
+  {
+    let emptyGraph = ModuleDependencyGraph(diagnosticEngine: diagnosticEngine,
+                                           reporter: reporter,
+                                           fileSystem: filesystem,
+                                           options: options)
+
+    for input in inputFiles {
+      guard let swiftDepsFile = outputFileMap.existingOutput(inputFile: input.file,
+                                                             outputType: .swiftDeps) else {
+        continue
+      }
+
+      assert(swiftDepsFile.extension == FileType.swiftDeps.rawValue)
+      let typedSwiftDepsFile = TypedVirtualPath(file: swiftDepsFile, type: .swiftDeps)
+      let dependencySource = DependencySource(typedSwiftDepsFile)
+      emptyGraph.inputDependencySourceMap[input] = dependencySource
+    }
+    return emptyGraph
+  }
+
   /// Builds a graph
   /// Returns nil if some input (i.e. .swift file) has no corresponding swiftdeps file.
   /// Returns a list of inputs whose swiftdeps files could not be read
@@ -63,7 +94,7 @@ extension ModuleDependencyGraph {
     diagnosticEngine: DiagnosticsEngine,
     inputs: Inputs,
     previousInputs: Set<VirtualPath>,
-    outputFileMap: OutputFileMap?,
+    outputFileMap: OutputFileMap,
     options: IncrementalCompilationState.Options,
     remarkDisabled: (String) -> Diagnostic.Message,
     reporter: IncrementalCompilationState.Reporter?,
@@ -81,8 +112,8 @@ extension ModuleDependencyGraph {
       options: options)
 
     let inputsAndSwiftdeps = inputs.map { input in
-      (input, outputFileMap?.existingOutput(inputFile: input.file,
-                                            outputType: .swiftDeps))
+      (input, outputFileMap.existingOutput(inputFile: input.file,
+                                           outputType: .swiftDeps))
     }
     for isd in inputsAndSwiftdeps where isd.1 == nil {
       // The legacy driver fails silently here.

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -55,7 +55,7 @@ struct CompileJobGroup {
   }
 }
 
-struct JobsInPhases {
+@_spi(Testing) public struct JobsInPhases {
   /// In WMO mode, also includes the multi-compile & its backends, since there are >1 backend jobs
   let beforeCompiles: [Job]
   let compileGroups: [CompileJobGroup]

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -410,6 +410,13 @@ extension TSCBasic.FileSystem {
     try resolvingVirtualPath(path, apply: readFileContents)
   }
 
+  func writeFileContents(_ path: VirtualPath, bytes: ByteString, atomically: Bool) throws {
+    try resolvingVirtualPath(path) { absolutePath in
+      try self.writeFileContents(absolutePath, bytes: bytes, atomically: atomically)
+    }
+  }
+
+
   func getFileInfo(_ path: VirtualPath) throws -> TSCBasic.FileInfo {
     try resolvingVirtualPath(path, apply: getFileInfo)
   }

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -16,7 +16,7 @@ import TSCBasic
 
 class DependencyGraphSerializationTests: XCTestCase {
   func roundTrip(_ graph: ModuleDependencyGraph) throws {
-    let mockPath = AbsolutePath("/module-dependency-graph")
+    let mockPath = VirtualPath.absolute(AbsolutePath("/module-dependency-graph"))
     let de = DiagnosticsEngine()
     let fs = InMemoryFileSystem()
     graph.write(to: mockPath, on: fs, compilerVersion: "Swift 99")


### PR DESCRIPTION
The refactoring of the incremental compilation state class is in three pieces:

1) Formalize the type of the InitialState computed by the initializer
2) Internalize computeModuleDependencyGraph and instead make a unified computeInitialState entrypoint (we'll need this for testing later)
3) Divide the status quo and cross-module initial state computations. There is no change to the status quo outside of the breakup of Driver.getBuildInfo

The cross-module path is slightly different than the status quo. For one, the incremental build need not fail entirely when either the build record or dependency graph cannot be read. In fact, it is a requirement that the incremental build proceed but schedule every single input file to rebuild, otherwise we won't have a module dependency graph to serialize!

As an aside, we ought to consider unifying the build record with the module dependency graph state we're writing here. They're read and written in lock-step when cross-module builds are turned on.