### PR TITLE
Indexing: include index file entry in supplementary output file map

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -226,7 +226,8 @@ extension Driver {
       primaryInputs: primaryInputs,
       inputsGeneratingCodeCount: inputsGeneratingCodeCount,
       inputOutputMap: inputOutputMap,
-      includeModuleTracePath: emitModuleTrace)
+      includeModuleTracePath: emitModuleTrace,
+      indexFilePath: indexFilePath)
 
     // Forward migrator flags.
     try commandLine.appendLast(.apiDiffDataFile, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -250,7 +250,8 @@ extension Driver {
                                                         primaryInputs: [TypedVirtualPath],
                                                         inputsGeneratingCodeCount: Int,
                                                         inputOutputMap: [TypedVirtualPath: TypedVirtualPath],
-                                                        includeModuleTracePath: Bool) throws -> [TypedVirtualPath] {
+                                                        includeModuleTracePath: Bool,
+                                                        indexFilePath: TypedVirtualPath?) throws -> [TypedVirtualPath] {
     var flaggedInputOutputPairs: [(flag: String, input: TypedVirtualPath?, output: TypedVirtualPath)] = []
 
     /// Add output of a particular type, if needed.
@@ -416,6 +417,11 @@ extension Driver {
 
       for flaggedPair in flaggedInputOutputPairs {
         addEntry(&entries, input: flaggedPair.input, output: flaggedPair.output)
+      }
+      // To match the legacy driver behavior, make sure we add an entry for the
+      // file under indexing and the primary output file path.
+      if let indexFilePath = indexFilePath, let idxOutput = inputOutputMap[indexFilePath] {
+        entries[indexFilePath.file] = [.indexData: idxOutput.file]
       }
       let outputFileMap = OutputFileMap(entries: entries)
       let path = RelativePath(createTemporaryFileName(prefix: "supplementaryOutputs"))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1514,6 +1514,52 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(plannedJobs[1].kind, .link)
   }
 
+
+  func testIndexFileEntryInSupplementaryFileOutputMap() throws {
+    var driver1 = try Driver(args: [
+      "swiftc", "foo1.swift", "foo2.swift", "foo3.swift", "foo4.swift", "foo5.swift",
+      "-index-file", "-index-file-path", "foo5.swift", "-o", "/tmp/t.o",
+      "-index-store-path", "/tmp/idx"
+    ])
+    let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
+    XCTAssertEqual(plannedJobs.count, 1)
+    let suppleArg = "-supplementary-output-file-map"
+    // Make sure we are using supplementary file map
+    XCTAssert(plannedJobs[0].commandLine.contains(.flag(suppleArg)))
+    let args = plannedJobs[0].commandLine
+    var fileMapPath: VirtualPath?
+    for pair in args.enumerated() {
+      if pair.element == .flag(suppleArg) {
+        let filemap = args[pair.offset + 1]
+        switch filemap {
+        case .path(let p):
+          fileMapPath = p
+        default:
+          break
+        }
+      }
+    }
+    XCTAssert(fileMapPath != nil)
+    switch fileMapPath! {
+    case .fileList(_, let list):
+      switch list {
+      case .outputFileMap(let map):
+        // This is to match the legacy driver behavior
+        // Make sure the supplementary output map has an entry for the Swift file
+        // under indexing and its indexData entry is the primary output file
+        let entry = map.entries[VirtualPath.relative(RelativePath("foo5.swift"))]!
+        XCTAssert(entry[.indexData]! == .absolute(AbsolutePath("/tmp/t.o")))
+        return
+      default:
+        break
+      }
+      break
+    default:
+      break
+    }
+    XCTAssert(false)
+  }
+
   func testMultiThreadedWholeModuleOptimizationCompiles() throws {
     do {
       var driver1 = try Driver(args: [


### PR DESCRIPTION
This is the behavior of the C++ driver and we should preserve it.

rdar://74127445