### PR TITLE
[Dependency Scanning] Do not decode `sourceFiles` fileds of the inter-module dependency graph into VirtualPaths

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -167,7 +167,7 @@ public struct ModuleInfo: Codable {
   public var modulePath: TextualVirtualPath
 
   /// The source files used to build this module.
-  public var sourceFiles: [TextualVirtualPath]?
+  public var sourceFiles: [String]?
 
   /// The set of direct module dependencies of this module.
   public var directDependencies: [ModuleDependencyId]?
@@ -193,7 +193,7 @@ public struct ModuleInfo: Codable {
   }
 
   public init(modulePath: TextualVirtualPath,
-              sourceFiles: [TextualVirtualPath]?,
+              sourceFiles: [String]?,
               directDependencies: [ModuleDependencyId]?,
               details: Details) {
     self.modulePath = modulePath

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -89,11 +89,9 @@ private extension SwiftScan {
     // Decode module path and source file locations
     let modulePathStr = try toSwiftString(api.swiftscan_module_info_get_module_path(moduleInfoRef))
     let modulePath = TextualVirtualPath(path: try VirtualPath(path: modulePathStr))
-    let sourceFiles: [TextualVirtualPath]?
+    let sourceFiles: [String]?
     if let sourceFilesSetRef = api.swiftscan_module_info_get_source_files(moduleInfoRef) {
-      sourceFiles = try toSwiftStringArray(sourceFilesSetRef.pointee).map {
-        TextualVirtualPath(path: try VirtualPath(path: $0))
-      }
+      sourceFiles = try toSwiftStringArray(sourceFilesSetRef.pointee)
     } else {
       sourceFiles = nil
     }


### PR DESCRIPTION
There are going to be a lot of them, and they are not currently used much in the driver and creating this many `VirtualPath` objects is very expensive.

https://github.com/apple/swift-driver/pull/437 got a bit overzealous.