### PR TITLE
Use the FrontendOverride when querying the `hostTriple`.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -530,8 +530,8 @@ public struct Driver {
 
     self.supportedFrontendFlags =
       try Self.computeSupportedCompilerFeatures(of: self.toolchain, hostTriple: self.hostTriple,
-                                                swiftCompilerPrefixArgs:
-                                                  swiftCompilerPrefixArgs,
+                                                parsedOptions: &self.parsedOptions,
+                                                diagnosticsEngine: diagnosticEngine,
                                                 fileSystem: fileSystem, executor: executor,
                                                 env: env)
 
@@ -2287,7 +2287,7 @@ extension Driver {
     }
   }
 
-  private struct FrontendOverride {
+  internal struct FrontendOverride {
     private let overridePath: AbsolutePath?
     let prefixArgs: [String]
 

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -419,8 +419,8 @@ public struct Driver {
 
     // Compute the host machine's triple
     self.hostTriple =
-      try Self.computeHostTriple(toolchain: self.toolchain,
-                                 executor: self.executor,
+      try Self.computeHostTriple(&self.parsedOptions, diagnosticsEngine: diagnosticEngine,
+                                 toolchain: self.toolchain, executor: self.executor,
                                  swiftCompilerPrefixArgs: self.swiftCompilerPrefixArgs)
 
     // Classify and collect all of the input files.
@@ -2154,12 +2154,20 @@ extension Driver {
   static let defaultToolchainType: Toolchain.Type = GenericUnixToolchain.self
   #endif
 
-  static func computeHostTriple(toolchain: Toolchain,
-                                executor: DriverExecutor,
-                                swiftCompilerPrefixArgs: [String]) throws -> Triple {
+  static func computeHostTriple(
+    _ parsedOptions: inout ParsedOptions,
+    diagnosticsEngine: DiagnosticsEngine,
+    toolchain: Toolchain,
+    executor: DriverExecutor,
+    swiftCompilerPrefixArgs: [String]) throws -> Triple {
+
+    let frontendOverride = try FrontendOverride(&parsedOptions, diagnosticsEngine)
+    frontendOverride.setUpForTargetInfo(toolchain)
+    defer { frontendOverride.setUpForCompilation(toolchain) }
     return try executor.execute(
       job: toolchain.printTargetInfoJob(target: nil, targetVariant: nil,
-                                        swiftCompilerPrefixArgs: swiftCompilerPrefixArgs),
+                                        swiftCompilerPrefixArgs:
+                                          frontendOverride.prefixArgsForTargetInfo),
       capturingJSONOutputAs: FrontendTargetInfo.self,
       forceResponseFiles: false,
       recordedInputModificationDates: [:]).target.triple
@@ -2203,7 +2211,8 @@ extension Driver {
                                        toolDirectory: toolDir)
 
     let frontendOverride = try FrontendOverride(&parsedOptions, diagnosticsEngine)
-
+    frontendOverride.setUpForTargetInfo(toolchain)
+    defer { frontendOverride.setUpForCompilation(toolchain) }
     // Find the SDK, if any.
     let sdkPath: VirtualPath? = Self.computeSDKPath(
       &parsedOptions, compilerMode: compilerMode, toolchain: toolchain,
@@ -2213,7 +2222,6 @@ extension Driver {
 
     // Query the frontend for target information.
     do {
-      frontendOverride.setUpForTargetInfo(toolchain)
       var info: FrontendTargetInfo = try executor.execute(
         job: toolchain.printTargetInfoJob(
           target: explicitTarget, targetVariant: explicitTargetVariant,
@@ -2248,7 +2256,6 @@ extension Driver {
         diagnosticsEngine.emit(.warning_inferring_simulator_target(originalTriple: explicitTarget,
                                                                    inferredTriple: info.target.triple))
       }
-      frontendOverride.setUpForCompilation(toolchain)
       return (toolchain, info, frontendOverride.prefixArgs)
     } catch let JobExecutionError.decodingError(decodingError,
                                                 dataToDecode,
@@ -2281,11 +2288,11 @@ extension Driver {
   }
 
   private struct FrontendOverride {
-    private let path: AbsolutePath?
+    private let overridePath: AbsolutePath?
     let prefixArgs: [String]
 
     init() {
-      path = nil
+      overridePath = nil
       prefixArgs = []
     }
 
@@ -2301,23 +2308,23 @@ extension Driver {
         self = Self()
         return
       }
-      path = try AbsolutePath(validating: pathString)
+      overridePath = try AbsolutePath(validating: pathString)
       prefixArgs = frontendCommandLine.dropFirst().map {String($0)}
     }
 
     var appliesToFetchingTargetInfo: Bool {
-      path?.basename != "Python"
+      return overridePath?.basename != "Python"
     }
     func setUpForTargetInfo(_ toolchain: Toolchain) {
-      if appliesToFetchingTargetInfo {
-        setUpForCompilation(toolchain)
+      if !appliesToFetchingTargetInfo {
+        toolchain.clearKnownToolPath(.swiftCompiler)
       }
     }
     var prefixArgsForTargetInfo: [String] {
       appliesToFetchingTargetInfo ? prefixArgs : []
     }
     func setUpForCompilation(_ toolchain: Toolchain) {
-      if let path = path {
+      if let path = overridePath {
         toolchain.overrideToolPath(.swiftCompiler, path: path)
       }
     }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -80,6 +80,10 @@ import SwiftOptions
     toolPaths[tool] = path
   }
 
+  public func clearKnownToolPath(_ tool: Tool) {
+    toolPaths.removeValue(forKey: tool)
+  }
+
   /// Path to the StdLib inside the SDK.
   public func sdkStdlib(sdk: AbsolutePath) -> AbsolutePath {
     sdk.appending(RelativePath("usr/lib/swift"))

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -86,6 +86,10 @@ import TSCBasic
     toolPaths[tool] = path
   }
 
+  public func clearKnownToolPath(_ tool: Tool) {
+    toolPaths.removeValue(forKey: tool)
+  }
+
   public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {
     return nil
   }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -46,6 +46,9 @@ public enum Tool: Hashable {
   /// Set an absolute path to be used for a particular tool.
   func overrideToolPath(_ tool: Tool, path: AbsolutePath)
 
+  /// Remove the absolute path used for a particular tool, in case it was overriden or cached.
+  func clearKnownToolPath(_ tool: Tool)
+
   /// Returns path of the default SDK, if there is one.
   func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath?
 

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -111,6 +111,10 @@ import SwiftOptions
     toolPaths[tool] = path
   }
 
+  public func clearKnownToolPath(_ tool: Tool) {
+    toolPaths.removeValue(forKey: tool)
+  }
+
   public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {
     return nil
   }


### PR DESCRIPTION
And fix the `FrontendOverride::setUpForTargetInfo` to clear the overridden compiler.

This should get the compiler tests in `Driver/Dependencies` running again.