### PR TITLE
Make the driver aware of all the flags the selected toolchain's `swift-frontend` supports.

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -177,6 +177,8 @@ typedef struct {
 
   //=== Cleanup Functions ---------------------------------------------------===//
   void
+  (*swiftscan_string_set_dispose)(swiftscan_string_set_t *);
+  void
   (*swiftscan_dependency_graph_dispose)(swiftscan_dependency_graph_t);
   void
   (*swiftscan_import_set_dispose)(swiftscan_import_set_t);
@@ -188,6 +190,12 @@ typedef struct {
   (*swiftscan_batch_scan_result_dispose)(swiftscan_batch_scan_result_t *);
   void
   (*swiftscan_scan_invocation_dispose)(swiftscan_scan_invocation_t);
+
+  //=== Functionality Query Functions ---------------------------------------===//
+  swiftscan_string_set_t *
+  (*swiftscan_compiler_supported_arguments_query)(void);
+  swiftscan_string_set_t *
+  (*swiftscan_compiler_supported_features_query)(void);
 
   //=== Scanner Functions ---------------------------------------------------===//  
   swiftscan_scanner_t (*swiftscan_scanner_create)(void);

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(SwiftDriver
   Jobs/CompileJob.swift
   Jobs/DarwinToolchain+LinkerSupport.swift
   Jobs/EmitModuleJob.swift
+  Jobs/EmitSupportedFeaturesJob.swift
   Jobs/FrontendJobHelpers.swift
   Jobs/GenerateDSYMJob.swift
   Jobs/GeneratePCHJob.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -304,6 +304,9 @@ public struct Driver {
   /// discovered/scanned modules and their infos.
   @_spi(Testing) public var externalBuildArtifacts: ExternalBuildArtifacts? = nil
 
+  /// A collection of all the flags the selected toolchain's `swift-frontend` supports
+  @_spi(Testing) public let supportedFrontendFlags: Set<String>
+
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in
     let stream = stderrStream
@@ -524,6 +527,13 @@ public struct Driver {
                                                                                compilerMode: compilerMode,
                                                                                importedObjCHeader: importedObjCHeader,
                                                                                outputFileMap: outputFileMap)
+
+    self.supportedFrontendFlags =
+      try Self.computeSupportedCompilerFeatures(of: self.toolchain, hostTriple: self.hostTriple,
+                                                swiftCompilerPrefixArgs:
+                                                  swiftCompilerPrefixArgs,
+                                                fileSystem: fileSystem, executor: executor,
+                                                env: env)
 
     self.enabledSanitizers = try Self.parseSanitizerArgValues(
       &parsedOptions,

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -79,7 +79,7 @@ extension Driver {
     case .swift, .image, .dSYM, .dependencies, .autolink, .swiftDocumentation, .swiftInterface,
          .privateSwiftInterface, .swiftSourceInfoFile, .diagnostics, .objcHeader, .swiftDeps,
          .remap, .tbd, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
-         .pch, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts, nil:
+         .pch, .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts, nil:
       return false
     }
   }
@@ -369,6 +369,8 @@ extension FileType {
       return .scanDependencies
     case .jsonTargetInfo:
       return .printTargetInfo
+    case .jsonCompilerFeatures:
+      return .emitSupportedFeatures
 
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -1,0 +1,81 @@
+//===---- EmitSupportedFeatures.swift - Swift Compiler Features Info Job ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===////
+
+import TSCBasic
+
+/// Describes information about the compiler's supported arguments and features
+@_spi(Testing) public struct SupportedCompilerFeatures: Codable {
+  var SupportedArguments: [String]
+  var SupportedFeatures: [String]
+}
+
+extension Toolchain {
+  func emitSupportedCompilerFeaturesJob(requiresInPlaceExecution: Bool = false,
+                                        swiftCompilerPrefixArgs: [String]) throws -> Job {
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    var inputs: [TypedVirtualPath] = []
+    commandLine.append(contentsOf: [.flag("-frontend"),
+                                    .flag("-emit-supported-features")])
+
+    // This action does not require any input files, but all frontend actions require
+    // at least one so we fake it.
+    // FIXME: Teach -emit-supported-features to not expect any inputs, like -print-target-info does.
+    let dummyInputPath = VirtualPath.temporaryWithKnownContents(.init("dummyInput.swift"),
+                                                                "".data(using: .utf8)!)
+    commandLine.appendPath(dummyInputPath)
+    inputs.append(TypedVirtualPath(file: dummyInputPath, type: .swift))
+    
+    return Job(
+      moduleName: "",
+      kind: .emitSupportedFeatures,
+      tool: .absolute(try getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      displayInputs: [],
+      inputs: inputs,
+      primaryInputs: [],
+      outputs: [.init(file: .standardOutput, type: .jsonCompilerFeatures)],
+      requiresInPlaceExecution: requiresInPlaceExecution,
+      supportsResponseFiles: false
+    )
+  }
+}
+
+extension Driver {
+  static func computeSupportedCompilerFeatures(of toolchain: Toolchain, hostTriple: Triple,
+                                               swiftCompilerPrefixArgs: [String],
+                                               fileSystem: FileSystem,
+                                               executor: DriverExecutor, env: [String: String])
+  throws -> Set<String> {
+    // If libSwiftScan library is present, use it to query
+    let swiftScanLibPath = try Self.getScanLibPath(of: toolchain,
+                                                   hostTriple: hostTriple,
+                                                   env: env)
+
+    if fileSystem.exists(swiftScanLibPath) {
+      let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
+      if libSwiftScanInstance.canQuerySupportedArguments() {
+        return try libSwiftScanInstance.querySupportedArguments()
+      }
+    }
+
+    // Fallback to invoking `swift-frontend -emit-supported-features`
+    let frontendFeaturesJob =
+      try toolchain.emitSupportedCompilerFeaturesJob(swiftCompilerPrefixArgs:
+                                                      swiftCompilerPrefixArgs)
+    let decodedSupportedFlagList = try executor.execute(
+      job: frontendFeaturesJob,
+      capturingJSONOutputAs: SupportedCompilerFeatures.self,
+      forceResponseFiles: false,
+      recordedInputModificationDates: [:]).SupportedArguments
+    return Set(decodedSupportedFlagList)
+  }
+}

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -31,6 +31,7 @@ public struct Job: Codable, Equatable, Hashable {
     case repl
     case verifyDebugInfo = "verify-debug-info"
     case printTargetInfo = "print-target-info"
+    case emitSupportedFeatures = "emit-supported-features"
     case versionRequest = "version-request"
     case scanDependencies = "scan-dependencies"
     case verifyModuleInterface = "verify-emitted-module-interface"
@@ -187,6 +188,9 @@ extension Job : CustomStringConvertible {
     case .backend:
       return "Embedding bitcode for \(moduleName) \(displayInputs.first?.file.basename ?? "")"
 
+    case .emitSupportedFeatures:
+      return "Emitting supported Swift compiler features"
+
     case .scanDependencies:
       return "Scanning dependencies for module \(moduleName)"
 
@@ -211,7 +215,7 @@ extension Job.Kind {
     switch self {
     case .backend, .compile, .mergeModule, .emitModule, .generatePCH,
         .generatePCM, .interpret, .repl, .printTargetInfo,
-        .versionRequest, .scanDependencies, .verifyModuleInterface:
+        .versionRequest, .emitSupportedFeatures, .scanDependencies, .verifyModuleInterface:
         return true
 
     case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo, .moduleWrap:
@@ -228,7 +232,7 @@ extension Job.Kind {
          .generatePCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
          .help, .link, .verifyDebugInfo, .scanDependencies,
-         .moduleWrap, .verifyModuleInterface:
+         .emitSupportedFeatures, .moduleWrap, .verifyModuleInterface:
       return false
     }
   }

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -222,7 +222,7 @@ private extension SwiftScan {
   }
 }
 
-private extension SwiftScan {
+internal extension SwiftScan {
   /// Convert a `swiftscan_string_ref_t` reference to a Swfit `String`, assuming the reference is to a valid string
   /// (non-null)
   func toSwiftString(_ string_ref: swiftscan_string_ref_t) throws -> String {
@@ -246,6 +246,18 @@ private extension SwiftScan {
                                                     count: Int(string_set.count)))
     for stringRef in stringRefArrray {
       result.append(try toSwiftString(stringRef))
+    }
+    return result
+  }
+
+  /// Convert a `swiftscan_string_set_t` reference to a Swfit `Set<String>`, assuming the individual string references
+  /// are to a valid strings (non-null)
+  func toSwiftStringSet(_ string_set: swiftscan_string_set_t) throws -> Set<String> {
+    var result = Set<String>()
+    let stringRefArrray = Array(UnsafeBufferPointer(start: string_set.strings,
+                                                    count: Int(string_set.count)))
+    for stringRef in stringRefArrray {
+      result.insert(try toSwiftString(stringRef))
     }
     return result
   }

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -26,6 +26,7 @@ public enum DependencyScanningError: Error, DiagnosticData {
   case invalidStringPtr
   case scanningLibraryInvocationMismatch(AbsolutePath, AbsolutePath)
   case scanningLibraryNotFound(AbsolutePath)
+  case argumentQueryFailed
 
   public var description: String {
     switch self {
@@ -47,12 +48,14 @@ public enum DependencyScanningError: Error, DiagnosticData {
         return "Dependency Scanning library differs across driver invocations: \(path1.description) and \(path2.description)"
       case .scanningLibraryNotFound(let path):
         return "Dependency Scanning library not found at path: \(path)"
+      case .argumentQueryFailed:
+        return "libSwiftScan supported compiler argument query failed"
     }
   }
 }
 
 /// Wrapper for libSwiftScan, taking care of initialization, shutdown, and dispatching dependency scanning queries.
-internal final class SwiftScan {
+@_spi(Testing) public final class SwiftScan {
   /// The path to the libSwiftScan dylib.
   let path: AbsolutePath
 
@@ -68,7 +71,7 @@ internal final class SwiftScan {
   /// Instance of a scanner, which maintains shared state across scan queries.
   let scanner: swiftscan_scanner_t;
 
-  init(dylib path: AbsolutePath) throws {
+  @_spi(Testing) public init(dylib path: AbsolutePath) throws {
     self.path = path
     #if os(Windows)
     self.dylib = try dlopen(path.pathString, mode: [])
@@ -177,6 +180,21 @@ internal final class SwiftScan {
     api.swiftscan_batch_scan_result_dispose(batchResultRefOrNull)
     return resultGraphMap
   }
+
+  @_spi(Testing) public func canQuerySupportedArguments() -> Bool {
+    return api.swiftscan_compiler_supported_arguments_query != nil &&
+           api.swiftscan_string_set_dispose != nil
+  }
+
+  @_spi(Testing) public func querySupportedArguments() throws -> Set<String> {
+    precondition(canQuerySupportedArguments())
+    if let queryResultStrings = api.swiftscan_compiler_supported_arguments_query!() {
+      defer { api.swiftscan_string_set_dispose!(queryResultStrings) }
+      return try toSwiftStringSet(queryResultStrings.pointee)
+    } else {
+      throw DependencyScanningError.argumentQueryFailed
+    }
+  }
 }
 
 private extension swiftscan_functions_t {
@@ -185,7 +203,18 @@ private extension swiftscan_functions_t {
 
     // MARK: Optional Methods
     // Future optional methods can be queried here
-
+    func loadOptional<T>(_ symbol: String) throws -> T? {
+      guard let sym: T = dlsym(swiftscan, symbol: symbol) else {
+        return nil
+      }
+      return sym
+    }
+    self.swiftscan_string_set_dispose =
+      try loadOptional("swiftscan_string_set_dispose")
+    self.swiftscan_compiler_supported_arguments_query =
+      try loadOptional("swiftscan_compiler_supported_arguments_query")
+    self.swiftscan_compiler_supported_features_query =
+      try loadOptional("swiftscan_compiler_supported_features_query")
 
     // MARK: Required Methods
     func loadRequired<T>(_ symbol: String) throws -> T {
@@ -301,7 +330,6 @@ private extension swiftscan_functions_t {
       try loadRequired("swiftscan_batch_scan_result_create")
     self.swiftscan_import_set_create =
       try loadRequired("swiftscan_import_set_create")
-
   }
 }
 

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -96,6 +96,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// JSON-based -print-target-info output
   case jsonTargetInfo = "targetInfo.json"
 
+  /// JSON-based -emit-supported-features output
+  case jsonCompilerFeatures = "compilerFeatures.json"
+
   /// JSON-based binary Swift module artifact description
   case jsonSwiftArtifacts = "artifacts.json"
 
@@ -167,6 +170,9 @@ extension FileType: CustomStringConvertible {
     case .jsonTargetInfo:
       return "json-target-info"
 
+    case .jsonCompilerFeatures:
+      return "json-supported-features"
+
     case .jsonSwiftArtifacts:
       return "json-module-artifacts"
 
@@ -203,7 +209,7 @@ extension FileType {
          .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
          .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
          .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile, .jsonDependencies,
-         .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts:
+         .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures, .jsonSwiftArtifacts:
       return false
     }
   }
@@ -278,6 +284,8 @@ extension FileType {
       return "json-dependencies"
     case .jsonTargetInfo:
       return "json-target-info"
+    case .jsonCompilerFeatures:
+      return "json-supported-features"
     case .jsonSwiftArtifacts:
       return "json-module-artifacts"
     case .importedModules:
@@ -302,7 +310,8 @@ extension FileType {
     case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
          .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface,
-         .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonSwiftArtifacts:
+         .jsonDependencies, .clangModuleMap, .jsonCompilerFeatures,
+         .jsonTargetInfo, .jsonSwiftArtifacts:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -322,7 +331,7 @@ extension FileType {
          .swiftSourceInfoFile, .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap,
          .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord,
          .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies, .clangModuleMap,
-         .jsonTargetInfo, .jsonSwiftArtifacts:
+         .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts:
       return false
     }
   }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -163,9 +163,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
               InterModuleDependencyGraph.self,
               from: ModuleDependenciesInputs.fastDependencyScannerOutput.data(using: .utf8)!)
       let dependencyOracle = InterModuleDependencyOracle()
+      let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
+                                                  hostTriple: driver.hostTriple,
+                                                  env: ProcessEnv.vars)
       try dependencyOracle
         .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
-                                       swiftScanLibPath: try driver.getScanLibPath(of: driver.toolchain))
+                                       swiftScanLibPath: scanLibPath)
       try dependencyOracle.mergeModules(from: moduleDependencyGraph)
       driver.explicitDependencyBuildPlanner =
         try ExplicitDependencyBuildPlanner(dependencyGraph: moduleDependencyGraph,
@@ -245,9 +248,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: commandLine, executor: executor,
                               externalBuildArtifacts: (targetModulePathMap, [:]),
                               interModuleDependencyOracle: dependencyOracle)
+      let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
+                                                  hostTriple: driver.hostTriple,
+                                                  env: ProcessEnv.vars)
       try dependencyOracle
         .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
-                                       swiftScanLibPath: try driver.getScanLibPath(of: driver.toolchain))
+                                       swiftScanLibPath: scanLibPath)
 
       // Plan explicit dependency jobs, after resolving placeholders to actual dependencies.
       try moduleDependencyGraph.resolvePlaceholderDependencies(for: (targetModulePathMap, [:]),
@@ -584,9 +590,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
     // The dependency oracle wraps an instance of libSwiftScan and ensures thread safety across
     // queries.
     let dependencyOracle = InterModuleDependencyOracle()
+    let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
+                                                hostTriple: driver.hostTriple,
+                                                env: ProcessEnv.vars)
     guard try dependencyOracle
             .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
-                                           swiftScanLibPath: try driver.getScanLibPath(of: driver.toolchain)) else {
+                                           swiftScanLibPath: scanLibPath) else {
       XCTFail("Dependency scanner library not found")
       return
     }


### PR DESCRIPTION
Building on https://github.com/apple/swift/pull/35882, make the driver aware of which swift-frontend flags its toolchain's compiler supports. 

- Add `supportedFrontendFlags` property to the Driver
- This property is computed using either:
      - A `libSwiftScan` query if an instance of the library is available and supports executing such query
      - A fallback mechanism that invokes `swift-frontend -emit-supported-features` 

For `libSwiftDriver`, this is critical for multiplexing library instances, and for the library's compatibility with different versions of the compiler.


Resolves rdar://73631930