### PR TITLE
Remove deprecated `externalBuildArtifacts` API.

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -166,7 +166,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
                                                   hostTriple: driver.hostTriple,
                                                   env: ProcessEnv.vars)
-      try dependencyOracle
+      let _ = try dependencyOracle
         .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
                                        swiftScanLibPath: scanLibPath)
       try dependencyOracle.mergeModules(from: moduleDependencyGraph)
@@ -246,12 +246,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                          "test.swift", "-module-name", "A", "-g"]
 
       var driver = try Driver(args: commandLine, executor: executor,
-                              externalBuildArtifacts: (targetModulePathMap, [:]),
+                              externalTargetModulePathMap: targetModulePathMap,
                               interModuleDependencyOracle: dependencyOracle)
       let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
                                                   hostTriple: driver.hostTriple,
                                                   env: ProcessEnv.vars)
-      try dependencyOracle
+      let _ = try dependencyOracle
         .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
                                        swiftScanLibPath: scanLibPath)
 


### PR DESCRIPTION
Its usage was removed in the SwiftPM Client a while back:
https://github.com/apple/swift-package-manager/pull/3042