### PR TITLE
[Incremental] Key hash caching

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -300,6 +300,7 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
 
   /*@_spi(Testing)*/ public let aspect: DeclAspect
   /*@_spi(Testing)*/ public let designator: Designator
+  public let hashValue: Int
 
 
   /*@_spi(Testing)*/ public init(
@@ -308,6 +309,10 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   {
     self.aspect = aspect
     self.designator = designator
+    var h = Hasher()
+    h.combine(aspect)
+    h.combine(designator)
+    self.hashValue = h.finalize()
   }
 
 

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -138,8 +138,7 @@ extension IncrementalCompilationState.InitialStateComputer {
     catch {
       diagnosticEngine.emit(
         warning: "Could not read \(dependencyGraphPath), will not do cross-module incremental builds")
-      reporter?.reportDisablingIncrementalBuild("Could not read priors from \(dependencyGraphPath)")
-      return nil
+      graphIfPresent = nil
     }
     guard let graph = graphIfPresent
     else {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -544,23 +544,27 @@ extension ModuleDependencyGraph {
           self.compilerVersionString = compilerVersionString
         case .moduleDepGraphNode:
           let kindCode = record.fields[0]
-          guard record.fields.count == 7,
+          guard record.fields.count == 9,
                 let declAspect = DependencyKey.DeclAspect(record.fields[1]),
-                record.fields[2] < identifiers.count,
-                record.fields[3] < identifiers.count,
+                record.fields[4] < identifiers.count,
+                record.fields[5] < identifiers.count,
                 case .blob(let fingerprintBlob) = record.payload,
                 let fingerprintStr = String(data: fingerprintBlob, encoding: .utf8)
           else {
             throw ReadError.malformedModuleDepGraphNodeRecord
           }
-          let context = identifiers[Int(record.fields[2])]
-          let identifier = identifiers[Int(record.fields[3])]
+          let hashHi = record.fields[2]
+          let hashLo = record.fields[3]
+          let hashValue = Int(bitPattern: UInt((hashHi << 32) | hashLo))
+          
+            let context = identifiers[Int(record.fields[4])]
+          let identifier = identifiers[Int(record.fields[5])]
           let designator = try DependencyKey.Designator(
             kindCode: kindCode, context: context, name: identifier, fileSystem: fileSystem)
           let key = DependencyKey(aspect: declAspect, designator: designator)
-          let hasSwiftDeps = Int(record.fields[4]) != 0
-          let swiftDepsStr = hasSwiftDeps ? identifiers[Int(record.fields[5])] : nil
-          let hasFingerprint = Int(record.fields[6]) != 0
+          let hasSwiftDeps = Int(record.fields[6]) != 0
+          let swiftDepsStr = hasSwiftDeps ? identifiers[Int(record.fields[7])] : nil
+          let hasFingerprint = Int(record.fields[8]) != 0
           let fingerprint = hasFingerprint ? fingerprintStr : nil
           guard let dependencySource = try swiftDepsStr
                   .map({ try VirtualPath(path: $0) })
@@ -570,7 +574,8 @@ extension ModuleDependencyGraph {
           }
           self.finalize(node: Node(key: key,
                                    fingerprint: fingerprint,
-                                   dependencySource: dependencySource))
+                                   dependencySource: dependencySource,
+                                   hashValue: hashValue))
         case .dependsOnNode:
           let kindCode = record.fields[0]
           guard record.fields.count == 4,
@@ -824,11 +829,15 @@ extension ModuleDependencyGraph {
         .fixed(bitWidth: 3),
         // dependency decl aspect discriminator
         .fixed(bitWidth: 1),
-        // dependency context
+        // hash hi value
+        .fixed(bitWidth: 32),
+        // hash lo value
+        .fixed(bitWidth: 32),
+         // dependency context
         .vbr(chunkBitWidth: 13),
         // dependency name
         .vbr(chunkBitWidth: 13),
-        // swiftdeps?
+       // swiftdeps?
         .fixed(bitWidth: 1),
         // swiftdeps path
         .vbr(chunkBitWidth: 13),
@@ -905,6 +914,7 @@ extension ModuleDependencyGraph {
             $0.append(RecordID.moduleDepGraphNode)
             $0.append(node.key.designator.code)
             $0.append(node.key.aspect.code)
+            $0.append(node.hashValue)
             $0.append(serializer.lookupIdentifierCode(
                         for: node.key.designator.context ?? ""))
             $0.append(serializer.lookupIdentifierCode(
@@ -913,7 +923,7 @@ extension ModuleDependencyGraph {
             $0.append(serializer.lookupIdentifierCode(
                         for: node.dependencySource?.file.name ?? ""))
             $0.append((node.fingerprint != nil) ? UInt32(1) : UInt32(0))
-          }, blob: node.fingerprint ?? "")
+         }, blob: node.fingerprint ?? "")
         }
 
         for key in graph.nodeFinder.usesByDef.keys {
@@ -957,6 +967,19 @@ extension ModuleDependencyGraph {
       }
       return ByteString(serializer.stream.data)
     }
+  }
+}
+
+fileprivate extension BitstreamWriter.RecordBuffer {
+  mutating func append(_ i: Int) {
+    assert(Int.bitWidth == Int64.bitWidth)
+    append(UInt64(bitPattern: Int64(i)))
+  }
+  mutating func append(_ u: UInt64) {
+    let hi = UInt32(u >> 32)
+    let lo = UInt32(u & 0xffffffff)
+    append(hi)
+    append(lo)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -132,6 +132,7 @@ extension SourceFileDependencyGraph {
     case unknownRecord
     case unexpectedSubblock
     case bogusNameOrContext
+    case noHash
     case unknownKind
   }
 


### PR DESCRIPTION
Builds on https://github.com/apple/swift-driver/pull/557 to also cache `DependencyKey` hashes. Saves another 10% according to one measured case.

The changes beyond the other PR are all in `DependencyKey`