### PR TITLE
Emit-module separately: fix use with -emit-library and -whole-module-optimization

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -76,6 +76,10 @@ extension Driver {
 
     addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: false)
 
+    if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
+      commandLine.appendFlag(.parseAsLibrary)
+    }
+
     commandLine.appendFlag(.o)
     commandLine.appendPath(moduleOutputPath)
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -96,7 +96,18 @@ extension Driver {
 
   /// Returns true if the emit module job should be created.
   var shouldCreateEmitModuleJob: Bool {
-    return forceEmitModuleBeforeCompile
-      || parsedOptions.hasArgument(.emitModuleSeparately)
+    mutating get {
+      return moduleOutputInfo.output != nil
+        && (forceEmitModuleBeforeCompile
+            || shouldEmitModuleSeparately())
+    }
+  }
+
+  /// Returns true if the -emit-module-separately is active.
+  mutating func shouldEmitModuleSeparately() -> Bool {
+    return parsedOptions.hasArgument(.emitModuleSeparately)
+           && !parsedOptions.hasFlag(positive: .wholeModuleOptimization,
+                                     negative: .noWholeModuleOptimization,
+                                     default: false)
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1836,6 +1836,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath("/foo/bar/Test.swiftdoc")))
       XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath("/foo/bar/Test.swiftsourceinfo")))
     }
+
+    do {
+      // Leave it to the whole-module job emit the swiftmodule even with the
+      // -experimental-emit-module-separately flag, basically ignoring it.
+      var driver = try Driver(args: ["swiftc", "-emit-library", "foo.swift", "-whole-module-optimization", "-emit-module-path", "foo.swiftmodule", "-experimental-emit-module-separately", "-target", "x86_64-apple-macosx10.15"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 2)
+    }
   }
 
   func testModuleWrapJob() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1817,6 +1817,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 4)
       XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-parse-as-library")))
       XCTAssertEqual(plannedJobs[0].outputs.count, 3)
       XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath("/foo/bar/Test.swiftmodule")))
       XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath("/foo/bar/Test.swiftdoc")))


### PR DESCRIPTION
Fix two issue observed with early adopters of `-experimental-emit-module-separately`:
- Pass on the `-parse-as-library` flag to the frontend avoiding considering single file target as a script. rdar://74713625
- Ignore the flag in whole-module builds leaving it to the single job to generate the module files.