### PR TITLE
Workaround a compiler error with SPI public type using `implementationOnly` properties.

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3124,16 +3124,8 @@ final class SwiftDriverTests: XCTestCase {
     do {
       let driver = try Driver(args: ["swift", "-target", "arm64-apple-ios12.0",
                                      "-resource-dir", "baz"])
-      // If a capable libSwiftScan is found, manually ensure we can get the supported arguments
-      let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
-                                                  hostTriple: driver.hostTriple,
-                                                  env: ProcessEnv.vars)
-      if localFileSystem.exists(scanLibPath) {
-        let libSwiftScanInstance = try SwiftScan(dylib: scanLibPath)
-        if libSwiftScanInstance.canQuerySupportedArguments() {
-          let supportedArguments = try libSwiftScanInstance.querySupportedArguments()
-          XCTAssertTrue(supportedArguments.contains("emit-module"))
-        }
+      if let libraryBasedResult = try driver.querySupportedArgumentsForTest() {
+        XCTAssertTrue(libraryBasedResult.contains("emit-module"))
       }
     }
     do {


### PR DESCRIPTION
Keep `SwiftScan` internal becuase using `@spi public` combined with using an `implementationOnly` property type does not work when building with 5.3 (as SwiftPM self-hosted PR testing does).

Doing this instead of https://github.com/apple/swift-driver/pull/485. 