### PR TITLE
XCTFail a dependency scanner test which relies on libSwiftScan if it can't be found

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -517,9 +517,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
     // The dependency oracle wraps an instance of libSwiftScan and ensures thread safety across
     // queries.
     let dependencyOracle = InterModuleDependencyOracle()
-    try dependencyOracle
-      .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
-                                     swiftScanLibPath: try driver.getScanLibPath(of: driver.toolchain))
+    guard try dependencyOracle
+            .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
+                                           swiftScanLibPath: try driver.getScanLibPath(of: driver.toolchain)) else {
+      XCTFail("Dependency scanner library not found")
+      return
+    }
     
     // Create a simple test case.
     try withTemporaryDirectory { path in


### PR DESCRIPTION
Otherwise, this test crashes when it calls `getDependencies`. With this change I can run the whole test suite using the frontend fallback. 