### PR TITLE
Use 'Incremental Imports' Terminology

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -60,7 +60,7 @@ public class IncrementalCompilationState {
       ? "Disabling"
       : "Enabling"
     reporter?.report(
-      "\(enablingOrDisabling) incremental cross-module building")
+      "\(enablingOrDisabling) incremental imports")
 
 
     guard let outputFileMap = driver.outputFileMap else {
@@ -120,8 +120,8 @@ extension IncrementalCompilationState {
     /// When this information is combined with the output file map, swiftdeps
     /// files can be located and loaded into the graph.
     ///
-    /// In a cross-module build, the dependency graph is derived from prior
-    /// state that is serialized alongside the build record.
+    /// In a build that is aware of incremental imports, the dependency graph is
+    /// derived from prior state that is serialized alongside the build record.
     let graph: ModuleDependencyGraph
     /// The set of compile jobs we can definitely skip given the state of the
     /// incremental dependency graph and the status of the input files for this
@@ -406,7 +406,7 @@ extension IncrementalCompilationState {
 
 extension IncrementalCompilationState {
   @_spi(Testing) public func writeDependencyGraph() {
-    // If the cross-module build is not enabled, the status quo dictates we
+    // If incremental imports not enabled, the status quo dictates we
     // not emit this file.
     if moduleDependencyGraph.info.areIncrementalImportsDisabled {
       return

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -30,7 +30,7 @@ extension IncrementalCompilationState {
     @_spi(Testing) public let diagnosticEngine: DiagnosticsEngine
     @_spi(Testing) public let readPriorsFromModuleDependencyGraph: Bool
     @_spi(Testing) public let alwaysRebuildDependents: Bool
-    @_spi(Testing) public let isCrossModuleIncrementalBuildEnabled: Bool
+    @_spi(Testing) public let areIncrementalImportsDisabled: Bool
     @_spi(Testing) public let verifyDependencyGraphAfterEveryImport: Bool
     @_spi(Testing) public let emitDependencyDotFileAfterEveryImport: Bool
     
@@ -69,7 +69,7 @@ extension IncrementalCompilationState {
       self.readPriorsFromModuleDependencyGraph = maybeBuildRecord != nil &&
         options.contains(.readPriorsFromModuleDependencyGraph)
       self.alwaysRebuildDependents = options.contains(.alwaysRebuildDependents)
-      self.isCrossModuleIncrementalBuildEnabled = options.contains(.enableCrossModuleIncrementalBuild)
+      self.areIncrementalImportsDisabled = options.contains(.disableIncrementalImports)
       self.verifyDependencyGraphAfterEveryImport = options.contains(.verifyDependencyGraphAfterEveryImport)
       self.emitDependencyDotFileAfterEveryImport = options.contains(.emitDependencyDotFileAfterEveryImport)
       self.buildTime = maybeBuildRecord?.buildTime ?? .distantPast

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -293,7 +293,7 @@ extension ModuleDependencyGraph {
 
     // If the graph already includes prior externals, then any new externals are changes
     // Short-circuit conjunction may avoid the modTime query
-    let shouldTryToProcess = info.isCrossModuleIncrementalBuildEnabled &&
+    let shouldTryToProcess = !info.areIncrementalImportsDisabled &&
       (isNewToTheGraph || lazyModTimer.hasExternalFileChanged)
 
     // Do this no matter what in order to integrate any incremental external dependencies.

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -152,12 +152,19 @@ extension Driver {
     if self.parsedOptions.contains(veriOpt) {
       options.formUnion(.verifyDependencyGraphAfterEveryImport)
     }
-    if self.parsedOptions.hasFlag(positive: .enableIncrementalImports,
-                                  negative: .disableIncrementalImports,
-                                  default: true) {
-      options.formUnion(.enableCrossModuleIncrementalBuild)
+
+    // Propagate the disable flag for cross-module incremental builds
+    // if necessary. Note because we're interested in *disabling* this feature,
+    // we consider the disable form to be the positive and enable to be the
+    // negative.
+    if self.parsedOptions.hasFlag(positive: .disableIncrementalImports,
+                                  negative: .enableIncrementalImports,
+                                  default: false) {
+      options.formUnion(.disableIncrementalImports)
+    } else {
       options.formUnion(.readPriorsFromModuleDependencyGraph)
     }
+
     return options
   }
 

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -89,6 +89,7 @@ extension Option {
   public static let disableImplicitSwiftModules: Option = Option("-disable-implicit-swift-modules", .flag, attributes: [.frontend, .noDriver], helpText: "Disable building Swift modules implicitly by the compiler")
   public static let disableIncrementalImports: Option = Option("-disable-incremental-imports", .flag, attributes: [.frontend], helpText: "Disable cross-module incremental build metadata and driver scheduling for Swift modules")
   public static let disableIncrementalLlvmCodegeneration: Option = Option("-disable-incremental-llvm-codegen", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable incremental llvm code generation.")
+  public static let disableInferPublicConcurrentValue: Option = Option("-disable-infer-public-concurrent-value", .flag, attributes: [.frontend, .noDriver], helpText: "Disable inference of ConcurrentValue conformances for public structs and enums")
   public static let disableInterfaceLockfile: Option = Option("-disable-interface-lock", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't lock interface file when building module")
   public static let disableInvalidEphemeralnessAsError: Option = Option("-disable-invalid-ephemeralness-as-error", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Diagnose invalid ephemeral to non-ephemeral conversions as warnings")
   public static let disableLegacyTypeInfo: Option = Option("-disable-legacy-type-info", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Completely disable legacy type layout")
@@ -223,7 +224,6 @@ extension Option {
   public static let enableExperimentalAdditiveArithmeticDerivation: Option = Option("-enable-experimental-additive-arithmetic-derivation", .flag, attributes: [.frontend], helpText: "Enable experimental 'AdditiveArithmetic' derived conformances")
   public static let enableExperimentalConcisePoundFile: Option = Option("-enable-experimental-concise-pound-file", .flag, attributes: [.frontend, .moduleInterface], helpText: "Enable experimental concise '#file' identifier")
   public static let enableExperimentalConcurrency: Option = Option("-enable-experimental-concurrency", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable experimental concurrency model")
-  public static let enableExperimentalCrossModuleIncrementalBuild: Option = Option("-enable-experimental-cross-module-incremental-build", .flag, attributes: [.frontend], helpText: "(experimental) Enable cross-module incremental build metadata and driver scheduling")
   public static let enableExperimentalCxxInterop: Option = Option("-enable-experimental-cxx-interop", .flag, helpText: "Allow importing C++ modules into Swift (experimental feature)")
   public static let enableExperimentalEnumCodableDerivation: Option = Option("-enable-experimental-enum-codable-derivation", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable experimental derivation of Codable for enums")
   public static let enableExperimentalFlowSensitiveConcurrentCaptures: Option = Option("-enable-experimental-flow-sensitive-concurrent-captures", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable flow-sensitive concurrent captures")
@@ -233,6 +233,7 @@ extension Option {
   public static let enableImplicitDynamic: Option = Option("-enable-implicit-dynamic", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Add 'dynamic' to all declarations")
   public static let enableIncrementalImports: Option = Option("-enable-incremental-imports", .flag, attributes: [.frontend], helpText: "Enable cross-module incremental build metadata and driver scheduling for Swift modules")
   public static let enableInferImportAsMember: Option = Option("-enable-infer-import-as-member", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Infer when a global could be imported as a member")
+  public static let enableInferPublicConcurrentValue: Option = Option("-enable-infer-public-concurrent-value", .flag, attributes: [.frontend, .noDriver], helpText: "Enable inference of ConcurrentValue conformances for public structs and enums")
   public static let enableInvalidEphemeralnessAsError: Option = Option("-enable-invalid-ephemeralness-as-error", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Diagnose invalid ephemeral to non-ephemeral conversions as errors")
   public static let enableLibraryEvolution: Option = Option("-enable-library-evolution", .flag, attributes: [.frontend, .moduleInterface], helpText: "Build the module to allow binary-compatible library evolution")
   public static let enableLlvmValueNames: Option = Option("-enable-llvm-value-names", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Add names to local values in LLVM IR")
@@ -309,6 +310,8 @@ extension Option {
   public static let indexIgnoreSystemModules: Option = Option("-index-ignore-system-modules", .flag, attributes: [.noInteractive], helpText: "Avoid indexing system modules")
   public static let indexStorePath: Option = Option("-index-store-path", .separate, attributes: [.frontend, .argumentIsPath], metaVar: "<path>", helpText: "Store indexing data to <path>")
   public static let indexSystemModules: Option = Option("-index-system-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Emit index data for imported serialized swift system modules")
+  public static let indexUnitOutputPathFilelist: Option = Option("-index-unit-output-path-filelist", .separate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Specify index unit output paths in a file rather than on the command line")
+  public static let indexUnitOutputPath: Option = Option("-index-unit-output-path", .separate, attributes: [.frontend, .argumentIsPath], metaVar: "<path>", helpText: "Use <path> as the output path in the produced index data.")
   public static let interpret: Option = Option("-interpret", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Immediate mode", group: .modes)
   public static let I: Option = Option("-I", .joinedOrSeparate, attributes: [.frontend, .argumentIsPath], helpText: "Add directory to the import search path")
   public static let i: Option = Option("-i", .flag, group: .modes)
@@ -593,6 +596,7 @@ extension Option {
       Option.disableImplicitSwiftModules,
       Option.disableIncrementalImports,
       Option.disableIncrementalLlvmCodegeneration,
+      Option.disableInferPublicConcurrentValue,
       Option.disableInterfaceLockfile,
       Option.disableInvalidEphemeralnessAsError,
       Option.disableLegacyTypeInfo,
@@ -727,7 +731,6 @@ extension Option {
       Option.enableExperimentalAdditiveArithmeticDerivation,
       Option.enableExperimentalConcisePoundFile,
       Option.enableExperimentalConcurrency,
-      Option.enableExperimentalCrossModuleIncrementalBuild,
       Option.enableExperimentalCxxInterop,
       Option.enableExperimentalEnumCodableDerivation,
       Option.enableExperimentalFlowSensitiveConcurrentCaptures,
@@ -737,6 +740,7 @@ extension Option {
       Option.enableImplicitDynamic,
       Option.enableIncrementalImports,
       Option.enableInferImportAsMember,
+      Option.enableInferPublicConcurrentValue,
       Option.enableInvalidEphemeralnessAsError,
       Option.enableLibraryEvolution,
       Option.enableLlvmValueNames,
@@ -813,6 +817,8 @@ extension Option {
       Option.indexIgnoreSystemModules,
       Option.indexStorePath,
       Option.indexSystemModules,
+      Option.indexUnitOutputPathFilelist,
+      Option.indexUnitOutputPath,
       Option.interpret,
       Option.I,
       Option.i,

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -593,7 +593,7 @@ extension IncrementalCompilationTests {
         // Leave off the part after the colon because it varies on Linux:
         // MacOS: The operation could not be completed. (TSCBasic.FileSystemError error 3.).
         // Linux: The operation couldn’t be completed. (TSCBasic.FileSystemError error 3.)
-        "Enabling incremental cross-module building",
+        "Enabling incremental imports",
         "Incremental compilation: Incremental compilation could not read build record at",
         "Incremental compilation: Disabling incremental build: could not read build record",
         "Incremental compilation: Created dependency graph from swiftdeps files",
@@ -617,7 +617,7 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Enabling incremental cross-module building",
+        "Enabling incremental imports",
         "Incremental compilation: Read dependency graph",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
@@ -637,7 +637,7 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Enabling incremental cross-module building",
+        "Enabling incremental imports",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: other.o <= other.swift}",
@@ -666,7 +666,7 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Enabling incremental cross-module building",
+        "Enabling incremental imports",
         "Incremental compilation: Read dependency graph",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
@@ -696,7 +696,7 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expectingRemarks: [
-        "Enabling incremental cross-module building",
+        "Enabling incremental imports",
         "Incremental compilation: Read dependency graph",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
@@ -736,7 +736,7 @@ extension IncrementalCompilationTests {
       checkDiagnostics: checkDiagnostics,
       extraArguments: [extraArgument],
       expectingRemarks: [
-        "Enabling incremental cross-module building",
+        "Enabling incremental imports",
         "Incremental compilation: Read dependency graph",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -458,8 +458,8 @@ extension IncrementalCompilationTests {
       (.driverShowIncremental, {$0.reporter != nil}),
       (.driverEmitFineGrainedDependencyDotFileAfterEveryImport, {$0.emitDependencyDotFileAfterEveryImport}),
       (.driverVerifyFineGrainedDependencyGraphAfterEveryImport, {$0.verifyDependencyGraphAfterEveryImport}),
-      (.enableIncrementalImports, {$0.isCrossModuleIncrementalBuildEnabled}),
-      (.disableIncrementalImports, {!$0.isCrossModuleIncrementalBuildEnabled}),
+      (.enableIncrementalImports, {!$0.areIncrementalImportsDisabled}),
+      (.disableIncrementalImports, {$0.areIncrementalImportsDisabled}),
     ]
 
     for (driverOption, stateOptionFn) in optionPairs {


### PR DESCRIPTION
Resync the options flag and drop the experimental cross-module incremental build terminology. The flags are sync'd to ToT Swift at https://github.com/apple/swift/pull/36254.