### PR TITLE
[Incremental] Add a check of the result of running the built app to the `IncrementalTestFramework`

### DIFF
--- a/Tests/IncrementalImportTests/AddFuncInImportedExtensionTest.swift
+++ b/Tests/IncrementalImportTests/AddFuncInImportedExtensionTest.swift
@@ -55,9 +55,11 @@ class AddFuncInImportedExtensionTest: XCTestCase {
       func cu() {_ = C()}
       """)
 
+    let mainFile = Source(named: "main", containing: "")
+
     let mainModule = Module(
       named: "main",
-      containing: [structConstructor, classConstructor],
+      containing: [mainFile, structConstructor, classConstructor],
       importing: [importedModule],
       producing: .executable)
 
@@ -69,14 +71,14 @@ class AddFuncInImportedExtensionTest: XCTestCase {
     // Define what is expected
     let whenAddOrRmFunc = ExpectedCompilations(
       always: [structExtension, classExtension, ],
-      andWhenDisabled: [structConstructor, classConstructor])
+      andWhenDisabled: [mainFile, structConstructor, classConstructor])
 
     let steps = [
-      Step(                    compiling: modules),
-      Step(                    compiling: modules, expecting: .none),
-      Step(adding: "withFunc", compiling: modules, expecting: whenAddOrRmFunc),
-      Step(                    compiling: modules, expecting: whenAddOrRmFunc),
-      Step(adding: "withFunc", compiling: modules, expecting: whenAddOrRmFunc),
+      Step(                    building: modules, .expecting(modules.allSourcesToCompile)),
+      Step(                    building: modules, .expecting(.none)),
+      Step(adding: "withFunc", building: modules, .expecting(whenAddOrRmFunc)),
+      Step(                    building: modules, .expecting(whenAddOrRmFunc)),
+      Step(adding: "withFunc", building: modules, .expecting(whenAddOrRmFunc)),
     ]
 
     // Do the test

--- a/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
+++ b/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
@@ -18,18 +18,54 @@ import SwiftOptions
 import IncrementalTestFramework
 
 /// Add and remove function in imported struct and in imported extension of imported struct.
+/// This is a very complicated test, so it is built programmatically.
 class HideAndShowFuncInStructAndExtensionTests: XCTestCase {
   func testHideAndShowFuncInStructAndExtension() throws {
+    try IncrementalTest.perform(steps)
+  }
+}
 
-    // MARK: - Define imported module
-    let imported = Source(named: "imported", containing: """
+/// The changes to be tested
+fileprivate let stepChanges: [[Change]] = [
+  [],
+  [],
+  [.exposeFuncInStruct],
+  [],
+  [.exposeFuncInExtension],
+  [],
+  Change.allCases,
+  [],
+  [.exposeFuncInStruct],
+  [.exposeFuncInExtension],
+  [.exposeFuncInStruct],
+  Change.allCases,
+  [.exposeFuncInExtension],
+  Change.allCases
+]
+
+
+// MARK: - Reify the source changes
+
+fileprivate enum Change: String, CustomStringConvertible, CaseIterable {
+  /// Make the imported specific method defined in a structure public
+  case exposeFuncInStruct
+
+  /// Make the imported specific method defined in an extension public
+  case exposeFuncInExtension
+
+  var name: String {rawValue}
+  var description: String {name}
+}
+
+// MARK: - Define imported module
+fileprivate let imported = Source(named: "imported", containing: """
         // Just for fun, a protocol, as well as the struc with the optional specific func.
         public protocol PP {}
         public struct S: PP {
           public init() {}
           // Optionally expose a specific function in the structure
-          //# publicInStruct public
-          static func inStruct(_ i: Int) {print("1: private")}
+          //# \(Change.exposeFuncInStruct) public
+          static func inStruct(_ i: Int) {print("specific in struct")}
           func fo() {}
         }
         public struct T {
@@ -38,93 +74,125 @@ class HideAndShowFuncInStructAndExtensionTests: XCTestCase {
         }
         extension S {
         // Optionally expose a specific function in the extension
-        //# publicInExtension public
-        static func inExtension(_ i: Int) {print("2: private")}
+        //# \(Change.exposeFuncInExtension) public
+        static func inExtension(_ i: Int) {print("specific in extension")}
         }
         """)
 
-    let importedModule = Module(named: "importedModule",
-                                containing: [imported],
-                                producing: .library)
+fileprivate let importedModule = Module(named: "importedModule",
+                                        containing: [imported],
+                                        producing: .library)
 
-    // MARK: - Define the main module
+// MARK: - Define the main module
 
-    let instantiatesS = Source(named: "instantiatesS", containing:  """
+fileprivate let instantiatesS = Source(named: "instantiatesS", containing:  """
         // Instantiate S
         import \(importedModule.name)
         func late() { _ = S() }
         """)
 
-    let callFunctionInExtension = Source(named: "callFunctionInExtension", containing: """
+fileprivate let callFunctionInExtension = Source(named: "callFunctionInExtension", containing: """
         // Call the function defined in an extension
         import \(importedModule.name)
         func fred() { S.inExtension(3) }
         """)
 
-    let noUseOfS = Source(named: "noUseOfS", containing: """
+fileprivate let noUseOfS = Source(named: "noUseOfS", containing: """
         /// Call a function in an unchanging struct
         import \(importedModule.name)
         func baz() { T.bar("asdf") }
         """)
 
-    let main = Source(named: "main", containing: """
+fileprivate let main = Source(named: "main", containing: """
         /// Extend S with general functions
         import \(importedModule.name)
         extension S {
           static func inStruct<I: SignedInteger>(_ si: I) {
-            print("1: not public")
+            print("general in struct")
           }
           static func inExtension<I: SignedInteger>(_ si: I) {
-            print("2: not public")
+            print("general in extension")
           }
         }
         S.inStruct(3)
+        S.inExtension(4)
         """)
 
-    let mainModule = Module(named: "mainModule",
-                            containing: [instantiatesS,
-                                         callFunctionInExtension,
-                                         noUseOfS,
-                                         main],
-                            importing: [importedModule],
-                            producing: .executable)
+fileprivate let mainModule = Module(named: "mainModule",
+                                    containing: [instantiatesS,
+                                                 callFunctionInExtension,
+                                                 noUseOfS,
+                                                 main],
+                                    importing: [importedModule],
+                                    producing: .executable)
 
-    // MARK: - Define the test
+// MARK: - Define the whole app
+fileprivate let modules = [importedModule, mainModule]
 
-    let modules = [importedModule, mainModule]
+// MARK: - Compute the expectations
+fileprivate extension Change {
+  var expectedCompilationsWithIncrementalImports: [Source] {
+    switch self {
+    case .exposeFuncInStruct:    return [callFunctionInExtension, imported, instantiatesS, main]
+    case .exposeFuncInExtension: return [callFunctionInExtension, imported,                main]
+    }
+  }
 
-    let addOrRmInStruct = ExpectedCompilations(
-      always: [callFunctionInExtension, imported, instantiatesS, main],
-      andWhenDisabled: [noUseOfS])
-
-    // Interestingly, changes to the imported extension do not change the
-    /// structure's instantiation. (Compare to above.)
-    let addOrRmInExt = ExpectedCompilations(
-      always: [callFunctionInExtension, imported, main],
-      andWhenDisabled: [instantiatesS, noUseOfS])
-
-    let addOrRmBoth = addOrRmInStruct
-
-    let steps = [
-      Step(          compiling: modules),
-      Step(adding: "publicInStruct"                     , compiling: modules, expecting: addOrRmInStruct),
-      Step(                                               compiling: modules, expecting: addOrRmInStruct),
-      Step(adding: "publicInExtension"                  , compiling: modules, expecting: addOrRmInExt   ),
-      Step(                                               compiling: modules, expecting: addOrRmInExt   ),
-      Step(adding: "publicInStruct", "publicInExtension", compiling: modules, expecting: addOrRmBoth    ),
-      Step(                                               compiling: modules, expecting: addOrRmBoth    ),
-      Step(adding: "publicInStruct"                     , compiling: modules, expecting: addOrRmInStruct),
-      Step(adding:                   "publicInExtension", compiling: modules, expecting: addOrRmInStruct),
-      Step(adding: "publicInStruct"                     , compiling: modules, expecting: addOrRmInStruct),
-      Step(adding: "publicInStruct", "publicInExtension", compiling: modules, expecting: addOrRmInExt   ),
-      Step(adding:                   "publicInExtension", compiling: modules, expecting: addOrRmInStruct),
-      Step(adding: "publicInStruct", "publicInExtension", compiling: modules, expecting: addOrRmInStruct),
-    ]
-
-    try IncrementalTest.perform(steps)
+  var locusOfExposure: String {
+    switch self {
+    case .exposeFuncInStruct:    return "struct"
+    case .exposeFuncInExtension: return "extension"
+    }
+  }
+  static var allLociOfExposure: [String] {
+    allCases.map {$0.locusOfExposure}
   }
 }
 
+// MARK: - Building a step from combinations of Changes
+fileprivate extension Array where Element == Change {
+  var addOns: [String] {map {$0.name} }
 
+  func expectedCompilations(_ prevStep: Step?) -> ExpectedCompilations {
+    guard let prevStep = prevStep else {
+      return modules.allSourcesToCompile
+    }
+    let deltas = Set(map{$0.name}).symmetricDifference(prevStep.addOns.map{$0.name})
+      .map {Change.init(rawValue: $0)!}
 
+    let expectedCompilationsWithIncrementalImports: [Source] =
+      deltas.reduce(into: Set<Source>()) {sources, change in
+        sources.formUnion(change.expectedCompilationsWithIncrementalImports)
+      }
+      .sorted()
 
+    let andWhenDisabled = deltas.isEmpty
+      ? []
+      : Set(modules.allSources).subtracting(expectedCompilationsWithIncrementalImports).sorted()
+
+    return ExpectedCompilations(always: expectedCompilationsWithIncrementalImports, andWhenDisabled: andWhenDisabled)
+  }
+
+  var expectedOutput: ExpectedProcessResult {
+    let specOrGen = Change.allCases .map {
+      contains($0) ? "specific" : "general"
+    }
+    let output = zip(specOrGen, Change.allLociOfExposure)
+      .map { "\($0.0) in \($0.1)"}
+      .joined(separator: "\n")
+    return ExpectedProcessResult(output: output)
+  }
+
+  func step(prior: Step?) -> Step {
+    Step(adding: addOns,
+         building: modules,
+         .expecting(expectedCompilations(prior), expectedOutput))
+  }
+}
+// MARK: - All steps
+
+var steps: [Step] {
+  stepChanges.reduce(into: []) { steps, changes in
+    steps.append(changes.step(prior: steps.last))
+  }
+}

--- a/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
+++ b/Tests/IncrementalImportTests/RenameMemberOfImportedStructTest.swift
@@ -62,11 +62,11 @@ class RenameMemberOfImportedStructTest: XCTestCase {
                                             andWhenDisabled: [other])
 
     let steps = [
-      Step(adding: ["original"], compiling: modules),
-      Step(adding: ["original"], compiling: modules, expecting: .none),
-      Step(adding: ["renamed"],  compiling: modules, expecting: whenRenaming),
-      Step(adding: ["original"], compiling: modules, expecting: whenRenaming),
-      Step(adding: ["renamed"],  compiling: modules, expecting: whenRenaming),
+      Step(adding: ["original"], building: modules, .expecting(modules.allSourcesToCompile)),
+      Step(adding: ["original"], building: modules, .expecting(.none)),
+      Step(adding: ["renamed"],  building: modules, .expecting(whenRenaming)),
+      Step(adding: ["original"], building: modules, .expecting(whenRenaming)),
+      Step(adding: ["renamed"],  building: modules, .expecting(whenRenaming)),
     ]
     try IncrementalTest.perform(steps)
   }

--- a/Tests/IncrementalTestFramework/AddOn.swift
+++ b/Tests/IncrementalTestFramework/AddOn.swift
@@ -16,9 +16,9 @@
 /// For example the line `var gazorp //# initGazorp = 17`
 /// will normall be compiled as written. But if the `Step` includes `initGazorp` in its `addOns`
 /// the line passed to the compiler will be `var gazorp  = 17`
-struct AddOn {
+public struct AddOn {
   /// The name of the `AddOn`. That is, the identifier in the above description.
-  let name: String
+  public let name: String
 
   init(named name: String) {
     self.name = name

--- a/Tests/IncrementalTestFramework/Expectation.swift
+++ b/Tests/IncrementalTestFramework/Expectation.swift
@@ -1,0 +1,37 @@
+//===-- Expectation.swift - Swift Testing ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+/// Everything expected from a step.
+public struct Expectation {
+  let compilations: ExpectedCompilations
+
+  /// If non-nil, the step produces an executable, and running it should produce this result.
+  let output: ExpectedProcessResult?
+
+  init(_ compilations: ExpectedCompilations, _ output: ExpectedProcessResult? = nil) {
+    self.compilations = compilations
+    self.output = output
+  }
+
+  public static func expecting(_ compilations: ExpectedCompilations,
+                               _ output: ExpectedProcessResult? = nil
+  ) -> Self {
+    self.init(compilations, output)
+  }
+
+  public static func expecting(_ compilations: ExpectedCompilations, _ output: String
+  ) -> Self {
+    self.init(compilations, ExpectedProcessResult(output: output))
+  }
+}

--- a/Tests/IncrementalTestFramework/ExpectedCompilations.swift
+++ b/Tests/IncrementalTestFramework/ExpectedCompilations.swift
@@ -44,9 +44,8 @@ public struct ExpectedCompilations {
   /// - Parameters:
   ///   - against: The actual compiled sources to check against.
   ///   - step: The `Step` that changed the source, ran the compiler, and needs to check the results.
-  ///   - stepIndex: The zero-origin index of the `Step` in this test.
   ///   - in: The context of this test.
-  func check(against actuals: [Source], step: Step, stepIndex: Int, in context: Context) {
+  func check(against actuals: [Source], step: Step, in context: Context) {
     let expectedSet = Set(expected(when: context.incrementalImports))
     let actualsSet = Set(actuals)
 
@@ -54,11 +53,11 @@ public struct ExpectedCompilations {
     let missingCompilations = expectedSet.subtracting( actualsSet).map {$0.name}.sorted()
 
     XCTAssert(extraCompilations.isEmpty,
-      "Extra compilations: \(extraCompilations), \(context), in step \(stepIndex), \(step.whatIsBuilt)",
+      "Extra compilations: \(extraCompilations), \(context.failMessage(step))",
       file: context.file, line: context.line)
 
     XCTAssert(missingCompilations.isEmpty,
-      "Missing compilations: \(missingCompilations), \(context), in step \(stepIndex), \(step.whatIsBuilt)",
+      "Missing compilations: \(missingCompilations), \(context.failMessage(step))",
       file: context.file, line: context.line)
   }
 

--- a/Tests/IncrementalTestFramework/ExpectedProcessResult.swift
+++ b/Tests/IncrementalTestFramework/ExpectedProcessResult.swift
@@ -1,0 +1,46 @@
+//===-------------- swift -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import TSCBasic
+
+public struct ExpectedProcessResult {
+  let output: String
+  let stderrOutput: String
+  let expectedExitCode: Int32
+
+  public init(output: String = "", stderrOutput: String = "", exitCode: Int32 = 0) {
+    self.output = output
+    self.stderrOutput = stderrOutput
+    self.expectedExitCode = exitCode
+  }
+
+  func check(against actual: ProcessResult?, step: Step, in context: Context) throws {
+    guard let actual = actual else {
+      context.fail("No result", step)
+      return
+    }
+    guard case let .terminated(actualExitCode) = actual.exitStatus
+    else {
+      context.fail("failed to run", step)
+      return
+    }
+    XCTAssertEqual(actualExitCode, expectedExitCode,
+                   context.failMessage(step),
+                   file: context.file, line: context.line)
+    try XCTAssertEqual(output, actual.utf8Output().spm_chomp(),
+                       context.failMessage(step),
+                   file: context.file, line: context.line)
+    try XCTAssertEqual(stderrOutput, actual.utf8stderrOutput().spm_chomp(),
+                       context.failMessage(step),
+                   file: context.file, line: context.line)
+  }
+}

--- a/Tests/IncrementalTestFramework/IncrementalTest.swift
+++ b/Tests/IncrementalTestFramework/IncrementalTest.swift
@@ -61,6 +61,7 @@ public struct IncrementalTest {
                context: Context(rootDir: rootDir,
                                 incrementalImports: incrementalImports,
                                 verbose: verbose,
+                                stepIndex: 0,
                                 file: file,
                                 line: line))
         .performSteps()
@@ -72,8 +73,14 @@ public struct IncrementalTest {
     self.context = context
   }
   private func performSteps() throws {
-    for (index, step) in steps.enumerated() { 
+    for (index, step) in steps.enumerated() {
+      if !context.verbose {
+        print("\(index)", terminator: " ")
+      }
       try step.perform(stepIndex: index, in: context)
+    }
+    if !context.verbose {
+      print("")
     }
   }
 }

--- a/Tests/IncrementalTestFramework/Module.swift
+++ b/Tests/IncrementalTestFramework/Module.swift
@@ -209,9 +209,7 @@ extension Module {
   }
 
   func run(step: Step, in context: Context) throws -> ProcessResult? {
-    let proc = Process(arguments: [context.executablePath(for: self).pathString],
-            workingDirectory: context.derivedDataPath(for: self),
-            verbose: false)
+    let proc = Process(arguments: [context.executablePath(for: self).pathString])
     try proc.launch()
     return try proc.waitUntilExit()
   }

--- a/Tests/IncrementalTestFramework/Source.swift
+++ b/Tests/IncrementalTestFramework/Source.swift
@@ -18,7 +18,8 @@ import TestUtilities
 
 /// A source file to be used in an incremental test.
 /// User edits can be simulated by using `AddOn`s.
-public struct Source: Hashable {
+public struct Source: Hashable, Comparable {
+
   /// E.g. "main" for "main.swift"
   public let name: String
 
@@ -49,4 +50,9 @@ public struct Source: Hashable {
     let contents = try fileSystem.readFileContents(absPath).cString
     self.init(named: name, containing: contents)
   }
+
+  public static func < (lhs: Source, rhs: Source) -> Bool {
+    lhs.name < rhs.name
+  }
+
 }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -429,7 +429,7 @@ extension IncrementalCompilationTests {
     else {
       throw XCTSkip("Cannot perform this test on this host")
     }
-    let allArgs = try commonArgs + extraArguments + sdkArgumentsForTesting
+    let allArgs = commonArgs + extraArguments + sdkArgumentsForTesting
     if checkDiagnostics {
       try assertDriverDiagnostics(args: allArgs) {driver, verifier in
         verifier.forbidUnexpected(.error, .warning, .note, .remark, .ignored)


### PR DESCRIPTION
Allow a test to specify an expectation for the stdout, stderr, and error codes. Add such a check to two of the tests.