### PR TITLE
Allow libSwiftDriver client passing down a compiler executable directory

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -353,6 +353,7 @@ public struct Driver {
     fileSystem: FileSystem = localFileSystem,
     executor: DriverExecutor,
     integratedDriver: Bool = true,
+    compilerExecutableDir: AbsolutePath? = nil,
     // FIXME: Duplication with externalBuildArtifacts and externalTargetModulePathMap
     // is a temporary backwards-compatibility shim to help transition SwiftPM to the new API
     externalBuildArtifacts: ExternalBuildArtifacts? = nil,
@@ -415,7 +416,8 @@ public struct Driver {
           &self.parsedOptions, diagnosticsEngine: diagnosticEngine,
           compilerMode: self.compilerMode, env: env,
           executor: self.executor, fileSystem: fileSystem,
-          useStaticResourceDir: self.useStaticResourceDir)
+          useStaticResourceDir: self.useStaticResourceDir,
+          compilerExecutableDir: compilerExecutableDir)
 
     // Compute the host machine's triple
     self.hostTriple =
@@ -2180,7 +2182,8 @@ extension Driver {
     env: [String: String],
     executor: DriverExecutor,
     fileSystem: FileSystem,
-    useStaticResourceDir: Bool
+    useStaticResourceDir: Bool,
+    compilerExecutableDir: AbsolutePath?
   ) throws -> (Toolchain, FrontendTargetInfo, [String]) {
     let explicitTarget = (parsedOptions.getLastArgument(.target)?.asSingle)
       .map {
@@ -2208,6 +2211,7 @@ extension Driver {
     }
     let toolchain = toolchainType.init(env: env, executor: executor,
                                        fileSystem: fileSystem,
+                                       compilerExecutableDir: compilerExecutableDir,
                                        toolDirectory: toolDir)
 
     let frontendOverride = try FrontendOverride(&parsedOptions, diagnosticsEngine)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -29,15 +29,20 @@ import SwiftOptions
   /// The file system to use for any file operations.
   public let fileSystem: FileSystem
 
+  // An externally provided path from where we should find compiler
+  public let compilerExecutableDir: AbsolutePath?
+
   // An externally provided path from where we should find tools like ld
   public let toolDirectory: AbsolutePath?
 
   public let dummyForTestingObjectFormat = Triple.ObjectFormat.macho
 
-  public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, toolDirectory: AbsolutePath? = nil) {
+  public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem,
+              compilerExecutableDir: AbsolutePath? = nil, toolDirectory: AbsolutePath? = nil) {
     self.env = env
     self.executor = executor
     self.fileSystem = fileSystem
+    self.compilerExecutableDir = compilerExecutableDir
     self.toolDirectory = toolDirectory
   }
 

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -24,14 +24,18 @@ import TSCBasic
   /// Doubles as path cache and point for overriding normal lookup
   private var toolPaths = [Tool: AbsolutePath]()
 
+  // An externally provided path from where we should find compiler
+  public let compilerExecutableDir: AbsolutePath?
+
   public let toolDirectory: AbsolutePath?
 
   public let dummyForTestingObjectFormat = Triple.ObjectFormat.elf
 
-  public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, toolDirectory: AbsolutePath? = nil) {
+  public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, compilerExecutableDir: AbsolutePath? = nil, toolDirectory: AbsolutePath? = nil) {
     self.env = env
     self.executor = executor
     self.fileSystem = fileSystem
+    self.compilerExecutableDir = compilerExecutableDir
     self.toolDirectory = toolDirectory
   }
 

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -28,7 +28,7 @@ public enum Tool: Hashable {
 /// Describes a toolchain, which includes information about compilers, linkers
 /// and other tools required to build Swift code.
 @_spi(Testing) public protocol Toolchain {
-  init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem, toolDirectory: AbsolutePath?)
+  init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem, compilerExecutableDir: AbsolutePath?, toolDirectory: AbsolutePath?)
 
   var env: [String: String] { get }
 
@@ -37,6 +37,9 @@ public enum Tool: Hashable {
   var searchPaths: [AbsolutePath] { get }
 
   var executor: DriverExecutor { get }
+
+  /// Where we should find compiler executables, e.g. XcodeDefault.xctoolchain/usr/bin
+  var compilerExecutableDir: AbsolutePath? { get }
 
   var toolDirectory: AbsolutePath? { get }
 
@@ -104,6 +107,12 @@ extension Toolchain {
 
   /// Returns the `executablePath`'s directory.
   public var executableDir: AbsolutePath {
+    // If the path is given via the initializer, use that.
+    if let givenDir = compilerExecutableDir {
+      return givenDir
+    }
+    // If the path isn't given, we are running the driver as an executable,
+    // so assuming the compiler is adjacent to the driver.
     guard let path = Bundle.main.executablePath else {
       fatalError("Could not find executable path.")
     }

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -45,14 +45,17 @@ import SwiftOptions
   /// Doubles as path cache and point for overriding normal lookup
   private var toolPaths = [Tool: AbsolutePath]()
 
+  public let compilerExecutableDir: AbsolutePath?
+
   public let toolDirectory: AbsolutePath?
 
   public let dummyForTestingObjectFormat = Triple.ObjectFormat.wasm
 
-  public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, toolDirectory: AbsolutePath? = nil) {
+  public init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem = localFileSystem, compilerExecutableDir: AbsolutePath? = nil, toolDirectory: AbsolutePath? = nil) {
     self.env = env
     self.executor = executor
     self.fileSystem = fileSystem
+    self.compilerExecutableDir = compilerExecutableDir
     self.toolDirectory = toolDirectory
   }
 


### PR DESCRIPTION
When using swift-driver as a library, we cannot assume compiler is adjacent to the
build system executable.