### PR TITLE
Block on emitting parseable-output messages in `executeJob`.

### DIFF
--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -523,7 +523,7 @@ class ExecuteJobRule: LLBuildRule {
       }
 
       // Inform the delegate.
-      context.delegateQueue.async {
+      context.delegateQueue.sync {
         context.executorDelegate.jobStarted(job: job, arguments: arguments, pid: pid)
         knownPId.insert(pid)
       }
@@ -549,7 +549,7 @@ class ExecuteJobRule: LLBuildRule {
       }
 
       // Inform the delegate about job finishing.
-      context.delegateQueue.async {
+      context.delegateQueue.sync {
         context.executorDelegate.jobFinished(job: job, result: result, pid: pid)
       }
       context.cancelBuildIfNeeded(result)
@@ -564,7 +564,7 @@ class ExecuteJobRule: LLBuildRule {
       // Only inform finished job if the job has been started, otherwise the build
       // system may complain about malformed output
       if (knownPId.contains(pid)) {
-        context.delegateQueue.async {
+        context.delegateQueue.sync {
           let result = ProcessResult(
             arguments: [],
             environment: env,


### PR DESCRIPTION
`executeJob` itself runs in a concurrent context.
Adding further asynchrony in emitting parseable-output here isn't worth the trouble it can cause because the performance implications of waiting for these messages to be emitted are likely negligible.

Blocking on calls to `jobStarted` and `jobFinished` defines away various possibilities for error states, for example - the executor concluding its workload and returning before all parseable-output messages have been emitted, potentially confusing the build system in the process.

Resolves rdar://74058113