### PR TITLE
Perform Input Modification Checks At the End of the Build

### DIFF
--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -648,7 +648,7 @@ extension TSCBasic.FileSystem {
     try resolvingVirtualPath(path, apply: exists)
   }
 
-  func lastModificationTime(for file: VirtualPath) throws -> Date {
+  public func lastModificationTime(for file: VirtualPath) throws -> Date {
     try resolvingVirtualPath(file) { path in
       #if os(macOS)
       var s = Darwin.stat()

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -323,9 +323,12 @@ final class JobExecutorTests: XCTestCase {
           $0 <<< "let bar = 3"
         }
 
-        // FIXME: It's unfortunate we diagnose this twice, once for each job which uses the input.
         verifier.expect(.error("input file '\(other.description)' was modified during the build"))
-        verifier.expect(.error("input file '\(other.description)' was modified during the build"))
+        // There's a tool-specific linker error that usually happens here from
+        // whatever job runs last - probably the linker.
+        // It's no use testing for a particular error message, let's just make
+        // sure we emit the diagnostic we need.
+        verifier.permitUnexpected(.error)
         XCTAssertThrowsError(try driver.run(jobs: jobs))
       }
     }


### PR DESCRIPTION
Also deduplicate them while we're at it. We don't need to ask each job for its input set, we just need to check the same set of files we recorded mod times for in the first place. This saves a quadratic amount of disk I/O and syscalls in the incremental and non-batch builds, which can be a huge wall time savings for large compiles.

In the incremental stress test, 15 seconds are just gone from total wall time. Total user time spent in stating files went from 7 seconds to 20 milliseconds!