### PR TITLE
[Incremental] Add writing dependency dot files

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(SwiftDriver
   "IncrementalCompilation/BidirectionalMap.swift"
   "IncrementalCompilation/BuildRecord.swift"
   "IncrementalCompilation/BuildRecordInfo.swift"
+  "IncrementalCompilation/DependencyGraphDotFileWriter.swift"
   "IncrementalCompilation/DependencyKey.swift"
   "IncrementalCompilation/DictionaryOfDictionaries.swift"
   "IncrementalCompilation/ExternalDependencyAndFingerprintEnforcer.swift"

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -252,6 +252,11 @@ import SwiftOptions
       .parentDirectory
       .appending(component: filename + ".priors")
   }
+
+  /// Directory to emit dot files into
+  var dotFileDirectory: VirtualPath {
+    buildRecordPath.parentDirectory
+  }
 }
 
 fileprivate extension AbsolutePath {

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -162,6 +162,16 @@ fileprivate extension DependencyKey.Designator {
       return .triangle
     }
   }
+
+  static let oneOfEachKind: [DependencyKey.Designator] = [
+      .topLevel(name: ""),
+      .dynamicLookup(name: ""),
+      .externalDepend(try! ExternalDependency(".")),
+      .sourceFileProvide(name: ""),
+      .nominal(context: ""),
+      .potentialMember(context: ""),
+      .member(context: "", name: "")
+  ]
 }
 
 // MARK: - writing one dot file

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -173,10 +173,12 @@ fileprivate struct DOTDependencyGraphSerializer<Graph: ExportableGraph> {
   private var nodeIDs = [Graph.Node: Int]()
   private var out: WritableByteStream
 
-  fileprivate init(_ graph: Graph,
-               _ stream: WritableByteStream,
-               includeExternals: Bool,
-               includeAPINotes: Bool) {
+  fileprivate init(
+    _ graph: Graph,
+    _ stream: WritableByteStream,
+    includeExternals: Bool,
+    includeAPINotes: Bool
+  ) {
     self.graph = graph
     self.out = stream
     self.includeExternals = includeExternals

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -1,0 +1,302 @@
+//===---------- DependencyGraphDotFileWriter.swift - Swift GraphViz -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+
+// MARK: - Asking to write dot files / interface
+public class DependencyGraphDotFileWriter {
+  /// Holds file-system and options
+  private let info: IncrementalCompilationState.InitialStateComputer
+
+  private var versionNumber = 0
+
+  init(_ info: IncrementalCompilationState.InitialStateComputer) {
+    self.info = info
+  }
+
+  func write(_ sfdg: SourceFileDependencyGraph) {
+    let basename = sfdg.dependencySource.shortDescription
+    write(sfdg, basename: basename)
+  }
+  
+  func write(_ mdg: ModuleDependencyGraph) {
+    write(mdg, basename: Self.moduleDependencyGraphBasename)
+  }
+
+  public static let moduleDependencyGraphBasename = "moduleDependencyGraph"
+}
+
+// MARK: Asking to write dot files / implementation
+fileprivate extension DependencyGraphDotFileWriter {
+  func write<Graph: ExportableGraph>(_ graph: Graph, basename: String) {
+    let path = dotFilePath(for: basename)
+    try! info.fileSystem.writeFileContents(path) { stream in
+      var s = DOTDependencyGraphSerializer<Graph>(
+        graph,
+        stream,
+        includeExternals: info.dependencyDotFilesIncludeExternals,
+        includeAPINotes: info.dependencyDotFilesIncludeAPINotes)
+      s.emit()
+    }
+  }
+
+  func dotFilePath(for basename: String) -> VirtualPath {
+    let nextVersionNumber = versionNumber
+    versionNumber += 1
+    return info.buildRecordInfo.dotFileDirectory
+      .appending(component: "\(basename).\(nextVersionNumber).dot")
+  }
+}
+
+// MARK: - Making dependency graphs exportable
+fileprivate protocol ExportableGraph {
+  var graphID: String {get}
+  associatedtype Node: ExportableNode
+  func forEachExportableNode(_ visit: (Node) -> Void)
+  func forEachExportableArc(_ visit: (Node, Node) -> Void)
+}
+
+extension SourceFileDependencyGraph: ExportableGraph {
+   fileprivate var graphID: String {
+    return try! VirtualPath(path: sourceFileName ?? "anonymous").basename
+  }
+  fileprivate func forEachExportableNode<Node: ExportableNode>(_ visit: (Node) -> Void) {
+    forEachNode { visit($0 as! Node) }
+  }
+  fileprivate func forEachExportableArc<Node: ExportableNode>(_ visit: (Node, Node) -> Void) {
+    forEachNode { use in
+      forEachDefDependedUpon(by: use) { def in
+        visit(def as! Node, use as! Node)
+      }
+    }
+  }
+}
+
+extension ModuleDependencyGraph: ExportableGraph {
+  fileprivate var graphID: String {
+    return "ModuleDependencyGraph"
+  }
+  fileprivate func forEachExportableNode<Node: ExportableNode>(
+    _ visit: (Node) -> Void) {
+    nodeFinder.forEachNode { visit($0 as! Node) }
+  }
+  fileprivate func forEachExportableArc<Node: ExportableNode>(
+    _ visit: (Node, Node) -> Void
+  ) {
+    nodeFinder.forEachNode {def in
+      for use in nodeFinder.uses(of: def) {
+        visit(def as! Node, use as! Node)
+      }
+    }
+  }
+}
+
+// MARK: - Making dependency graph nodes exportable
+fileprivate protocol ExportableNode: Hashable {
+  var key: DependencyKey {get}
+  var isProvides: Bool {get}
+  var label: String {get}
+}
+
+extension SourceFileDependencyGraph.Node: ExportableNode {
+}
+
+extension ModuleDependencyGraph.Node: ExportableNode {
+  fileprivate var isProvides: Bool {
+    !isExpat
+  }
+}
+
+extension ExportableNode {
+  fileprivate func emit(id: Int, to out: inout WritableByteStream) {
+    out <<< DotFileNode(id: id, node: self).description <<< "\n"
+  }
+
+  fileprivate var label: String {
+    "\(key.description) \(isProvides ? "here" : "somewhere else")"
+  }
+
+  fileprivate var isExternal: Bool {
+    key.designator.externalDependency != nil
+  }
+  fileprivate var isAPINotes: Bool {
+    key.designator.externalDependency?.file.extension == "apinotes"
+  }
+
+  fileprivate var shape: Shape {
+    key.designator.shape
+  }
+  fileprivate var fillColor: Color {
+    isProvides ? .azure : key.aspect == .interface ? .yellow : .white
+  }
+  fileprivate var style: Style? {
+    isProvides ? .solid : .dotted
+  }
+}
+
+
+fileprivate extension DependencyKey.Designator {
+  var shape: Shape {
+    switch self {
+    case .topLevel:
+      return .box
+    case .dynamicLookup:
+      return .diamond
+    case .externalDepend:
+      return .house
+    case .sourceFileProvide:
+      return .hexagon
+    case .nominal:
+      return .parallelogram
+    case .potentialMember:
+      return .ellipse
+    case .member:
+      return .triangle
+    }
+  }
+}
+
+// MARK: - writing one dot file
+
+fileprivate struct DOTDependencyGraphSerializer<Graph: ExportableGraph> {
+  private let includeExternals: Bool
+  private let includeAPINotes: Bool
+  private let graph: Graph
+  private var nodeIDs = [Graph.Node: Int]()
+  private var out: WritableByteStream
+
+  fileprivate init(_ graph: Graph,
+               _ stream: WritableByteStream,
+               includeExternals: Bool,
+               includeAPINotes: Bool) {
+    self.graph = graph
+    self.out = stream
+    self.includeExternals = includeExternals
+    self.includeAPINotes = includeAPINotes
+  }
+
+  fileprivate mutating func emit() {
+    emitPrelude()
+    emitLegend()
+    emitNodes()
+    emitArcs()
+    emitPostlude()
+  }
+
+  private func emitPrelude() {
+    out <<< "digraph " <<< graph.graphID.quoted <<< " {\n"
+  }
+  private mutating func emitLegend() {
+    for dummy in DependencyKey.Designator.oneOfEachKind {
+      out <<< DotFileNode(forLegend: dummy).description <<< "\n"
+    }
+  }
+  private mutating func emitNodes() {
+    graph.forEachExportableNode { (n: Graph.Node) in
+      if include(n) {
+        n.emit(id: register(n), to: &out)
+      }
+    }
+  }
+
+  private mutating func register(_ n: Graph.Node) -> Int {
+    let newValue = nodeIDs.count
+    let oldValue = nodeIDs.updateValue(newValue, forKey: n)
+    assert(oldValue == nil, "not nil")
+    return newValue
+  }
+
+  private func emitArcs() {
+    graph.forEachExportableArc { (def: Graph.Node, use: Graph.Node) in
+      if include(def: def, use: use) {
+        out <<< DotFileArc(defID: nodeIDs[def]!, useID: nodeIDs[use]!).description <<< "\n"
+      }
+    }
+  }
+  private func emitPostlude() {
+    out <<< "\n}\n"
+  }
+
+  func include(_ n: Graph.Node) -> Bool {
+    let externalPredicate = includeExternals || !n.isExternal
+    let apiPredicate = includeAPINotes || !n.isAPINotes
+    return externalPredicate && apiPredicate;
+  }
+
+  func include(def: Graph.Node, use: Graph.Node) -> Bool {
+    include(def) && include(use)
+  }
+}
+
+fileprivate extension String {
+  var quoted: String {
+    "\"" + replacingOccurrences(of: "\"", with: "\\\"") + "\""
+  }
+}
+
+fileprivate struct DotFileNode: CustomStringConvertible {
+  let id: String
+  let label: String
+  let shape: Shape
+  let fillColor: Color
+  let style: Style?
+
+  init<Node: ExportableNode>(id: Int, node: Node) {
+    self.id = String(id)
+    self.label = node.label
+    self.shape = node.shape
+    self.fillColor = node.fillColor
+    self.style = node.style
+  }
+
+  init(forLegend designator: DependencyKey.Designator) {
+    self.id = designator.shape.rawValue
+    self.label = designator.kindName
+    self.shape = designator.shape
+    self.fillColor = .azure
+    self.style = nil
+  }
+
+  var description: String {
+    let bodyString: String = [
+      ("label", label),
+      ("shape", shape.rawValue),
+      ("fillcolor", fillColor.rawValue),
+      style.map {("style", $0.rawValue)}
+    ]
+      .compactMap {
+        $0.map {name, value  in "\(name) = \"\(value)\""}
+      }
+      .joined(separator: ", ")
+
+    return "\(id.quoted) [ \(bodyString) ]"
+  }
+}
+
+fileprivate struct DotFileArc: CustomStringConvertible {
+  let defID, useID: Int
+
+  var description: String {
+    "\(defID) -> \(useID);"
+  }
+}
+
+fileprivate enum Shape: String {
+  case box, parallelogram, ellipse, triangle, diamond, house, hexagon
+}
+
+fileprivate enum Color: String {
+  case azure, white, yellow
+}
+
+fileprivate enum Style: String {
+  case solid, dotted
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -195,16 +195,6 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
     /// `name` field corresponds to the *unmangled* name of the member.
     case member(context: String, name: String)
 
-    public static let oneOfEachKind: [Designator] = [
-        .topLevel(name: ""),
-        .dynamicLookup(name: ""),
-        .externalDepend(try! ExternalDependency(".")),
-        .sourceFileProvide(name: ""),
-        .nominal(context: ""),
-        .potentialMember(context: ""),
-        .member(context: "", name: "")
-    ]
-
     var externalDependency: ExternalDependency? {
       switch self {
       case let .externalDepend(externalDependency):

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -38,6 +38,11 @@ import TSCBasic
     file.name
   }
 
+  public var shortDescription: String {
+    DependencySource(file).map { $0.shortDescription }
+    ?? file.basename
+  }
+
   public static func < (lhs: Self, rhs: Self) -> Bool {
     lhs.file.name < rhs.file.name
   }
@@ -190,12 +195,72 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
     /// `name` field corresponds to the *unmangled* name of the member.
     case member(context: String, name: String)
 
+    public static let oneOfEachKind: [Designator] = [
+        .topLevel(name: ""),
+        .dynamicLookup(name: ""),
+        .externalDepend(try! ExternalDependency(".")),
+        .sourceFileProvide(name: ""),
+        .nominal(context: ""),
+        .potentialMember(context: ""),
+        .member(context: "", name: "")
+    ]
+
     var externalDependency: ExternalDependency? {
       switch self {
       case let .externalDepend(externalDependency):
         return externalDependency
       default:
         return nil
+      }
+    }
+
+    public var context: String? {
+      switch self {
+      case .topLevel(name: _):
+        return nil
+      case .dynamicLookup(name: _):
+        return nil
+      case .externalDepend(_):
+        return nil
+      case .sourceFileProvide(name: _):
+        return nil
+      case .nominal(context: let context):
+        return context
+      case .potentialMember(context: let context):
+        return context
+      case .member(context: let context, name: _):
+        return context
+      }
+    }
+
+    public var name: String? {
+      switch self {
+      case .topLevel(name: let name):
+        return name
+      case .dynamicLookup(name: let name):
+        return name
+      case .externalDepend(let path):
+        return path.file.name
+      case .sourceFileProvide(name: let name):
+        return name
+      case .member(context: _, name: let name):
+        return name
+      case .nominal(context: _):
+        return nil
+      case .potentialMember(context: _):
+        return nil
+      }
+    }
+
+    public var kindName: String {
+      switch self {
+      case .topLevel: return "top-level"
+      case .nominal: return "nominal"
+      case .potentialMember: return "potential member"
+      case .member: return "member"
+      case .dynamicLookup: return "dynamic lookup"
+      case .externalDepend: return "external"
+      case .sourceFileProvide: return "source file"
       }
     }
 
@@ -212,7 +277,7 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
       case let .dynamicLookup(name: name):
         return "AnyObject member '\(name)'"
       case let .externalDepend(externalDependency):
-        return "import '\(externalDependency)'"
+        return "import '\(externalDependency.shortDescription)'"
       case let .sourceFileProvide(name: name):
         return "source file \((try? VirtualPath(path: name).basename) ?? name)"
       }

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -33,6 +33,11 @@ extension IncrementalCompilationState {
     @_spi(Testing) public let isCrossModuleIncrementalBuildEnabled: Bool
     @_spi(Testing) public let verifyDependencyGraphAfterEveryImport: Bool
     @_spi(Testing) public let emitDependencyDotFileAfterEveryImport: Bool
+    
+    /// Options, someday
+    @_spi(Testing) public let dependencyDotFilesIncludeExternals: Bool = true
+    @_spi(Testing) public let dependencyDotFilesIncludeAPINotes: Bool = false
+
     @_spi(Testing) public let buildTime: Date
 
     @_spi(Testing) public init(
@@ -143,6 +148,8 @@ extension IncrementalCompilationState.InitialStateComputer {
     guard graph.populateInputDependencySourceMap() else {
       return nil
     }
+    graph.dotFileWriter?.write(graph)
+
     // Any externals not already in graph must be additions which should trigger
     // recompilation. Thus, `ChangedOrAdded`.
     let nodesInvalidatedByExternals = graph.collectNodesInvalidatedByChangedOrAddedExternals()

--- a/Sources/SwiftDriver/IncrementalCompilation/KeyAndFingerprintHolder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/KeyAndFingerprintHolder.swift
@@ -14,7 +14,9 @@ import Foundation
 
 
 /// Encapsulates the invariant required for anything with a DependencyKey and an fingerprint
-public struct KeyAndFingerprintHolder: ExternalDependencyAndFingerprintEnforcer {
+public struct KeyAndFingerprintHolder:
+  ExternalDependencyAndFingerprintEnforcer, Equatable, Hashable
+{
   /// Def->use arcs go by DependencyKey. There may be >1 node for a given key.
   let key: DependencyKey
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -75,3 +75,19 @@ extension DependencySource: Comparable {
     lhs.file.name < rhs.file.name
   }
 }
+
+// MARK: - describing
+extension DependencySource {
+  /// Answer a single name; for swift modules, the right thing is one level up
+  public var shortDescription: String {
+    switch typedFile.type {
+    case .swiftDeps:
+      return file.basename
+    case .swiftModule:
+      return file.parentDirectory.basename
+    default:
+      return file.name
+    }
+  }
+}
+

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -82,9 +82,8 @@ extension ModuleDependencyGraph.Integrator {
     if destination.info.verifyDependencyGraphAfterEveryImport {
       integrator.verifyAfterImporting()
     }
-    if destination.info.emitDependencyDotFileAfterEveryImport {
-      destination.emitDotFile(g)
-    }
+    destination.dotFileWriter?.write(g)
+    destination.dotFileWriter?.write(destination)
     return integrator.results
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -30,8 +30,8 @@ import TSCUtility
      implementation: allNodes[SourceFileDependencyGraph.sourceFileProvidesImplementationSequenceNumber])
   }
   
-  public func forEachNode(_ doIt: (Node) -> Void) {
-    allNodes.forEach(doIt)
+  public func forEachNode(_ visit: (Node) -> Void) {
+    allNodes.forEach(visit)
   }
   
   public func forEachDefDependedUpon(by node: Node, _ doIt: (Node) -> Void) {
@@ -47,7 +47,11 @@ import TSCUtility
       }
     }
   }
-  
+
+  public var sourceFileName: String? {
+    sourceFileNodePair.interface.key.designator.name
+  }
+
   @discardableResult public func verify() -> Bool {
     assert(Array(allNodes.indices) == allNodes.map { $0.sequenceNumber })
     forEachNode {
@@ -58,7 +62,7 @@ import TSCUtility
 }
 
 extension SourceFileDependencyGraph {
-  public struct Node: CustomStringConvertible {
+  public struct Node: Equatable, Hashable, CustomStringConvertible {
     public let keyAndFingerprint: KeyAndFingerprintHolder
     public var key: DependencyKey { keyAndFingerprint.key }
     public var fingerprint: String? { keyAndFingerprint.fingerprint }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -154,7 +154,6 @@ extension Driver {
     }
     if self.parsedOptions.contains(.enableExperimentalCrossModuleIncrementalBuild) {
       options.formUnion(.enableCrossModuleIncrementalBuild)
-      #warning("dmu: separate option for now??")
       options.formUnion(.readPriorsFromModuleDependencyGraph)
     }
     return options

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -416,6 +416,11 @@ extension TSCBasic.FileSystem {
     }
   }
 
+  func writeFileContents(_ path: VirtualPath, body: (WritableByteStream) -> Void) throws {
+    try resolvingVirtualPath(path) { absolutePath in
+      try self.writeFileContents(absolutePath, body: body)
+    }
+  }
 
   func getFileInfo(_ path: VirtualPath) throws -> TSCBasic.FileInfo {
     try resolvingVirtualPath(path, apply: getFileInfo)

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -135,3 +135,14 @@ extension IncrementalCompilationState.InitialStateComputer {
               diagnosticsEngine)
   }
 }
+
+func `is`<S: StringProtocol>(dotFileName a: S, lessThan b: S) -> Bool {
+  let sequenceNumbers = [a, b].map { Int($0.split(separator: ".").dropLast().last!)! }
+  return sequenceNumbers[0] < sequenceNumbers[1]
+}
+
+extension Collection where Element: StringProtocol {
+  func sortedByDotFileSequenceNumbers() -> [Element] {
+    sorted(by: `is`(dotFileName:lessThan:))
+  }
+}

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -716,7 +716,7 @@ final class IncrementalCompilationTests: XCTestCase {
   }
   func doABuild(_ message: String,
                 checkDiagnostics: Bool,
-                extraArguments: [String] ,
+                extraArguments: [String],
                 expectingRemarks texts: [String],
                 whenAutolinking: [String]) throws {
     try doABuild(


### PR DESCRIPTION
Add capability to write dot files for source file- and module- dependency graphs. It's a debugging facility for the incremental work. (`-driver-emit-fine-grained-dependency-dot-file-after-every-import`)