### PR TITLE
Add some directives to enable OpenBSD support.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -800,7 +800,7 @@ extension Driver {
   ///
   /// - Parameter content: response file's content to be tokenized.
   private static func tokenizeResponseFile(_ content: String) -> [String] {
-    #if !os(macOS) && !os(Linux) && !os(Android)
+    #if !os(macOS) && !os(Linux) && !os(Android) && !os(OpenBSD)
       #warning("Response file tokenization unimplemented for platform; behavior may be incorrect")
     #endif
     return content.split { $0 == "\n" || $0 == "\r\n" }

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -16,7 +16,7 @@ import Darwin
 import Glibc
 #endif
 
-#if os(macOS) || os(Linux) || os(Android)
+#if os(macOS) || os(Linux) || os(Android) || os(OpenBSD)
 // Adapted from llvm::sys::commandLineFitsWithinSystemLimits.
 func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
   let upperBound = sysconf(Int32(_SC_ARG_MAX))


### PR DESCRIPTION
These are not compile blockers, but it makes sense to set these anyway.