### PR TITLE
Interrupt handler: terminate (SIGINT) running compiler processes and allow the driver to exit gracefully.

### DIFF
--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -539,7 +539,11 @@ class ExecuteJobRule: LLBuildRule {
           }
 #if !os(Windows)
         case let .signalled(signal):
-          context.diagnosticsEngine.emit(.error_command_signalled(kind: job.kind, signal: signal))
+          // An interrupt of an individual compiler job means it was deliberatly cancelled,
+          // most likely by the driver itself. This does not constitute an error.
+          if signal != SIGINT {
+            context.diagnosticsEngine.emit(.error_command_signalled(kind: job.kind, signal: signal))
+          }
 #endif
         }
       }


### PR DESCRIPTION
We need to ensure that we terminate (SIGINT) the running compiler processes without emitting an error that those processes got terminated, and allow the driver to continue execution so that it is able to emit parseable-output which communicates that the terminated compiler jobs were interrupted. 

Resolves rdar://74527749