### PR TITLE
[Perf] Drop Some Places We Re-Materialize Input Files

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -61,7 +61,7 @@ internal extension Driver {
     }
 
     // Pass on the input files
-    commandLine.append(contentsOf: inputFiles.map { .path($0.file)})
+    commandLine.append(contentsOf: inputFiles.map { .path($0.file) })
     return (inputs, commandLine)
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -423,14 +423,12 @@ extension OutputFileMap {
 // MARK: SourceFiles
 @_spi(Testing) public struct SourceFiles {
   let currentInOrder: [TypedVirtualPath]
-  private let currentSet: Set<VirtualPath>
-  let previous: Set<VirtualPath>
+  private let previous: Set<VirtualPath>
   let disappeared: [VirtualPath]
 
   init(inputFiles: [TypedVirtualPath], buildRecord: BuildRecord?) {
     self.currentInOrder = inputFiles.filter {$0.type == .swift}
     let currentSet = Set(currentInOrder.map {$0.file} )
-    self.currentSet = currentSet
     self.previous = buildRecord.map {
       Set($0.inputInfos.keys)
     } ?? Set()

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -59,10 +59,8 @@ extension Driver {
 
     commandLine.appendFlags("-frontend", "-emit-module", "-experimental-skip-non-inlinable-function-bodies-without-types")
 
-    let swiftInputFiles = inputFiles.filter { $0.type.isPartOfSwiftCompilation }
-
     // Add the inputs.
-    for input in swiftInputFiles {
+    for input in self.inputFiles where input.type.isPartOfSwiftCompilation {
       commandLine.append(.path(input.file))
       inputs.append(input)
     }


### PR DESCRIPTION
Creating in-memory collections that are derived from the set of input files is potentially expensive for large compilations.