### PR TITLE
Re-Sync Options Flags

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -168,12 +168,8 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
     /// The `name` of the file is a path to the `swiftdeps` file named in
     /// the output file map for a given Swift file.
     ///
-    /// If the filename is a swiftmodule, and if it was built by a compilation with
-    /// `-enable-experimental-cross-module-incremental-build`, the swiftmodule file
-    /// contains a special section with swiftdeps information for the module
-    /// in it. In that case the enclosing node should have a fingerprint.
-    ///
-
+    /// Swiftmodule files may contain a special section with swiftdeps information
+    /// for the module. In that case the enclosing node should have a fingerprint.
     case sourceFileProvide(name: String)
     /// A "nominal" type that is used, or defined by this file.
     ///

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -61,9 +61,15 @@ extension Driver {
     try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
     try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
 
-    // Propagate cross-module incremental builds flag so dependency information
-    // shows up in swiftmodules.
-    try commandLine.appendLast(.enableExperimentalCrossModuleIncrementalBuild, from: &parsedOptions)
+    // Propagate the disable flag for cross-module incremental builds
+    // if necessary. Note because we're interested in *disabling* this feature,
+    // we consider the disable form to be the positive and enable to be the
+    // negative.
+    if parsedOptions.hasFlag(positive: .disableIncrementalImports,
+                             negative: .enableIncrementalImports,
+                             default: false) {
+      try commandLine.appendLast(.disableIncrementalImports, from: &parsedOptions)
+    }
 
     commandLine.appendFlag(.o)
     commandLine.appendPath(moduleOutputInfo.output!.outputPath)

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -152,7 +152,9 @@ extension Driver {
     if self.parsedOptions.contains(veriOpt) {
       options.formUnion(.verifyDependencyGraphAfterEveryImport)
     }
-    if self.parsedOptions.contains(.enableExperimentalCrossModuleIncrementalBuild) {
+    if self.parsedOptions.hasFlag(positive: .enableIncrementalImports,
+                                  negative: .disableIncrementalImports,
+                                  default: true) {
       options.formUnion(.enableCrossModuleIncrementalBuild)
       options.formUnion(.readPriorsFromModuleDependencyGraph)
     }

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -87,6 +87,7 @@ extension Option {
   public static let disableGenericMetadataPrespecialization: Option = Option("-disable-generic-metadata-prespecialization", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Do not statically specialize metadata for generic types at types that are known to be used in source.")
   public static let disableImplicitConcurrencyModuleImport: Option = Option("-disable-implicit-concurrency-module-import", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable the implicit import of the _Concurrency module.")
   public static let disableImplicitSwiftModules: Option = Option("-disable-implicit-swift-modules", .flag, attributes: [.frontend, .noDriver], helpText: "Disable building Swift modules implicitly by the compiler")
+  public static let disableIncrementalImports: Option = Option("-disable-incremental-imports", .flag, attributes: [.frontend], helpText: "Disable cross-module incremental build metadata and driver scheduling for Swift modules")
   public static let disableIncrementalLlvmCodegeneration: Option = Option("-disable-incremental-llvm-codegen", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable incremental llvm code generation.")
   public static let disableInterfaceLockfile: Option = Option("-disable-interface-lock", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't lock interface file when building module")
   public static let disableInvalidEphemeralnessAsError: Option = Option("-disable-invalid-ephemeralness-as-error", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Diagnose invalid ephemeral to non-ephemeral conversions as warnings")
@@ -109,7 +110,6 @@ extension Option {
   public static let disablePreviousImplementationCallsInDynamicReplacements: Option = Option("-disable-previous-implementation-calls-in-dynamic-replacements", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable calling the previous implementation in dynamic replacements")
   public static let disableReflectionMetadata: Option = Option("-disable-reflection-metadata", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable emission of reflection metadata for nominal types")
   public static let disableReflectionNames: Option = Option("-disable-reflection-names", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable emission of names of stored properties and enum cases inreflection metadata")
-  public static let disableRequestBasedIncrementalDependencies: Option = Option("-disable-request-based-incremental-dependencies", .flag, attributes: [.frontend], helpText: "Disable request-based name tracking")
   public static let disableSilOwnershipVerifier: Option = Option("-disable-sil-ownership-verifier", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Do not verify ownership invariants during SIL Verification ")
   public static let disableSilPartialApply: Option = Option("-disable-sil-partial-apply", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable use of partial_apply in SIL generation")
   public static let disableSilPerfOptzns: Option = Option("-disable-sil-perf-optzns", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't run SIL performance optimization passes")
@@ -223,14 +223,15 @@ extension Option {
   public static let enableExperimentalAdditiveArithmeticDerivation: Option = Option("-enable-experimental-additive-arithmetic-derivation", .flag, attributes: [.frontend], helpText: "Enable experimental 'AdditiveArithmetic' derived conformances")
   public static let enableExperimentalConcisePoundFile: Option = Option("-enable-experimental-concise-pound-file", .flag, attributes: [.frontend, .moduleInterface], helpText: "Enable experimental concise '#file' identifier")
   public static let enableExperimentalConcurrency: Option = Option("-enable-experimental-concurrency", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable experimental concurrency model")
-  public static let enableExperimentalConcurrentValueChecking: Option = Option("-enable-experimental-concurrent-value-checking", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable ConcurrentValue checking")
   public static let enableExperimentalCrossModuleIncrementalBuild: Option = Option("-enable-experimental-cross-module-incremental-build", .flag, attributes: [.frontend], helpText: "(experimental) Enable cross-module incremental build metadata and driver scheduling")
   public static let enableExperimentalCxxInterop: Option = Option("-enable-experimental-cxx-interop", .flag, helpText: "Allow importing C++ modules into Swift (experimental feature)")
+  public static let enableExperimentalEnumCodableDerivation: Option = Option("-enable-experimental-enum-codable-derivation", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable experimental derivation of Codable for enums")
   public static let enableExperimentalFlowSensitiveConcurrentCaptures: Option = Option("-enable-experimental-flow-sensitive-concurrent-captures", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable flow-sensitive concurrent captures")
   public static let enableExperimentalForwardModeDifferentiation: Option = Option("-enable-experimental-forward-mode-differentiation", .flag, attributes: [.frontend], helpText: "Enable experimental forward mode differentiation")
   public static let enableExperimentalStaticAssert: Option = Option("-enable-experimental-static-assert", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental #assert")
   public static let enableFuzzyForwardScanTrailingClosureMatching: Option = Option("-enable-fuzzy-forward-scan-trailing-closure-matching", .flag, attributes: [.frontend], helpText: "Enable fuzzy forward-scan trailing closure matching")
   public static let enableImplicitDynamic: Option = Option("-enable-implicit-dynamic", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Add 'dynamic' to all declarations")
+  public static let enableIncrementalImports: Option = Option("-enable-incremental-imports", .flag, attributes: [.frontend], helpText: "Enable cross-module incremental build metadata and driver scheduling for Swift modules")
   public static let enableInferImportAsMember: Option = Option("-enable-infer-import-as-member", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Infer when a global could be imported as a member")
   public static let enableInvalidEphemeralnessAsError: Option = Option("-enable-invalid-ephemeralness-as-error", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Diagnose invalid ephemeral to non-ephemeral conversions as errors")
   public static let enableLibraryEvolution: Option = Option("-enable-library-evolution", .flag, attributes: [.frontend, .moduleInterface], helpText: "Build the module to allow binary-compatible library evolution")
@@ -242,8 +243,8 @@ extension Option {
   public static let enableObjcInterop: Option = Option("-enable-objc-interop", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable Objective-C interop code generation and config directives")
   public static let enableOnlyOneDependencyFile: Option = Option("-enable-only-one-dependency-file", .flag, attributes: [.doesNotAffectIncrementalBuild], helpText: "Enables incremental build optimization that only produces one dependencies file")
   public static let enableOperatorDesignatedTypes: Option = Option("-enable-operator-designated-types", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable operator designated types")
+  public static let enableOssaModules: Option = Option("-enable-ossa-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Always serialize SIL in ossa form. If this flag is not passed in, when optimizing ownership will be lowered before serializing SIL")
   public static let enablePrivateImports: Option = Option("-enable-private-imports", .flag, attributes: [.helpHidden, .frontend, .noInteractive], helpText: "Allows this module's internal and private API to be accessed")
-  public static let enableRequestBasedIncrementalDependencies: Option = Option("-enable-request-based-incremental-dependencies", .flag, attributes: [.frontend], helpText: "Enable request-based name tracking")
   public static let enableResilience: Option = Option("-enable-resilience", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Deprecated, use -enable-library-evolution instead")
   public static let enableSilOpaqueValues: Option = Option("-enable-sil-opaque-values", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable SIL Opaque Values")
   public static let enableSourceImport: Option = Option("-enable-source-import", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable importing of Swift source files")
@@ -590,6 +591,7 @@ extension Option {
       Option.disableGenericMetadataPrespecialization,
       Option.disableImplicitConcurrencyModuleImport,
       Option.disableImplicitSwiftModules,
+      Option.disableIncrementalImports,
       Option.disableIncrementalLlvmCodegeneration,
       Option.disableInterfaceLockfile,
       Option.disableInvalidEphemeralnessAsError,
@@ -612,7 +614,6 @@ extension Option {
       Option.disablePreviousImplementationCallsInDynamicReplacements,
       Option.disableReflectionMetadata,
       Option.disableReflectionNames,
-      Option.disableRequestBasedIncrementalDependencies,
       Option.disableSilOwnershipVerifier,
       Option.disableSilPartialApply,
       Option.disableSilPerfOptzns,
@@ -726,14 +727,15 @@ extension Option {
       Option.enableExperimentalAdditiveArithmeticDerivation,
       Option.enableExperimentalConcisePoundFile,
       Option.enableExperimentalConcurrency,
-      Option.enableExperimentalConcurrentValueChecking,
       Option.enableExperimentalCrossModuleIncrementalBuild,
       Option.enableExperimentalCxxInterop,
+      Option.enableExperimentalEnumCodableDerivation,
       Option.enableExperimentalFlowSensitiveConcurrentCaptures,
       Option.enableExperimentalForwardModeDifferentiation,
       Option.enableExperimentalStaticAssert,
       Option.enableFuzzyForwardScanTrailingClosureMatching,
       Option.enableImplicitDynamic,
+      Option.enableIncrementalImports,
       Option.enableInferImportAsMember,
       Option.enableInvalidEphemeralnessAsError,
       Option.enableLibraryEvolution,
@@ -745,8 +747,8 @@ extension Option {
       Option.enableObjcInterop,
       Option.enableOnlyOneDependencyFile,
       Option.enableOperatorDesignatedTypes,
+      Option.enableOssaModules,
       Option.enablePrivateImports,
-      Option.enableRequestBasedIncrementalDependencies,
       Option.enableResilience,
       Option.enableSilOpaqueValues,
       Option.enableSourceImport,

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -458,7 +458,8 @@ extension IncrementalCompilationTests {
       (.driverShowIncremental, {$0.reporter != nil}),
       (.driverEmitFineGrainedDependencyDotFileAfterEveryImport, {$0.emitDependencyDotFileAfterEveryImport}),
       (.driverVerifyFineGrainedDependencyGraphAfterEveryImport, {$0.verifyDependencyGraphAfterEveryImport}),
-      (.enableExperimentalCrossModuleIncrementalBuild, {$0.isCrossModuleIncrementalBuildEnabled}),
+      (.enableIncrementalImports, {$0.isCrossModuleIncrementalBuildEnabled}),
+      (.disableIncrementalImports, {!$0.isCrossModuleIncrementalBuildEnabled}),
     ]
 
     for (driverOption, stateOptionFn) in optionPairs {
@@ -516,12 +517,10 @@ extension IncrementalCompilationTests {
     expectNoDotFiles()
     try tryInitial(extraArguments: [
       "-driver-emit-fine-grained-dependency-dot-file-after-every-import",
-      "-enable-experimental-cross-module-incremental-build"
     ])
     removeDotFiles()
     tryTouchingOther(extraArguments: [
       "-driver-emit-fine-grained-dependency-dot-file-after-every-import",
-      "-enable-experimental-cross-module-incremental-build"
     ])
 
     expect(dotFilesFor: [
@@ -594,7 +593,7 @@ extension IncrementalCompilationTests {
         // Leave off the part after the colon because it varies on Linux:
         // MacOS: The operation could not be completed. (TSCBasic.FileSystemError error 3.).
         // Linux: The operation couldn’t be completed. (TSCBasic.FileSystemError error 3.)
-        "Disabling incremental cross-module building",
+        "Enabling incremental cross-module building",
         "Incremental compilation: Incremental compilation could not read build record at",
         "Incremental compilation: Disabling incremental build: could not read build record",
         "Incremental compilation: Created dependency graph from swiftdeps files",
@@ -618,8 +617,8 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Disabling incremental cross-module building",
-        "Incremental compilation: Created dependency graph from swiftdeps files",
+        "Enabling incremental cross-module building",
+        "Incremental compilation: Read dependency graph",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
@@ -638,13 +637,13 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Disabling incremental cross-module building",
-        "Incremental compilation: Created dependency graph from swiftdeps files",
+        "Enabling incremental cross-module building",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: other.o <= other.swift}",
         "Incremental compilation: not scheduling dependents of other.swift; unknown changes",
         "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
+        "Incremental compilation: Read dependency graph",
         "Found 1 batchable job",
         "Forming into 1 batch",
         "Adding {compile: other.swift} to batch 0",
@@ -667,8 +666,8 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Disabling incremental cross-module building",
-        "Incremental compilation: Created dependency graph from swiftdeps files",
+        "Enabling incremental cross-module building",
+        "Incremental compilation: Read dependency graph",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -697,8 +696,8 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Disabling incremental cross-module building",
-        "Incremental compilation: Created dependency graph from swiftdeps files",
+        "Enabling incremental cross-module building",
+        "Incremental compilation: Read dependency graph",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -737,8 +736,8 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: [extraArgument],
       expectingRemarks: [
-        "Disabling incremental cross-module building",
-        "Incremental compilation: Created dependency graph from swiftdeps files",
+        "Enabling incremental cross-module building",
+        "Incremental compilation: Read dependency graph",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
         "Incremental compilation: scheduling dependents of main.swift; -driver-always-rebuild-dependents",
@@ -845,7 +844,6 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
           "-emit-module",
           "-output-file-map", ofm.pathString,
           "-module-name", "MagicKit",
-          "-enable-experimental-cross-module-incremental-build",
           "-working-directory", path.pathString,
           "-c",
           magic.pathString,
@@ -871,7 +869,6 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
         "-emit-module",
         "-output-file-map", ofm.pathString,
         "-module-name", "theModule",
-        "-enable-experimental-cross-module-incremental-build",
         "-I", path.pathString,
         "-working-directory", path.pathString,
         "-c",


### PR DESCRIPTION
Now that cross-module incremental builds are controlled by -{enable,disable}-incremental-imports, resync the options and teach merge-modules to propagate the disable flag.

rdar://74363450