### PR TITLE
[RFC] Implement -driver-skip-execution

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1014,6 +1014,7 @@ extension Driver {
       delegate: jobExecutionDelegate,
       numParallelJobs: numParallelJobs ?? 1,
       forceResponseFiles: forceResponseFiles,
+      skipProcessExecution: parsedOptions.contains(.driverSkipExecution),
       recordedInputModificationDates: recordedInputModificationDates)
   }
 

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -28,6 +28,15 @@ public protocol DriverExecutor {
                delegate: JobExecutionDelegate,
                numParallelJobs: Int,
                forceResponseFiles: Bool,
+               skipProcessExecution: Bool,
+               recordedInputModificationDates: [TypedVirtualPath: Date]
+  ) throws
+  
+  // FIXME: Stub for SPM
+  func execute(workload: DriverExecutorWorkload,
+               delegate: JobExecutionDelegate,
+               numParallelJobs: Int,
+               forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath: Date]
   ) throws
 
@@ -115,7 +124,7 @@ extension DriverExecutor {
       forceResponseFiles: forceResponseFiles,
       recordedInputModificationDates: recordedInputModificationDates)
   }
-
+  
   static func computeReturnCode(exitStatus: ProcessResult.ExitStatus) -> Int {
     var returnCode: Int
     switch exitStatus {
@@ -127,6 +136,42 @@ extension DriverExecutor {
       #endif
     }
     return returnCode
+  }
+}
+
+// FIXME: stubs to prevent breaking SPM build. If none of these are implemented they will infinite loop until stack overflow.
+// These should be cleaned up quickly.
+extension DriverExecutor {
+  public func execute(
+    workload: DriverExecutorWorkload,
+    delegate: JobExecutionDelegate,
+    numParallelJobs: Int,
+    forceResponseFiles: Bool,
+    recordedInputModificationDates: [TypedVirtualPath: Date]
+  ) throws {
+    return try execute(
+      workload: workload,
+      delegate: delegate,
+      numParallelJobs: numParallelJobs,
+      forceResponseFiles: forceResponseFiles,
+      skipProcessExecution: false,
+      recordedInputModificationDates: recordedInputModificationDates)
+  }
+  
+  public func execute(
+    workload: DriverExecutorWorkload,
+    delegate: JobExecutionDelegate,
+    numParallelJobs: Int,
+    forceResponseFiles: Bool,
+    skipProcessExecution: Bool,
+    recordedInputModificationDates: [TypedVirtualPath: Date]
+  ) throws {
+    return try execute(
+      workload: workload,
+      delegate: delegate,
+      numParallelJobs: numParallelJobs,
+      forceResponseFiles: forceResponseFiles,
+      recordedInputModificationDates: recordedInputModificationDates)
   }
 }
 

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -61,6 +61,7 @@ public final class SwiftDriverExecutor: DriverExecutor {
                       delegate: JobExecutionDelegate,
                       numParallelJobs: Int = 1,
                       forceResponseFiles: Bool = false,
+                      skipProcessExecution: Bool,
                       recordedInputModificationDates: [TypedVirtualPath: Date] = [:]
   ) throws {
     let llbuildExecutor = MultiJobExecutor(
@@ -71,7 +72,8 @@ public final class SwiftDriverExecutor: DriverExecutor {
       numParallelJobs: numParallelJobs,
       processSet: processSet,
       forceResponseFiles: forceResponseFiles,
-      recordedInputModificationDates: recordedInputModificationDates)
+      recordedInputModificationDates: recordedInputModificationDates,
+      processType: skipProcessExecution ? DummyProcess.self : TSCBasic.Process.self)
     try llbuildExecutor.execute(env: env, fileSystem: fileSystem)
   }
 
@@ -96,5 +98,35 @@ public final class SwiftDriverExecutor: DriverExecutor {
       }
     }
     return result
+  }
+}
+
+/// C++ driver uses fake processes when skipping driver execution, instead of just skipping execution entirely.
+/// This distinction is important, because it allows parsable output to be emitted for the jobs.
+private struct DummyProcess: ProcessProtocol {
+  private static var nextProcessID: TSCBasic.Process.ProcessID = 0
+
+  let processID: TSCBasic.Process.ProcessID
+  private let arguments: [String]
+  private let env: [String: String]
+
+  private init(arguments: [String], env: [String: String]) {
+    processID = Self.nextProcessID
+    Self.nextProcessID += 1
+
+    self.arguments = arguments
+    self.env = env
+  }
+
+  func waitUntilExit() throws -> ProcessResult {
+    return .init(arguments: arguments,
+                 environment: env,
+                 exitStatus: .terminated(code: 0),
+                 output: .success([UInt8]("Output placeholder\n".utf8CString.map { UInt8($0) })),
+                 stderrOutput: .success([UInt8]("Error placeholder\n".utf8CString.map { UInt8($0) })))
+  }
+
+  static func launchProcess(arguments: [String], env: [String: String]) throws -> DummyProcess {
+    return DummyProcess(arguments: arguments, env: env)
   }
 }


### PR DESCRIPTION
`-driver-skip-execution` in c++ driver replaces the TaskQueue with DummyTaskQueue. DummyTaskQueue honors the number of parallel tasks but otherwise mocks out process execution and has it return 0 and output `Output placeholder\n`.
This flag is most useful for testing in combination with `-parseable-output` when you don't want the jobs to actually run.

First complication: swift-driver calls out to the frontend for more than just jobs, so the executor can't be completely mocked out. Also the executor handles quite a bit more work than the c++ TaskQueue, so a mock version would require much more duplicated logic.

Second complication: The swift-driver's executor code lives in `SwiftDriverExecution`, and providing it new information requires making API changes to `DriverExecutor` this is a source break to SPM (without tacky shims put in place).

Looking at the state of `-driver-skip-execution` usage in lit tests:
- 12 total usages in 8 files
- 3 are used with `-driver-print-jobs` which makes `-driver-skip-execution` ignored. That leaves 6 being used with `-parseable-output` (2 (in emit-dependencies.swift) could have test rewritten to use `-driver-print-jobs`) and 3 with `-driver-show-job-lifecycle`.

Questions: Does this kind of process mock provide value in swift-driver? If no, how do we handle the lit test failures?

My thoughts on that question:
This level of mocking and testing can easily be done in XCTest, if we were confident in coverage, we could `REQUIRES: cplusplus_driver`.
The only test this PR actually fixes is `emit-dependencies.swift` which can be fixed in the test by changing it to `-driver-print-jobs`. The reasons for other test not being fixed are:
- Parseable output: This tests rely on the ordering of JSON output by the c++ driver. The swift-driver uses JSONEncoder to format the JSON output, which doesn't match the c++ driver.
- `-driver-show-job-lifecycle`: These 3 tests are for batch mode, I believe the behavior is correct here, but the output isn't 100% the same and some of the ordering is different. Also these tests run even when the compile isn't mocked out (just slower).

TLDR: I think support for this flag is of little value given that most of the tests that rely on it are Parseable output and fail anyway, but it is a flag supported by the C++ driver, so maybe we want to continue supporting it.