### PR TITLE
[Incremental] Recover better from malformed prior ModuleDependencyGraph

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -138,8 +138,7 @@ extension IncrementalCompilationState.InitialStateComputer {
     catch {
       diagnosticEngine.emit(
         warning: "Could not read \(dependencyGraphPath), will not do cross-module incremental builds")
-      reporter?.reportDisablingIncrementalBuild("Could not read priors from \(dependencyGraphPath)")
-      return nil
+      graphIfPresent = nil
     }
     guard let graph = graphIfPresent
     else {


### PR DESCRIPTION
If the prior graph gets corrupted, or we change the format, the driver needs to recover from reading a malformed one by writing a good one. By remaining in incremental mode, this change will do that.