### PR TITLE
[Incremental] Simplify integration logic using a phase concept & Use wrapper types

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(SwiftDriver
   "IncrementalCompilation/DependencyGraphDotFileWriter.swift"
   "IncrementalCompilation/DependencyKey.swift"
   "IncrementalCompilation/DictionaryOfDictionaries.swift"
+  "IncrementalCompilation/DirectAndTransitiveCollections.swift"
   "IncrementalCompilation/ExternalDependencyAndFingerprintEnforcer.swift"
   "IncrementalCompilation/IncrementalCompilationState.swift"
   "IncrementalCompilation/InitialStateComputer.swift"

--- a/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
@@ -1,0 +1,46 @@
+//===------------------ DirectAndTransitiveCollections.swift --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Use the type system to ensure that dependencies are transitively closed
+// without doing too much work at the leaves of the call tree
+
+public struct DirectlyInvalidatedNodes {
+  typealias Node = ModuleDependencyGraph.Node
+  var contents = Set<Node>()
+
+  init(_ s: Set<Node> = Set()) {
+    self.contents = s
+  }
+
+  init<Nodes: Sequence>(_ nodes: Nodes)
+  where Nodes.Element == Node
+  {
+    self.init(Set(nodes))
+  }
+
+  mutating func insert(_ e: Node) {
+    contents.insert(e)
+  }
+  mutating func formUnion(_ nodes: DirectlyInvalidatedNodes) {
+    contents.formUnion(nodes.contents)
+  }
+}
+
+//extension Sequence {
+//  func reduce(into initialResult: DirectlyInvalidatedNodes,
+//              _ updateAccumulatingResult: (inout: DirectlyInvalidatedNodes, Element) -> Void) {
+//    var r = initialResult
+//    reduce(into: r.contents, updateAccumulatingResult)
+//    return r
+//    }
+//  }
+//}

--- a/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
@@ -13,34 +13,74 @@
 // Use the type system to ensure that dependencies are transitively closed
 // without doing too much work at the leaves of the call tree
 
-public struct DirectlyInvalidatedNodes {
-  typealias Node = ModuleDependencyGraph.Node
-  var contents = Set<Node>()
+public struct Transitively {}
+public struct Directly {}
 
-  init(_ s: Set<Node> = Set()) {
+public struct InvalidatedSet<ClosureLevel, Element: Hashable>: Sequence {
+  var contents: Set<Element>
+
+  init(_ s: Set<Element> = Set()) {
     self.contents = s
   }
-
-  init<Nodes: Sequence>(_ nodes: Nodes)
-  where Nodes.Element == Node
+  init<Elements: Sequence>(_ elements: Elements)
+  where Elements.Element == Element
   {
-    self.init(Set(nodes))
+    self.init(Set(elements))
   }
-
-  mutating func insert(_ e: Node) {
+  mutating func insert(_ e: Element) {
     contents.insert(e)
   }
-  mutating func formUnion(_ nodes: DirectlyInvalidatedNodes) {
-    contents.formUnion(nodes.contents)
+  mutating func formUnion<Elements: Sequence>(_ elements: Elements)
+  where Elements.Element == Element{
+    contents.formUnion(elements)
+  }
+  public func makeIterator() -> Set<Element>.Iterator {
+    contents.makeIterator()
+  }
+  public func map<R>(_ transform: (Element) -> R) -> InvalidatedArray<ClosureLevel, R> {
+    InvalidatedArray(contents.map(transform))
+  }
+  public func compactMap<R>(_ transform: (Element) -> R? ) -> InvalidatedArray<ClosureLevel, R> {
+    InvalidatedArray(contents.compactMap(transform))
   }
 }
 
-//extension Sequence {
-//  func reduce(into initialResult: DirectlyInvalidatedNodes,
-//              _ updateAccumulatingResult: (inout: DirectlyInvalidatedNodes, Element) -> Void) {
-//    var r = initialResult
-//    reduce(into: r.contents, updateAccumulatingResult)
-//    return r
-//    }
-//  }
-//}
+extension InvalidatedSet where Element: Comparable {
+  func sorted() -> InvalidatedArray<ClosureLevel, Element> {
+    InvalidatedArray(contents.sorted())
+  }
+}
+
+public struct InvalidatedArray<ClosureLevel, Element>: Sequence {
+  var contents: [Element]
+
+  init(_ s: [Element] = []) {
+    self.contents = s
+  }
+  init<Elements: Sequence>(_ elements: Elements)
+  where Elements.Element == Element
+  {
+    self.init(Array(elements))
+  }
+  public func makeIterator() -> Array<Element>.Iterator {
+    contents.makeIterator()
+  }
+  public mutating func append(_ e: Element) {
+    contents.append(e)
+  }
+  public func reduce<R: Hashable>(
+    into initialResult: InvalidatedSet<ClosureLevel, R>,
+    _ updateAccumulatingResult: (inout Set<R>, Element) -> ()
+  ) -> InvalidatedSet<ClosureLevel, R> {
+    InvalidatedSet(
+      contents.reduce(into: initialResult.contents, updateAccumulatingResult))
+  }
+  public var count: Int { contents.count }
+}
+
+public typealias TransitivelyInvalidatedNodeArray = InvalidatedArray<Transitively, ModuleDependencyGraph.Node>
+public typealias TransitivelyInvalidatedSourceSet = InvalidatedSet<Transitively, DependencySource>
+public typealias TransitivelyInvalidatedInputArray = InvalidatedArray<Transitively, TypedVirtualPath>
+public typealias TransitivelyInvalidatedInputSet = InvalidatedSet<Transitively, TypedVirtualPath>
+public typealias DirectlyInvalidatedNodeArray = InvalidatedArray<Directly, ModuleDependencyGraph.Node>
+public typealias DirectlyInvalidatedNodeSet = InvalidatedSet<Directly, ModuleDependencyGraph.Node>

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -182,9 +182,6 @@ extension Diagnostic.Message {
         "output file map has no master dependencies entry (\"\(FileType.swiftDeps)\" under \"\")"
     )
   }
-  fileprivate static func remark_disabling_incremental_build(because why: String) -> Diagnostic.Message {
-    return .remark("Disabling incremental build: \(why)")
-  }
 
   static let remarkDisabled = Diagnostic.Message.remark_incremental_compilation_has_been_disabled
 
@@ -201,13 +198,6 @@ extension Diagnostic.Message {
   }
 }
 
-
-// MARK: - Scheduling the first wave, i.e. the mandatory pre- and compile jobs
-
-extension IncrementalCompilationState {
-
-
-}
 
 // MARK: - Scheduling the 2nd wave
 extension IncrementalCompilationState {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -249,13 +249,13 @@ extension IncrementalCompilationState {
   }
 
   private func collectInputsInvalidated(byCompiling input: TypedVirtualPath)
-  -> Set<TypedVirtualPath> {
+  -> TransitivelyInvalidatedInputSet {
     if let found = moduleDependencyGraph.collectInputsRequiringCompilation(byCompiling: input) {
       return found
     }
     self.reporter?.report(
       "Failed to read some dependencies source; compiling everything", input)
-    return Set<TypedVirtualPath>(skippedCompileGroups.keys)
+    return TransitivelyInvalidatedInputSet(skippedCompileGroups.keys)
   }
 
   /// Find the jobs that now must be run that were not originally known to be needed.

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -116,7 +116,7 @@ extension IncrementalCompilationState.InitialStateComputer {
   /// For inputs with swiftDeps in OFM, but no readable file, puts input in graph map, but no nodes in graph:
   ///   caller must ensure scheduling of those
   private func computeGraphAndInputsInvalidatedByExternals()
-  -> (ModuleDependencyGraph, Set<TypedVirtualPath>)? {
+  -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet)? {
     precondition(sourceFiles.disappeared.isEmpty,
                  "Would have to remove nodes from the graph if reading prior")
     if readPriorsFromModuleDependencyGraph {
@@ -128,7 +128,7 @@ extension IncrementalCompilationState.InitialStateComputer {
   }
 
   private func readPriorGraphAndCollectInputsInvalidatedByChangedOrAddedExternals(
-  ) -> (ModuleDependencyGraph, Set<TypedVirtualPath>)?
+  ) -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet)?
   {
     let dependencyGraphPath = buildRecordInfo.dependencyGraphPath
     let graphIfPresent: ModuleDependencyGraph?
@@ -154,9 +154,9 @@ extension IncrementalCompilationState.InitialStateComputer {
     // recompilation. Thus, `ChangedOrAdded`.
     let nodesDirectlyInvalidatedByExternals = graph.collectNodesInvalidatedByChangedOrAddedExternals()
     // Wait till the last minute to do the transitive closure as an optimization.
-    let inputsTransitivelyInvalidatedByExternals = graph.collectInputsUsingTransitivelyInvalidated(
+    let inputsInvalidatedByExternals = graph.collectInputsUsingInvalidated(
       nodes: nodesDirectlyInvalidatedByExternals)
-    return (graph, inputsTransitivelyInvalidatedByExternals)
+    return (graph, inputsInvalidatedByExternals)
   }
 
   /// Builds a graph
@@ -167,7 +167,7 @@ extension IncrementalCompilationState.InitialStateComputer {
   /// For externalDependencies, puts then in graph.fingerprintedExternalDependencies, but otherwise
   /// does nothing special.
   private func buildInitialGraphFromSwiftDepsAndCollectInputsInvalidatedByChangedExternals(
-  ) -> (ModuleDependencyGraph, Set<TypedVirtualPath>)?
+  ) -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet)?
   {
     let graph = ModuleDependencyGraph(self, .buildingWithoutAPrior)
     assert(outputFileMap.onlySourceFilesHaveSwiftDeps())
@@ -175,7 +175,7 @@ extension IncrementalCompilationState.InitialStateComputer {
       return nil
     }
 
-    var inputsInvalidatedByChangedExternals = Set<TypedVirtualPath>()
+    var inputsInvalidatedByChangedExternals = TransitivelyInvalidatedInputSet()
     for input in sourceFiles.currentInOrder {
        guard let invalidatedInputs = graph.collectInputsRequiringCompilationFromExternalsFoundByCompiling(input: input)
       else {
@@ -195,7 +195,7 @@ extension IncrementalCompilationState.InitialStateComputer {
   /// listed in fingerprintExternalDependencies.
   private func computeInputsAndGroups(
     _ moduleDependencyGraph: ModuleDependencyGraph,
-    _ inputsInvalidatedByExternals: Set<TypedVirtualPath>,
+    _ inputsInvalidatedByExternals: TransitivelyInvalidatedInputSet,
     batchJobFormer: inout Driver
   ) throws -> (skippedCompileGroups: [TypedVirtualPath: CompileJobGroup],
                mandatoryJobsInOrder: [Job])
@@ -249,7 +249,7 @@ extension IncrementalCompilationState.InitialStateComputer {
 
   /// Figure out which compilation inputs are *not* mandatory
   private func computeSkippedCompilationInputs(
-    inputsInvalidatedByExternals: Set<TypedVirtualPath>,
+    inputsInvalidatedByExternals: TransitivelyInvalidatedInputSet,
     _ moduleDependencyGraph: ModuleDependencyGraph,
     _ buildRecord: BuildRecord
   ) -> Set<TypedVirtualPath> {
@@ -285,7 +285,7 @@ extension IncrementalCompilationState.InitialStateComputer {
     // as each first wave job finished.
     let speculativeInputs = collectInputsToBeSpeculativelyRecompiled(
       changedInputs: changedInputs,
-      externalDependents: Array(inputsInvalidatedByExternals),
+      externalDependents: inputsInvalidatedByExternals,
       inputsMissingOutputs: Set(inputsMissingOutputs),
       moduleDependencyGraph)
       .subtracting(definitelyRequiredInputs)
@@ -371,28 +371,28 @@ extension IncrementalCompilationState.InitialStateComputer {
   /// before the whole frontend job finished.
   private func collectInputsToBeSpeculativelyRecompiled(
     changedInputs: [ChangedInput],
-    externalDependents: [TypedVirtualPath],
+    externalDependents: TransitivelyInvalidatedInputSet,
     inputsMissingOutputs: Set<TypedVirtualPath>,
     _ moduleDependencyGraph: ModuleDependencyGraph
   ) -> Set<TypedVirtualPath> {
     let cascadingChangedInputs = computeCascadingChangedInputs(
       from: changedInputs,
       inputsMissingOutputs: inputsMissingOutputs)
-    let cascadingExternalDependents = alwaysRebuildDependents ? externalDependents : []
-    // Collect the dependent files to speculatively schedule
-    var dependentFiles = Set<TypedVirtualPath>()
-    let cascadingFileSet = Set(cascadingChangedInputs).union(cascadingExternalDependents)
-    for cascadingFile in cascadingFileSet {
-      let dependentsOfOneFile = moduleDependencyGraph
-        .collectInputsTransitivelyInvalidatedBy(input: cascadingFile)
-      for dep in dependentsOfOneFile where !cascadingFileSet.contains(dep) {
-        if dependentFiles.insert(dep).0 {
+
+    var inputsToBeCertainlyRecompiled = alwaysRebuildDependents ? externalDependents : TransitivelyInvalidatedInputSet()
+    inputsToBeCertainlyRecompiled.formUnion(cascadingChangedInputs)
+
+    return inputsToBeCertainlyRecompiled.reduce(into: Set()) {
+      speculativelyRecompiledInputs, certainlyRecompiledInput in
+      let speculativeDependents = moduleDependencyGraph.collectInputsInvalidatedBy(input: certainlyRecompiledInput)
+      for speculativeDependent in speculativeDependents
+      where !inputsToBeCertainlyRecompiled.contains(speculativeDependent) {
+        if speculativelyRecompiledInputs.insert(speculativeDependent).inserted {
           reporter?.report(
-            "Immediately scheduling dependent on \(cascadingFile.file.basename)", dep)
+            "Immediately scheduling dependent on \(certainlyRecompiledInput.file.basename)", speculativeDependent)
         }
       }
     }
-    return dependentFiles
   }
 
   // Collect the files that will be compiled whose dependents should be schedule

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -167,7 +167,7 @@ extension IncrementalCompilationState.InitialStateComputer {
   private func buildInitialGraphFromSwiftDepsAndCollectInputsInvalidatedByChangedExternals(
   ) -> (ModuleDependencyGraph, Set<TypedVirtualPath>)?
   {
-    let graph = ModuleDependencyGraph(self)
+    let graph = ModuleDependencyGraph(self, .buildingWithoutAPrior)
     assert(outputFileMap.onlySourceFilesHaveSwiftDeps())
     guard graph.populateInputDependencySourceMap() else {
       return nil
@@ -215,9 +215,13 @@ extension IncrementalCompilationState.InitialStateComputer {
         batchJobFormer.formBatchedJobs(
           mandatoryCompileGroupsInOrder.flatMap {$0.allJobs()},
           showJobLifecycle: showJobLifecycle)
+
+      moduleDependencyGraph.phase = .buildingAfterEachCompilation
       return (skippedCompileGroups: [:],
               mandatoryJobsInOrder: mandatoryJobsInOrder)
     }
+    moduleDependencyGraph.phase = .updatingAfterCompilation
+
 
     let skippedInputs = computeSkippedCompilationInputs(
       inputsInvalidatedByExternals: inputsInvalidatedByExternals,

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -152,9 +152,11 @@ extension IncrementalCompilationState.InitialStateComputer {
 
     // Any externals not already in graph must be additions which should trigger
     // recompilation. Thus, `ChangedOrAdded`.
-    let nodesInvalidatedByExternals = graph.collectNodesInvalidatedByChangedOrAddedExternals()
-    let inputsInvalidatedByExternals = graph.collectInputsUsingTransitivelyInvalidated(nodes: nodesInvalidatedByExternals)
-    return (graph, inputsInvalidatedByExternals)
+    let nodesDirectlyInvalidatedByExternals = graph.collectNodesDirectlyInvalidatedByChangedOrAddedExternals()
+    // Wait till the last minute to do the transitive closure as an optimization.
+    let inputsTransitivelyInvalidatedByExternals = graph.collectInputsUsingTransitivelyInvalidated(
+      nodes: nodesDirectlyInvalidatedByExternals)
+    return (graph, inputsTransitivelyInvalidatedByExternals)
   }
 
   /// Builds a graph

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -173,8 +173,6 @@ extension IncrementalCompilationState.InitialStateComputer {
       return nil
     }
 
-    // Every external will be an addition to the graph, but may not cause
-    // a recompile, so includeAddedExternals is false.
     var inputsInvalidatedByChangedExternals = Set<TypedVirtualPath>()
     for input in sourceFiles.currentInOrder {
        guard let invalidatedInputs = graph.collectInputsRequiringCompilationFromExternalsFoundByCompiling(input: input)

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -152,7 +152,7 @@ extension IncrementalCompilationState.InitialStateComputer {
 
     // Any externals not already in graph must be additions which should trigger
     // recompilation. Thus, `ChangedOrAdded`.
-    let nodesDirectlyInvalidatedByExternals = graph.collectNodesDirectlyInvalidatedByChangedOrAddedExternals()
+    let nodesDirectlyInvalidatedByExternals = graph.collectNodesInvalidatedByChangedOrAddedExternals()
     // Wait till the last minute to do the transitive closure as an optimization.
     let inputsTransitivelyInvalidatedByExternals = graph.collectInputsUsingTransitivelyInvalidated(
       nodes: nodesDirectlyInvalidatedByExternals)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -23,7 +23,7 @@ extension ModuleDependencyGraph {
     // Shorthands
     /*@_spi(Testing)*/ public typealias Graph = ModuleDependencyGraph
 
-    public private(set) var invalidatedNodes = DirectlyInvalidatedNodes()
+    public private(set) var invalidatedNodes = DirectlyInvalidatedNodeSet()
 
     /// the graph to be integrated
     let sourceGraph: SourceFileDependencyGraph
@@ -68,7 +68,7 @@ extension ModuleDependencyGraph.Integrator {
   /*@_spi(Testing)*/ public static func integrate(
     from g: SourceFileDependencyGraph,
     into destination: Graph
-  ) -> DirectlyInvalidatedNodes {
+  ) -> DirectlyInvalidatedNodeSet {
     var integrator = Self(sourceGraph: g, destination: destination)
     integrator.integrate()
 
@@ -208,7 +208,7 @@ extension ModuleDependencyGraph.Integrator {
 // MARK: - Results {
 extension ModuleDependencyGraph.Integrator {
   /*@_spi(Testing)*/
-  mutating func collectUsesOfSomeExternal(_ invalidated: DirectlyInvalidatedNodes)
+  mutating func collectUsesOfSomeExternal(_ invalidated: DirectlyInvalidatedNodeSet)
   {
     invalidatedNodes.formUnion(invalidated)
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -31,20 +31,15 @@ extension ModuleDependencyGraph {
     /// the graph to be integrated into
     let destination: ModuleDependencyGraph
 
-    /// The graph already includes externalDeps from prior compilations
-    let includeAddedExternals: Bool
-
     /// Starts with all nodes in dependencySource. Nodes that persist will be removed.
     /// After integration is complete, contains the nodes that have disappeared.
     var disappearedNodes = [DependencyKey: Graph.Node]()
 
     init(sourceGraph: SourceFileDependencyGraph,
-         destination: ModuleDependencyGraph,
-         includeAddedExternals: Bool)
+         destination: ModuleDependencyGraph)
     {
       self.sourceGraph = sourceGraph
       self.destination = destination
-      self.includeAddedExternals = includeAddedExternals
       self.disappearedNodes = destination.nodeFinder
         .findNodes(for: sourceGraph.dependencySource)
         ?? [:]
@@ -64,12 +59,9 @@ extension ModuleDependencyGraph.Integrator {
   /// Common to scheduling both waves.
   /*@_spi(Testing)*/ public static func integrate(
     from g: SourceFileDependencyGraph,
-    into destination: Graph,
-    includeAddedExternals: Bool
+    into destination: Graph
   ) -> Results {
-    var integrator = Self(sourceGraph: g,
-                          destination: destination,
-                          includeAddedExternals: includeAddedExternals)
+    var integrator = Self(sourceGraph: g, destination: destination)
     integrator.integrate()
 
     if destination.info.verifyDependencyGraphAfterEveryImport {
@@ -205,8 +197,7 @@ extension ModuleDependencyGraph.Integrator {
     moduleFileGraphUseNode moduleUseNode: Graph.Node) {
 
     let invalidated = destination.collectNodesInvalidatedByProcessing(
-      fingerprintedExternalDependency: fingerprintedExternalDependency,
-      includeAddedExternals: includeAddedExternals)
+      fingerprintedExternalDependency: fingerprintedExternalDependency)
     results.addNodesInvalidatedByUsingSomeExternal(invalidated)
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -75,7 +75,8 @@ extension ModuleDependencyGraph.Integrator {
   private mutating func integrate() {
     integrateEachSourceNode()
     handleDisappearedNodes()
-    destination.ensureGraphWillRetrace(results.allInvalidatedNodes)
+    // Ensure transitive closure will get started.
+    destination.ensureGraphWillRetrace(results.allDirectlyInvalidatedNodes)
   }
   private mutating func integrateEachSourceNode() {
     sourceGraph.forEachNode { integrate(oneNode: $0) }
@@ -196,9 +197,9 @@ extension ModuleDependencyGraph.Integrator {
     externalDependency fingerprintedExternalDependency: FingerprintedExternalDependency,
     moduleFileGraphUseNode moduleUseNode: Graph.Node) {
 
-    let invalidated = destination.collectNodesInvalidatedByProcessing(
+    let invalidated = destination.collectNodesDirectlyInvalidatedByProcessing(
       fingerprintedExternalDependency: fingerprintedExternalDependency)
-    results.addNodesInvalidatedByUsingSomeExternal(invalidated)
+    results.addNodesDirectlyInvalidatedByUsingSomeExternal(invalidated)
   }
 }
 
@@ -208,25 +209,25 @@ extension ModuleDependencyGraph.Integrator {
   public struct Results {
     typealias Node = ModuleDependencyGraph.Node
 
-    private(set) var allInvalidatedNodes = Set<Node>()
-    private(set) var nodesInvalidatedByUsingSomeExternal = Set<Node>()
+    private(set) var allDirectlyInvalidatedNodes = Set<Node>()
+    private(set) var nodesDirectlyInvalidatedByUsingSomeExternal = Set<Node>()
 
-    mutating func addNodesInvalidatedByUsingSomeExternal(_ invalidated: Set<Node>)
+    mutating func addNodesDirectlyInvalidatedByUsingSomeExternal(_ invalidated: Set<Node>)
     {
-      allInvalidatedNodes.formUnion(invalidated)
-      nodesInvalidatedByUsingSomeExternal.formUnion(invalidated)
+      allDirectlyInvalidatedNodes.formUnion(invalidated)
+      allDirectlyInvalidatedNodes.formUnion(invalidated)
     }
     mutating func addDisappeared(_ node: Node) {
-      allInvalidatedNodes.insert(node)
+      allDirectlyInvalidatedNodes.insert(node)
     }
     mutating func addChanged(_ node: Node) {
-      allInvalidatedNodes.insert(node)
+      allDirectlyInvalidatedNodes.insert(node)
     }
     mutating func addPatriated(_ node: Node) {
-      allInvalidatedNodes.insert(node)
+      allDirectlyInvalidatedNodes.insert(node)
     }
     mutating func addNew(_ node: Node) {
-      allInvalidatedNodes.insert(node)
+      allDirectlyInvalidatedNodes.insert(node)
     }
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -76,7 +76,7 @@ extension ModuleDependencyGraph.Integrator {
     integrateEachSourceNode()
     handleDisappearedNodes()
     // Ensure transitive closure will get started.
-    destination.ensureGraphWillRetrace(results.allDirectlyInvalidatedNodes)
+    destination.ensureGraphWillRetrace(results.all)
   }
   private mutating func integrateEachSourceNode() {
     sourceGraph.forEachNode { integrate(oneNode: $0) }
@@ -197,9 +197,9 @@ extension ModuleDependencyGraph.Integrator {
     externalDependency fingerprintedExternalDependency: FingerprintedExternalDependency,
     moduleFileGraphUseNode moduleUseNode: Graph.Node) {
 
-    let invalidated = destination.collectNodesDirectlyInvalidatedByProcessing(
+    let invalidated = destination.collectNodesInvalidatedByProcessing(
       fingerprintedExternalDependency: fingerprintedExternalDependency)
-    results.addNodesDirectlyInvalidatedByUsingSomeExternal(invalidated)
+    results.addUsesOfSomeExternal(invalidated)
   }
 }
 
@@ -209,25 +209,25 @@ extension ModuleDependencyGraph.Integrator {
   public struct Results {
     typealias Node = ModuleDependencyGraph.Node
 
-    private(set) var allDirectlyInvalidatedNodes = Set<Node>()
-    private(set) var nodesDirectlyInvalidatedByUsingSomeExternal = Set<Node>()
+    private(set) var all = DirectlyInvalidatedNodes()
+    private(set) var usesOfSomeExternal = DirectlyInvalidatedNodes()
 
-    mutating func addNodesDirectlyInvalidatedByUsingSomeExternal(_ invalidated: Set<Node>)
+    mutating func addUsesOfSomeExternal(_ invalidated: DirectlyInvalidatedNodes)
     {
-      allDirectlyInvalidatedNodes.formUnion(invalidated)
-      allDirectlyInvalidatedNodes.formUnion(invalidated)
+      all.formUnion(invalidated)
+      usesOfSomeExternal.formUnion(invalidated)
     }
     mutating func addDisappeared(_ node: Node) {
-      allDirectlyInvalidatedNodes.insert(node)
+      all.insert(node)
     }
     mutating func addChanged(_ node: Node) {
-      allDirectlyInvalidatedNodes.insert(node)
+      all.insert(node)
     }
     mutating func addPatriated(_ node: Node) {
-      allDirectlyInvalidatedNodes.insert(node)
+      all.insert(node)
     }
     mutating func addNew(_ node: Node) {
-      allDirectlyInvalidatedNodes.insert(node)
+      all.insert(node)
     }
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -37,13 +37,11 @@ extension ModuleDependencyGraph.Tracer {
 
   /// Find all uses of `defs` that have not already been traced.
   /// (If already traced, jobs have already been scheduled.)
-  static func collectPreviouslyUntracedNodesUsing<Nodes: Sequence> (
-    defNodes: Nodes,
+  static func collectPreviouslyUntracedNodesUsing(
+    defNodes: DirectlyInvalidatedNodes,
     in graph: ModuleDependencyGraph,
     diagnosticEngine: DiagnosticsEngine
-  ) -> Self
-  where Nodes.Element == ModuleDependencyGraph.Node
-  {
+  ) -> Self {
     var tracer = Self(collectingUsesOf: defNodes,
                       in: graph,
                       diagnosticEngine: diagnosticEngine)
@@ -51,14 +49,12 @@ extension ModuleDependencyGraph.Tracer {
     return tracer
   }
 
-  private init<Nodes: Sequence>(collectingUsesOf defs: Nodes,
+  private init(collectingUsesOf defs: DirectlyInvalidatedNodes,
                in graph: ModuleDependencyGraph,
-               diagnosticEngine: DiagnosticsEngine)
-  where Nodes.Element == ModuleDependencyGraph.Node
-  {
+               diagnosticEngine: DiagnosticsEngine) {
     self.graph = graph
     // Sort so "Tracing" diagnostics are deterministically ordered
-    self.startingPoints = defs.sorted()
+    self.startingPoints = defs.contents.sorted()
     self.currentPathIfTracing = graph.info.reporter != nil ? [] : nil
     self.diagnosticEngine = diagnosticEngine
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -18,10 +18,10 @@ extension ModuleDependencyGraph {
   struct Tracer {
     typealias Graph = ModuleDependencyGraph
 
-    let startingPoints: [Node]
+    let startingPoints: DirectlyInvalidatedNodeArray
     let graph: ModuleDependencyGraph
 
-    private(set) var tracedUses: [Node] = []
+    private(set) var tracedUses = TransitivelyInvalidatedNodeArray()
 
     /// Record the paths taking so that  -driver-show-incremental can explain why things are recompiled
     /// If tracing dependencies, holds a vector used to hold the current path
@@ -38,7 +38,7 @@ extension ModuleDependencyGraph.Tracer {
   /// Find all uses of `defs` that have not already been traced.
   /// (If already traced, jobs have already been scheduled.)
   static func collectPreviouslyUntracedNodesUsing(
-    defNodes: DirectlyInvalidatedNodes,
+    defNodes: DirectlyInvalidatedNodeSet,
     in graph: ModuleDependencyGraph,
     diagnosticEngine: DiagnosticsEngine
   ) -> Self {
@@ -49,12 +49,12 @@ extension ModuleDependencyGraph.Tracer {
     return tracer
   }
 
-  private init(collectingUsesOf defs: DirectlyInvalidatedNodes,
+  private init(collectingUsesOf defs: DirectlyInvalidatedNodeSet,
                in graph: ModuleDependencyGraph,
                diagnosticEngine: DiagnosticsEngine) {
     self.graph = graph
     // Sort so "Tracing" diagnostics are deterministically ordered
-    self.startingPoints = defs.contents.sorted()
+    self.startingPoints = defs.sorted()
     self.currentPathIfTracing = graph.info.reporter != nil ? [] : nil
     self.diagnosticEngine = diagnosticEngine
   }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -651,6 +651,8 @@ final class IncrementalCompilationTests: XCTestCase {
         "Forming batch job from 1 constituents: main.swift",
         "Starting Compiling main.swift",
         "Finished Compiling main.swift",
+        "Incremental compilation: Fingerprint changed for interface of source file main.swiftdeps in main.swiftdeps",
+        "Incremental compilation: Fingerprint changed for implementation of source file main.swiftdeps in main.swiftdeps",
         "Incremental compilation: Traced: interface of source file main.swiftdeps in main.swift -> interface of top-level name 'foo' in main.swift -> implementation of source file other.swiftdeps in other.swift",
         "Incremental compilation: Queuing because of dependencies discovered later:  {compile: other.o <= other.swift}",
         "Incremental compilation: Scheduling invalidated  {compile: other.o <= other.swift}",

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -942,7 +942,7 @@ extension ModuleDependencyGraph {
     mock diagnosticEngine: DiagnosticsEngine,
     options: IncrementalCompilationState.Options = [ .verifyDependencyGraphAfterEveryImport ]
   ) {
-    self.init(IncrementalCompilationState.InitialStateComputer.mock())
+    self.init(IncrementalCompilationState.InitialStateComputer.mock(), .buildingWithoutAPrior)
   }
 
 

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -984,7 +984,7 @@ extension ModuleDependencyGraph {
     _ interfaceHashIfPresent: String? = nil,
     includePrivateDeps: Bool = true,
     hadCompilationError: Bool = false
-  ) -> Set<Node> {
+  ) -> DirectlyInvalidatedNodes {
     let dependencySource = DependencySource(mock: swiftDepsIndex)
     // Only needed for serialization testing:
     mockMapEntry(TypedVirtualPath.init(mockInput: swiftDepsIndex),
@@ -1001,7 +1001,7 @@ extension ModuleDependencyGraph {
 
     let results = Integrator.integrate(from: sfdg, into: self)
 
-    return results.allDirectlyInvalidatedNodes
+    return results.all
   }
 
   func findUntracedSwiftDepsDependent(onExternal s: String) -> [Int] {
@@ -1015,7 +1015,7 @@ extension ModuleDependencyGraph {
     on fingerprintedExternalDependency: FingerprintedExternalDependency
   ) -> [DependencySource] {
     var foundSources = [DependencySource]()
-    for dependent in self.collectUntracedNodesDirectlyUsing(fingerprintedExternalDependency) {
+    for dependent in collectUntracedNodesUsing(fingerprintedExternalDependency).contents {
       let dependencySource = dependent.dependencySource!
       foundSources.append(dependencySource)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -754,8 +754,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     let graph = ModuleDependencyGraph(mock: de)
     _ = graph.getInvalidatedNodesForSimulatedLoad(
       0,
-      [MockDependencyKind.nominal: ["A@1"]],
-      includeAddedExternals: false)
+      [MockDependencyKind.nominal: ["A@1"]])
   }
 
   func testUseFingerprints() {
@@ -955,7 +954,6 @@ extension ModuleDependencyGraph {
   {
     _ = getInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex, dependencyDescriptions,
-      includeAddedExternals: false,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError)
@@ -971,7 +969,6 @@ extension ModuleDependencyGraph {
     let invalidatedNodes = getInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex,
       dependencyDescriptions,
-      includeAddedExternals: true,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError)
@@ -984,7 +981,6 @@ extension ModuleDependencyGraph {
   func getInvalidatedNodesForSimulatedLoad(
     _ swiftDepsIndex: Int,
     _ dependencyDescriptions: [MockDependencyKind: [String]],
-    includeAddedExternals: Bool,
     _ interfaceHashIfPresent: String? = nil,
     includePrivateDeps: Bool = true,
     hadCompilationError: Bool = false
@@ -1003,9 +999,7 @@ extension ModuleDependencyGraph {
       interfaceHash: interfaceHash,
       dependencyDescriptions)
 
-    let results = Integrator.integrate(from: sfdg,
-                                      into: self,
-                                      includeAddedExternals: includeAddedExternals)
+    let results = Integrator.integrate(from: sfdg, into: self)
 
     return results.allInvalidatedNodes
   }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -752,7 +752,7 @@ class ModuleDependencyGraphTests: XCTestCase {
 
   func testLoadPassesWithFingerprint() {
     let graph = ModuleDependencyGraph(mock: de)
-    _ = graph.getInvalidatedNodesForSimulatedLoad(
+    _ = graph.getDirectlyInvalidatedNodesForSimulatedLoad(
       0,
       [MockDependencyKind.nominal: ["A@1"]])
   }
@@ -952,7 +952,7 @@ extension ModuleDependencyGraph {
     includePrivateDeps: Bool = true,
     hadCompilationError: Bool = false)
   {
-    _ = getInvalidatedNodesForSimulatedLoad(
+    _ = getDirectlyInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex, dependencyDescriptions,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
@@ -966,19 +966,19 @@ extension ModuleDependencyGraph {
                       hadCompilationError: Bool = false)
   -> [Int]
   {
-    let invalidatedNodes = getInvalidatedNodesForSimulatedLoad(
+    let directlyIinvalidatedNodes = getDirectlyInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex,
       dependencyDescriptions,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError)
 
-    return collectSwiftDepsUsingTransitivelyInvalidated(nodes: invalidatedNodes)
+    return collectSwiftDepsUsingTransitivelyInvalidated(nodes: directlyIinvalidatedNodes)
       .map { $0.mockID }
   }
 
 
-  func getInvalidatedNodesForSimulatedLoad(
+  func getDirectlyInvalidatedNodesForSimulatedLoad(
     _ swiftDepsIndex: Int,
     _ dependencyDescriptions: [MockDependencyKind: [String]],
     _ interfaceHashIfPresent: String? = nil,
@@ -1001,7 +1001,7 @@ extension ModuleDependencyGraph {
 
     let results = Integrator.integrate(from: sfdg, into: self)
 
-    return results.allInvalidatedNodes
+    return results.allDirectlyInvalidatedNodes
   }
 
   func findUntracedSwiftDepsDependent(onExternal s: String) -> [Int] {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -966,6 +966,7 @@ extension ModuleDependencyGraph {
                       hadCompilationError: Bool = false)
   -> [Int]
   {
+    phase = .updatingAfterCompilation
     let directlyIinvalidatedNodes = getDirectlyInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex,
       dependencyDescriptions,
@@ -999,9 +1000,7 @@ extension ModuleDependencyGraph {
       interfaceHash: interfaceHash,
       dependencyDescriptions)
 
-    let results = Integrator.integrate(from: sfdg, into: self)
-
-    return results.all
+    return Integrator.integrate(from: sfdg, into: self)
   }
 
   func findUntracedSwiftDepsDependent(onExternal s: String) -> [Int] {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -44,23 +44,23 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.topLevel: ["b0", "b->"]])
     graph.simulateLoad(2, [.topLevel: ["c0", "c->"]])
 
-    XCTAssertEqual(1, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(1, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
     // Mark 0 again -- should be no change.
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(1, graph.collectMockSwiftDepsTransitivelyUsing(2).count)
+    XCTAssertEqual(1, graph.collectMockSwiftDepsUsing(2).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(1, graph.collectMockSwiftDepsTransitivelyUsing(1).count)
+    XCTAssertEqual(1, graph.collectMockSwiftDepsUsing(1).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -72,7 +72,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.nominal: ["a", "a->"]])
     graph.simulateLoad(1, [.topLevel: ["a", "b->"]])
 
-    XCTAssertEqual(1, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(1, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -83,7 +83,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.nominal: ["a->", "b"]])
     graph.simulateLoad(1, [.topLevel: ["b->", "a"]])
 
-    XCTAssertEqual(1, graph.collectMockSwiftDepsTransitivelyUsing(1).count)
+    XCTAssertEqual(1, graph.collectMockSwiftDepsUsing(1).count)
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -97,7 +97,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(3, [.member: ["b,aa->"]])
     graph.simulateLoad(4, [.member: ["b,bb->"]])
 
-    XCTAssertEqual(1, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(1, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -111,14 +111,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad(1, [.topLevel: ["x->", "b->", "z->"]])
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -130,14 +130,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.topLevel: ["x", "b", "z"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(1)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(1)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -149,14 +149,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "z->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -168,14 +168,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["a->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -188,14 +188,14 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.nominal: ["a->"], .topLevel: ["a->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -209,15 +209,15 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.nominal: ["a->"], .topLevel: ["a->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    let _ = graph.collectMockSwiftDepsTransitivelyUsing(0)
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    let _ = graph.collectMockSwiftDepsUsing(0)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -229,14 +229,14 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1,
                        [.dynamicLookup: ["x->", "b->", "z->"]])
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -249,14 +249,14 @@ class ModuleDependencyGraphTests: XCTestCase {
                        [.member: ["x,xx->", "b,bb->", "z,zz->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
   }
@@ -269,7 +269,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["q->", "b->", "s->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -278,7 +278,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -292,7 +292,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["q->", "r->", "c->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -301,7 +301,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -315,7 +315,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["z->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -324,7 +324,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -338,7 +338,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["#z->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -347,7 +347,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
-    XCTAssertEqual(0, graph.collectMockSwiftDepsTransitivelyUsing(0).count)
+    XCTAssertEqual(0, graph.collectMockSwiftDepsUsing(0).count)
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 1))
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
@@ -361,7 +361,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["z->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -381,7 +381,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(12, [.topLevel: ["q->", "q"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2)) //?????
@@ -394,7 +394,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 12))
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(10)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(10)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(10))
       XCTAssertTrue(swiftDeps.contains(11))
@@ -416,7 +416,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -442,7 +442,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -467,7 +467,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(1, [.nominal: ["a->"]])
     graph.simulateLoad(2, [.nominal: ["b->"]])
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(1)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(1)
       XCTAssertEqual(1, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -495,7 +495,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["b->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(1)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(1)
       XCTAssertEqual(1, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -524,7 +524,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.topLevel: ["x->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
       XCTAssertTrue(swiftDeps.contains(2))
@@ -534,7 +534,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 2))
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(0, swiftDeps.count)
     }
     XCTAssertTrue(graph.haveAnyNodesBeenTraversed(inMock: 0))
@@ -552,7 +552,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(1))
     }
@@ -580,7 +580,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     XCTAssertFalse(graph.haveAnyNodesBeenTraversed(inMock: 1))
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(0)
       XCTAssertEqual(2, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
       XCTAssertTrue(swiftDeps.contains(1))
@@ -709,7 +709,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(0, [.topLevel: ["a", "b->"]])
     graph.simulateLoad(1, [.topLevel: ["a->", "b"]])
 
-    let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+    let swiftDeps = graph.collectMockSwiftDepsUsing(0)
     XCTAssertTrue(swiftDeps.contains(1))
   }
 
@@ -721,7 +721,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B1->"]])
 
     do {
-      let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(1)
+      let swiftDeps = graph.collectMockSwiftDepsUsing(1)
       XCTAssertEqual(3, swiftDeps.count)
       XCTAssertTrue(swiftDeps.contains(0))
       XCTAssertTrue(swiftDeps.contains(1))
@@ -752,7 +752,7 @@ class ModuleDependencyGraphTests: XCTestCase {
 
   func testLoadPassesWithFingerprint() {
     let graph = ModuleDependencyGraph(mock: de)
-    _ = graph.getDirectlyInvalidatedNodesForSimulatedLoad(
+    _ = graph.getInvalidatedNodesForSimulatedLoad(
       0,
       [MockDependencyKind.nominal: ["A@1"]])
   }
@@ -846,7 +846,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B->"]])
     graph.simulateLoad(3, [.nominal: ["C->"]])
 
-    let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+    let swiftDeps = graph.collectMockSwiftDepsUsing(0)
     XCTAssertTrue(swiftDeps.contains(0))
     XCTAssertTrue(swiftDeps.contains(1))
     XCTAssertTrue(swiftDeps.contains(2))
@@ -863,7 +863,7 @@ class ModuleDependencyGraphTests: XCTestCase {
     graph.simulateLoad(2, [.nominal: ["B->"]])
     graph.simulateLoad(3, [.nominal: ["C->"]])
 
-    let swiftDeps = graph.collectMockSwiftDepsTransitivelyUsing(0)
+    let swiftDeps = graph.collectMockSwiftDepsUsing(0)
     XCTAssertTrue(swiftDeps.contains(0))
     XCTAssertTrue(swiftDeps.contains(1))
     XCTAssertTrue(swiftDeps.contains(2))
@@ -952,7 +952,7 @@ extension ModuleDependencyGraph {
     includePrivateDeps: Bool = true,
     hadCompilationError: Bool = false)
   {
-    _ = getDirectlyInvalidatedNodesForSimulatedLoad(
+    _ = getInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex, dependencyDescriptions,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
@@ -967,25 +967,25 @@ extension ModuleDependencyGraph {
   -> [Int]
   {
     phase = .updatingAfterCompilation
-    let directlyIinvalidatedNodes = getDirectlyInvalidatedNodesForSimulatedLoad(
+    let directlyIinvalidatedNodes = getInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex,
       dependencyDescriptions,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError)
 
-    return collectSwiftDepsUsingTransitivelyInvalidated(nodes: directlyIinvalidatedNodes)
+    return collectSwiftDepsUsingInvalidated(nodes: directlyIinvalidatedNodes)
       .map { $0.mockID }
   }
 
 
-  func getDirectlyInvalidatedNodesForSimulatedLoad(
+  func getInvalidatedNodesForSimulatedLoad(
     _ swiftDepsIndex: Int,
     _ dependencyDescriptions: [MockDependencyKind: [String]],
     _ interfaceHashIfPresent: String? = nil,
     includePrivateDeps: Bool = true,
     hadCompilationError: Bool = false
-  ) -> DirectlyInvalidatedNodes {
+  ) -> DirectlyInvalidatedNodeSet {
     let dependencySource = DependencySource(mock: swiftDepsIndex)
     // Only needed for serialization testing:
     mockMapEntry(TypedVirtualPath.init(mockInput: swiftDepsIndex),
@@ -1020,18 +1020,19 @@ extension ModuleDependencyGraph {
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive
       // Don't return job twice.
       let filesToRebuild =
-        collectSwiftDepsTransitivelyUsing(dependencySource: dependencySource)
+        collectSwiftDepsUsing(dependencySource: dependencySource)
         .filter({ marked in marked != dependencySource })
       foundSources.append(contentsOf: filesToRebuild)
     }
     return foundSources
   }
 
-
-  fileprivate func collectMockSwiftDepsTransitivelyUsing(_ i: Int) -> [Int] {
-    collectSwiftDepsTransitivelyUsing(dependencySource: DependencySource(mock: i))
+  fileprivate func collectMockSwiftDepsUsing(_ i: Int) -> TransitivelyInvalidatedMockInputArray {
+    collectSwiftDepsUsing(dependencySource: DependencySource(mock: i))
       .map { $0.mockID }
   }
+
+  fileprivate typealias TransitivelyInvalidatedMockInputArray = InvalidatedArray<Transitively, Int>
 
   func containsExternalDependency(_ path: String, fingerprint: String? = nil)
   -> Bool {


### PR DESCRIPTION
Suggest reviewing commit-by-commit:
1. Adds a test
2. Simplifies integration logic by using a `phase` variable in the `ModuleDependencyGraph`
3. Introduces wrappers for sets and arrays in order to use the type system to enforce the transitive closing where needed.

Your feedback is sought!