### PR TITLE
Remove VirtualPath's Hashable Conformance

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -485,7 +485,7 @@ public struct Driver {
     if shouldUseInputFileList {
       let swiftInputs = inputFiles.filter(\.type.isPartOfSwiftCompilation)
       let path = RelativePath(createTemporaryFileName(prefix: "sources"))
-      self.allSourcesFileList = .fileList(path, .list(swiftInputs.map(\.file)))
+      self.allSourcesFileList = .fileList(path, .list(swiftInputs.map(\.fileHandle)))
     } else {
       self.allSourcesFileList = nil
     }
@@ -1038,7 +1038,7 @@ extension Driver {
 
   private func printBindings(_ job: Job) {
     stdoutStream <<< #"# ""# <<< targetTriple.triple
-    stdoutStream <<< #"" - ""# <<< job.tool.basename
+    stdoutStream <<< #"" - ""# <<< VirtualPath.lookup(job.tool).basename
     stdoutStream <<< #"", inputs: ["#
     stdoutStream <<< job.displayInputs.map { "\"" + $0.file.name + "\"" }.joined(separator: ", ")
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -165,7 +165,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
       jobs.append(Job(
         moduleName: moduleId.moduleName,
         kind: .emitModule,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        tool: try toolchain.getToolPathHandle(.swiftCompiler),
         commandLine: commandLine,
         inputs: inputs,
         primaryInputs: [],
@@ -228,7 +228,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
         jobs.append(Job(
           moduleName: moduleId.moduleName,
           kind: .generatePCM,
-          tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+          tool: try toolchain.getToolPathHandle(.swiftCompiler),
           commandLine: commandLine,
           inputs: inputs,
           primaryInputs: [],

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -29,7 +29,7 @@ internal extension Driver {
     // Construct the scanning job.
     return Job(moduleName: moduleOutputInfo.name,
                kind: .scanDependencies,
-               tool: VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler)),
+               tool: try toolchain.getToolPathHandle(.swiftCompiler),
                commandLine: commandLine,
                displayInputs: inputs,
                inputs: inputs,
@@ -266,7 +266,7 @@ internal extension Driver {
     // Construct the scanning job.
     return Job(moduleName: moduleOutputInfo.name,
                kind: .scanDependencies,
-               tool: VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler)),
+               tool: try toolchain.getToolPathHandle(.swiftCompiler),
                commandLine: commandLine,
                displayInputs: inputs,
                inputs: inputs,

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -427,12 +427,12 @@ extension OutputFileMap {
 // MARK: SourceFiles
 @_spi(Testing) public struct SourceFiles {
   let currentInOrder: [TypedVirtualPath]
-  private let previous: Set<VirtualPath>
-  let disappeared: [VirtualPath]
+  private let previous: Set<VirtualPath.Handle>
+  let disappeared: [VirtualPath.Handle]
 
   init(inputFiles: [TypedVirtualPath], buildRecord: BuildRecord?) {
     self.currentInOrder = inputFiles.filter {$0.type == .swift}
-    let currentSet = Set(currentInOrder.map {$0.file} )
+    let currentSet = Set(currentInOrder.map {$0.fileHandle} )
     self.previous = buildRecord.map {
       Set($0.inputInfos.keys)
     } ?? Set()
@@ -440,7 +440,7 @@ extension OutputFileMap {
     self.disappeared = previous.filter {!currentSet.contains($0)}
   }
 
-  func isANewInput(_ file: VirtualPath) -> Bool {
+  func isANewInput(_ file: VirtualPath.Handle) -> Bool {
     !previous.contains(file)
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -84,7 +84,7 @@ extension IncrementalCompilationState {
           reporter.report(
             "Incremental compilation has been disabled, " +
               " because  the following inputs were used in the previous compilation but not in this one: "
-              + sourceFiles.disappeared.map {$0.basename} .joined(separator: ", "))
+              + sourceFiles.disappeared.map {VirtualPath.lookup($0).basename} .joined(separator: ", "))
         }
         return nil
       }
@@ -349,7 +349,7 @@ extension IncrementalCompilationState.InitialStateComputer {
       let input = group.primaryInput
       let modDate = buildRecordInfo.compilationInputModificationDates[input]
         ?? Date.distantFuture
-      let inputInfo = outOfDateBuildRecord.inputInfos[input.file]
+      let inputInfo = outOfDateBuildRecord.inputInfos[input.fileHandle]
       let previousCompilationStatus = inputInfo?.status ?? .newlyAdded
       let previousModTime = inputInfo?.previousModTime
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -108,7 +108,7 @@ extension ModuleDependencyGraph {
     input: TypedVirtualPath
   ) -> TransitivelyInvalidatedInputSet? {
     // do not try to read swiftdeps of a new input
-    if info.sourceFiles.isANewInput(input.file) {
+    if info.sourceFiles.isANewInput(input.fileHandle) {
       return TransitivelyInvalidatedInputSet()
     }
     return collectInputsRequiringCompilationAfterProcessing(

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -43,7 +43,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .autolinkExtract,
-      tool: .absolute(try toolchain.getToolPath(.swiftAutolinkExtract)),
+      tool: try toolchain.getToolPathHandle(.swiftAutolinkExtract),
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -68,7 +68,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .backend,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       displayInputs: inputs,
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -101,7 +101,7 @@ extension Array where Element == Job.ArgTemplate {
 
     case .joined:
       if option.attributes.contains(.argumentIsPath) {
-        append(.joinedOptionAndPath(option.spelling, try VirtualPath(path: argument.asSingle)))
+        append(.joinedOptionAndPathHandle(option.spelling, try VirtualPath.intern(path: argument.asSingle)))
       } else {
         appendFlag(option.spelling + argument.asSingle)
       }
@@ -171,12 +171,12 @@ extension Array where Element == Job.ArgTemplate {
       switch $0 {
         case .flag(let string):
           return string.spm_shellEscaped()
-        case .path(let path):
-          return path.name.spm_shellEscaped()
-      case .responseFilePath(let path):
-        return "@\(path.name.spm_shellEscaped())"
-      case let .joinedOptionAndPath(option, path):
-        return option.spm_shellEscaped() + path.name.spm_shellEscaped()
+        case .pathHandle(let path):
+          return VirtualPath.lookup(path).name.spm_shellEscaped()
+      case .responseFilePathHandle(let path):
+        return "@\(VirtualPath.lookup(path).name.spm_shellEscaped())"
+      case let .joinedOptionAndPathHandle(option, path):
+        return option.spm_shellEscaped() + VirtualPath.lookup(path).name.spm_shellEscaped()
       case let .squashedArgumentList(option, args):
         return (option + args.joinedUnresolvedArguments).spm_shellEscaped()
       }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -122,7 +122,7 @@ extension Driver {
       // primary file list
       commandLine.appendFlag(.primaryFilelist)
       let path = RelativePath(createTemporaryFileName(prefix: "primaryInputs"))
-      commandLine.appendPath(.fileList(path, .list(primaryInputs.map(\.file))))
+      commandLine.appendPath(.fileList(path, .list(primaryInputs.map(\.fileHandle))))
     }
 
     let isTopLevel = isTopLevelOutput(type: outputType)
@@ -297,7 +297,7 @@ extension Driver {
     if primaryOutputs.count > fileListThreshold {
       commandLine.appendFlag(.outputFilelist)
       let path = RelativePath(createTemporaryFileName(prefix: "outputs"))
-      commandLine.appendPath(.fileList(path, .list(primaryOutputs.map { $0.file })))
+      commandLine.appendPath(.fileList(path, .list(primaryOutputs.map { $0.fileHandle })))
     } else {
       for primaryOutput in primaryOutputs {
         commandLine.appendFlag(.o)
@@ -310,7 +310,7 @@ extension Driver {
       if primaryIndexUnitOutputs.count > fileListThreshold {
         commandLine.appendFlag(.indexUnitOutputPathFilelist)
         let path = RelativePath(createTemporaryFileName(prefix: "index-unit-outputs"))
-        commandLine.appendPath(.fileList(path, .list(primaryIndexUnitOutputs.map { $0.file })))
+        commandLine.appendPath(.fileList(path, .list(primaryIndexUnitOutputs.map { $0.fileHandle })))
       } else {
         for primaryIndexUnitOutput in primaryIndexUnitOutputs {
           commandLine.appendFlag(.indexUnitOutputPath)
@@ -366,7 +366,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .compile,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       displayInputs: primaryInputs,
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -252,16 +252,16 @@ extension DarwinToolchain {
     if shouldUseInputFileList {
       commandLine.appendFlag(.filelist)
       let path = RelativePath(createTemporaryFileName(prefix: "inputs", suffix: "LinkFileList"))
-      var inputPaths = [VirtualPath]()
+      var inputPaths = [VirtualPath.Handle]()
       var inputModules = [VirtualPath]()
       for input in inputs {
         if input.type == .swiftModule && linkerOutputType != .staticLibrary {
-          inputPaths.append(input.file)
+          inputPaths.append(input.fileHandle)
           inputModules.append(input.file)
         } else if input.type == .object {
-          inputPaths.append(input.file)
+          inputPaths.append(input.fileHandle)
         } else if input.type == .llvmBitcode {
-          inputPaths.append(input.file)
+          inputPaths.append(input.fileHandle)
         }
       }
       commandLine.appendPath(.fileList(path, .list(inputPaths)))

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -84,7 +84,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .emitModule,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -38,7 +38,7 @@ extension Toolchain {
     return Job(
       moduleName: "",
       kind: .emitSupportedFeatures,
-      tool: .absolute(try getToolPath(.swiftCompiler)),
+      tool: try getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -25,7 +25,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .generateDSYM,
-      tool: .absolute(try toolchain.getToolPath(.dsymutil)),
+      tool: try toolchain.getToolPathHandle(.dsymutil),
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -64,7 +64,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .generatePCH,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -55,7 +55,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .generatePCM,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -43,7 +43,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .interpret,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -43,23 +43,35 @@ public struct Job: Codable, Equatable, Hashable {
     case flag(String)
 
     /// Represents a virtual path on disk.
-    case path(VirtualPath)
+    case pathHandle(VirtualPath.Handle)
 
     /// Represents a response file path prefixed by '@'.
-    case responseFilePath(VirtualPath)
+    case responseFilePathHandle(VirtualPath.Handle)
 
     /// Represents a joined option+path combo.
-    case joinedOptionAndPath(String, VirtualPath)
+    case joinedOptionAndPathHandle(String, VirtualPath.Handle)
 
     /// Represents a list of arguments squashed together and passed as a single argument.
     case squashedArgumentList(option: String, args: [ArgTemplate])
+
+    public static func path(_ path: VirtualPath) -> ArgTemplate {
+      return .pathHandle(path.intern())
+    }
+
+    public static func responseFilePath(_ path: VirtualPath) -> ArgTemplate {
+      return .responseFilePathHandle(path.intern())
+    }
+
+    public static func joinedOptionAndPath(_ option: String, _ path: VirtualPath) -> ArgTemplate {
+      return .joinedOptionAndPathHandle(option, path.intern())
+    }
   }
 
   /// The Swift module this job involves.
   public var moduleName: String
 
   /// The tool to invoke.
-  public var tool: VirtualPath
+  public var tool: VirtualPath.Handle
 
   /// The command-line arguments of the job.
   public var commandLine: [ArgTemplate]
@@ -97,7 +109,7 @@ public struct Job: Codable, Equatable, Hashable {
   public init(
     moduleName: String,
     kind: Kind,
-    tool: VirtualPath,
+    tool: VirtualPath.Handle,
     commandLine: [ArgTemplate],
     displayInputs: [TypedVirtualPath]? = nil,
     inputs: [TypedVirtualPath],
@@ -264,13 +276,13 @@ extension Job.ArgTemplate: Codable {
     case let .flag(a1):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .flag)
       try unkeyedContainer.encode(a1)
-    case let .path(a1):
+    case let .pathHandle(a1):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .path)
       try unkeyedContainer.encode(a1)
-    case let .responseFilePath(a1):
+    case let .responseFilePathHandle(a1):
       var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .responseFilePath)
       try unkeyedContainer.encode(a1)
-    case let .joinedOptionAndPath(option, path):
+    case let .joinedOptionAndPathHandle(option, path):
       var keyedContainer = container.nestedContainer(
         keyedBy: CodingKeys.JoinedOptionAndPathCodingKeys.self,
         forKey: .joinedOptionAndPath)
@@ -307,8 +319,8 @@ extension Job.ArgTemplate: Codable {
       let keyedValues = try values.nestedContainer(
         keyedBy: CodingKeys.JoinedOptionAndPathCodingKeys.self,
         forKey: .joinedOptionAndPath)
-      self = .joinedOptionAndPath(try keyedValues.decode(String.self, forKey: .option),
-                                  try keyedValues.decode(VirtualPath.self, forKey: .path))
+      self = .joinedOptionAndPathHandle(try keyedValues.decode(String.self, forKey: .option),
+                                        try keyedValues.decode(VirtualPath.Handle.self, forKey: .path))
     case .squashedArgumentList:
       let keyedValues = try values.nestedContainer(
         keyedBy: CodingKeys.SquashedArgumentListCodingKeys.self,

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -68,7 +68,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .link,
-      tool: .absolute(toolPath),
+      tool: VirtualPath.absolute(toolPath).intern(),
       commandLine: commandLine,
       displayInputs: inputs,
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -27,7 +27,7 @@ extension Driver {
     if shouldUseInputFileList {
       commandLine.appendFlag(.filelist)
       let path = RelativePath(createTemporaryFileName(prefix: "inputs"))
-      commandLine.appendPath(.fileList(path, .list(inputsFromOutputs.map { $0.file })))
+      commandLine.appendPath(.fileList(path, .list(inputsFromOutputs.map { $0.fileHandle })))
       inputs.append(contentsOf: inputsFromOutputs)
       
       for input in providedInputs {
@@ -77,7 +77,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .mergeModule,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
+++ b/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
@@ -29,7 +29,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .moduleWrap,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       inputs: [moduleInput],
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -573,7 +573,7 @@ extension Driver {
       return Job(
         moduleName: moduleOutputInfo.name,
         kind: .versionRequest,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        tool: try toolchain.getToolPathHandle(.swiftCompiler),
         commandLine: [.flag("--version")],
         inputs: [],
         primaryInputs: [],
@@ -589,7 +589,7 @@ extension Driver {
       return Job(
         moduleName: moduleOutputInfo.name,
         kind: .help,
-        tool: .absolute(try toolchain.getToolPath(.swiftHelp)),
+        tool: try toolchain.getToolPathHandle(.swiftHelp),
         commandLine: commandLine,
         inputs: [],
         primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -163,7 +163,7 @@ extension Toolchain {
     return Job(
       moduleName: "",
       kind: .printTargetInfo,
-      tool: .absolute(try getToolPath(.swiftCompiler)),
+      tool: try getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       displayInputs: [],
       inputs: [],

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -26,7 +26,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .repl,
-      tool: .absolute(try toolchain.getToolPath(.lldb)),
+      tool: try toolchain.getToolPathHandle(.lldb),
       commandLine: lldbCommandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
@@ -23,7 +23,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .verifyDebugInfo,
-      tool: .absolute(try toolchain.getToolPath(.dwarfdump)),
+      tool: VirtualPath.absolute(try toolchain.getToolPath(.dwarfdump)).intern(),
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -31,7 +31,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .verifyModuleInterface,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: try toolchain.getToolPathHandle(.swiftCompiler),
       commandLine: commandLine,
       displayInputs: [interfaceInput],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -91,7 +91,7 @@ extension WebAssemblyToolchain {
         if input.type == .autolink {
           return .responseFilePath(input.file)
         } else if input.type == .object {
-          return .path(input.file)
+          return .pathHandle(input.fileHandle)
         } else {
           return nil
         }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -196,6 +196,10 @@ extension Toolchain {
     inputs: inout [TypedVirtualPath],
     frontendTargetInfo: FrontendTargetInfo
   ) throws {}
+
+  public func getToolPathHandle(_ tool: Tool) throws -> VirtualPath.Handle {
+    return try VirtualPath.absolute(self.getToolPath(tool)).intern()
+  }
 }
 
 @_spi(Testing) public enum ToolchainError: Swift.Error {

--- a/Sources/SwiftDriver/Utilities/DOTJobGraphSerializer.swift
+++ b/Sources/SwiftDriver/Utilities/DOTJobGraphSerializer.swift
@@ -37,7 +37,7 @@ import TSCBasic
     if let count = kindCounter[job.kind] {
       label += " \(count)"
     }
-    label += " (\(findToolName(job.tool)))"
+    label += " (\(findToolName(VirtualPath.lookup(job.tool))))"
     kindCounter[job.kind, default: 0] += 1
     return label
   }

--- a/Sources/SwiftDriver/Utilities/FileList.swift
+++ b/Sources/SwiftDriver/Utilities/FileList.swift
@@ -14,7 +14,7 @@ import Foundation
 
 public enum FileList: Hashable {
   /// File of file paths
-  case list([VirtualPath])
+  case list([VirtualPath.Handle])
   /// YAML OutputFileMap
   case outputFileMap(OutputFileMap)
 }
@@ -30,7 +30,7 @@ extension FileList: Codable {
     let key = try container.decode(Key.self)
     switch key {
     case .list:
-      let contents = try container.decode([VirtualPath].self)
+      let contents = try container.decode([VirtualPath.Handle].self)
       self = .list(contents)
     case .outputFileMap:
       let map = try container.decode(OutputFileMap.self)

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -17,7 +17,7 @@ import Darwin
 #endif
 
 /// A virtual path.
-public enum VirtualPath: Hashable {
+public enum VirtualPath {
   private static var pathCache = PathCache()
 
   /// A relative path that has not been resolved based on the current working
@@ -200,7 +200,9 @@ public enum VirtualPath: Hashable {
       return self
     }
   }
+}
 
+extension VirtualPath: Equatable {
   public static func == (lhs: VirtualPath, rhs: VirtualPath) -> Bool {
     switch (lhs, rhs) {
     case (.standardOutput, .standardOutput), (.standardInput, .standardInput):

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -82,11 +82,11 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
         XCTAssert(job.commandLine.contains(explicitDepsFlag))
         let jsonDepsPathIndex = job.commandLine.firstIndex(of: explicitDepsFlag)
         let jsonDepsPathArg = job.commandLine[jsonDepsPathIndex! + 1]
-        guard case .path(let jsonDepsPath) = jsonDepsPathArg else {
+        guard case .pathHandle(let jsonDepsHandle) = jsonDepsPathArg else {
           XCTFail("No JSON dependency file path found.")
           return
         }
-        guard case let .temporaryWithKnownContents(_, contents) = jsonDepsPath else {
+        guard case let .temporaryWithKnownContents(_, contents) = VirtualPath.lookup(jsonDepsHandle) else {
           XCTFail("Unexpected path type")
           return
         }
@@ -103,12 +103,12 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
         XCTAssert(job.commandLine.contains(explicitDepsFlag))
         let jsonDepsPathIndex = job.commandLine.firstIndex(of: explicitDepsFlag)
         let jsonDepsPathArg = job.commandLine[jsonDepsPathIndex! + 1]
-        guard case .path(let jsonDepsPath) = jsonDepsPathArg else {
+        guard case .pathHandle(let jsonDepsHandle) = jsonDepsPathArg else {
           XCTFail("No JSON dependency file path found.")
           return
         }
         let contents =
-          try localFileSystem.readFileContents(jsonDepsPath.absolutePath!)
+          try localFileSystem.readFileContents(VirtualPath.lookup(jsonDepsHandle).absolutePath!)
         let dependencyInfoList = try JSONDecoder().decode(Array<SwiftModuleArtifactInfo>.self,
                                                       from: Data(contents.contents))
         let dependencyArtifacts =

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -30,13 +30,13 @@ final class NonincrementalCompilationTests: XCTestCase {
                        Date(legacyDriverSecsAndNanos: [1570318779, 32358000]))
     try XCTAssertEqual(buildRecord.inputInfos,
                        [
-                        VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"):
+                        VirtualPath.intern(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"):
                           InputInfo(status: .needsCascadingBuild,
                                     previousModTime: Date(legacyDriverSecsAndNanos: [1570318778, 0])),
-                        VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"):
+                        VirtualPath.intern(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"):
                           InputInfo(status: .upToDate,
                                     previousModTime: Date(legacyDriverSecsAndNanos: [1570083660, 0])),
-                        VirtualPath(path: "/Volumes/gazorp.swift"):
+                        VirtualPath.intern(path: "/Volumes/gazorp.swift"):
                           InputInfo(status: .needsNonCascadingBuild,
                                     previousModTime:  Date(legacyDriverSecsAndNanos: [0, 0]))
                        ])
@@ -55,13 +55,13 @@ final class NonincrementalCompilationTests: XCTestCase {
                        Date(legacyDriverSecsAndNanos: [1570318779, 32358000]))
     try XCTAssertEqual(buildRecord.inputInfos,
                        [
-                        VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"):
+                        VirtualPath.intern(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"):
                           InputInfo(status: .needsCascadingBuild,
                                     previousModTime: Date(legacyDriverSecsAndNanos: [1570318778, 0])),
-                        VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"):
+                        VirtualPath.intern(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"):
                           InputInfo(status: .upToDate,
                                     previousModTime: Date(legacyDriverSecsAndNanos: [1570083660, 0])),
-                        VirtualPath(path: "/Volumes/gazorp.swift"):
+                        VirtualPath.intern(path: "/Volumes/gazorp.swift"):
                           InputInfo(status: .needsNonCascadingBuild,
                                     previousModTime:  Date(legacyDriverSecsAndNanos: [0, 0]))
                        ])
@@ -225,20 +225,20 @@ final class NonincrementalCompilationTests: XCTestCase {
     XCTAssert(isCloseEnough(buildRecord.buildTime.legacyDriverSecsAndNanos,
                             [1570318779, 32357931]))
 
-    XCTAssertEqual(try! buildRecord.inputInfos[VirtualPath(path: file2 )]!.status,
+    XCTAssertEqual(try! buildRecord.inputInfos[VirtualPath.intern(path: file2 )]!.status,
                    .needsCascadingBuild)
     XCTAssert(try! isCloseEnough(
-                XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: file2 )])
+                XCTUnwrap(buildRecord.inputInfos[VirtualPath.intern(path: file2 )])
                   .previousModTime.legacyDriverSecsAndNanos,
                 [1570318778, 0]))
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp)]).status,
+    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath.intern(path: gazorp)]).status,
                    .needsNonCascadingBuild)
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp)])
+    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath.intern(path: gazorp)])
                     .previousModTime.legacyDriverSecsAndNanos,
                    [0, 0])
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main  )]).status,
+    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath.intern(path: main  )]).status,
                    .upToDate)
-    XCTAssert(try! isCloseEnough(XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main  )])
+    XCTAssert(try! isCloseEnough(XCTUnwrap(buildRecord.inputInfos[VirtualPath.intern(path: main  )])
                                    .previousModTime.legacyDriverSecsAndNanos,
                                  [1570083660, 0]))
 

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -110,9 +110,9 @@ final class JobExecutorTests: XCTestCase {
 
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       resolver.pathMapping = [
-        .relative(RelativePath("foo.swift")): foo.pathString,
-        .relative(RelativePath("main.swift")): main.pathString,
-        .relative(RelativePath("main")): exec.pathString,
+        VirtualPath.relative(RelativePath("foo.swift")).intern(): foo.pathString,
+        VirtualPath.relative(RelativePath("main.swift")).intern(): main.pathString,
+        VirtualPath.relative(RelativePath("main")).intern(): exec.pathString,
       ]
 
       let inputs: [String: TypedVirtualPath] = [
@@ -123,7 +123,7 @@ final class JobExecutorTests: XCTestCase {
       let compileFoo = Job(
         moduleName: "main",
         kind: .compile,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        tool: try toolchain.getToolPathHandle(.swiftCompiler),
         commandLine: [
           "-frontend",
           "-c",
@@ -145,7 +145,7 @@ final class JobExecutorTests: XCTestCase {
       let compileMain = Job(
         moduleName: "main",
         kind: .compile,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        tool: try toolchain.getToolPathHandle(.swiftCompiler),
         commandLine: [
           "-frontend",
           "-c",
@@ -167,7 +167,7 @@ final class JobExecutorTests: XCTestCase {
       let link = Job(
         moduleName: "main",
         kind: .link,
-        tool: .absolute(try toolchain.getToolPath(.dynamicLinker)),
+        tool: try toolchain.getToolPathHandle(.dynamicLinker),
         commandLine: [
           .path(.temporary(RelativePath("foo.o"))),
           .path(.temporary(RelativePath("main.o"))),
@@ -215,7 +215,7 @@ final class JobExecutorTests: XCTestCase {
     let job = Job(
       moduleName: "main",
       kind: .compile,
-      tool: .absolute(AbsolutePath("/usr/bin/swift")),
+      tool: VirtualPath.absolute(AbsolutePath("/usr/bin/swift")).intern(),
       commandLine: [.flag("something")],
       inputs: [],
       primaryInputs: [],
@@ -296,7 +296,7 @@ final class JobExecutorTests: XCTestCase {
                                            env: [:])
     let job = Job(moduleName: "Module",
                   kind: .compile,
-                  tool: .absolute(.init("/path/to/the tool")),
+                  tool: VirtualPath.absolute(.init("/path/to/the tool")).intern(),
                   commandLine: [.path(.absolute(.init("/with space"))),
                                 .path(.absolute(.init("/withoutspace")))],
                   inputs: [], primaryInputs: [], outputs: [])

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1421,7 +1421,7 @@ extension Job {
                                       type: .swift)
     try! self.init(moduleName: "nothing",
                    kind: .compile,
-                   tool: VirtualPath(path: ""),
+                   tool: VirtualPath.intern(path: ""),
                    commandLine: [],
                    inputs:  [input],
                    primaryInputs: [input],


### PR DESCRIPTION
This conformance was quite expensive. Remove it to force future authors to use VirtualPath.Handle.

This patch is performance-neutral.