### PR TITLE
Use Our Own Stat for Mod Times

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -436,7 +436,7 @@ public struct Driver {
     self.recordedInputModificationDates = .init(uniqueKeysWithValues:
       Set(inputFiles).compactMap {
         guard let modTime = try? fileSystem
-          .getFileInfo($0.file).modTime else { return nil }
+          .lastModificationTime(for: $0.file) else { return nil }
         return ($0, modTime)
     })
 

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -30,10 +30,6 @@ import TSCBasic
     self.isSwiftModule = file.extension == FileType.swiftModule.rawValue
   }
 
-  func modTime(_ fileSystem: FileSystem) -> Date? {
-    try? fileSystem.getFileInfo(file).modTime
-  }
-
   var swiftModuleFile: TypedVirtualPath? {
     isSwiftModule ? TypedVirtualPath(file: file, type: .swiftModule) : nil
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -324,7 +324,8 @@ extension ModuleDependencyGraph {
     if let hasChanged = externalDependencyModTimeCache[externalDependency] {
       return hasChanged
     }
-    let hasChanged = (externalDependency.modTime(info.fileSystem) ?? .distantFuture)
+    let depFile = externalDependency.file
+    let hasChanged = ((try? info.fileSystem.lastModificationTime(for: depFile)) ?? .distantFuture)
       >= info.buildTime
     externalDependencyModTimeCache[externalDependency] = hasChanged
     return hasChanged

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -136,7 +136,7 @@ extension Job {
   public func verifyInputsNotModified(since recordedInputModificationDates: [TypedVirtualPath: Date], fileSystem: FileSystem) throws {
     for input in inputs {
       if let recordedModificationTime = recordedInputModificationDates[input],
-         try fileSystem.getFileInfo(input.file).modTime != recordedModificationTime {
+         try fileSystem.lastModificationTime(for: input.file) != recordedModificationTime {
         throw InputError.inputUnexpectedlyModified(input)
       }
     }


### PR DESCRIPTION
The overhead from Foundation is around 10x due to the fact that it has
to do the syscall, allocate a dictionary, convert all the entries, then
bridge the whole enchilada back to Swift.

For a 1000 file incremental build, 40 seconds of overhead was removed from build
execution.