### PR TITLE
Add -working-directory argument to incremental tests' `runDriver` routine.

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -267,7 +267,7 @@ final class NonincrementalCompilationTests: XCTestCase {
         $0 <<< "let bar = 2"
       }
       try assertDriverDiagnostics(args: [
-        "swiftc", "-module-name", "theModule",
+        "swiftc", "-module-name", "theModule", "-working-directory", path.pathString,
         main.pathString, other.pathString
       ] + otherArgs) {driver, verifier in
         verifier.forbidUnexpected(.error, .warning, .note, .remark, .ignored)


### PR DESCRIPTION
Otherwise they deposit various build products into the package root (e.g. `main.o`, `other.o`, etc.).