### PR TITLE
[Test] Harden Explicit Module Build test

### DIFF
--- a/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
@@ -4,5 +4,4 @@
 @_exported import G
 import Swift
 public func overlayFuncG() { }
-let stringG : String = "Build"
 #endif

--- a/TestInputs/ExplicitModuleBuilds/Swift/Swift.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/Swift.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.4-dev (LLVM bd2476a8056e227, Swift 68ac381af6ca0e3)
+// swift-module-flags: -disable-objc-attr-requires-foundation-module -target x86_64-apple-macosx10.9 -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -enable-experimental-concise-pound-file -module-name Swift
+import SwiftShims

--- a/TestInputs/ExplicitModuleBuilds/Swift/SwiftOnoneSupport.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/SwiftOnoneSupport.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.4-dev (LLVM bd2476a8056e227, Swift 68ac381af6ca0e3)
+// swift-module-flags: -disable-objc-attr-requires-foundation-module -target x86_64-apple-macosx10.9 -enable-objc-interop -enable-library-evolution -module-link-name swiftSwiftOnoneSupport -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -module-name SwiftOnoneSupport
+import Swift


### PR DESCRIPTION
Make sure we always find the stdlib on Darwin, and use custom "fake" interfaces for stdlib and OnoneSupport in the dependency scanning test.