### PR TITLE
[Build Script Helper] Do not pass `-Ddispatch_DIR` to the Yams CMake build

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -474,9 +474,6 @@ def build_yams_using_cmake(args, target, swiftc_exec, build_dir, base_cmake_flag
     yams_cmake_flags.append('-DCMAKE_C_FLAGS=-target %s' % target)
   else:
     yams_cmake_flags.append('-DCMAKE_C_FLAGS=-fPIC -target %s' % target)
-    if args.dispatch_build_dir:
-      yams_cmake_flags.append(get_dispatch_cmake_arg(args))
-
     if args.foundation_build_dir:
       yams_cmake_flags.append(get_foundation_cmake_arg(args))
   yams_swift_flags = swift_flags[:]


### PR DESCRIPTION
[Change analagous to: https://github.com/apple/swift-package-manager/pull/3363]
With the version-bump of Yams in apple/swift#36366, Yams 4.0.2 now actually expresses the dependency on Dispatch in its CMake config.

With the current behavior of passing `-Ddispatch_DIR` to its CMake build, we have the following problem on Linux:
- swift's `build-script` installs Dispatch into a just-built toolchain which we use to build swift-driver, which will contain, among other things, the Dispatch `.swiftmodule`.
- The compiler workspace checkout of swift-corelibs-libdispatch also contains a copy of the Dispatch `.swiftmodule`.

Both of these will be found, leading to build failures like:
```
/home/buildnode/jenkins/workspace/swift-PR-Linux/branch-main/swift-nightly-install/usr/lib/swift/dispatch/module.modulemap:1:8: error: redefinition of module 'Dispatch'
19:37:47 module Dispatch {
19:37:47        ^
19:37:47 /home/buildnode/jenkins/workspace/swift-PR-Linux/branch-main/swift-corelibs-libdispatch/dispatch/module.modulemap:1:8: note: previously defined here
19:37:47 module Dispatch {
19:37:47        ^
19:37:47
```
We also cannot put off building `libDispatch` until swift-driver is built, because the `libDispatch` dylib is required to link swift-driver.
Not passing `-Ddispatch_DIR` to Yams' CMake build causes it to successfully locate the Dispatch package in the just-built toolchain on its own.