### PR TITLE
Re-enable Embedded Dependencies Test

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/KeyAndFingerprintEnforcer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/KeyAndFingerprintEnforcer.swift
@@ -29,12 +29,13 @@ extension KeyAndFingerprintEnforcer {
     guard let file = externalDependency.file else {
       throw KeyAndFingerprintEnforcerError.noFile(externalDependency)
     }
-    guard let fingerprint = self.fingerprint,
-          file.extension == FileType.swiftModule.rawValue
-    else {
+    guard let fingerprint = self.fingerprint else {
       return
     }
-    throw KeyAndFingerprintEnforcerError.onlySwiftModulesHaveFingerprints(externalDependency, fingerprint)
+    
+    guard file.extension == FileType.swiftModule.rawValue else {
+      throw KeyAndFingerprintEnforcerError.onlySwiftModulesHaveFingerprints(externalDependency, fingerprint)
+    }
   }
 }
 enum KeyAndFingerprintEnforcerError: LocalizedError {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -765,8 +765,6 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
   }
   
   func testEmbeddedModuleDependencies() throws {
-    throw XCTSkip("Requires new frontend work to remove incremental external dependencies distinction.")
-    /*
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       do {
@@ -822,8 +820,9 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
 
-      let data = try localFileSystem.readFileContents(path.appending(component: "main.swiftdeps"))
-      let graph = try SourceFileDependencyGraph(data: data, fromSwiftModule: false)
+      let sourcePath = path.appending(component: "main.swiftdeps")
+      let data = try localFileSystem.readFileContents(sourcePath)
+      let graph = try XCTUnwrap(SourceFileDependencyGraph(data: data, from: DependencySource(.absolute(sourcePath)), fromSwiftModule: false))
       XCTAssertEqual(graph.majorVersion, 1)
       XCTAssertEqual(graph.minorVersion, 0)
       graph.verify()
@@ -840,6 +839,6 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
         }
       }
       XCTAssertTrue(foundNode)
-    }*/
+    }
   }
 }


### PR DESCRIPTION
Also correct a bogus assert that was firing when external dependency nodes didn't have fingerprints.