### PR TITLE
Temporarily Disable Reading Priors from the Module DepGraph

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -156,7 +156,13 @@ extension Driver {
                                   negative: .disableIncrementalImports,
                                   default: true) {
       options.formUnion(.enableCrossModuleIncrementalBuild)
-      options.formUnion(.readPriorsFromModuleDependencyGraph)
+      // FIXME: Re-enable once there is a way for the legacy test suite to
+      // disable this option in the driver. There's an impedance mismatch
+      // in a few tests that want to make sure that reading malformed swiftdeps
+      // files does the right thing with respect to the incremental build. If
+      // we're reading priors from the module dependency graph, they won't
+      // ever fail as expected!
+      // options.formUnion(.readPriorsFromModuleDependencyGraph)
     }
     return options
   }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -514,6 +514,8 @@ extension IncrementalCompilationTests {
   }
 
   func testDependencyDotFilesCross() throws {
+    throw XCTSkip("Re-enable once the legacy tests are tolerant of module dep graph priors")
+    /*
     expectNoDotFiles()
     try tryInitial(extraArguments: [
       "-driver-emit-fine-grained-dependency-dot-file-after-every-import",
@@ -527,7 +529,7 @@ extension IncrementalCompilationTests {
       DependencyGraphDotFileWriter.moduleDependencyGraphBasename,
       "other.swiftdeps",
       DependencyGraphDotFileWriter.moduleDependencyGraphBasename,
-    ])
+    ])*/
   }
 
   func expectNoDotFiles() {
@@ -618,7 +620,7 @@ extension IncrementalCompilationTests {
       extraArguments: extraArguments,
       expectingRemarks: [
         "Enabling incremental cross-module building",
-        "Incremental compilation: Read dependency graph",
+        "Incremental compilation: Created dependency graph from swiftdeps files",
         "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
@@ -643,7 +645,7 @@ extension IncrementalCompilationTests {
         "Incremental compilation: Queuing (initial):  {compile: other.o <= other.swift}",
         "Incremental compilation: not scheduling dependents of other.swift; unknown changes",
         "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
-        "Incremental compilation: Read dependency graph",
+        "Incremental compilation: Created dependency graph from swiftdeps files",
         "Found 1 batchable job",
         "Forming into 1 batch",
         "Adding {compile: other.swift} to batch 0",
@@ -667,7 +669,7 @@ extension IncrementalCompilationTests {
       extraArguments: extraArguments,
       expectingRemarks: [
         "Enabling incremental cross-module building",
-        "Incremental compilation: Read dependency graph",
+        "Incremental compilation: Created dependency graph from swiftdeps files",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: Scheduing changed input  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -697,7 +699,7 @@ extension IncrementalCompilationTests {
       extraArguments: extraArguments,
       expectingRemarks: [
         "Enabling incremental cross-module building",
-        "Incremental compilation: Read dependency graph",
+        "Incremental compilation: Created dependency graph from swiftdeps files",
         "Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
@@ -737,7 +739,7 @@ extension IncrementalCompilationTests {
       extraArguments: [extraArgument],
       expectingRemarks: [
         "Enabling incremental cross-module building",
-        "Incremental compilation: Read dependency graph",
+        "Incremental compilation: Created dependency graph from swiftdeps files",
         "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
         "Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}",
         "Incremental compilation: scheduling dependents of main.swift; -driver-always-rebuild-dependents",


### PR DESCRIPTION
Turning this on by default without considering the legacy tests means
those tests that try to e.g. make sure the driver does the right thing
when there are malformed Swiftdeps will not run correctly. Since, with
this flag enabled, we never even read them!