### PR TITLE
[Incremental] Improve printing for debugging

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -66,7 +66,7 @@ fileprivate protocol ExportableGraph {
 
 extension SourceFileDependencyGraph: ExportableGraph {
    fileprivate var graphID: String {
-    return try! VirtualPath(path: sourceFileName ?? "anonymous").basename
+    return try! VirtualPath(path: sourceFileName).basename
   }
   fileprivate func forEachExportableNode<Node: ExportableNode>(_ visit: (Node) -> Void) {
     forEachNode { visit($0 as! Node) }

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -22,7 +22,11 @@ import TSCBasic
 
   /*@_spi(Testing)*/ public init(_ fileName: String)
   throws {
-    self.file = try VirtualPath(path: fileName)
+    self.init(try VirtualPath(path: fileName))
+  }
+
+  init(_ file: VirtualPath) {
+    self.file = file
     self.isSwiftModule = file.extension == FileType.swiftModule.rawValue
   }
 
@@ -35,7 +39,13 @@ import TSCBasic
   }
 
   public var description: String {
-    file.name
+    switch file.extension {
+    case FileType.swiftModule.rawValue:
+      // Swift modules have an extra component at the end that is not descriptive
+      return file.parentDirectory.basename
+    default:
+      return file.basename
+    }
   }
 
   public var shortDescription: String {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -313,7 +313,7 @@ extension ModuleDependencyGraph {
     fed.incrementalDependencySource?
       .read(in: info.fileSystem, reporter: info.reporter)
       .map { unserializedDepGraph in
-        info.reporter?.report("Integrating changes from", fed.externalDependency.file)
+        info.reporter?.report("Integrating changes from: \(fed.externalDependency)")
         return Integrator.integrate(
           from: unserializedDepGraph,
           into: self,

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -42,7 +42,7 @@ public struct DependencySource: Hashable, CustomStringConvertible {
   public var file: VirtualPath { typedFile.file }
 
   public var description: String {
-    file.description
+    ExternalDependency(file).description
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -48,8 +48,8 @@ import TSCUtility
     }
   }
 
-  public var sourceFileName: String? {
-    sourceFileNodePair.interface.key.designator.name
+  public var sourceFileName: String {
+    dependencySource.file.name
   }
 
   @discardableResult public func verify() -> Bool {


### PR DESCRIPTION
When printing out swiftdeps and swiftmodules for the debugging remarks and in the dot graphs, just use the basename of the swiftdeps and the parent-directory of the swiftmodules. (Because every swiftmodule has the same basename, the parent carries the info.)

Also, get the source name for a `SourceFileDependencyGraph` from its `DependencySource`, which is statically guaranteed to be present.