### PR TITLE
[Explciti Module Builds] Cache the computation of Clang module dependency PCM names.

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -446,7 +446,7 @@ extension Driver {
   /// to inputs and command line arguments of a compile job.
   func addExplicitModuleBuildArguments(inputs: inout [TypedVirtualPath],
                                        commandLine: inout [Job.ArgTemplate]) throws {
-    guard let dependencyPlanner = explicitDependencyBuildPlanner else {
+    guard var dependencyPlanner = explicitDependencyBuildPlanner else {
       fatalError("No dependency planner in Explicit Module Build mode.")
     }
     try dependencyPlanner.resolveMainModuleDependencies(inputs: &inputs, commandLine: &commandLine)

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -484,8 +484,7 @@ extension Driver {
     explicitDependencyBuildPlanner =
       try ExplicitDependencyBuildPlanner(dependencyGraph: dependencyGraph,
                                          toolchain: toolchain,
-                                         integratedDriver: integratedDriver,
-                                         mainModuleName: moduleOutputInfo.name)
+                                         integratedDriver: integratedDriver)
 
     return try explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
   }


### PR DESCRIPTION
These .PCM filenames are computed as `moduleName` + `hash(PCMArgs)`, using SHA256, in `targetEncodedClangModuleName`.
Avoid re-computing this filename for every direct and transitive depending module by caching the computed hashed names.