### PR TITLE
[NFC] Workaround compiler issue by renaming some optionals

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/BidirectionalMap.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BidirectionalMap.swift
@@ -26,9 +26,9 @@ public struct BidirectionalMap<T1: Hashable, T2: Hashable>: Equatable, Sequence 
       return value
     }
     set {
-      if let newValue = newValue {
-        map1[key] = newValue
-        map2[newValue] = key
+      if let someNewValue = newValue {
+        map1[key] = someNewValue
+        map2[someNewValue] = key
         return
       }
       if let oldValue = map1.removeValue(forKey: key) {
@@ -45,9 +45,9 @@ public struct BidirectionalMap<T1: Hashable, T2: Hashable>: Equatable, Sequence 
       return value
     }
     set {
-      if let newValue = newValue {
-        map2[key] = newValue
-        map1[newValue] = key
+      if let someNewValue = newValue {
+        map2[key] = someNewValue
+        map1[someNewValue] = key
         return
       }
       if let oldValue = map2.removeValue(forKey: key) {

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -126,9 +126,9 @@ extension IncrementalCompilationState.InitialStateComputer {
   ) -> (ModuleDependencyGraph, Set<TypedVirtualPath>)?
   {
     let dependencyGraphPath = buildRecordInfo.dependencyGraphPath
-    let graph: ModuleDependencyGraph?
+    let graphIfPresent: ModuleDependencyGraph?
     do {
-      graph = try ModuleDependencyGraph.read( from: dependencyGraphPath, info: self)
+      graphIfPresent = try ModuleDependencyGraph.read( from: dependencyGraphPath, info: self)
     }
     catch {
       diagnosticEngine.emit(
@@ -136,7 +136,7 @@ extension IncrementalCompilationState.InitialStateComputer {
       reporter?.reportDisablingIncrementalBuild("Could not read priors from \(dependencyGraphPath)")
       return nil
     }
-    guard let graph = graph
+    guard let graph = graphIfPresent
     else {
       return buildInitialGraphFromSwiftDepsAndCollectInputsInvalidatedByChangedExternals()
     }


### PR DESCRIPTION
In some cases, some versions of the compiler cannot cope with `if let foo = foo`. So just rename the variables in the problematic cases.