### PR TITLE
Emit a remark on interrupt of the driver

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -26,6 +26,7 @@ do {
     // The underlying swift compiler isn't ready to be safely interrupted yet and
     // interrupting them may cause red-herring build failures that may pollute the build
     // log.
+    diagnosticsEngine.emit(.remark("Compilation process interrupted"))
   }
 
   if ProcessEnv.vars["SWIFT_ENABLE_EXPLICIT_MODULE"] != nil {


### PR DESCRIPTION
This should help distinguish cases where the driver invocation was interrupted by the client (e.g. a build system) vs. exited with a failure on its own.