### PR TITLE
Revert "Tweak test relying on versioned clang module re-scanning to not need it."

### DIFF
--- a/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
+++ b/TestInputs/ExplicitModuleBuilds/CHeaders/G.h
@@ -1,7 +1,5 @@
-//#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 110000
-// FIXME: Versioned re-scanning has an intermittend failure so the test that relies on it is disabled
-// temporarily (rdar://74812312)
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 110000
 #include "X.h"
-//#endif
+#endif
 
 void funcG(void);

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -628,10 +628,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let expectedNumberOfDependencies: Int
       if driver.targetTriple.isMacOSX,
          driver.targetTriple.version(for: .macOS) >= Triple.Version(11, 0, 0) {
-        // FIXME: Versioned re-scanning has an intermittend failure so the test that relies on it
-        // is disabled temporarily (rdar://74812312)
-        // expectedNumberOfDependencies = 11
-        expectedNumberOfDependencies = 12
+        expectedNumberOfDependencies = 11
       } else {
         expectedNumberOfDependencies = 12
       }


### PR DESCRIPTION
This reverts commit b2ac19551894dbd905fd0c68ea2b3dd429ea8977.
The underlying Dependency Scanner is fixed in: https://github.com/apple/swift/pull/36294
We will need to wait for that PR to make it to a toolchain snapshot before merging this. 