### PR TITLE
Do not add precompiled bridging header to a Compile job's display inputs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1080,8 +1080,13 @@ extension Driver {
       }
       // All input action IDs for this action.
       var inputIds = [UInt]()
+
+      var jobInputs = job.primaryInputs.isEmpty ? job.inputs : job.primaryInputs
+      if let pchPath = bridgingPrecompiledHeader, job.kind == .compile {
+        jobInputs.append(TypedVirtualPath(file: pchPath, type: .pch))
+      }
       // Collect input job IDs.
-      for input in job.displayInputs.isEmpty ? job.inputs : job.displayInputs {
+      for input in jobInputs {
         if let id = inputIdMap[input] {
           inputIds.append(id)
           continue

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -304,20 +304,17 @@ extension Driver {
       inputs.append(TypedVirtualPath(file: moduleOutputInfo.output!.outputPath, type: .swiftModule))
     }
 
-    var displayInputs = primaryInputs
-
     // Bridging header is needed for compiling these .swift sources.
     if let pchPath = bridgingPrecompiledHeader {
       let pchInput = TypedVirtualPath(file: pchPath, type: .pch)
       inputs.append(pchInput)
-      displayInputs.append(pchInput)
     }
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .compile,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,
-      displayInputs: displayInputs,
+      displayInputs: primaryInputs,
       inputs: inputs,
       primaryInputs: primaryInputs,
       outputs: outputs,

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -67,11 +67,17 @@ public struct Job: Codable, Equatable, Hashable {
   /// Whether or not the job supports using response files to pass command line arguments.
   public var supportsResponseFiles: Bool
 
-  /// The list of inputs to use for displaying purposes.
-  public var displayInputs: [TypedVirtualPath]
-
-  /// The list of inputs for this job.
+  /// The list of inputs for this job. These are all files that must be provided in order for this job to execute,
+  /// and this list, along with the corresponding `outputs` is used to establish producer-consumer dependency
+  /// relationship among jobs.
   public var inputs: [TypedVirtualPath]
+
+  /// The list of inputs to use for displaying purposes. These files are the ones the driver will communicate
+  /// to the user/client as being objects of the selected compilation action.
+  /// For example, a frontend job to compile a `.swift` source file may require multiple binary `inputs`,
+  /// such as a pre-compiled bridging header and binary Swift module dependencies, but only the input `.swift`
+  /// source file is meant to be the displayed object of compilation - a display input.
+  public var displayInputs: [TypedVirtualPath]
 
   /// The primary inputs for compile jobs
   public var primaryInputs: [TypedVirtualPath]


### PR DESCRIPTION
"Display inputs" are used to convey to the user/client the set of input files that a given compile job will build, e.g. in parseable-output.

The driver is relying on the presence of the bridging PCH in `displayInputs` because the `printActions` code relies on `displayInputs`, when they are present. Unlike parseable-output, action printing is used for compiler debugging purposes only, and given that `printActions` is a best-effort emulation of the legacy driver behavior that doesn't really exist in the new driver, we can just as well get away with using `primaryInputs` and ensure `compile` job actions refer to the corresponding precompiled header, to keep the C++ tests passing (`test/Driver/actions.swift` & `test/Driver/actions-dsym.swift`).