### PR TITLE
Revert "Remove deprecated `externalBuildArtifacts` API."

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -343,10 +343,9 @@ public struct Driver {
   ///   expand response files, etc. By default this is the local filesystem.
   /// - Parameter executor: Used by the driver to execute jobs. The default argument
   ///   is present to streamline testing, it shouldn't be used in production.
-  /// - Parameter externalTargetModulePathMap: All external artifacts a build system may pass in as input to the explicit
-  ///   build of the current module. Consists of a map of externally-built targets, and their corresponding binary modules.
-  /// - Parameter interModuleDependencyOracle: A dependency oracle instance, re-used in multiple-target builds
-  ///   to make use of caching of common dependency scanning queries
+  /// - Parameter externalBuildArtifacts: All external artifacts a build system may pass in as input to the explicit
+  ///   build of the current module. Consists of a map of externally-built targets, and a map of all previously
+  ///   discovered/scanned modules.
   public init(
     args: [String],
     env: [String: String] = ProcessEnv.vars,
@@ -355,6 +354,9 @@ public struct Driver {
     executor: DriverExecutor,
     integratedDriver: Bool = true,
     compilerExecutableDir: AbsolutePath? = nil,
+    // FIXME: Duplication with externalBuildArtifacts and externalTargetModulePathMap
+    // is a temporary backwards-compatibility shim to help transition SwiftPM to the new API
+    externalBuildArtifacts: ExternalBuildArtifacts? = nil,
     externalTargetModulePathMap: ExternalTargetModulePathMap? = nil,
     interModuleDependencyOracle: InterModuleDependencyOracle? = nil
   ) throws {
@@ -364,6 +366,12 @@ public struct Driver {
 
     self.diagnosticEngine = diagnosticsEngine
     self.executor = executor
+
+    if let externalArtifacts = externalBuildArtifacts {
+      self.externalBuildArtifacts = externalArtifacts
+    } else if let externalTargetPaths = externalTargetModulePathMap {
+      self.externalBuildArtifacts = (externalTargetPaths, [:])
+    }
 
     if case .subcommand = try Self.invocationRunMode(forArgs: args).mode {
       throw Error.subcommandPassedToDriver
@@ -455,6 +463,14 @@ public struct Driver {
       self.interModuleDependencyOracle = dependencyOracle
     } else {
       self.interModuleDependencyOracle = InterModuleDependencyOracle()
+
+      // This is a shim for backwards-compatibility with ModuleInfoMap-based API
+      // used by SwiftPM
+      if let externalArtifacts = externalBuildArtifacts {
+        if !externalArtifacts.1.isEmpty {
+          try self.interModuleDependencyOracle.mergeModules(from: externalArtifacts.1)
+        }
+      }
     }
 
     self.fileListThreshold = try Self.computeFileListThreshold(&self.parsedOptions, diagnosticsEngine: diagnosticsEngine)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -166,7 +166,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
                                                   hostTriple: driver.hostTriple,
                                                   env: ProcessEnv.vars)
-      let _ = try dependencyOracle
+      try dependencyOracle
         .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
                                        swiftScanLibPath: scanLibPath)
       try dependencyOracle.mergeModules(from: moduleDependencyGraph)
@@ -246,12 +246,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                          "test.swift", "-module-name", "A", "-g"]
 
       var driver = try Driver(args: commandLine, executor: executor,
-                              externalTargetModulePathMap: targetModulePathMap,
+                              externalBuildArtifacts: (targetModulePathMap, [:]),
                               interModuleDependencyOracle: dependencyOracle)
       let scanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
                                                   hostTriple: driver.hostTriple,
                                                   env: ProcessEnv.vars)
-      let _ = try dependencyOracle
+      try dependencyOracle
         .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
                                        swiftScanLibPath: scanLibPath)
 


### PR DESCRIPTION
Reverts apple/swift-driver#529

This seems to have caused failures in SwiftPM Linux CI, 
e.g.: https://github.com/apple/swift-package-manager/pull/3338