### PR TITLE
Use an Array When Computing Primary Inputs

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -133,11 +133,14 @@ extension Driver {
     // If we will be passing primary files via -primary-file, form a set of primary input files so
     // we can check more quickly.
     let usesPrimaryFileInputs: Bool
-    let primaryInputFiles: Set<TypedVirtualPath>
+    // N.B. We use an array instead of a hashed collection like a set because
+    // TypedVirtualPaths are quite expensive to hash. To the point where a
+    // linear scan beats Set.contains by a factor of 4 for heavy workloads.
+    let primaryInputFiles: [TypedVirtualPath]
     if compilerMode.usesPrimaryFileInputs {
       assert(!primaryInputs.isEmpty)
       usesPrimaryFileInputs = true
-      primaryInputFiles = Set(primaryInputs)
+      primaryInputFiles = primaryInputs
     } else if let path = indexFilePath {
       // If -index-file is used, we perform a single compile but pass the
       // -index-file-path as a primary input file.

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -108,9 +108,6 @@ extension Driver {
                                  outputType: FileType?,
                                  commandLine: inout [Job.ArgTemplate])
   -> ([TypedVirtualPath], [TypedVirtualPath]) {
-    // Collect the set of input files that are part of the Swift compilation.
-    let swiftInputFiles: [TypedVirtualPath] = inputFiles.filter { $0.type.isPartOfSwiftCompilation }
-
     let useInputFileList: Bool
     if let allSourcesFileList = allSourcesFileList {
       useInputFileList = true
@@ -157,7 +154,8 @@ extension Driver {
     var primaryOutputs: [TypedVirtualPath] = []
     var primaryIndexUnitOutputs: [TypedVirtualPath] = []
     var indexUnitOutputDiffers = false
-    for input in swiftInputFiles {
+    let firstSwiftInput = inputs.count
+    for input in self.inputFiles where input.type.isPartOfSwiftCompilation {
       inputs.append(input)
 
       let isPrimary = usesPrimaryFileInputs && primaryInputFiles.contains(input)
@@ -194,7 +192,7 @@ extension Driver {
     // When not using primary file inputs or multithreading, add a single output.
     if let outputType = outputType,
        !usesPrimaryFileInputs && !(isMultithreaded && outputType.isAfterLLVM) {
-      let input = TypedVirtualPath(file: OutputFileMap.singleInputKey, type: swiftInputFiles[0].type)
+      let input = TypedVirtualPath(file: OutputFileMap.singleInputKey, type: inputs[firstSwiftInput].type)
       let output = computePrimaryOutput(for: input,
                                         outputType: outputType,
                                         isTopLevel: isTopLevel)


### PR DESCRIPTION
Unfortunately, (Typed)VirtualPath's Hashable conformance is wildly expensive to the point that constructing and searching a hashed collection is much more expensive than a linear scan. Preliminary tests show a factor of 4 improvement here by switching to a linear scan for large workloads.

While I'm here, avoid materializing the filtered collection of input files and just use a loop condition. This saves an enormous amount of transient memory during the planning step. 