### PR TITLE
[Incremental] Delay converting external dependency file names to paths as an optimization.

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -166,7 +166,7 @@ fileprivate extension DependencyKey.Designator {
   static let oneOfEachKind: [DependencyKey.Designator] = [
       .topLevel(name: ""),
       .dynamicLookup(name: ""),
-      .externalDepend(try! ExternalDependency(".")),
+    .externalDepend(try! ExternalDependency(fileName: ".")),
       .sourceFileProvide(name: ""),
       .nominal(context: ""),
       .potentialMember(context: ""),

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -128,7 +128,8 @@ extension ExportableNode {
     key.designator.externalDependency != nil
   }
   fileprivate var isAPINotes: Bool {
-    key.designator.externalDependency?.file.extension == "apinotes"
+    key.designator.externalDependency?.fileName.hasSuffix("apinotes")
+    ?? false
   }
 
   fileprivate var shape: Shape {

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -128,7 +128,7 @@ extension ExportableNode {
     key.designator.externalDependency != nil
   }
   fileprivate var isAPINotes: Bool {
-    key.designator.externalDependency?.fileName.hasSuffix("apinotes")
+    key.designator.externalDependency?.fileName.hasSuffix(".apinotes")
     ?? false
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -167,7 +167,7 @@ fileprivate extension DependencyKey.Designator {
   static let oneOfEachKind: [DependencyKey.Designator] = [
       .topLevel(name: ""),
       .dynamicLookup(name: ""),
-    .externalDepend(try! ExternalDependency(fileName: ".")),
+    .externalDepend(ExternalDependency(fileName: ".")),
       .sourceFileProvide(name: ""),
       .nominal(context: ""),
       .potentialMember(context: ""),

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -20,13 +20,13 @@ import TSCBasic
   /// Cache this
   let isSwiftModule: Bool
 
-  /*@_spi(Testing)*/ public init(_ fileName: String)
+  /*@_spi(Testing)*/ public init(fileName: String)
   throws {
-    self.init(try VirtualPath(path: fileName))
+    self.init(path: try VirtualPath(path: fileName))
   }
 
-  init(_ file: VirtualPath) {
-    self.file = file
+  init(path: VirtualPath) {
+    self.file = path
     self.isSwiftModule = file.extension == FileType.swiftModule.rawValue
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -24,7 +24,7 @@ import TSCBasic
   }
 
   /// Should only be called by debugging functions or functions that are cached
-  private func getPath() -> VirtualPath? {
+  func getPath() -> VirtualPath? {
     try? VirtualPath(path: fileName)
   }
   

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -27,13 +27,7 @@ import TSCBasic
   private func getPath() -> VirtualPath? {
     try? VirtualPath(path: fileName)
   }
-
-  func slowModTime(_ fileSystem: FileSystem) -> Date? {
-    getPath().flatMap {
-      try? fileSystem.getFileInfo($0).modTime
-    }
-  }
-
+  
   /// Cache this here
   var isSwiftModule: Bool {
     fileName.hasSuffix(".\(FileType.swiftModule.rawValue)")

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -19,12 +19,8 @@ import TSCBasic
   /// Delay computing the path as an optimization.
   let fileName: String
 
-  /// Cache this
-  let isSwiftModule: Bool
-
   /*@_spi(Testing)*/ public init(fileName: String) {
     self.fileName = fileName
-    self.isSwiftModule = fileName.hasSuffix(FileType.swiftModule.rawValue)
   }
 
   /// Should only be called by debugging functions or functions that are cached
@@ -36,6 +32,11 @@ import TSCBasic
     getPath().flatMap {
       try? fileSystem.getFileInfo($0).modTime
     }
+  }
+
+  /// Cache this here
+  var isSwiftModule: Bool {
+    fileName.hasSuffix(".\(FileType.swiftModule.rawValue)")
   }
 
   var swiftModuleFile: TypedVirtualPath? {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -324,7 +324,10 @@ extension ModuleDependencyGraph {
     if let hasChanged = externalDependencyModTimeCache[externalDependency] {
       return hasChanged
     }
-    let depFile = externalDependency.file
+    guard let depFile = externalDependency.getPath()
+    else {
+      return true
+    }
     let hasChanged = ((try? info.fileSystem.lastModificationTime(for: depFile)) ?? .distantFuture)
       >= info.buildTime
     externalDependencyModTimeCache[externalDependency] = hasChanged
@@ -615,7 +618,7 @@ extension ModuleDependencyGraph {
           let path = identifiers[Int(record.fields[0])]
           let hasFingerprint = Int(record.fields[1]) != 0
           let fingerprint = hasFingerprint ? fingerprintStr : nil
-          try self.graph.fingerprintedExternalDependencies.insert(
+          self.graph.fingerprintedExternalDependencies.insert(
             FingerprintedExternalDependency(ExternalDependency(fileName: path), fingerprint))
         case .identifierNode:
           guard record.fields.count == 0,
@@ -1002,7 +1005,7 @@ fileprivate extension DependencyKey.Designator {
       self = .dynamicLookup(name: name)
     case 5:
       try mustBeEmpty(context)
-      self = .externalDepend(try ExternalDependency(fileName: name))
+      self = .externalDepend(ExternalDependency(fileName: name))
     case 6:
       try mustBeEmpty(context)
       self = .sourceFileProvide(name: name)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -324,7 +324,7 @@ extension ModuleDependencyGraph {
     if let hasChanged = externalDependencyModTimeCache[externalDependency] {
       return hasChanged
     }
-    guard let depFile = externalDependency.getPath()
+    guard let depFile = externalDependency.path
     else {
       return true
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -793,7 +793,7 @@ extension ModuleDependencyGraph {
       }
 
       for edF in graph.fingerprintedExternalDependencies {
-        self.addIdentifier(edF.externalDependency.file.name)
+        self.addIdentifier(edF.externalDependency.fileName)
       }
 
       for str in self.identifiersToWrite {
@@ -944,7 +944,7 @@ extension ModuleDependencyGraph {
           serializer.stream.writeRecord(serializer.abbreviations[.externalDepNode]!, {
             $0.append(RecordID.externalDepNode)
             $0.append(serializer.lookupIdentifierCode(
-                        for: fingerprintedExternalDependency.externalDependency.file.name))
+                        for: fingerprintedExternalDependency.externalDependency.fileName))
             $0.append((fingerprintedExternalDependency.fingerprint != nil) ? UInt32(1) : UInt32(0))
           }, 
           blob: (fingerprintedExternalDependency.fingerprint ?? ""))

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -616,7 +616,7 @@ extension ModuleDependencyGraph {
           let hasFingerprint = Int(record.fields[1]) != 0
           let fingerprint = hasFingerprint ? fingerprintStr : nil
           try self.graph.fingerprintedExternalDependencies.insert(
-            FingerprintedExternalDependency(ExternalDependency(path), fingerprint))
+            FingerprintedExternalDependency(ExternalDependency(fileName: path), fingerprint))
         case .identifierNode:
           guard record.fields.count == 0,
                 case .blob(let identifierBlob) = record.payload,
@@ -1002,7 +1002,7 @@ fileprivate extension DependencyKey.Designator {
       self = .dynamicLookup(name: name)
     case 5:
       try mustBeEmpty(context)
-      self = .externalDepend(try ExternalDependency(name))
+      self = .externalDepend(try ExternalDependency(fileName: name))
     case 6:
       try mustBeEmpty(context)
       self = .sourceFileProvide(name: name)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -42,7 +42,7 @@ public struct DependencySource: Hashable, CustomStringConvertible {
   public var file: VirtualPath { typedFile.file }
 
   public var description: String {
-    ExternalDependency(path: file).description
+    ExternalDependency(fileName: file.name).description
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -42,7 +42,7 @@ public struct DependencySource: Hashable, CustomStringConvertible {
   public var file: VirtualPath { typedFile.file }
 
   public var description: String {
-    ExternalDependency(file).description
+    ExternalDependency(path: file).description
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -338,7 +338,7 @@ fileprivate extension DependencyKey.Designator {
       self = .dynamicLookup(name: name)
     case 5:
       try mustBeEmpty(context)
-      self = try .externalDepend(ExternalDependency(name))
+      self = try .externalDepend(ExternalDependency(fileName: name))
     case 6:
       try mustBeEmpty(context)
       self = .sourceFileProvide(name: name)

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -338,7 +338,7 @@ fileprivate extension DependencyKey.Designator {
       self = .dynamicLookup(name: name)
     case 5:
       try mustBeEmpty(context)
-      self = try .externalDepend(ExternalDependency(fileName: name))
+      self = .externalDepend(ExternalDependency(fileName: name))
     case 6:
       try mustBeEmpty(context)
       self = .sourceFileProvide(name: name)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -897,7 +897,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       graph.verify()
 
       var foundNode = false
-      let swiftmodulePath = try! ExternalDependency(path.appending(component: "MagicKit.swiftmodule").pathString)
+      let swiftmodulePath = try! ExternalDependency(fileName: path.appending(component: "MagicKit.swiftmodule").pathString)
       graph.forEachNode { node in
         if case .externalDepend(swiftmodulePath) = node.key.designator {
           XCTAssertFalse(foundNode)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -897,7 +897,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       graph.verify()
 
       var foundNode = false
-      let swiftmodulePath = try! ExternalDependency(fileName: path.appending(component: "MagicKit.swiftmodule").pathString)
+      let swiftmodulePath = ExternalDependency(fileName: path.appending(component: "MagicKit.swiftmodule").pathString)
       graph.forEachNode { node in
         if case .externalDepend(swiftmodulePath) = node.key.designator {
           XCTAssertFalse(foundNode)

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1037,7 +1037,7 @@ extension ModuleDependencyGraph {
   func containsExternalDependency(_ path: String, fingerprint: String? = nil)
   -> Bool {
     fingerprintedExternalDependencies.contains(
-      FingerprintedExternalDependency(try! ExternalDependency(path),
+      FingerprintedExternalDependency(try! ExternalDependency(fileName: path),
                                       fingerprint))
   }
 }
@@ -1391,7 +1391,7 @@ fileprivate extension String {
 
 fileprivate extension ExternalDependency {
   static func mocking(_ name: String) throws -> Self {
-    return try Self(name)
+    return try Self(fileName: name)
   }
 }
 
@@ -1457,7 +1457,7 @@ fileprivate extension DependencyKey.Designator {
       self = .dynamicLookup(name: name!)
     case .externalDepend:
       mustBeAbsent(context)
-      self = .externalDepend(try ExternalDependency(name!))
+      self = .externalDepend(try ExternalDependency(fileName: name!))
     case .sourceFileProvide:
       mustBeAbsent(context)
       self = .sourceFileProvide(name: name!)

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1037,7 +1037,7 @@ extension ModuleDependencyGraph {
   func containsExternalDependency(_ path: String, fingerprint: String? = nil)
   -> Bool {
     fingerprintedExternalDependencies.contains(
-      FingerprintedExternalDependency(try! ExternalDependency(fileName: path),
+      FingerprintedExternalDependency(ExternalDependency(fileName: path),
                                       fingerprint))
   }
 }
@@ -1391,7 +1391,7 @@ fileprivate extension String {
 
 fileprivate extension ExternalDependency {
   static func mocking(_ name: String) throws -> Self {
-    return try Self(fileName: name)
+    return Self(fileName: name)
   }
 }
 
@@ -1457,7 +1457,7 @@ fileprivate extension DependencyKey.Designator {
       self = .dynamicLookup(name: name!)
     case .externalDepend:
       mustBeAbsent(context)
-      self = .externalDepend(try ExternalDependency(fileName: name!))
+      self = .externalDepend(ExternalDependency(fileName: name!))
     case .sourceFileProvide:
       mustBeAbsent(context)
       self = .sourceFileProvide(name: name!)


### PR DESCRIPTION
Delay converting external dependency file names to paths as an optimization. For example, on a clean build, the external dependency names might never have to be used as paths; but this PR may not go quite that far. Still more than doubles the speed I measured in a no-priors build.