### PR TITLE
[Incremental Optimization] Combines https://github.com/apple/swift-driver/pull/557 with https://github.com/apple/swift-driver/pull/547

### DIFF
--- a/Sources/SwiftDriver/Driver/ModuleOutputInfo.swift
+++ b/Sources/SwiftDriver/Driver/ModuleOutputInfo.swift
@@ -16,12 +16,12 @@
   /// How should the Swift module output be handled?
   public enum ModuleOutput: Equatable {
     /// The Swift module is a top-level output.
-    case topLevel(VirtualPath)
+    case topLevel(VirtualPath.Handle)
 
     /// The Swift module is an auxiliary output.
-    case auxiliary(VirtualPath)
+    case auxiliary(VirtualPath.Handle)
 
-    public var outputPath: VirtualPath {
+    public var outputPath: VirtualPath.Handle {
       switch self {
       case .topLevel(let path):
         return path

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -14,41 +14,45 @@ import Foundation
 
 /// Mapping of input file paths to specific output files.
 public struct OutputFileMap: Hashable, Codable {
-  static let singleInputKey = VirtualPath.relative(RelativePath(""))
+  static let singleInputKey = try! VirtualPath.intern(path: ".")
 
   /// The known mapping from input file to specific output files.
-  public var entries: [VirtualPath : [FileType : VirtualPath]] = [:]
+  public var entries: [VirtualPath.Handle: [FileType: VirtualPath.Handle]] = [:]
 
   public init() { }
 
-  public init(entries: [VirtualPath : [FileType : VirtualPath]]) {
+  public init(entries: [VirtualPath.Handle: [FileType: VirtualPath.Handle]]) {
     self.entries = entries
   }
 
   /// For the given input file, retrieve or create an output file for the given
   /// file type.
-  public func getOutput(inputFile: VirtualPath, outputType: FileType) -> VirtualPath {
+  public func getOutput(inputFile: VirtualPath.Handle, outputType: FileType) -> VirtualPath.Handle {
     // If we already have an output file, retrieve it.
     if let output = existingOutput(inputFile: inputFile, outputType: outputType) {
       return output
     }
 
+    let inputFile = VirtualPath.lookup(inputFile)
     if inputFile == .standardOutput {
       fatalError("Standard output cannot be an input file")
     }
 
     // Form the virtual path.
-    return .temporary(RelativePath(inputFile.basenameWithoutExt.appendingFileTypeExtension(outputType)))
+    return .constant(.temporary(RelativePath(inputFile.basenameWithoutExt.appendingFileTypeExtension(outputType))))
   }
 
-  public func existingOutput(inputFile: VirtualPath, outputType: FileType) -> VirtualPath? {
+  public func existingOutput(inputFile: VirtualPath.Handle, outputType: FileType) -> VirtualPath.Handle? {
     if let path = entries[inputFile]?[outputType] {
       return path
     }
     switch outputType {
     case .swiftDocumentation, .swiftSourceInfoFile:
       // Infer paths for these entities using .swiftmodule path.
-      return entries[inputFile]?[.swiftModule]?.replacingExtension(with: outputType)
+      guard let path = entries[inputFile]?[.swiftModule] else {
+        return nil
+      }
+      return .constant(VirtualPath.lookup(path).replacingExtension(with: outputType))
 
     case .object:
       // We may generate .o files from bitcode .bc files, but the output file map
@@ -67,21 +71,21 @@ public struct OutputFileMap: Hashable, Codable {
     }
   }
 
-  public func existingOutputForSingleInput(outputType: FileType) -> VirtualPath? {
+  public func existingOutputForSingleInput(outputType: FileType) -> VirtualPath.Handle? {
     existingOutput(inputFile: Self.singleInputKey, outputType: outputType)
   }
 
   public func resolveRelativePaths(relativeTo absPath: AbsolutePath) -> OutputFileMap {
-    let resolvedKeyValues: [(VirtualPath, [FileType : VirtualPath])] = entries.map {
-      let resolvedKey: VirtualPath
+    let resolvedKeyValues: [(VirtualPath.Handle, [FileType : VirtualPath.Handle])] = entries.map { entry in
+      let resolvedKey: VirtualPath.Handle
       // Special case for single dependency record, leave it as is
-      if $0.key == Self.singleInputKey {
-        resolvedKey = $0.key
+      if entry.key == Self.singleInputKey {
+        resolvedKey = entry.key
       } else {
-        resolvedKey = $0.key.resolvedRelativePath(base: absPath)
+        resolvedKey = try! VirtualPath.intern(path: VirtualPath.lookup(entry.key).resolvedRelativePath(base: absPath).description)
       }
-      let resolvedValue = $0.value.mapValues {
-        $0.resolvedRelativePath(base: absPath)
+      let resolvedValue = entry.value.mapValues {
+        try! VirtualPath.intern(path: VirtualPath.lookup($0).resolvedRelativePath(base: absPath).description)
       }
       return (resolvedKey, resolvedValue)
     }
@@ -94,8 +98,8 @@ public struct OutputFileMap: Hashable, Codable {
   public func getInput(outputFile: VirtualPath) -> VirtualPath? {
     entries
       .compactMap {
-        $0.value.values.contains(outputFile)
-          ? $0.key
+        $0.value.values.contains(.constant(outputFile))
+          ? VirtualPath.lookup($0.key)
           : nil
       }
       .first
@@ -141,11 +145,11 @@ public struct OutputFileMap: Hashable, Codable {
   /// Human-readable texual representation
   var description: String {
     var result = ""
-    func outputPairDescription(inputPath: VirtualPath, outputPair: (FileType, VirtualPath))
+    func outputPairDescription(inputPath: VirtualPath.Handle, outputPair: (FileType, VirtualPath.Handle))
     -> String {
       "\(inputPath.description) -> \(outputPair.0.description): \"\(outputPair.1.description)\"\n"
     }
-    let maps = entries.map { ($0, $1) }.sorted { $0.0.description < $1.0.description }
+    let maps = entries.map { ($0, $1) }.sorted { VirtualPath.lookup($0.0).description < VirtualPath.lookup($1.0).description }
     for (input, map) in maps {
       let pairs = map.map { ($0, $1) }.sorted { $0.0.description < $1.0.description }
       for (outputType, outputPath) in pairs {
@@ -228,23 +232,23 @@ fileprivate struct OutputFileMapJSON: Codable {
   }
 
   /// Converts into virtual path entries.
-  func toVirtualOutputFileMap() throws -> [VirtualPath : [FileType : VirtualPath]] {
+  func toVirtualOutputFileMap() throws -> [VirtualPath.Handle : [FileType : VirtualPath.Handle]] {
     Dictionary(try entries.map { input, entry in
-      (try VirtualPath(path: input), try entry.paths.mapValues(VirtualPath.init(path:)))
+      (try VirtualPath.intern(path: input), try entry.paths.mapValues(VirtualPath.intern(path:)))
     }, uniquingKeysWith: { $1 })
   }
 
   /// Converts from virtual path entries
   static func fromVirtualOutputFileMap(
-    _ entries: [VirtualPath : [FileType : VirtualPath]]
+    _ entries: [VirtualPath.Handle : [FileType : VirtualPath.Handle]]
   ) -> Self {
-    func convert(entry: (key: VirtualPath, value: [FileType: VirtualPath])) -> (String, Entry) {
+    func convert(entry: (key: VirtualPath.Handle, value: [FileType: VirtualPath.Handle])) -> (String, Entry) {
       // We use a VirtualPath with an empty path for the master entry, but its name is "." and we need ""
-      let fixedIfMaster = entry.key.name == "." ? "" : entry.key.name
+      let fixedIfMaster = VirtualPath.lookup(entry.key).name == "." ? "" : VirtualPath.lookup(entry.key).name
       return (fixedIfMaster, convert(outputs: entry.value))
     }
-    func convert(outputs: [FileType: VirtualPath]) -> Entry {
-      Entry(paths: outputs.mapValues({ $0.name }))
+    func convert(outputs: [FileType: VirtualPath.Handle]) -> Entry {
+      Entry(paths: outputs.mapValues({ VirtualPath.lookup($0).name }))
     }
     return Self(entries: Dictionary(uniqueKeysWithValues: entries.map(convert(entry:))))
   }

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -142,13 +142,13 @@ public final class ArgsResolver {
       // and the frontend (llvm) only seems to support implicit block format.
       try fileSystem.writeFileContents(absPath) { out in
         for (input, map) in outputFileMap.entries {
-          out <<< quoteAndEscape(path: input) <<< ":"
+          out <<< quoteAndEscape(path: VirtualPath.lookup(input)) <<< ":"
           if map.isEmpty {
             out <<< " {}\n"
           } else {
             out <<< "\n"
             for (type, output) in map {
-              out <<< "  " <<< type.name <<< ": " <<< quoteAndEscape(path: output) <<< "\n"
+              out <<< "  " <<< type.name <<< ": " <<< quoteAndEscape(path: VirtualPath.lookup(output)) <<< "\n"
             }
           }
         }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -34,8 +34,8 @@ import TSCBasic
        let newModuleId: ModuleDependencyId = .swiftPrebuiltExternal(externalModuleId.moduleName)
       let newExternalModuleDetails =
         try SwiftPrebuiltExternalModuleDetails(compiledModulePath:
-                                                TextualVirtualPath(path: .absolute(externalModulePath)))
-      let newInfo = ModuleInfo(modulePath: TextualVirtualPath(path: .absolute(externalModulePath)),
+                                                TextualVirtualPath(path: .constant(.absolute(externalModulePath))))
+      let newInfo = ModuleInfo(modulePath: TextualVirtualPath(path: .constant(.absolute(externalModulePath))),
                                sourceFiles: [],
                                directDependencies: currentInfo.directDependencies,
                                details: .swiftPrebuiltExternal(newExternalModuleDetails))

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -34,7 +34,7 @@ internal extension Driver {
                displayInputs: inputs,
                inputs: inputs,
                primaryInputs: [],
-               outputs: [TypedVirtualPath(file: .standardOutput, type: .jsonDependencies)],
+               outputs: [TypedVirtualPath(file: .constant(.standardOutput), type: .jsonDependencies)],
                supportsResponseFiles: true)
   }
 
@@ -76,7 +76,7 @@ internal extension Driver {
       placeholderArtifacts.append(
           SwiftModuleArtifactInfo(name: moduleId.moduleName,
                                   modulePath: TextualVirtualPath(path:
-                                                    .absolute(binaryModulePath))))
+                                                                  .constant(.absolute(binaryModulePath)))))
     }
 
     // All other already-scanned Swift modules
@@ -255,10 +255,10 @@ internal extension Driver {
     let outputs: [TypedVirtualPath] = try moduleInfos.map {
       switch $0 {
         case .swift(let swiftModuleBatchScanInfo):
-          return TypedVirtualPath(file: try VirtualPath(path: swiftModuleBatchScanInfo.output),
+          return TypedVirtualPath(file: try VirtualPath.intern(path: swiftModuleBatchScanInfo.output),
                                   type: .jsonDependencies)
         case .clang(let clangModuleBatchScanInfo):
-          return TypedVirtualPath(file: try VirtualPath(path: clangModuleBatchScanInfo.output),
+          return TypedVirtualPath(file: try VirtualPath.intern(path: clangModuleBatchScanInfo.output),
                                   type: .jsonDependencies)
       }
     }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/PlaceholderDependencyResolution.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/PlaceholderDependencyResolution.swift
@@ -123,8 +123,8 @@ fileprivate extension InterModuleDependencyGraph {
 
     let newExternalModuleDetails =
       try SwiftPrebuiltExternalModuleDetails(compiledModulePath:
-                                              TextualVirtualPath(path: .absolute(placeholderPath)))
-    let newInfo = ModuleInfo(modulePath: TextualVirtualPath(path: .absolute(placeholderPath)),
+                                              TextualVirtualPath(path: .constant(.absolute(placeholderPath))))
+    let newInfo = ModuleInfo(modulePath: TextualVirtualPath(path: .constant(.absolute(placeholderPath))),
                              sourceFiles: [],
                              directDependencies: externalModuleInfo.directDependencies,
                              details: .swiftPrebuiltExternal(newExternalModuleDetails))

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -140,8 +140,8 @@ import SwiftOptions
       return nil
     }
     return workingDirectory
-      .map(partialBuildRecordPath.resolvedRelativePath(base:))
-      ?? partialBuildRecordPath
+      .map(VirtualPath.lookup(partialBuildRecordPath).resolvedRelativePath(base:))
+      ?? VirtualPath.lookup(partialBuildRecordPath)
   }
 
   /// Write out the build record.

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -108,7 +108,7 @@ public struct FingerprintedExternalDependency: Hashable, Equatable, ExternalDepe
 /// A `DependencyKey` carries all of the information necessary to uniquely
 /// identify a dependency node in the graph, and serves as a point of identity
 /// for the dependency graph's map from definitions to uses.
-public struct DependencyKey: Hashable, CustomStringConvertible {
+public struct DependencyKey: CustomStringConvertible {
   /// Captures which facet of the dependency structure a dependency key represents.
   ///
   /// A `DeclAspect` is used to separate dependencies with a scope limited to
@@ -308,7 +308,8 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
 
   /*@_spi(Testing)*/ public let aspect: DeclAspect
   /*@_spi(Testing)*/ public let designator: Designator
-  public let hashValue: Int
+
+  private let cachedHash: Int
 
 
   /*@_spi(Testing)*/ public init(
@@ -317,12 +318,8 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   {
     self.aspect = aspect
     self.designator = designator
-    var h = Hasher()
-    h.combine(aspect)
-    h.combine(designator)
-    self.hashValue = h.finalize()
+    self.cachedHash = Self.computeHash(aspect, designator)
   }
-
 
   /*@_spi(Testing)*/ public var correspondingImplementation: Self? {
     guard aspect == .interface  else {
@@ -339,6 +336,24 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   func verify() -> Bool {
     // This space reserved for future use.
     return true
+  }
+}
+
+extension DependencyKey: Equatable, Hashable {
+
+  private static func computeHash(_ aspect: DeclAspect, _ designator: Designator) -> Int {
+    var h = Hasher()
+    h.combine(aspect)
+    h.combine(designator)
+    return h.finalize()
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(cachedHash)
+  }
+
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    lhs.aspect == rhs.aspect && lhs.designator == rhs.designator
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -308,6 +308,7 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
 
   /*@_spi(Testing)*/ public let aspect: DeclAspect
   /*@_spi(Testing)*/ public let designator: Designator
+  public let hashValue: Int
 
 
   /*@_spi(Testing)*/ public init(
@@ -316,6 +317,10 @@ public struct DependencyKey: Hashable, CustomStringConvertible {
   {
     self.aspect = aspect
     self.designator = designator
+    var h = Hasher()
+    h.combine(aspect)
+    h.combine(designator)
+    self.hashValue = h.finalize()
   }
 
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -302,8 +302,8 @@ extension IncrementalCompilationState {
         report(message, pathIfGiven?.file)
         return
       }
-      let output = outputFileMap.getOutput(inputFile: path.file, outputType: .object)
-      let compiling = " {compile: \(output.basename) <= \(input.basename)}"
+      let output = outputFileMap.getOutput(inputFile: path.fileHandle, outputType: .object)
+      let compiling = " {compile: \(VirtualPath.lookup(output).basename) <= \(input.basename)}"
       diagnosticEngine.emit(.remark_incremental_compilation(because: "\(message) \(compiling)"))
     }
 
@@ -405,9 +405,8 @@ extension IncrementalCompilationState {
 // MARK: - OutputFileMap
 extension OutputFileMap {
   func onlySourceFilesHaveSwiftDeps() -> Bool {
-    let nonSourceFilesWithSwiftDeps = entries.compactMap {
-      input, outputs in
-      input.extension != FileType.swift.rawValue &&
+    let nonSourceFilesWithSwiftDeps = entries.compactMap { input, outputs in
+      VirtualPath.lookup(input).extension != FileType.swift.rawValue &&
         input.description != "." &&
         outputs.keys.contains(.swiftDeps)
         ? input

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -27,8 +27,8 @@ public struct DependencySource: Hashable, CustomStringConvertible {
 
   /*@_spi(Testing)*/
   /// Returns nil if cannot be a source
-  public init?(_ file: VirtualPath) {
-    let ext = file.extension
+  public init?(_ file: VirtualPath.Handle) {
+    let ext = VirtualPath.lookup(file).extension
     guard let type =
       ext == FileType.swiftDeps  .rawValue ? FileType.swiftDeps :
       ext == FileType.swiftModule.rawValue ? FileType.swiftModule
@@ -42,7 +42,7 @@ public struct DependencySource: Hashable, CustomStringConvertible {
   public var file: VirtualPath { typedFile.file }
 
   public var description: String {
-    ExternalDependency(fileName: file.name).description
+    ExternalDependency(self.typedFile.fileHandle).description
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -42,7 +42,7 @@ public struct DependencySource: Hashable, CustomStringConvertible {
   public var file: VirtualPath { typedFile.file }
 
   public var description: String {
-    ExternalDependency(self.typedFile.fileHandle).description
+    ExternalDependency(fileName: self.file.name).description
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -54,7 +54,7 @@ extension ModuleDependencyGraph {
     /// invocation that has not kicked off any compiles yet.
     @_spi(Testing) public private(set) var isTraced: Bool = false
 
-    public let hashValue: Int
+    private let cachedHash: Int
 
     /// This dependencySource is the file where the swiftDeps, etc. was read, not necessarily anything in the
     /// SourceFileDependencyGraph or the DependencyKeys
@@ -62,7 +62,7 @@ extension ModuleDependencyGraph {
          dependencySource: DependencySource?) {
       self.keyAndFingerprint = try! KeyAndFingerprintHolder(key, fingerprint)
       self.dependencySource = dependencySource
-      self.hashValue = Self.computeHash(key, dependencySource)
+      self.cachedHash = Self.computeHash(key, dependencySource)
     }
   }
 }
@@ -92,6 +92,10 @@ extension ModuleDependencyGraph.Node: Equatable, Hashable {
     h.combine(key)
     h.combine(source)
     return h.finalize()
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(cachedHash)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -54,12 +54,15 @@ extension ModuleDependencyGraph {
     /// invocation that has not kicked off any compiles yet.
     @_spi(Testing) public private(set) var isTraced: Bool = false
 
+    public let hashValue: Int
+
     /// This dependencySource is the file where the swiftDeps, etc. was read, not necessarily anything in the
     /// SourceFileDependencyGraph or the DependencyKeys
     init(key: DependencyKey, fingerprint: String?,
          dependencySource: DependencySource?) {
       self.keyAndFingerprint = try! KeyAndFingerprintHolder(key, fingerprint)
       self.dependencySource = dependencySource
+      self.hashValue = Self.computeHash(key, dependencySource)
     }
   }
 }
@@ -84,9 +87,11 @@ extension ModuleDependencyGraph.Node: Equatable, Hashable {
     lhs.keyAndFingerprint.key == rhs.keyAndFingerprint.key &&
     lhs.dependencySource == rhs.dependencySource
   }
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(keyAndFingerprint.key)
-    hasher.combine(dependencySource)
+  static private func computeHash(_ key: DependencyKey, _ source: DependencySource?) -> Int {
+    var h = Hasher()
+    h.combine(key)
+    h.combine(source)
+    return h.finalize()
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -47,7 +47,7 @@ extension Driver {
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],
-      outputs: [.init(file: output, type: .autolink)],
+      outputs: [.init(file: .constant(output), type: .autolink)],
       supportsResponseFiles: true
     )
   }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -27,12 +27,12 @@ extension Driver {
   }
 
   mutating func computeIndexUnitOutput(for input: TypedVirtualPath, outputType: FileType, topLevel: Bool) -> TypedVirtualPath? {
-    if let path = outputFileMap?.existingOutput(inputFile: input.file, outputType: .indexUnitOutputPath) {
+    if let path = outputFileMap?.existingOutput(inputFile: input.fileHandle, outputType: .indexUnitOutputPath) {
       return TypedVirtualPath(file: path, type: outputType)
     }
     if topLevel {
       if let baseOutput = parsedOptions.getLastArgument(.indexUnitOutputPath)?.asSingle,
-         let baseOutputPath = try? VirtualPath(path: baseOutput) {
+         let baseOutputPath = try? VirtualPath.intern(path: baseOutput) {
         return TypedVirtualPath(file: baseOutputPath, type: outputType)
       }
     }
@@ -41,16 +41,16 @@ extension Driver {
 
   mutating func computePrimaryOutput(for input: TypedVirtualPath, outputType: FileType,
                                         isTopLevel: Bool) -> TypedVirtualPath {
-    if let path = outputFileMap?.existingOutput(inputFile: input.file, outputType: outputType) {
+    if let path = outputFileMap?.existingOutput(inputFile: input.fileHandle, outputType: outputType) {
       return TypedVirtualPath(file: path, type: outputType)
     }
 
     if isTopLevel {
       if let baseOutput = parsedOptions.getLastArgument(.o)?.asSingle,
-         let baseOutputPath = try? VirtualPath(path: baseOutput) {
+         let baseOutputPath = try? VirtualPath.intern(path: baseOutput) {
         return TypedVirtualPath(file: baseOutputPath, type: outputType)
       } else if compilerOutputType?.isTextual == true {
-        return TypedVirtualPath(file: .standardOutput, type: outputType)
+        return TypedVirtualPath(file: .constant(.standardOutput), type: outputType)
       } else if outputType == .swiftModule, let moduleOutput = moduleOutputInfo.output {
         return TypedVirtualPath(file: moduleOutput.outputPath, type: outputType)
       }
@@ -64,10 +64,10 @@ extension Driver {
     }
 
     if !isTopLevel {
-      return TypedVirtualPath(file:VirtualPath.temporary(.init(baseName.appendingFileTypeExtension(outputType))),
+      return TypedVirtualPath(file: .constant(.temporary(.init(baseName.appendingFileTypeExtension(outputType)))),
                               type: outputType)
     }
-    return TypedVirtualPath(file: useWorkingDirectory(.init(baseName.appendingFileTypeExtension(outputType))), type: outputType)
+    return TypedVirtualPath(file: .constant(useWorkingDirectory(.init(baseName.appendingFileTypeExtension(outputType)))), type: outputType)
   }
 
   /// Is this compile job top-level

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -124,7 +124,7 @@ extension DarwinToolchain {
   }
 
   private func addPlatformVersionArg(to commandLine: inout [Job.ArgTemplate],
-                                     for triple: Triple, sdkPath: VirtualPath?) {
+                                     for triple: Triple, sdkPath: VirtualPath.Handle?) {
     assert(triple.isDarwin)
     let platformName = triple.darwinPlatform!.linkerPlatformName
     let platformVersion = triple.darwinLinkerPlatformVersion
@@ -146,7 +146,7 @@ extension DarwinToolchain {
     to commandLine: inout [Job.ArgTemplate],
     targetTriple: Triple,
     targetVariantTriple: Triple?,
-    sdkPath: VirtualPath?
+    sdkPath: VirtualPath.Handle?
   ) {
     addPlatformVersionArg(to: &commandLine, for: targetTriple, sdkPath: sdkPath)
     if let variantTriple = targetVariantTriple {
@@ -361,7 +361,7 @@ extension DarwinToolchain {
     // Add the SDK path
     if let sdkPath = targetInfo.sdkPath?.path {
       commandLine.appendFlag("-syslibroot")
-      commandLine.appendPath(sdkPath)
+      commandLine.appendPath(VirtualPath.lookup(sdkPath))
     }
 
     commandLine.appendFlags(

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -18,11 +18,11 @@ extension Driver {
       isMergeModule: Bool
   ) {
     // Add supplemental outputs.
-    func addSupplementalOutput(path: VirtualPath?, flag: String, type: FileType) {
+    func addSupplementalOutput(path: VirtualPath.Handle?, flag: String, type: FileType) {
       guard let path = path else { return }
 
       commandLine.appendFlag(flag)
-      commandLine.appendPath(path)
+      commandLine.appendPath(VirtualPath.lookup(path))
       outputs.append(.init(file: path, type: type))
     }
 
@@ -42,7 +42,7 @@ extension Driver {
       var path = dependenciesFilePath
       // FIXME: Hack to workaround the fact that SwiftPM/Xcode don't pass this path right now.
       if parsedOptions.getLastArgument(.emitDependenciesPath) == nil {
-        path = moduleOutputInfo.output!.outputPath.replacingExtension(with: .dependencies)
+        path = .constant(VirtualPath.lookup(moduleOutputInfo.output!.outputPath).replacingExtension(with: .dependencies))
       }
       addSupplementalOutput(path: path, flag: "-emit-dependencies-path", type: .dependencies)
     }
@@ -79,7 +79,7 @@ extension Driver {
     }
 
     commandLine.appendFlag(.o)
-    commandLine.appendPath(moduleOutputPath)
+    commandLine.appendPath(VirtualPath.lookup(moduleOutputPath))
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -33,7 +33,7 @@ extension Toolchain {
     let dummyInputPath = VirtualPath.temporaryWithKnownContents(.init("dummyInput.swift"),
                                                                 "".data(using: .utf8)!)
     commandLine.appendPath(dummyInputPath)
-    inputs.append(TypedVirtualPath(file: dummyInputPath, type: .swift))
+    inputs.append(TypedVirtualPath(file: .constant(dummyInputPath), type: .swift))
     
     return Job(
       moduleName: "",
@@ -43,7 +43,7 @@ extension Toolchain {
       displayInputs: [],
       inputs: inputs,
       primaryInputs: [],
-      outputs: [.init(file: .standardOutput, type: .jsonCompilerFeatures)],
+      outputs: [.init(file: .constant(.standardOutput), type: .jsonCompilerFeatures)],
       requiresInPlaceExecution: requiresInPlaceExecution,
       supportsResponseFiles: false
     )

--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -30,7 +30,7 @@ extension Driver {
       displayInputs: [],
       inputs: inputs,
       primaryInputs: [],
-      outputs: [.init(file: outputPath, type: .dSYM)]
+      outputs: [.init(file: .constant(outputPath), type: .dSYM)]
     )
   }
 }

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -31,8 +31,8 @@ extension Driver {
     if parsedOptions.hasArgument(.serializeDiagnostics), let outputDirectory = parsedOptions.getLastArgument(.pchOutputDir)?.asSingle {
       commandLine.appendFlag(.serializeDiagnosticsPath)
       let path: VirtualPath
-      if let outputPath = outputFileMap?.existingOutput(inputFile: input.file, outputType: .diagnostics) {
-        path = outputPath
+      if let outputPath = outputFileMap?.existingOutput(inputFile: input.fileHandle, outputType: .diagnostics) {
+        path = VirtualPath.lookup(outputPath)
       } else if let modulePath = parsedOptions.getLastArgument(.emitModulePath) {
         // TODO: does this hash need to be persistent?
         let code = UInt(bitPattern: modulePath.asSingle.hashValue)
@@ -43,7 +43,7 @@ extension Driver {
         path = .temporary(RelativePath(input.file.basenameWithoutExt.appendingFileTypeExtension(.diagnostics)))
       }
       commandLine.appendPath(path)
-      outputs.append(.init(file: path, type: .diagnostics))
+      outputs.append(.init(file: .constant(path), type: .diagnostics))
     }
 
     inputs.append(input)

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -34,12 +34,12 @@ extension Driver {
     // Compute the output file.
     let output: TypedVirtualPath
     if let outputArg = parsedOptions.getLastArgument(.o) {
-      output = .init(file: try VirtualPath(path: outputArg.asSingle),
+      output = .init(file: try .constant(VirtualPath(path: outputArg.asSingle)),
                      type: .pcm)
     } else {
       output = .init(
-        file: try VirtualPath(
-          path: moduleOutputInfo.name.appendingFileTypeExtension(.pcm)),
+        file: try .constant(VirtualPath(
+          path: moduleOutputInfo.name.appendingFileTypeExtension(.pcm))),
         type: .pcm)
     }
 

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -144,7 +144,7 @@ extension GenericUnixToolchain {
         }
       }
 
-      let swiftrtPath = targetInfo.runtimeResourcePath.path
+      let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
         .appending(
           components: targetTriple.platformName() ?? "",
           String(majorArchitectureName(for: targetTriple)),
@@ -178,7 +178,7 @@ extension GenericUnixToolchain {
 
       if let path = targetInfo.sdkPath?.path {
         commandLine.appendFlag("--sysroot")
-        commandLine.appendPath(path)
+        commandLine.appendPath(VirtualPath.lookup(path))
       }
 
       // Add the runtime library link paths.
@@ -190,7 +190,7 @@ extension GenericUnixToolchain {
       // Link the standard library. In two paths, we do this using a .lnk file
       // if we're going that route, we'll set `linkFilePath` to the path to that
       // file.
-      var linkFilePath: VirtualPath? = targetInfo.runtimeResourcePath.path
+      var linkFilePath: VirtualPath? = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
         .appending(component: targetTriple.platformName() ?? "")
 
       if staticExecutable {
@@ -229,7 +229,7 @@ extension GenericUnixToolchain {
       }
 
       if parsedOptions.hasArgument(.profileGenerate) {
-        let libProfile = targetInfo.runtimeResourcePath.path
+        let libProfile = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
           .appending(components: "clang", "lib", targetTriple.osName,
                                  "libclang_rt.profile-\(targetTriple.archName).a")
         commandLine.appendPath(libProfile)

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -73,7 +73,7 @@ extension Driver {
       displayInputs: inputs,
       inputs: inputs,
       primaryInputs: [],
-      outputs: [.init(file: outputFile, type: .image)]
+      outputs: [.init(file: .constant(outputFile), type: .image)]
     )
   }
 }

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -72,7 +72,7 @@ extension Driver {
     }
 
     commandLine.appendFlag(.o)
-    commandLine.appendPath(moduleOutputInfo.output!.outputPath)
+    commandLine.appendPath(VirtualPath.lookup(moduleOutputInfo.output!.outputPath))
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
+++ b/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
@@ -33,7 +33,7 @@ extension Driver {
       commandLine: commandLine,
       inputs: [moduleInput],
       primaryInputs: [],
-      outputs: [.init(file: outputPath, type: .object)],
+      outputs: [.init(file: .constant(outputPath), type: .object)],
       supportsResponseFiles: true
     )
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -533,17 +533,17 @@ extension Driver {
         guard moduleId.moduleName != dependencyGraph.mainModuleName else {
           continue
         }
-        let modulePath = moduleInfo.modulePath
+        let modulePath = VirtualPath.lookup(moduleInfo.modulePath.path)
         // Only update paths on modules which do not already specify a path beyond their module name
         // and a file extension.
-        if modulePath.path.description == moduleId.moduleName + ".swiftmodule" ||
-            modulePath.path.description == moduleId.moduleName + ".pcm" {
+        if modulePath.description == moduleId.moduleName + ".swiftmodule" ||
+            modulePath.description == moduleId.moduleName + ".pcm" {
           // Use VirtualPath to get the OS-specific path separators right.
           let modulePathInCache =
             try VirtualPath(path: moduleCachePath!)
-              .appending(component: modulePath.path.description)
+              .appending(component: modulePath.description)
           dependencyGraph.modules[moduleId]!.modulePath =
-            TextualVirtualPath(path: modulePathInCache)
+            TextualVirtualPath(path: .constant(modulePathInCache))
         }
       }
     }

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -168,7 +168,7 @@ extension Toolchain {
       displayInputs: [],
       inputs: [],
       primaryInputs: [],
-      outputs: [.init(file: .standardOutput, type: .jsonTargetInfo)],
+      outputs: [.init(file: .constant(.standardOutput), type: .jsonTargetInfo)],
       requiresInPlaceExecution: requiresInPlaceExecution,
       supportsResponseFiles: false
     )

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -34,7 +34,7 @@ extension DarwinToolchain {
   public func platformSpecificInterpreterEnvironmentVariables(
     env: [String : String],
     parsedOptions: inout ParsedOptions,
-    sdkPath: VirtualPath?,
+    sdkPath: VirtualPath.Handle?,
     targetInfo: FrontendTargetInfo) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
@@ -62,7 +62,7 @@ extension GenericUnixToolchain {
   public func platformSpecificInterpreterEnvironmentVariables(
     env: [String : String],
     parsedOptions: inout ParsedOptions,
-    sdkPath: VirtualPath?,
+    sdkPath: VirtualPath.Handle?,
     targetInfo: FrontendTargetInfo) throws -> [String: String] {
     var envVars: [String: String] = [:]
 

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -24,7 +24,7 @@ extension Toolchain {
     for targetInfo: FrontendTargetInfo,
     parsedOptions: inout ParsedOptions
   ) throws -> VirtualPath {
-    return targetInfo.runtimeResourcePath.path
+    return VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
       .appending(components: "clang", "lib",
                  targetInfo.target.triple.platformName(conflatingDarwin: true)!)
   }
@@ -32,11 +32,11 @@ extension Toolchain {
   func runtimeLibraryPaths(
     for targetInfo: FrontendTargetInfo,
     parsedOptions: inout ParsedOptions,
-    sdkPath: VirtualPath?,
+    sdkPath: VirtualPath.Handle?,
     isShared: Bool
   ) throws -> [VirtualPath] {
     let triple = targetInfo.target.triple
-    let resourceDirPath = targetInfo.runtimeResourcePath.path.appending(component: triple.platformName() ?? "")
+    let resourceDirPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path).appending(component: triple.platformName() ?? "")
     var result = [resourceDirPath]
 
     let secondaryResourceDir = computeSecondaryResourceDirPath(for: triple, primaryPath: resourceDirPath)
@@ -44,7 +44,7 @@ extension Toolchain {
       result.append(path)
     }
 
-    if let sdkPath = sdkPath {
+    if let sdkPath = sdkPath.map(VirtualPath.lookup) {
       // If we added the secondary resource dir, we also need the iOSSupport directory.
       if secondaryResourceDir != nil {
         result.append(sdkPath.appending(components: "System", "iOSSupport", "usr", "lib", "swift"))
@@ -103,7 +103,7 @@ extension DarwinToolchain {
     // Link compatibility libraries, if we're deploying back to OSes that
     // have an older Swift runtime.
     func addArgsForBackDeployLib(_ libName: String) throws {
-      let backDeployLibPath = targetInfo.runtimeResourcePath.path
+      let backDeployLibPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
         .appending(components: targetTriple.platformName() ?? "", libName)
       if try fileSystem.exists(backDeployLibPath) {
         commandLine.append(.flag("-force_load"))

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -24,7 +24,7 @@ extension Driver {
     if let output = serializedDiagnosticsFilePath {
       outputFile = TypedVirtualPath(file: output, type: .diagnostics)
     } else {
-      outputFile = TypedVirtualPath(file: interfaceInput.file.replacingExtension(with: .diagnostics),
+      outputFile = TypedVirtualPath(file: .constant(interfaceInput.file.replacingExtension(with: .diagnostics)),
                                     type: .diagnostics)
     }
 

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -78,7 +78,7 @@ extension WebAssemblyToolchain {
         isShared: false
       )
 
-      let swiftrtPath = targetInfo.runtimeResourcePath.path
+      let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
         .appending(
           components: targetTriple.platformName() ?? "",
           targetTriple.archName,
@@ -100,7 +100,7 @@ extension WebAssemblyToolchain {
 
       if let path = targetInfo.sdkPath?.path {
         commandLine.appendFlag("--sysroot")
-        commandLine.appendPath(path)
+        commandLine.appendPath(VirtualPath.lookup(path))
       }
 
       // Add the runtime library link paths.
@@ -110,7 +110,7 @@ extension WebAssemblyToolchain {
       }
 
       // Link the standard library.
-      let linkFilePath: VirtualPath = targetInfo.runtimeResourcePath.path
+      let linkFilePath: VirtualPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
         .appending(
           components: targetTriple.platformName() ?? "",
           "static-executable-args.lnk"

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -88,7 +88,7 @@ private extension SwiftScan {
 
     // Decode module path and source file locations
     let modulePathStr = try toSwiftString(api.swiftscan_module_info_get_module_path(moduleInfoRef))
-    let modulePath = TextualVirtualPath(path: try VirtualPath(path: modulePathStr))
+    let modulePath = TextualVirtualPath(path: try VirtualPath.intern(path: modulePathStr))
     let sourceFiles: [String]?
     if let sourceFilesSetRef = api.swiftscan_module_info_get_source_files(moduleInfoRef) {
       sourceFiles = try toSwiftStringArray(sourceFilesSetRef.pointee)
@@ -270,7 +270,7 @@ private extension SwiftScan {
                               -> swiftscan_string_ref_t)
   throws -> TextualVirtualPath? {
     let strDetail = try getOptionalStringDetail(from: detailsRef, using: query)
-    return strDetail != nil ? TextualVirtualPath(path: try VirtualPath(path: strDetail!)) : nil
+    return strDetail != nil ? TextualVirtualPath(path: try VirtualPath.intern(path: strDetail!)) : nil
   }
 
   /// From a `swiftscan_module_details_t` reference, extract a `String?` detail using the specified API query
@@ -291,7 +291,7 @@ private extension SwiftScan {
                      fieldName: String)
   throws -> TextualVirtualPath {
     let strDetail = try getStringDetail(from: detailsRef, using: query, fieldName: fieldName)
-    return TextualVirtualPath(path: try VirtualPath(path: strDetail))
+    return TextualVirtualPath(path: try VirtualPath.intern(path: strDetail))
   }
 
   /// From a `swiftscan_module_details_t` reference, extract a `String` detail using the specified API query,
@@ -314,7 +314,7 @@ private extension SwiftScan {
     guard let strArrDetail = try getOptionalStringArrayDetail(from: detailsRef, using: query) else {
       return nil
     }
-    return try strArrDetail.map { TextualVirtualPath(path: try VirtualPath(path: $0)) }
+    return try strArrDetail.map { TextualVirtualPath(path: try VirtualPath.intern(path: $0)) }
   }
 
   /// From a `swiftscan_module_details_t` reference, extract a `[String]?` detail using the specified API query

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -287,11 +287,11 @@ import SwiftOptions
   // SDK info is computed lazily. This should not generally be accessed directly.
   private var _sdkInfo: DarwinSDKInfo? = nil
 
-  func getTargetSDKInfo(sdkPath: VirtualPath) -> DarwinSDKInfo? {
+  func getTargetSDKInfo(sdkPath: VirtualPath.Handle) -> DarwinSDKInfo? {
     if let info = _sdkInfo {
       return info
     } else {
-      let sdkSettingsPath = sdkPath.appending(component: "SDKSettings.json")
+      let sdkSettingsPath = VirtualPath.lookup(sdkPath).appending(component: "SDKSettings.json")
       guard let contents = try? fileSystem.readFileContents(sdkSettingsPath) else { return nil }
       guard let sdkInfo = try? JSONDecoder().decode(DarwinSDKInfo.self,
                                                     from: Data(contents.contents)) else { return nil }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -88,7 +88,7 @@ public enum Tool: Hashable {
   func platformSpecificInterpreterEnvironmentVariables(
     env: [String: String],
     parsedOptions: inout ParsedOptions,
-    sdkPath: VirtualPath?,
+    sdkPath: VirtualPath.Handle?,
     targetInfo: FrontendTargetInfo) throws -> [String: String]
 
   func addPlatformSpecificCommonFrontendOptions(

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -134,7 +134,7 @@ import SwiftOptions
 
   public func platformSpecificInterpreterEnvironmentVariables(env: [String : String],
                                                               parsedOptions: inout ParsedOptions,
-                                                              sdkPath: VirtualPath?,
+                                                              sdkPath: VirtualPath.Handle?,
                                                               targetInfo: FrontendTargetInfo) throws -> [String : String] {
     throw Error.interactiveModeUnsupportedForTarget(targetInfo.target.triple.triple)
   }

--- a/Sources/SwiftDriver/Utilities/TypedVirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/TypedVirtualPath.swift
@@ -12,13 +12,17 @@
 /// A path for which the type of the input is known.
 public struct TypedVirtualPath: Hashable, Codable {
   /// The file this input refers to.
-  public let file: VirtualPath
+  public let fileHandle: VirtualPath.Handle
 
   /// The type of file we are working with.
   public let type: FileType
 
-  public init(file: VirtualPath, type: FileType) {
-    self.file = file
+  public var file: VirtualPath {
+    return VirtualPath.lookup(self.fileHandle)
+  }
+  
+  public init(file: VirtualPath.Handle, type: FileType) {
+    self.fileHandle = file
     self.type = type
   }
 }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -21,7 +21,7 @@ private func checkExplicitModuleBuildJob(job: Job,
                                          pcmArgs: [String],
                                          moduleId: ModuleDependencyId,
                                          dependencyOracle: InterModuleDependencyOracle,
-                                         pcmFileEncoder: (ModuleInfo, [String]) -> VirtualPath)
+                                         pcmFileEncoder: (ModuleInfo, [String]) -> VirtualPath.Handle)
 throws {
   let moduleInfo = dependencyOracle.getExternalModuleInfo(of: moduleId)!
   var downstreamPCMArgs = pcmArgs
@@ -39,7 +39,7 @@ throws {
           let typedCandidatePath = TypedVirtualPath(file: candidatePath,
                                                     type: .swiftModule)
           XCTAssertTrue(job.inputs.contains(typedCandidatePath))
-          XCTAssertTrue(job.commandLine.contains(.path(candidatePath)))
+          XCTAssertTrue(job.commandLine.contains(.path(VirtualPath.lookup(candidatePath))))
         }
         XCTAssertTrue(job.commandLine.filter {$0 == .flag("-candidate-module-file")}.count == compiledCandidateList.count)
       }
@@ -70,7 +70,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
                                                      pcmArgs: [String],
                                                      moduleInfo : ModuleInfo,
                                                      dependencyOracle: InterModuleDependencyOracle,
-                                                     pcmFileEncoder: (ModuleInfo, [String]) -> VirtualPath
+                                                     pcmFileEncoder: (ModuleInfo, [String]) -> VirtualPath.Handle
 ) throws {
   for dependencyId in moduleInfo.directDependencies! {
     let dependencyInfo = dependencyOracle.getExternalModuleInfo(of: dependencyId)!
@@ -179,7 +179,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       for job in modulePrebuildJobs {
         XCTAssertEqual(job.outputs.count, 1)
         XCTAssertFalse(driver.isExplicitMainModuleJob(job: job))
-        let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath in
+        let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath.Handle in
           try! driver.explicitDependencyBuildPlanner!.targetEncodedClangModuleFilePath(for: moduleInfo,
                                                                                        hashParts: hashParts)
         }
@@ -336,7 +336,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       if driver.targetTriple.isDarwin {
         pcmArgs9.append(contentsOf: ["-Xcc", "-fapinotes-swift-version=5"])
       }
-      let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath in
+      let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath.Handle in
         try! driver.explicitDependencyBuildPlanner!.targetEncodedClangModuleFilePath(for: moduleInfo,
                                                                                      hashParts: hashParts)
       }
@@ -479,7 +479,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       if driver.targetTriple.isDarwin {
         pcmArgs9.append(contentsOf: ["-Xcc", "-fapinotes-swift-version=5"])
       }
-      let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath in
+      let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath.Handle in
         try! driver.explicitDependencyBuildPlanner!.targetEncodedClangModuleFilePath(for: moduleInfo,
                                                                                      hashParts: hashParts)
       }

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -53,13 +53,13 @@ extension ModuleDependencyGraph {
 
 extension TypedVirtualPath {
   init(mockInput i: Int) {
-    self.init(file: try! VirtualPath(path: "\(i).swift"), type: .swift)
+    self.init(file: try! VirtualPath.intern(path: "\(i).swift"), type: .swift)
   }
 }
 
 extension DependencySource {
   init(mock i: Int) {
-    self.init(try! VirtualPath(path: String(i) + "." + FileType.swiftDeps.rawValue))!
+    self.init(try! VirtualPath.intern(path: String(i) + "." + FileType.swiftDeps.rawValue))!
   }
 
   var mockID: Int {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -70,7 +70,7 @@ final class NonincrementalCompilationTests: XCTestCase {
   func testReadBinarySourceFileDependencyGraph() throws {
     let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
                                                          for: "main.swiftdeps"))
-    let dependencySource = DependencySource(VirtualPath.absolute(absolutePath))!
+    let dependencySource = DependencySource(.constant(.absolute(absolutePath)))!
     let graph = try XCTUnwrap(
       try SourceFileDependencyGraph(
         contentsOf: dependencySource,
@@ -119,7 +119,7 @@ final class NonincrementalCompilationTests: XCTestCase {
                                                          for: "hello.swiftdeps"))
     let graph = try XCTUnwrap(
       try SourceFileDependencyGraph(
-        contentsOf: DependencySource(VirtualPath.absolute(absolutePath))!,
+        contentsOf: DependencySource(.constant(.absolute(absolutePath)))!,
         on: localFileSystem))
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)
@@ -173,7 +173,7 @@ final class NonincrementalCompilationTests: XCTestCase {
     let data = try localFileSystem.readFileContents(absolutePath)
     let graph = try XCTUnwrap(
       try SourceFileDependencyGraph(data: data,
-                                    from: DependencySource(.absolute(absolutePath))!,
+                                    from: DependencySource(.constant(.absolute(absolutePath)))!,
                                     fromSwiftModule: true))
     XCTAssertEqual(graph.majorVersion, 1)
     XCTAssertEqual(graph.minorVersion, 0)
@@ -890,7 +890,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       let sourcePath = path.appending(component: "main.swiftdeps")
       let data = try localFileSystem.readFileContents(sourcePath)
       let graph = try XCTUnwrap(SourceFileDependencyGraph(data: data,
-                                                          from: DependencySource(.absolute(sourcePath))!,
+                                                          from: DependencySource(.constant(.absolute(sourcePath)))!,
                                                           fromSwiftModule: false))
       XCTAssertEqual(graph.majorVersion, 1)
       XCTAssertEqual(graph.minorVersion, 0)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -70,7 +70,7 @@ final class NonincrementalCompilationTests: XCTestCase {
   func testReadBinarySourceFileDependencyGraph() throws {
     let absolutePath = try XCTUnwrap(Fixture.fixturePath(at: RelativePath("Incremental"),
                                                          for: "main.swiftdeps"))
-    let dependencySource = DependencySource(.constant(.absolute(absolutePath)))!
+    let dependencySource = DependencySource(VirtualPath.Handle.constant(.absolute(absolutePath)))!
     let graph = try XCTUnwrap(
       try SourceFileDependencyGraph(
         contentsOf: dependencySource,

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -116,8 +116,8 @@ final class JobExecutorTests: XCTestCase {
       ]
 
       let inputs: [String: TypedVirtualPath] = [
-        "foo" : .init(file: .relative(RelativePath( "foo.swift")), type: .swift),
-        "main": .init(file: .relative(RelativePath("main.swift")), type: .swift)
+        "foo" : .init(file: .constant(.relative(RelativePath( "foo.swift"))), type: .swift),
+        "main": .init(file: .constant(.relative(RelativePath("main.swift"))), type: .swift)
       ]
 
       let compileFoo = Job(
@@ -139,7 +139,7 @@ final class JobExecutorTests: XCTestCase {
         ],
         inputs: Array(inputs.values),
         primaryInputs: [inputs["foo"]!],
-        outputs: [.init(file: .temporary(RelativePath("foo.o")), type: .object)]
+        outputs: [.init(file: .constant(.temporary(RelativePath("foo.o"))), type: .object)]
       )
 
       let compileMain = Job(
@@ -161,7 +161,7 @@ final class JobExecutorTests: XCTestCase {
         ],
         inputs: Array(inputs.values),
         primaryInputs: [inputs["main"]!],
-        outputs: [.init(file: .temporary(RelativePath("main.o")), type: .object)]
+        outputs: [.init(file: .constant(.temporary(RelativePath("main.o"))), type: .object)]
       )
 
       let link = Job(
@@ -182,11 +182,11 @@ final class JobExecutorTests: XCTestCase {
           .path(.relative(RelativePath("main"))),
         ],
         inputs: [
-          .init(file: .temporary(RelativePath("foo.o")), type: .object),
-          .init(file: .temporary(RelativePath("main.o")), type: .object),
+          .init(file: .constant(.temporary(RelativePath("foo.o"))), type: .object),
+          .init(file: .constant(.temporary(RelativePath("main.o"))), type: .object),
         ],
         primaryInputs: [],
-        outputs: [.init(file: .relative(RelativePath("main")), type: .image)]
+        outputs: [.init(file: .constant(.relative(RelativePath("main"))), type: .image)]
       )
 
       let delegate = JobCollectingDelegate()
@@ -219,7 +219,7 @@ final class JobExecutorTests: XCTestCase {
       commandLine: [.flag("something")],
       inputs: [],
       primaryInputs: [],
-      outputs: [.init(file: .temporary(RelativePath("main")), type: .object)]
+      outputs: [.init(file: .constant(.temporary(RelativePath("main"))), type: .object)]
     )
 
     let delegate = JobCollectingDelegate()
@@ -283,7 +283,7 @@ final class JobExecutorTests: XCTestCase {
 
       XCTAssertThrowsError(try driver.run(jobs: jobs)) {
         XCTAssertEqual($0 as? Job.InputError,
-                       .inputUnexpectedlyModified(TypedVirtualPath(file: .absolute(main), type: .swift)))
+                       .inputUnexpectedlyModified(TypedVirtualPath(file: .constant(.absolute(main)), type: .swift)))
       }
 
     }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1417,7 +1417,7 @@ fileprivate extension DependencyKey {
 
 extension Job {
   init(_ dummyBaseName: String) {
-    let input = try! TypedVirtualPath(file: VirtualPath(path: dummyBaseName + ".swift"),
+    let input = try! TypedVirtualPath(file: VirtualPath.intern(path: dummyBaseName + ".swift"),
                                       type: .swift)
     try! self.init(moduleName: "nothing",
                    kind: .compile,
@@ -1425,7 +1425,7 @@ extension Job {
                    commandLine: [],
                    inputs:  [input],
                    primaryInputs: [input],
-                   outputs: [TypedVirtualPath(file: VirtualPath(path: dummyBaseName + ".swiftdeps"), type: .swiftDeps)])
+                   outputs: [TypedVirtualPath(file: VirtualPath.intern(path: dummyBaseName + ".swiftdeps"), type: .swiftDeps)])
   }
 
 }


### PR DESCRIPTION
Combines better prior recovery, hash caching, and VirtualPath interning. *Very* preliminary measurement shows 14% less user time for a null-compilation with priors (with incremental imports), compared to the legacy driver. 11% less real time.

Marked DNM because the history needs to be cleaned up, or else this PR should be broken up into separate ones.

Thoughts?

EDIT: The history isn't as bad as I thought. @CodaFi , Do you want to merge the interning PR? If so, the 2nd commit in this one might help.