### PR TITLE
[Incremental] Fix fingerprint integration bug, add a test, and add debugging affordances.

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -307,7 +307,8 @@ extension ModuleDependencyGraph {
     fed.incrementalDependencySource?
       .read(in: info.fileSystem, reporter: info.reporter)
       .map { unserializedDepGraph in
-        Integrator.integrate(
+        info.reporter?.report("Integrating changes from", fed.externalDependency.file)
+        return Integrator.integrate(
           from: unserializedDepGraph,
           into: self,
           includeAddedExternals: includeAddedExternals)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -136,6 +136,7 @@ extension ModuleDependencyGraph.Integrator {
     // Node was and still is. Do not remove it.
     disappearedNodes.removeValue(forKey: matchHere.key)
     if matchHere.fingerprint != integrand.fingerprint {
+      matchHere.setFingerprint(integrand.fingerprint)
       results.allInvalidatedNodes.insert(matchHere)
     }
     return matchHere

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -23,6 +23,10 @@ extension ModuleDependencyGraph {
   /// (Cargo-culted and modified from the legacy driver.)
   ///
   /// Use a class, not a struct because otherwise it would be duplicated for each thing it uses
+  ///
+  /// Neither the `fingerprint`, nor the `isTraced` value is part of the node's identity.
+  /// Neither of these must be considered for equality testing or hashing because their
+  /// value is subject to change during integration and tracing.
 
   public final class Node {
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -173,6 +173,7 @@ extension ModuleDependencyGraph.NodeFinder {
     let replacement = Graph.Node(key: original.key,
                                  fingerprint: newFingerprint,
                                  dependencySource: newDependencySource)
+    assert(original.isExpat, "Would have to search every use in usesByDef if original could be a use.")
     if usesByDef.removeValue(original, forKey: original.key) != nil {
       usesByDef.insertValue(replacement, forKey: original.key)
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -58,7 +58,7 @@ import TSCUtility
 }
 
 extension SourceFileDependencyGraph {
-  public struct Node {
+  public struct Node: CustomStringConvertible {
     public let keyAndFingerprint: KeyAndFingerprintHolder
     public var key: DependencyKey { keyAndFingerprint.key }
     public var fingerprint: String? { keyAndFingerprint.fingerprint }
@@ -91,6 +91,17 @@ extension SourceFileDependencyGraph {
           assert(sequenceNumber == SourceFileDependencyGraph.sourceFileProvidesImplementationSequenceNumber)
         }
       }
+    }
+
+    public var description: String {
+      [
+        key.description,
+        fingerprint.map {"fingerprint: \($0.description)"},
+        isProvides ? "provides" : "depends",
+        defsIDependUpon.isEmpty ? nil : "depends on \(defsIDependUpon.count)"
+      ]
+        .compactMap{$0}
+        .joined(separator: ", ")
     }
   }
 }

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -29,6 +29,24 @@ extension ModuleDependencyGraph {
     }
     return false
   }
+
+  func setUntraced() {
+    nodeFinder.forEachNode {
+      $0.setUntraced()
+    }
+  }
+
+  func ensureIsSerializable() {
+    var nodeIDs = Set<Node>()
+    nodeFinder.forEachNode { node in
+      nodeIDs.insert(node)
+    }
+    for key in nodeFinder.usesByDef.keys {
+      for use in nodeFinder.usesByDef[key, default: []] {
+        XCTAssertTrue(nodeIDs.contains(use), "Node ID was not registered! \(use), \(String(describing: use.fingerprint))")
+      }
+    }
+  }
 }
 
 // MARK: - mocking


### PR DESCRIPTION
When integrating a node where the only change is its fingerprint, it's critical to set the fingerprint of the integrated-to node on the module dependency graph to match the node being integrated. That way, if its fingerprint changes back and it gets integrated again, the change will be noticed. 

The above was not happening. This PR adds a test case, fixes the bug, adds a nice `description` to source file dependency nodes (to aid in debugging), and also adds a check to ensure that a graph is serializable. 