### PR TITLE
[Incremental Imports; testing NFC] Add new testing framework for incremental imports, etc

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,18 @@ let package = Package(
     /// Driver tests.
     .testTarget(
       name: "SwiftDriverTests",
-      dependencies: ["SwiftDriver", "SwiftDriverExecution", "swift-driver"]),
+      dependencies: ["SwiftDriver", "SwiftDriverExecution", "swift-driver",
+                     "TestUtilities"]),
+
+    /// IncrementalImport tests
+    .testTarget(
+      name: "IncrementalImportTests",
+      dependencies: ["SwiftDriver", "SwiftOptions","TestUtilities"]),
+
+    .target(
+      name: "TestUtilities",
+      dependencies: ["SwiftDriver", "SwiftDriverExecution"],
+      path: "Tests/TestUtilities"),
 
     /// The options library.
     .target(

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -63,7 +63,7 @@ import TSCBasic
 public struct FingerprintedExternalDependency: Hashable, Equatable, ExternalDependencyAndFingerprintEnforcer {
   let externalDependency: ExternalDependency
   let fingerprint: String?
-  init(_ externalDependency: ExternalDependency, _ fingerprint: String?) {
+  @_spi(Testing) public init(_ externalDependency: ExternalDependency, _ fingerprint: String?) {
     self.externalDependency = externalDependency
     self.fingerprint = fingerprint
     assert(verifyExternalDependencyAndFingerprint())

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -35,7 +35,7 @@ import SwiftOptions
   /// For debugging, something to write out files for visualizing graphs
   let dotFileWriter: DependencyGraphDotFileWriter?
 
-  var phase: Phase
+  @_spi(Testing) public var phase: Phase
 
   public init(_ info: IncrementalCompilationState.InitialStateComputer,
               _ phase: Phase
@@ -1069,7 +1069,7 @@ extension Set where Element == FingerprintedExternalDependency {
 
 /// This should be in a test file, but addMapEntry should be private.
 extension ModuleDependencyGraph {
-  func mockMapEntry(
+  @_spi(Testing) public func mockMapEntry(
     _ mockInput: TypedVirtualPath,
     _ mockDependencySource: DependencySource
   ) {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -45,7 +45,7 @@ extension ModuleDependencyGraph {
     /// Nodes can move from file to file when the driver reads the result of a
     /// compilation.
     /// Nil represents a node with no known residance
-    let dependencySource: DependencySource?
+    @_spi(Testing) public let dependencySource: DependencySource?
     var isExpat: Bool { dependencySource == nil }
 
     /// When integrating a change, the driver finds untraced nodes so it can kick off jobs that have not been

--- a/Tests/IncrementalImportTests/ClassExtension.swift
+++ b/Tests/IncrementalImportTests/ClassExtension.swift
@@ -1,0 +1,97 @@
+//===-------------- ClassExtensionTest.swift - Swift Testing --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+
+/// Shows that adding a class method in an extension in a submodule causes the user importing the class
+/// to get recompiled, but not for a struct.
+class ClassExtensionTest: XCTestCase {
+  func testClassExtension() throws {
+    try Test.test()
+  }
+  struct Test: TestProtocol {
+    static let start: State = .withoutFunc
+    static let steps: [Step<State>] = [
+      Step(.withFunc,    expectedCompilations),
+      Step(.withoutFunc, expectedCompilations),
+      Step(.withFunc,    expectedCompilations),
+    ]
+
+    static let expectedCompilations = Expectation<SourceVersion>(
+      with:    [.classUser, .withStructFunc, .withClassFunc],
+      without: [.classUser, .withStructFunc, .withClassFunc, .structUser])
+
+    enum State: String, StateProtocol {
+      case withFunc, withoutFunc
+      var jobs: [BuildJob<Module>] {
+        let importedVersions: [SourceVersion]
+        switch self {
+        case .withFunc: importedVersions = [.withStructFunc, .withClassFunc]
+        case .withoutFunc: importedVersions = [.withoutStructFunc, .withoutClassFunc]
+        }
+        return [BuildJob(.imported, importedVersions + [.definer]),
+                BuildJob(.main, [.classUser, .structUser])]
+      }
+    }
+
+    enum Module: String, ModuleProtocol {
+      typealias SourceVersion = Test.SourceVersion
+
+      case main, imported
+
+      var imports: [Self] {
+        switch self {
+        case .main:     return [.imported]
+        case .imported: return []
+        }
+      }
+      var isLibrary: Bool {
+        switch self {
+        case .main:     return false
+        case .imported: return true
+        }
+      }
+    }
+
+
+    enum SourceVersion: String, SourceVersionProtocol {
+      case classUser, structUser,
+          withStructFunc, withoutStructFunc, withClassFunc, withoutClassFunc,
+          definer
+      
+      var fileName: String {
+        switch self {
+        case .withStructFunc, .withoutStructFunc: return "structFuncDef"
+        case .withClassFunc,  .withoutClassFunc:  return "classFuncDef"
+        default: return name
+        }
+      }
+      var code: String {
+        switch self {
+        case .structUser: return "import \(Module.imported.nameToImport); func su() {S()}"
+        case .classUser:  return "import \(Module.imported.nameToImport); func cu() {C()}"
+        case .withStructFunc:    return "public extension S { func foo() {} }"
+        case .withClassFunc:     return "public extension C { func foo() {} }"
+        case .withoutStructFunc: return "public extension S{}"
+        case .withoutClassFunc:  return "public extension C{}"
+        case .definer: return """
+          open class C {public init() {}}
+          public struct S {public init() {}}
+          """
+        }
+      }
+    }
+  }
+}

--- a/Tests/IncrementalImportTests/ClassExtension.swift
+++ b/Tests/IncrementalImportTests/ClassExtension.swift
@@ -19,7 +19,7 @@ import SwiftOptions
 /// to get recompiled, but not for a struct.
 class ClassExtensionTest: XCTestCase {
   func testClassExtension() throws {
-    try Test.test()
+    try Test.test(verbose: false)
   }
   struct Test: TestProtocol {
     static let start: State = .withoutFunc

--- a/Tests/IncrementalImportTests/ClassExtension.swift
+++ b/Tests/IncrementalImportTests/ClassExtension.swift
@@ -80,8 +80,8 @@ class ClassExtensionTest: XCTestCase {
       }
       var code: String {
         switch self {
-        case .structUser: return "import \(Module.imported.nameToImport); func su() {S()}"
-        case .classUser:  return "import \(Module.imported.nameToImport); func cu() {C()}"
+        case .structUser: return "import \(Module.imported.nameToImport); func su() {_ = S()}"
+        case .classUser:  return "import \(Module.imported.nameToImport); func cu() {_ = C()}"
         case .withStructFunc:    return "public extension S { func foo() {} }"
         case .withClassFunc:     return "public extension C { func foo() {} }"
         case .withoutStructFunc: return "public extension S{}"

--- a/Tests/IncrementalImportTests/ClassExtension.swift
+++ b/Tests/IncrementalImportTests/ClassExtension.swift
@@ -38,7 +38,7 @@ class ClassExtensionTest: XCTestCase {
       var jobs: [BuildJob<Module>] {
         let importedVersions: [SourceVersion]
         switch self {
-        case .withFunc: importedVersions = [.withStructFunc, .withClassFunc]
+        case    .withFunc: importedVersions = [   .withStructFunc,    .withClassFunc]
         case .withoutFunc: importedVersions = [.withoutStructFunc, .withoutClassFunc]
         }
         return [BuildJob(.imported, importedVersions + [.definer]),

--- a/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
+++ b/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
@@ -1,0 +1,85 @@
+import Foundation
+//===------ ExtensionChangeWithinModuleTests.swift - Swift Testing --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+
+class ExtensionChangeWithinModuleTests: XCTestCase {
+  func testExtensionChangeWithinModule() throws {
+    try ExtensionChange.test()
+  }
+}
+
+fileprivate struct ExtensionChange: TestProtocol {
+  static let start: State = .noFunc
+  static let steps: [Step<State>] = [
+    Step(.withFunc, expectedCompilations),
+    Step(.noFunc,   expectedCompilations),
+    Step(.withFunc, expectedCompilations),
+  ]
+  static var expectedCompilations: Expectation<SourceVersion> =
+    Expectation(with: [.main, .noFunc, .instantiator], without: [.main, .noFunc, .instantiator, .userOfT])
+
+
+  enum State: String, StateProtocol {
+    case noFunc, withFunc
+
+    var jobs: [BuildJob<Module>] {
+      switch self {
+      case   .noFunc: return [BuildJob(.mainM, [.main,   .noFunc, .instantiator])]
+      case .withFunc: return [BuildJob(.mainM, [.main, .withFunc, .instantiator])]
+      }
+    }
+  }
+
+  enum Module: String, ModuleProtocol {
+    typealias SourceVersion = ExtensionChange.SourceVersion
+    case mainM
+
+    var imports: [Self] { return [] }
+    var isLibrary: Bool { false }
+  }
+
+  enum SourceVersion: String, SourceVersionProtocol {
+    case main, noFunc, withFunc, instantiator, userOfT
+
+    var fileName: String {
+      switch self {
+      case .noFunc, .withFunc: return "extensionHolder"
+      default:                 return name
+      }
+    }
+
+    var code: String {
+      switch self {
+      case .main: return """
+        struct S { static func foo<I: SignedInteger>(_ si: I) {} }
+        S.foo(3)
+        """
+      case .noFunc: return """
+        extension S {}
+        struct T {static func foo() {}}
+        """
+      case .withFunc: return """
+        extension S { static func foo(_ i: Int) {} }
+        struct T {static func foo() {}}
+        """
+      case .instantiator: return "func bar() {S()}"
+      case .userOfT: return "func baz() {T.foo()}"
+      }
+    }
+  }
+}
+

--- a/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
+++ b/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
@@ -18,7 +18,7 @@ import SwiftOptions
 
 class ExtensionChangeWithinModuleTests: XCTestCase {
   func testExtensionChangeWithinModule() throws {
-    try ExtensionChange.test()
+    try ExtensionChange.test(verbose: false)
   }
 }
 

--- a/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
+++ b/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
@@ -30,7 +30,8 @@ fileprivate struct ExtensionChange: TestProtocol {
     Step(.withFunc, expectedCompilations),
   ]
   static var expectedCompilations: Expectation<SourceVersion> =
-    Expectation(with: [.main, .noFunc, .instantiator], without: [.main, .noFunc, .instantiator, .userOfT])
+    Expectation(with:    [.main, .noFunc],
+                without: [.main, .noFunc])
 
 
   enum State: String, StateProtocol {
@@ -64,20 +65,25 @@ fileprivate struct ExtensionChange: TestProtocol {
 
     var code: String {
       switch self {
-      case .main: return """
-        struct S { static func foo<I: SignedInteger>(_ si: I) {} }
-        S.foo(3)
+      case .main:
+        return """
+          struct S {static func foo<I: SignedInteger>(_ si: I) {}}
+          S.foo(3)
         """
-      case .noFunc: return """
-        extension S {}
-        struct T {static func foo() {}}
+      case .noFunc:
+        return """
+          extension S {}
+          struct T {static func foo() {}}
         """
-      case .withFunc: return """
-        extension S { static func foo(_ i: Int) {} }
-        struct T {static func foo() {}}
+      case .withFunc:
+        return """
+          extension S {static func foo(_ i: Int) {}}
+          struct T {static func foo() {}}
         """
-      case .instantiator: return "func bar() { _ = S() }"
-      case .userOfT: return "func baz() {T.foo()}"
+      case .instantiator:
+        return "func bar() {_ = S()}"
+      case .userOfT:
+        return "func baz() {T.foo()}"
       }
     }
   }

--- a/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
+++ b/Tests/IncrementalImportTests/ExtensionChangeWithinModule.swift
@@ -76,7 +76,7 @@ fileprivate struct ExtensionChange: TestProtocol {
         extension S { static func foo(_ i: Int) {} }
         struct T {static func foo() {}}
         """
-      case .instantiator: return "func bar() {S()}"
+      case .instantiator: return "func bar() { _ = S() }"
       case .userOfT: return "func baz() {T.foo()}"
       }
     }

--- a/Tests/IncrementalImportTests/Framework/BuildJob.swift
+++ b/Tests/IncrementalImportTests/Framework/BuildJob.swift
@@ -1,0 +1,98 @@
+//===---------------- BuildJob.swift - Swift Testing -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+import TestUtilities
+
+/// Everything needed to invoke the driver and build a module.
+/// (See `TestProtocol`.)
+struct BuildJob<Module: ModuleProtocol> {
+  typealias SourceVersion = Module.SourceVersion
+
+  /// The module to be compiled
+  let module: Module
+
+  /// The source versions to be compiled. Can vary.
+  let sourceVersions: [SourceVersion]
+
+  init(_ module: Module, _ sourceVersions: [SourceVersion]) {
+    self.module = module
+    self.sourceVersions = sourceVersions
+  }
+
+  /// Update the contents of the source files.
+  func updateChangedSources(_ context: TestContext) {
+    sourceVersions.forEach {$0.updateIfChanged(context)}
+  }
+
+  /// Returns the basenames without extension of the compiled source files.
+  func run(_ context: TestContext) -> [String] {
+    writeOFM(context)
+    let allArgs = arguments(context)
+
+    var collector = CompiledSourceCollector()
+    let diagnosticsEngine = DiagnosticsEngine(handlers: [
+                                                Driver.stderrDiagnosticsHandler,
+                                                {collector.handle(diagnostic: $0)}])
+
+    var driver = try! Driver(args: allArgs, diagnosticsEngine: diagnosticsEngine)
+    let jobs = try! driver.planBuild()
+    try! driver.run(jobs: jobs)
+
+    return collector.compiledSources(context)
+  }
+
+  private func writeOFM(_ context: TestContext) {
+    OutputFileMapCreator.write(
+      module: module.name,
+      inputPaths: sourceVersions.map {$0.path(context)},
+      derivedData: module.derivedDataPath(context),
+      to: module.outputFileMapPath(context))
+  }
+
+  func arguments(_ context: TestContext) -> [String] {
+    var libraryArgs: [String] {
+      ["-parse-as-library",
+       "-emit-module-path", module.swiftmodulePath(context).pathString]
+    }
+    var appArgs: [String] {
+      let swiftModules = module.imports .map {
+        $0.swiftmodulePath(context).parentDirectory.pathString
+      }
+      return swiftModules.flatMap { ["-I", $0, "-F", $0] }
+    }
+    var incrementalImportsArgs: [String] {
+      // ["-\(withIncrementalImports ? "en" : "dis")able-incremental-imports"]
+      context.withIncrementalImports
+        ? ["-enable-experimental-cross-module-incremental-build"]
+        : []
+    }
+    return Array(
+    [
+      [
+        "swiftc",
+        "-no-color-diagnostics",
+        "-incremental",
+        "-driver-show-incremental",
+        "-driver-show-job-lifecycle",
+        "-c",
+        "-module-name", module.nameToImport,
+        "-output-file-map", module.outputFileMapPath(context).pathString,
+      ],
+      incrementalImportsArgs,
+      module.isLibrary ? libraryArgs : appArgs,
+      sourceVersions.map {$0.path(context).pathString}
+    ].joined())
+  }
+}

--- a/Tests/IncrementalImportTests/Framework/BuildJob.swift
+++ b/Tests/IncrementalImportTests/Framework/BuildJob.swift
@@ -78,8 +78,8 @@ struct BuildJob<Module: ModuleProtocol> {
     var incrementalImportsArgs: [String] {
       // ["-\(withIncrementalImports ? "en" : "dis")able-incremental-imports"]
       context.withIncrementalImports
-        ? ["-enable-experimental-cross-module-incremental-build"]
-        : []
+        ? [ "-enable-incremental-imports"]
+        : ["-disable-incremental-imports"]
     }
     return Array(
     [

--- a/Tests/IncrementalImportTests/Framework/BuildJob.swift
+++ b/Tests/IncrementalImportTests/Framework/BuildJob.swift
@@ -42,9 +42,12 @@ struct BuildJob<Module: ModuleProtocol> {
     let allArgs = arguments(context)
 
     var collector = CompiledSourceCollector()
-    let diagnosticsEngine = DiagnosticsEngine(handlers: [
-                                                Driver.stderrDiagnosticsHandler,
-                                                {collector.handle(diagnostic: $0)}])
+    let handlers = [
+        {collector.handle(diagnostic: $0)},
+        context.verbose ? Driver.stderrDiagnosticsHandler : nil
+      ]
+      .compactMap {$0}
+    let diagnosticsEngine = DiagnosticsEngine(handlers: handlers)
 
     var driver = try! Driver(args: allArgs, diagnosticsEngine: diagnosticsEngine)
     let jobs = try! driver.planBuild()

--- a/Tests/IncrementalImportTests/Framework/CompiledSourceCollector.swift
+++ b/Tests/IncrementalImportTests/Framework/CompiledSourceCollector.swift
@@ -1,0 +1,50 @@
+//===---------- CompiledSourceCollector.swift - Swift Testing -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+import TestUtilities
+
+/// Creates a `DiagnosticsEngine` that collects which sources were compiled.
+/// (See `TestProtocol`.)
+struct CompiledSourceCollector {
+  private var collectedCompiledSources = [String]()
+
+  private func getCompiledSources(from d: Diagnostic) -> [String] {
+    let dd = d.description
+    guard let startOfSources = dd.range(of: "Starting Compiling ")?.upperBound
+    else {
+      return []
+    }
+    return dd.suffix(from: startOfSources)
+      .split(separator: ",")
+      .map {$0.drop(while: {$0 == " "})}
+      .map { (s: Substring) -> Substring in
+        assert(s.hasSuffix(".swift"))
+        return s.dropLast(".swift".count)
+      }
+      .compactMap {String($0)}
+  }
+
+  mutating func handle(diagnostic d: Diagnostic) {
+    collectedCompiledSources.append(contentsOf: getCompiledSources(from: d))
+  }
+
+  func compiledSources(_ context: TestContext) ->  [String] {
+    XCTAssertEqual(Set(collectedCompiledSources).count, collectedCompiledSources.count,
+                   "No file should be compiled twice",
+                   file: context.testFile, line: context.testLine)
+    return collectedCompiledSources
+  }
+}

--- a/Tests/IncrementalImportTests/Framework/Expectation.swift
+++ b/Tests/IncrementalImportTests/Framework/Expectation.swift
@@ -1,0 +1,55 @@
+//===------------------- Expectation.swift - Swift Testing ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+/// What is supposed to be recompiled when taking a step.
+/// (See `TestProtocol`.)
+struct Expectation<SourceVersion: SourceVersionProtocol> {
+
+  /// Expected when incremental imports are enabled
+  private let withIncrementalImports: [SourceVersion]
+
+  // Expected when incremental imports are disabled
+  private let withoutIncrementalImports: [SourceVersion]
+
+  init(with: [SourceVersion], without: [SourceVersion]) {
+    self.withIncrementalImports = with
+    self.withoutIncrementalImports = without
+  }
+
+  /// Return the appropriate expectation
+  private func when(in context: TestContext) -> [SourceVersion] {
+    context.withIncrementalImports
+      ? withIncrementalImports : withoutIncrementalImports
+  }
+
+  /// Check actuals against expectations
+  func check(against actuals: [String], _ context: TestContext, nextStateName: String) {
+    let expected = when(in: context)
+    let expectedSet = Set(expected.map {$0.fileName})
+    let actualsSet = Set(actuals)
+
+    let extraCompilations = actualsSet.subtracting(expectedSet)
+    let missingCompilations = expectedSet.subtracting(actualsSet)
+
+    XCTAssertEqual(
+      extraCompilations, [],
+      "Extra compilations, \(context), step \(nextStateName)",
+      file: context.testFile, line: context.testLine)
+
+    XCTAssertEqual(
+      missingCompilations, [],
+      "Missing compilations, \(context), step \(nextStateName)",
+      file: context.testFile, line: context.testLine)
+  }
+}

--- a/Tests/IncrementalImportTests/Framework/Expectation.swift
+++ b/Tests/IncrementalImportTests/Framework/Expectation.swift
@@ -42,14 +42,12 @@ struct Expectation<SourceVersion: SourceVersionProtocol> {
     let extraCompilations = actualsSet.subtracting(expectedSet)
     let missingCompilations = expectedSet.subtracting(actualsSet)
 
-    XCTAssertEqual(
-      extraCompilations, [],
-      "Extra compilations, \(context), step \(nextStateName)",
+    XCTAssert(extraCompilations.isEmpty,
+      "Extra compilations: \(extraCompilations), \(context), in state: \(nextStateName)",
       file: context.testFile, line: context.testLine)
 
-    XCTAssertEqual(
-      missingCompilations, [],
-      "Missing compilations, \(context), step \(nextStateName)",
+    XCTAssert(missingCompilations.isEmpty,
+      "Missing compilations: \(missingCompilations), \(context), in state: \(nextStateName)",
       file: context.testFile, line: context.testLine)
   }
 }

--- a/Tests/IncrementalImportTests/Framework/ModuleProtocol.swift
+++ b/Tests/IncrementalImportTests/Framework/ModuleProtocol.swift
@@ -1,0 +1,48 @@
+//===--------------- ModuleProtocol.swift - Swift Testing -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+import TestUtilities
+
+
+/// Each test must implement an enum that conforms and describes the modules in the test.
+/// (See `TestProtocol`.)
+protocol ModuleProtocol: NameableByRawValue, CaseIterable {
+  /// The type of the Source (versions)
+  associatedtype SourceVersion: SourceVersionProtocol
+
+  /// The modules imported by this module, if any.
+  var imports: [Self] {get}
+
+  /// Returns true iff the module is a library, vs an app
+  var isLibrary: Bool {get}
+}
+
+extension ModuleProtocol {
+  /// The name of the module, as appears in the `import` statement
+  var nameToImport: String { name }
+
+  func createDerivedDataDir(_ context: TestContext) {
+    try! localFileSystem.createDirectory(derivedDataPath(context))
+  }
+  func derivedDataPath(_ context: TestContext) -> AbsolutePath {
+    context.rootDir.appending(component: "\(nameToImport)DD")
+  }
+  func outputFileMapPath(_ context: TestContext) -> AbsolutePath {
+    derivedDataPath(context).appending(component: "OFM")
+  }
+  func swiftmodulePath(_ context: TestContext) -> AbsolutePath {
+    derivedDataPath(context).appending(component: "\(nameToImport).swiftmodule")
+  }
+}

--- a/Tests/IncrementalImportTests/Framework/NameableByRawValue.swift
+++ b/Tests/IncrementalImportTests/Framework/NameableByRawValue.swift
@@ -1,0 +1,20 @@
+//===-------------- NameableByRawValue.swift - Swift Testing --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// String raw values are used as names for source files and modules.
+/// (See `TestProtocol`.)
+protocol NameableByRawValue: RawRepresentable where RawValue == String {
+}
+
+extension NameableByRawValue {
+  var name: String {rawValue}
+}

--- a/Tests/IncrementalImportTests/Framework/SourceVersionProtocol.swift
+++ b/Tests/IncrementalImportTests/Framework/SourceVersionProtocol.swift
@@ -1,0 +1,43 @@
+//===----------- SourceVersionProtocol.swift - Swift Testing --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+import TestUtilities
+
+/// A `SourceVersion` is a particular version of some source file.
+/// (See `TestProtocol`.)
+protocol SourceVersionProtocol: NameableByRawValue, Hashable {
+
+  /// The source code for this version, i.e. the file contents.
+  var code: String {get}
+
+  /// The basename without extension of the corresponding file.
+  var fileName: String {get}
+}
+
+extension SourceVersionProtocol {
+
+  func path(_ context: TestContext) -> AbsolutePath {
+    context.rootDir.appending(component: "\(fileName).swift")
+  }
+
+  /// If this version is different from what is in the file, update the file.
+  func updateIfChanged(_ context: TestContext) {
+    XCTAssertNoThrow(
+      try localFileSystem.writeIfChanged(path: path(context),
+                                         bytes: ByteString(encodingAsUTF8: code)),
+      file: context.testFile, line: context.testLine)
+  }
+}

--- a/Tests/IncrementalImportTests/Framework/StateProtocol.swift
+++ b/Tests/IncrementalImportTests/Framework/StateProtocol.swift
@@ -1,0 +1,66 @@
+//===--------------- StateProtocol.swift - Swift Testing ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+import TestUtilities
+
+/// A state is a sequence of jobs to run, where each job defines the source-versions to be used.
+/// A state is entered by mutating the source files and running the jobs.
+/// (See `TestProtocol`.)
+protocol StateProtocol: NameableByRawValue {
+  associatedtype Module: ModuleProtocol
+  typealias SourceVersion = Module.SourceVersion
+
+  /// The jobs will be run in sequence.
+  var jobs: [BuildJob<Module>] {get}
+}
+
+extension StateProtocol {
+  /// Bring source files into agreement with desired versions
+  private func updateChangedSources(_ context: TestContext) {
+    for job in jobs {
+      job.updateChangedSources(context)
+    }
+  }
+
+  /// Sources in every job
+  var allInputs: [SourceVersion] {
+    Array( jobs.reduce(into: Set()) { sources, job in
+      sources.formUnion(job.sourceVersions)
+    })
+  }
+
+  /// This state is the initial state. Create the sources, compile, and check.
+  func enterInitialStateAndCheck(_ context: TestContext) {
+    let compiledSources = enter(context)
+    initialExpectations.check(against: compiledSources, context, nextStateName: "setup")
+  }
+
+  /// Enter this state: update the sources, compile, and return what was actually compiled.
+  func enter(_ context: TestContext) -> [String] {
+    updateChangedSources(context)
+    return compile(context)
+  }
+
+  /// Builds the entire project, returning what was recompiled.
+   private func compile(_ context: TestContext) -> [String] {
+     jobs.flatMap{ $0.run(context) }
+   }
+
+  /// What should be compiled for the initial set up.
+  var initialExpectations: Expectation<SourceVersion> {
+    Expectation(with: allInputs, without: allInputs)
+  }
+}

--- a/Tests/IncrementalImportTests/Framework/StateProtocol.swift
+++ b/Tests/IncrementalImportTests/Framework/StateProtocol.swift
@@ -50,6 +50,9 @@ extension StateProtocol {
 
   /// Enter this state: update the sources, compile, and return what was actually compiled.
   func enter(_ context: TestContext) -> [String] {
+    if context.verbose {
+      print("Entering", nextState.name, "state")
+    }
     updateChangedSources(context)
     return compile(context)
   }

--- a/Tests/IncrementalImportTests/Framework/StateProtocol.swift
+++ b/Tests/IncrementalImportTests/Framework/StateProtocol.swift
@@ -51,7 +51,7 @@ extension StateProtocol {
   /// Enter this state: update the sources, compile, and return what was actually compiled.
   func enter(_ context: TestContext) -> [String] {
     if context.verbose {
-      print("Entering", nextState.name, "state")
+      print("Entering", name, "state")
     }
     updateChangedSources(context)
     return compile(context)

--- a/Tests/IncrementalImportTests/Framework/Step.swift
+++ b/Tests/IncrementalImportTests/Framework/Step.swift
@@ -1,0 +1,33 @@
+//===-------------- Step.swift - Swift Testing --------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A test step: includes the source state to compile and what compilations are expected.
+/// A given test consists of a start state, and a sequence of steps.
+/// (See `TestProtocol`.)
+struct Step<State: StateProtocol> {
+  typealias SourceVersion = State.Module.SourceVersion
+  let nextState: State
+  let expecting: Expectation<SourceVersion>
+
+  init(_ nextState: State, _ expecting: Expectation<SourceVersion>) {
+    self.nextState = nextState
+    self.expecting = expecting
+  }
+
+  func mutateAndRebuildAndCheck(_ context: TestContext) {
+    print(nextState.name)
+    let compiledSources = nextState.enter(context)
+    expecting.check(against: compiledSources, context, nextStateName: nextState.name)
+  }
+
+  var allSourceVersions: [SourceVersion] {nextState.allInputs}
+}

--- a/Tests/IncrementalImportTests/Framework/Step.swift
+++ b/Tests/IncrementalImportTests/Framework/Step.swift
@@ -24,7 +24,9 @@ struct Step<State: StateProtocol> {
   }
 
   func mutateAndRebuildAndCheck(_ context: TestContext) {
-    print(nextState.name)
+    if context.verbose {
+      print(nextState.name)
+    }
     let compiledSources = nextState.enter(context)
     expecting.check(against: compiledSources, context, nextStateName: nextState.name)
   }

--- a/Tests/IncrementalImportTests/Framework/Step.swift
+++ b/Tests/IncrementalImportTests/Framework/Step.swift
@@ -24,9 +24,6 @@ struct Step<State: StateProtocol> {
   }
 
   func mutateAndRebuildAndCheck(_ context: TestContext) {
-    if context.verbose {
-      print(nextState.name)
-    }
     let compiledSources = nextState.enter(context)
     expecting.check(against: compiledSources, context, nextStateName: nextState.name)
   }

--- a/Tests/IncrementalImportTests/Framework/TestContext.swift
+++ b/Tests/IncrementalImportTests/Framework/TestContext.swift
@@ -20,16 +20,21 @@ struct TestContext: CustomStringConvertible {
   /// Are incremental imports enabled? Tests both ways.
   let withIncrementalImports: Bool
 
+  /// Print out much more info to help debug the test
+  let verbose: Bool
+
   /// The original locus of the test, for error-reporting.
   let testFile: StaticString
   let testLine: UInt
 
   init(in rootDir: AbsolutePath,
        withIncrementalImports: Bool,
+       verbose: Bool,
        testFile: StaticString,
        testLine: UInt) {
     self.rootDir = rootDir
     self.withIncrementalImports = withIncrementalImports
+    self.verbose = verbose
     self.testFile = testFile
     self.testLine = testLine
   }

--- a/Tests/IncrementalImportTests/Framework/TestContext.swift
+++ b/Tests/IncrementalImportTests/Framework/TestContext.swift
@@ -1,0 +1,40 @@
+//===-------------- TestContext.swift - Swift Testing ----------- ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+
+/// Bundles up (incidental) values to be passed down to the various functions.
+/// (See `TestProtocol`.)
+struct TestContext: CustomStringConvertible {
+  /// The root directory of the test; temporary
+  let rootDir: AbsolutePath
+
+  /// Are incremental imports enabled? Tests both ways.
+  let withIncrementalImports: Bool
+
+  /// The original locus of the test, for error-reporting.
+  let testFile: StaticString
+  let testLine: UInt
+
+  init(in rootDir: AbsolutePath,
+       withIncrementalImports: Bool,
+       testFile: StaticString,
+       testLine: UInt) {
+    self.rootDir = rootDir
+    self.withIncrementalImports = withIncrementalImports
+    self.testFile = testFile
+    self.testLine = testLine
+  }
+
+  var description: String {
+    "\(withIncrementalImports ? "with" : "without") incremental imports"
+  }
+}

--- a/Tests/IncrementalImportTests/Framework/TestProtocol.swift
+++ b/Tests/IncrementalImportTests/Framework/TestProtocol.swift
@@ -46,12 +46,16 @@ protocol TestProtocol {
 
 extension TestProtocol {
   /// The top-level function, runs the whole test.
-  static func test(testFile: StaticString = #file, testLine: UInt = #line) throws {
+  static func test(verbose: Bool,
+                   testFile: StaticString = #file,
+                   testLine: UInt = #line
+  ) throws {
     for withIncrementalImports in [false, true] { 
       try withTemporaryDirectory { rootDir in
         Self()
           .test(TestContext(in: rootDir,
                             withIncrementalImports: withIncrementalImports,
+                            verbose: verbose,
                             testFile: testFile,
                             testLine: testLine))
       }

--- a/Tests/IncrementalImportTests/Framework/TestProtocol.swift
+++ b/Tests/IncrementalImportTests/Framework/TestProtocol.swift
@@ -1,0 +1,79 @@
+//===------------- TestProtocol.swift - Swift Testing ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+import TestUtilities
+
+/// A framework for easily adding multi-module tests of the incremental imports
+/// It uses enumerations for `Step`s, `State`s, `Module`s and `Source`s because the tests must be
+/// able to name these, and enum cases give static checkability.
+/// (One cannot misspell a name, and using `switch`es, one cannot omit a case.)
+
+/// Each test creates a `struct`, conforming to this protocol.
+/// That `struct` must:
+/// - Include a type `Step`
+/// - Specify the initial state for all the source versions in the test.
+/// - Specify the sequence of steps that constitute the test.
+///
+/// A state is a a collection of compile jobs to be run, where each compile job specifies a module
+/// and a set of source versions.
+///
+/// A step is a state to which the source files will be updated, and the expected files to be recompiled.
+protocol TestProtocol {
+  associatedtype State: StateProtocol
+  typealias Module = State.Module
+
+  init()
+
+  /// The initial state to put the sources in including the initial compile jobs.
+  static var start: State {get}
+
+  /// The sequence of states to move to and what is expected when so doing.
+  static var steps: [Step<State>] {get}
+}
+
+extension TestProtocol {
+  /// The top-level function, runs the whole test.
+  static func test(testFile: StaticString = #file, testLine: UInt = #line) throws {
+    for withIncrementalImports in [false, true] { 
+      try withTemporaryDirectory { rootDir in
+        Self()
+          .test(TestContext(in: rootDir,
+                            withIncrementalImports: withIncrementalImports,
+                            testFile: testFile,
+                            testLine: testLine))
+      }
+    }
+  }
+
+  /// Run the test with or without incremental imports.
+  private func test(_ context: TestContext) {
+    XCTAssertNoThrow(
+      try localFileSystem.changeCurrentWorkingDirectory(to: context.rootDir),
+      file: context.testFile, line: context.testLine)
+    createDerivedDataDirs(context)
+
+    Self.start.enterInitialStateAndCheck(context)
+    for step in Self.steps {
+      step.mutateAndRebuildAndCheck(context)
+    }
+  }
+
+  private func createDerivedDataDirs(_ context: TestContext) {
+    for module in Module.allCases {
+      module.createDerivedDataDir(context)
+    }
+  }
+}

--- a/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
+++ b/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
@@ -17,10 +17,10 @@ import SwiftOptions
 
 class HideAndShowFuncInStructAndExtensionTests: XCTestCase {
   func testHideAndShowFuncInStruct() throws {
-    try HideAndShowFuncInStruct.test()
+    try HideAndShowFuncInStruct.test(verbose: false)
   }
   func testHideAndShowFuncInExtension() throws {
-    try HideAndShowFuncInExtension.test()
+    try HideAndShowFuncInExtension.test(verbose: false)
   }
 }
 

--- a/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
+++ b/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
@@ -157,7 +157,7 @@ fileprivate extension HideAndShowFuncState.Module {
                   """
       case .instantiatesS: return """
                  import \(Module.importedModule.nameToImport)
-                 func late() { S() }
+                 func late() { _ = S() }
                  """
       case .importedWithoutPublicFuncs: return """
                   public protocol PP {}

--- a/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
+++ b/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
@@ -1,0 +1,233 @@
+//===-- HideAndShowFuncInStructAndExtensionTests.swift - Swift Testing ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+
+class HideAndShowFuncInStructAndExtensionTests: XCTestCase {
+  func testHideAndShowFuncInStruct() throws {
+    try HideAndShowFuncInStruct.test()
+  }
+  func testHideAndShowFuncInExtension() throws {
+    try HideAndShowFuncInExtension.test()
+  }
+}
+
+fileprivate struct HideAndShowFuncInStruct: TestProtocol {
+  typealias State = HideAndShowFuncState
+  static let start: State = .bothHidden
+  static let steps: [Step<State>] = [
+    Step(.shownInStruct, State.expectedCompilationsWhenChangingStruct),
+    Step(.bothHidden,  State.expectedCompilationsWhenChangingStruct),
+  ]
+}
+fileprivate struct HideAndShowFuncInExtension: TestProtocol {
+  typealias State = HideAndShowFuncState
+  static let start: State = .bothHidden
+  static let steps: [Step<State>] = [
+    Step(.shownInExtension,  State.expectedCompilationsWhenChangingExtension),
+    Step(.bothHidden,  State.expectedCompilationsWhenChangingExtension),
+  ]
+}
+
+
+fileprivate enum HideAndShowFuncState: String, StateProtocol {
+  case bothHidden, shownInStruct, shownInExtension, bothShown
+
+  var jobs: [BuildJob<Module>] {
+    let importedSourceVersion: SourceVersion
+    switch self {
+    case .bothHidden:        importedSourceVersion = .importedWithoutPublicFuncs
+    case .shownInStruct:     importedSourceVersion = .importedFileWithPublicFuncInStruct
+    case .shownInExtension:  importedSourceVersion = .importedFileWithPublicFuncInExtension
+    case .bothShown:         importedSourceVersion = .importedFileWithPublicFuncInStructAndExtension
+    }
+    let  subJob = BuildJob<Module>(.importedModule, [importedSourceVersion])
+    let mainJob = BuildJob<Module>(.mainModule,
+                                            [.definesGeneralFuncsAndCallsFuncInStruct,
+                                             .noUseOfS,
+                                             .callsFuncInExtension,
+                                             .instantiatesS])
+    return [subJob, mainJob]
+  }
+}
+
+
+fileprivate extension HideAndShowFuncState {
+  static  var expectedCompilationsWhenChangingStruct: Expectation<Module.SourceVersion> {
+    Expectation(with: [.definesGeneralFuncsAndCallsFuncInStruct,
+                       .callsFuncInExtension,
+                       .instantiatesS,
+                       .importedWithoutPublicFuncs],
+                without: [.importedWithoutPublicFuncs,
+                          .definesGeneralFuncsAndCallsFuncInStruct,
+                          .noUseOfS,
+                          .callsFuncInExtension,
+                          .instantiatesS])
+  }
+  static  var expectedCompilationsWhenChangingExtension: Expectation<Module.SourceVersion> {
+    Expectation(with: [.definesGeneralFuncsAndCallsFuncInStruct,
+                       .callsFuncInExtension,
+                       .importedWithoutPublicFuncs],
+                without: [.importedWithoutPublicFuncs,
+                          .definesGeneralFuncsAndCallsFuncInStruct,
+                          .noUseOfS,
+                          .callsFuncInExtension,
+                          .instantiatesS])
+  }
+}
+
+fileprivate extension HideAndShowFuncState {
+  enum Module: String, ModuleProtocol {
+    case importedModule, mainModule
+
+    var imports: [Self] {
+      switch self {
+      case .importedModule:  return []
+      case .mainModule:      return [.importedModule]
+      }
+    }
+
+    var isLibrary: Bool {
+      switch self {
+      case .importedModule: return true
+      case .mainModule:      return false
+      }
+    }
+  }
+}
+
+fileprivate extension HideAndShowFuncState.Module {
+  enum SourceVersion: String, SourceVersionProtocol {
+    typealias Module = HideAndShowFuncState.Module
+
+    case importedWithoutPublicFuncs,
+         importedFileWithPublicFuncInStruct,
+         importedFileWithPublicFuncInExtension,
+         importedFileWithPublicFuncInStructAndExtension,
+         definesGeneralFuncsAndCallsFuncInStruct,
+         noUseOfS,
+         callsFuncInExtension,
+         instantiatesS
+
+    var fileName: String {
+      switch self {
+      case .importedWithoutPublicFuncs,
+           .importedFileWithPublicFuncInStruct,
+           .importedFileWithPublicFuncInExtension,
+           .importedFileWithPublicFuncInStructAndExtension:
+        return "importedFile"
+      case .definesGeneralFuncsAndCallsFuncInStruct: return "main"
+      default: return name
+      }
+    }
+
+    var code: String {
+      switch self {
+      case .definesGeneralFuncsAndCallsFuncInStruct: return """
+                  import \(Module.importedModule.nameToImport)
+                  extension S {
+                    static func inStruct<I: SignedInteger>(_ si: I) {
+                      print("1: not public")
+                    }
+                    static func inExtension<I: SignedInteger>(_ si: I) {
+                      print("2: not public")
+                    }
+                  }
+                  S.inStruct(3)
+                  """
+      case .noUseOfS: return """
+                  import \(Module.importedModule.nameToImport)
+                  func baz() { T.bar("asdf") }
+                  """
+      case .callsFuncInExtension: return """
+                  import \(Module.importedModule.nameToImport)
+                  func fred() { S.inExtension(3) }
+                  """
+      case .instantiatesS: return """
+                 import \(Module.importedModule.nameToImport)
+                 func late() { S() }
+                 """
+      case .importedWithoutPublicFuncs: return """
+                  public protocol PP {}
+                  public struct S: PP {
+                    public init() {}
+                    // public // was commented out; should rebuild users of inStruct
+                    static func inStruct(_ i: Int) {print("1: private")}
+                    func fo() {}
+                  }
+                  public struct T {
+                    public init() {}
+                    public static func bar(_ s: String) {print(s)}
+                  }
+                  extension S {
+                   // public
+                   static func inExtension(_ i: Int) {print("2: private")}
+                  }
+                  """
+      case .importedFileWithPublicFuncInStruct: return """
+                  public protocol PP {}
+                  public struct S: PP {
+                    public init() {}
+                    public // was uncommented out; should rebuild users of inStruct
+                    static func inStruct(_ i: Int) {print("1: private")}
+                    func fo() {}
+                  }
+                  public struct T {
+                    public init() {}
+                    public static func bar(_ s: String) {print(s)}
+                  }
+                  extension S {
+                   // public
+                   static func inExtension(_ i: Int) {print("2: private")}
+                  }
+                  """
+      case .importedFileWithPublicFuncInExtension: return """
+                  public protocol PP {}
+                  public struct S: PP {
+                    public init() {}
+                    // public // was commented out; should rebuild users of inStruct
+                    static func inStruct(_ i: Int) {print("1: private")}
+                    func fo() {}
+                  }
+                  public struct T {
+                    public init() {}
+                    public static func bar(_ s: String) {print(s)}
+                  }
+                  extension S {
+                   public
+                   static func inExtension(_ i: Int) {print("2: private")}
+                  }
+                  """
+      case .importedFileWithPublicFuncInStructAndExtension: return """
+                  public protocol PP {}
+                  public struct S: PP {
+                    public init() {}
+                    public
+                    static func inStruct(_ i: Int) {print("1: private")}
+                    func fo() {}
+                  }
+                  public struct T {
+                    public init() {}
+                    public static func bar(_ s: String) {print(s)}
+                  }
+                  extension S {
+                   public  // was uncommented; should rebuild users of inExtension
+                   static func inExtension(_ i: Int) {print("2: private")}
+                  }
+                  """
+      }
+    }
+  }
+}

--- a/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
+++ b/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
@@ -1,0 +1,124 @@
+//===--------------- IncrementalImportTests.swift - Swift Testing ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+@_spi(Testing) import SwiftDriver
+import SwiftOptions
+
+// MARK: - Test cases
+class RenameMemberOfImportedStructTest: XCTestCase {
+  func testRenamingMember() throws {
+    try RenameMemberOfImportedStruct.test()
+  }
+}
+
+// MARK: - RenameMemberOfImportedStruct
+
+/// Change the name of a member of an imported struct.
+/// Ensure that only the users get rebuilt
+fileprivate struct RenameMemberOfImportedStruct: TestProtocol {
+  static let start = State.initial
+  static let steps: [Step<State>] = [
+    Step(.renamed, expecting), Step(.initial, expecting)]
+
+  static var expecting: Expectation<SourceVersion> {
+    Expectation(with: [.mainFile, .originalMember],
+                without: [.mainFile, .otherFile, .originalMember])
+  }
+}
+
+fileprivate extension RenameMemberOfImportedStruct {
+  enum State: String, StateProtocol {
+    case initial, renamed
+
+    var jobs: [BuildJob<Module>] {
+      let importedSource: SourceVersion
+      switch self {
+      case .initial: importedSource = .originalMember
+      case .renamed: importedSource = .renamedMember
+      }
+      return [
+        BuildJob(.importedModule, [importedSource]),
+        BuildJob(.mainModule, [.mainFile, .otherFile])
+      ]
+    }
+  }
+}
+
+fileprivate extension RenameMemberOfImportedStruct {
+  enum Module: String, ModuleProtocol {
+    typealias SourceVersion = RenameMemberOfImportedStruct.SourceVersion
+
+    // Must be in build order
+    case importedModule, mainModule
+
+    var imports: [Module] {
+      switch self {
+      case .importedModule: return []
+      case .mainModule: return [.importedModule]
+      }
+    }
+    var isLibrary: Bool {
+      switch self {
+      case .importedModule: return true
+      case .mainModule: return false
+      }
+    }
+  }
+}
+
+fileprivate extension RenameMemberOfImportedStruct {
+  enum SourceVersion: String, SourceVersionProtocol {
+
+    case mainFile, otherFile, originalMember, renamedMember
+
+    var fileName: String {
+      switch self {
+      case .renamedMember, .originalMember: return "memberDefiner"
+      case .mainFile: return "main"
+      default: return name
+      }
+    }
+
+    var code: String {
+      switch self {
+      case .mainFile:
+        return """
+               import \(Module.importedModule.nameToImport)
+               ImportedStruct().importedMember()
+               """
+      case .otherFile:
+        return ""
+      case .originalMember:
+        return """
+                  public struct ImportedStruct {
+                    public init() {}
+                    public func importedMember() {}
+                    // change the name below, only mainFile should rebuild:
+                    public func nameToBeChanged() {}
+                  }
+                  """
+      case .renamedMember:
+        return """
+                  public struct ImportedStruct {
+                    public init() {}
+                    public func importedMember() {}
+                    // change the name below, only mainFile should rebuild:
+                    public func nameWasChanged() {}
+                  }
+                  """
+      }
+    }
+  }
+}
+

--- a/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
+++ b/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
@@ -18,7 +18,7 @@ import SwiftOptions
 // MARK: - Test cases
 class RenameMemberOfImportedStructTest: XCTestCase {
   func testRenamingMember() throws {
-    try RenameMemberOfImportedStruct.test(verbose: true)
+    try RenameMemberOfImportedStruct.test(verbose: false)
   }
 }
 

--- a/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
+++ b/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
@@ -18,7 +18,7 @@ import SwiftOptions
 // MARK: - Test cases
 class RenameMemberOfImportedStructTest: XCTestCase {
   func testRenamingMember() throws {
-    try RenameMemberOfImportedStruct.test()
+    try RenameMemberOfImportedStruct.test(verbose: false)
   }
 }
 

--- a/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
+++ b/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
@@ -18,7 +18,7 @@ import SwiftOptions
 // MARK: - Test cases
 class RenameMemberOfImportedStructTest: XCTestCase {
   func testRenamingMember() throws {
-    try RenameMemberOfImportedStruct.test(verbose: false)
+    try RenameMemberOfImportedStruct.test(verbose: true)
   }
 }
 

--- a/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
+++ b/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
@@ -13,6 +13,7 @@
 import XCTest
 import SwiftDriver
 import TSCBasic
+import TestUtilities
 
 func assertDriverDiagnostics(
   args: [String],

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -425,7 +425,11 @@ extension IncrementalCompilationTests {
       try? driver.run(jobs: jobs)
     }
 
-    let allArgs = try commonArgs + extraArguments + Driver.sdkArgumentsForTesting()
+    guard let sdkArgumentsForTesting = Driver.sdkArgumentsForTesting()
+    else {
+      throw XCTSkipIf(true, "Cannot perform this test on this host")
+    }
+    let allArgs = try commonArgs + extraArguments + sdkArgumentsForTesting
     if checkDiagnostics {
       try assertDriverDiagnostics(args: allArgs) {driver, verifier in
         verifier.forbidUnexpected(.error, .warning, .note, .remark, .ignored)
@@ -470,9 +474,13 @@ extension IncrementalCompilationTests {
         expectingRemarks: [],
         whenAutolinking: [])
 
+      guard let sdkArgumentsForTesting = Driver.sdkArgumentsForTesting()
+      else {
+        throw XCTSkipIf(true, "Cannot perform this test on this host")
+      }
       var driver = try Driver(args: self.commonArgs + [
         driverOption.spelling,
-      ] + Driver.sdkArgumentsForTesting())
+      ] + sdkArgumentsForTesting)
       _ = try driver.planBuild()
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
       let state = try XCTUnwrap(driver.incrementalCompilationState)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -425,9 +425,9 @@ extension IncrementalCompilationTests {
       try? driver.run(jobs: jobs)
     }
 
-    guard let sdkArgumentsForTesting = Driver.sdkArgumentsForTesting()
+    guard let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting()
     else {
-      throw XCTSkipIf(true, "Cannot perform this test on this host")
+      throw XCTSkip("Cannot perform this test on this host")
     }
     let allArgs = try commonArgs + extraArguments + sdkArgumentsForTesting
     if checkDiagnostics {
@@ -474,9 +474,9 @@ extension IncrementalCompilationTests {
         expectingRemarks: [],
         whenAutolinking: [])
 
-      guard let sdkArgumentsForTesting = Driver.sdkArgumentsForTesting()
+      guard let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting()
       else {
-        throw XCTSkipIf(true, "Cannot perform this test on this host")
+        throw XCTSkip("Cannot perform this test on this host")
       }
       var driver = try Driver(args: self.commonArgs + [
         driverOption.spelling,

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -14,6 +14,7 @@ import TSCBasic
 
 @_spi(Testing) import SwiftDriver
 import SwiftOptions
+import TestUtilities
 
 // MARK: - Baseline: nonincremental
 final class NonincrementalCompilationTests: XCTestCase {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import SwiftDriver
+@_spi(Testing) import SwiftDriver
 import TSCBasic
 
 class ModuleDependencyGraphTests: XCTestCase {

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1014,7 +1014,7 @@ extension ModuleDependencyGraph {
     on fingerprintedExternalDependency: FingerprintedExternalDependency
   ) -> [DependencySource] {
     var foundSources = [DependencySource]()
-    for dependent in collectUntracedNodesUsing(fingerprintedExternalDependency).contents {
+    for dependent in collectUntracedNodesUsing(fingerprintedExternalDependency) {
       let dependencySource = dependent.dependencySource!
       foundSources.append(dependencySource)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive

--- a/Tests/TestUtilities/OutputFileMapCreator.swift
+++ b/Tests/TestUtilities/OutputFileMapCreator.swift
@@ -9,12 +9,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import XCTest
+
 import TSCBasic
 
 import Foundation
 
-struct OutputFileMapCreator {
+public struct OutputFileMapCreator {
   private let module: String
   private let inputPaths: [AbsolutePath]
   private let derivedData: AbsolutePath
@@ -25,10 +25,10 @@ struct OutputFileMapCreator {
     self.derivedData = derivedData
   }
 
-  static func write(module: String,
-               inputPaths: [AbsolutePath],
-               derivedData: AbsolutePath,
-               to dst: AbsolutePath) {
+  public static func write(module: String,
+                           inputPaths: [AbsolutePath],
+                           derivedData: AbsolutePath,
+                           to dst: AbsolutePath) {
     let creator = Self(module: module, inputPaths: inputPaths, derivedData: derivedData)
     try! localFileSystem.writeFileContents(dst, bytes: ByteString(creator.generateData()))
   }


### PR DESCRIPTION
The main item here is a new testing framework testing the incremental import feature of the driver.
It uses enums and protocols to get a lot of static checking. A test is typically:

- a `SourceVersion` enum conforming to `SourceVersionProtocol` that defines cases for each version of source code, & defines the filename for each version.
- a `Module` enum conforming to `ModuleProtocol` that defines cases for each module, which modules are libraries vs apps, and which modules import which other modules.
- a `State` enum conforming to `StateProtocol` that defines cases for each state, and the jobs required to put the test in that state. (A job is defined by the module it is building, and the set of source versions being compiled.)
- a struct conforming to `TestProtocol` that defines the start state of the test, and a series of steps to perform. Each step consists of a state to be reached, and expectations for what should be compiled in reaching that state.

With this framework, files can be added, changed, or removed from state to state. Any topology of modules can be specified. Thanks to @CodaFi for suggesting this degree of versatility.

This PR also removes uses of `@testable` imports, as well as incorporating a few tests using the new framework.