### PR TITLE
Clean Up the MultiDictionary Interface

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -889,7 +889,7 @@ extension ModuleDependencyGraph {
             $0.append(serializer.lookupIdentifierCode(
                         for: key.designator.name ?? ""))
           }
-          for use in graph.nodeFinder.usesByDef[key]?.values ?? [] {
+          for use in graph.nodeFinder.usesByDef[key, default: []] {
             guard let useID = serializer.nodeIDs[use] else {
               fatalError("Node ID was not registered! \(use)")
             }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -151,7 +151,7 @@ extension ModuleDependencyGraph.NodeFinder {
   }
   
   private mutating func removeUsings(of nodeToNotUse: Graph.Node) {
-    usesByDef.removeValue(nodeToNotUse)
+    usesByDef.removeOccurrences(of: nodeToNotUse)
     assert(defsUsing(nodeToNotUse).isEmpty)
   }
   

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -179,7 +179,9 @@ extension ModuleDependencyGraph.NodeFinder {
     let replacement = Graph.Node(key: original.key,
                                  fingerprint: newFingerprint,
                                  dependencySource: newDependencySource)
-    usesByDef.replace(original, with: replacement, forKey: original.key)
+    if usesByDef.removeValue(original, forKey: original.key) != nil {
+      usesByDef.insertValue(replacement, forKey: original.key)
+    }
     nodeMap.removeValue(forKey: original.mapKey)
     nodeMap.updateValue(replacement, forKey: replacement.mapKey)
     return replacement

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -114,7 +114,7 @@ extension ModuleDependencyGraph.NodeFinder {
     }
   }
   
-  func defsUsing(_ n: Graph.Node) -> [DependencyKey] {
+  func defsUsing(_ n: Graph.Node) -> Set<DependencyKey> {
     usesByDef.keysContainingValue(n)
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -138,7 +138,7 @@ extension ModuleDependencyGraph.NodeFinder {
   /// record def-use, return if is new use
   mutating func record(def: DependencyKey, use: Graph.Node) -> Bool {
     verifyUseIsOK(use)
-    return usesByDef.addValue(use, forKey: def)
+    return usesByDef.insertValue(use, forKey: def)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -81,7 +81,7 @@ extension ModuleDependencyGraph.NodeFinder {
   /// - Returns: A set of nodes corresponding to the uses of the given
   ///            definition node.
   func uses(of def: Graph.Node) -> Set<Graph.Node> {
-    var uses = usesByDef[def.key, default: Set()].values
+    var uses = usesByDef[def.key, default: Set()]
     if let impl = findCorrespondingImplementation(of: def) {
       uses.insert(impl)
     }
@@ -206,10 +206,11 @@ extension ModuleDependencyGraph.NodeFinder {
   }
   
   private func verifyUsesByDef() {
-    usesByDef.forEach {
-      def, use in
-      // def may have disappeared from graph, nothing to do
-      verifyUseIsOK(use)
+    usesByDef.forEach { def, uses in
+      for use in uses {
+        // def may have disappeared from graph, nothing to do
+        verifyUseIsOK(use)
+      }
     }
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -77,13 +77,7 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
   public subscript(key: Key, default defaultValues: @autoclosure () -> Set<Value>) -> Set<Value> {
     self.dictionary[key, default: defaultValues()]
   }
-  
-  /// Returns true if inserted
-  public mutating func addValue(_ v: Value, forKey key: Key) -> Bool {
-    if var inner = outerDict[key] {
-      let old = inner.insert(v).inserted
-      outerDict[key] = inner
-      return old
+
   /// Returns a set of keys that the given value is associated with.
   ///
   /// - Parameter v: The value to search for among the key-value associations in
@@ -96,8 +90,6 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
       }
       acc.insert(next.key)
     }
-    outerDict[key] = Set([v])
-    return true
   }
   
   public mutating func removeValue(_ v: Value) {
@@ -110,6 +102,17 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
     changedPairs.forEach {
       outerDict[$0.key] = $0.value
     }
+
+  /// Inserts the given value in the set of values associated with the given key.
+  ///
+  /// - Parameters:
+  ///   - v: The value to insert.
+  ///   - key: The key used to associate the given value with a set of elements.
+  /// - Returns: `true` if the value was not previously associated with any
+  ///            other values for the given key. Else, returns `false.
+  @discardableResult
+  public mutating func insertValue(_ v: Value, forKey key: Key) -> Bool {
+    return self.dictionary[key, default: []].insert(v).inserted
   }
   
   @discardableResult

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -91,17 +91,6 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
       acc.insert(next.key)
     }
   }
-  
-  public mutating func removeValue(_ v: Value) {
-    let changedPairs = outerDict.compactMap { kv -> (key: Key, value: Set<Value>?)? in
-      var vals = kv.value
-      guard vals.contains(v) else { return nil}
-      vals.remove(v)
-      return (key: kv.key, value: (vals.isEmpty ? nil : vals))
-    }
-    changedPairs.forEach {
-      outerDict[$0.key] = $0.value
-    }
 
   /// Inserts the given value in the set of values associated with the given key.
   ///
@@ -126,5 +115,16 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
     vals.insert(replacement)
     outerDict.updateValue(vals, forKey: key)
     return true
+  /// Removes all occurrences of the given value from all entries in this
+  /// multi-dictionary.
+  ///
+  /// - Note: If this value is used as a key, this function does not erase its
+  ///         entries from the underlying dictionary.
+  ///
+  /// - Parameter v: The value to remove.
+  public mutating func removeOccurrences(of v: Value) {
+    for k in self.dictionary.keys {
+      self.dictionary[k]!.remove(v)
+    }
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Like a Dictionary, but can have >1 value per key (i.e., a multimap)
+/// A collection that associates keys with one or more values.
 struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
   private var dictionary: Dictionary<Key, Set<Value>> = [:]
   

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -64,12 +64,20 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
     return self.dictionary.values
   }
 
-  public subscript(key: Key, default defaultValues: @autoclosure () -> Set<Value>) -> (key: Key, values: Set<Value>) {
-    self[key] ?? (key: key, values: defaultValues())
+  /// Accesses the values associated with the given key for reading and writing.
+  public subscript(key: Key) -> Set<Value>? {
+    self.dictionary[key]
   }
   
   public func keysContainingValue(_ v: Value) -> [Key] {
-    outerDict.compactMap { (k, vs) in vs.contains(v) ? k : nil }
+
+  /// Accesses the values associated with the given key for reading and writing.
+  ///
+  /// If this multi-dictionary doesn’t contain the given key, accesses the
+  /// provided default value as if the key and default value existed in
+  /// this multi-dictionary.
+  public subscript(key: Key, default defaultValues: @autoclosure () -> Set<Value>) -> Set<Value> {
+    self.dictionary[key, default: defaultValues()]
   }
   
   /// Returns true if inserted

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -12,46 +12,46 @@
 
 /// Like a Dictionary, but can have >1 value per key (i.e., a multimap)
 struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
-  public typealias OuterDict = [Key: Set<Value>]
-  public typealias InnerSet = Set<Value>
-  private var outerDict = OuterDict()
+  private var dictionary: Dictionary<Key, Set<Value>> = [:]
   
-  public typealias Element = (key: Key, value: Value)
-  
-  public enum Index: Comparable {
-    case end
-    case notEnd(OuterDict.Index, InnerSet.Index)
+  public typealias Element = (Key, Set<Value>)
+  public typealias Index = Dictionary<Key, Set<Value>>.Index
+
+  /// The number of key-value pairs in this multi-dictionary.
+  public var count: Int {
+    self.dictionary.count
   }
-  
+
+  /// The position of the first element in a nonempty multi-dictionary.
   public var startIndex: Index {
-    outerDict.first.map {Index.notEnd(outerDict.startIndex, $0.value.startIndex)} ?? .end
+    self.dictionary.startIndex
   }
-  public var endIndex: Index {.end}
-  
-  public func index(after i: Index) -> Index {
-    switch i {
-    case .end: fatalError()
-    case let .notEnd(outerIndex, innerIndex):
-      let innerSet = outerDict[outerIndex].value
-      let nextInner = innerSet.index(after: innerIndex)
-      if nextInner < innerSet.endIndex {
-        return .notEnd(outerIndex, nextInner)
-      }
-      let nextOuter = outerDict.index(after: outerIndex)
-      if nextOuter < outerDict.endIndex {
-        return .notEnd(nextOuter, outerDict[nextOuter].value.startIndex)
-      }
-      return .end
-    }
+
+  /// The collection’s “past the end” position—that is, the position one greater
+  /// than the last valid subscript argument.
+  public var endIndex: Index {
+    self.dictionary.endIndex
   }
-  
-  public subscript(position: Index) -> (key: Key, value: Value) {
-    switch position {
-    case .end: fatalError()
-    case  let .notEnd(outerIndex, innerIndex):
-      let (key, vals) = outerDict[outerIndex]
-      return (key: key, value: vals[innerIndex])
-    }
+
+  /// Returns the index for the given key.
+  ///
+  /// - Parameter key: The key to find in the multi-dictionary.
+  /// - Returns: The index for key and its associated value if key is in the
+  ///            multi-dictionary; otherwise, nil.
+  public func index(forKey key: Key) -> Dictionary<Key, Set<Value>>.Index? {
+    self.dictionary.index(forKey: key)
+  }
+
+  /// Computes the position immediately after the given index.
+  ///
+  /// - Parameter i: A valid index of the collection. i must be less than endIndex.
+  /// - Returns: The position immediately after the given index.
+  func index(after i: Dictionary<Key, Set<Value>>.Index) -> Dictionary<Key, Set<Value>>.Index {
+    self.dictionary.index(after: i)
+  }
+
+  subscript(position: Dictionary<Key, Set<Value>>.Index) -> (Key, Set<Value>) {
+    self.dictionary[position]
   }
 
   /// A collection containing just the keys of this multi-dictionary.

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -55,12 +55,13 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
   }
 
   /// A collection containing just the keys of this multi-dictionary.
-  public var keys: OuterDict.Keys {
-    return self.outerDict.keys
+  public var keys: Dictionary<Key, Set<Value>>.Keys {
+    return self.dictionary.keys
   }
-  
-  public subscript(key: Key) -> (key: Key, values: Set<Value>)? {
-    outerDict[key].map { (key: key, values: $0) }
+
+  /// A collection containing just the values of this multi-dictionary.
+  public var values: Dictionary<Key, Set<Value>>.Values {
+    return self.dictionary.values
   }
 
   public subscript(key: Key, default defaultValues: @autoclosure () -> Set<Value>) -> (key: Key, values: Set<Value>) {

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -103,18 +103,18 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
   public mutating func insertValue(_ v: Value, forKey key: Key) -> Bool {
     return self.dictionary[key, default: []].insert(v).inserted
   }
-  
+
+  /// Removes the given value from the set of values associated with the given key.
+  ///
+  /// - Parameters:
+  ///   - v: The value to remove.
+  ///   - key: The key used to associate the given value with a set of elements.
+  /// - Returns: The removed element, if any.
   @discardableResult
-  public mutating func replace(_ original: Value,
-                               with replacement: Value,
-                               forKey key: Key)
-  -> Bool
-  {
-    guard var vals = outerDict[key],
-          let _ = vals.remove(original) else { return false }
-    vals.insert(replacement)
-    outerDict.updateValue(vals, forKey: key)
-    return true
+  public mutating func removeValue(_ v: Value, forKey key: Key) -> Value? {
+    return self.dictionary[key, default: []].remove(v)
+  }
+
   /// Removes all occurrences of the given value from all entries in this
   /// multi-dictionary.
   ///

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -68,8 +68,6 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
   public subscript(key: Key) -> Set<Value>? {
     self.dictionary[key]
   }
-  
-  public func keysContainingValue(_ v: Value) -> [Key] {
 
   /// Accesses the values associated with the given key for reading and writing.
   ///
@@ -86,6 +84,17 @@ struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
       let old = inner.insert(v).inserted
       outerDict[key] = inner
       return old
+  /// Returns a set of keys that the given value is associated with.
+  ///
+  /// - Parameter v: The value to search for among the key-value associations in
+  ///                this dictionary.
+  /// - Returns: The set of keys associated with the given value.
+  public func keysContainingValue(_ v: Value) -> Set<Key> {
+    return self.dictionary.reduce(into: Set<Key>()) { acc, next in
+      guard next.value.contains(v) else {
+        return
+      }
+      acc.insert(next.key)
     }
     outerDict[key] = Set([v])
     return true


### PR DESCRIPTION
- Clean up subscripting so accessing one-past-the-end indices is no longer possible
- Make the interface for Multidictionary more closely align to either Dictionary or Set
- Document everything

This PR should be NFC, but we'll see if anything was relying on the old subscript order.