### PR TITLE
[Incremental Imports; performance] Reserve use capacity when deserializing module dep graph

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -485,6 +485,7 @@ extension ModuleDependencyGraph {
       }
 
       func finalizeGraph() -> ModuleDependencyGraph {
+        self.graph.nodeFinder.reserveUseCapacity(self.nodeUses.count)
         for (dependencyKey, useIDs) in self.nodeUses {
           for useID in useIDs {
             let isNewUse = self.graph.nodeFinder

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -134,6 +134,10 @@ extension ModuleDependencyGraph.NodeFinder {
     verifyUseIsOK(use)
     return usesByDef.insertValue(use, forKey: def)
   }
+
+  mutating func reserveUseCapacity(_ minimumCapacity: Int) {
+    usesByDef.reserveCapacity(minimumCapacity)
+  }
 }
 
 // MARK: - removing

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -127,4 +127,8 @@
       self.dictionary[k]!.remove(v)
     }
   }
+
+  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+    self.dictionary.reserveCapacity(minimumCapacity)
+  }
 }


### PR DESCRIPTION
Reserve space in the `usesByDef` dictionary. May reserve too much.