### PR TITLE
Add an option that causes individual `swift-frontend` invocations to emit parseable output, instead of the driver.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -503,6 +503,7 @@ public struct Driver {
                                fileSystem: fileSystem,
                                workingDirectory: workingDirectory,
                                diagnosticEngine: diagnosticEngine)
+    Self.validateParseableOutputArgs(&parsedOptions, diagnosticEngine: diagnosticEngine)
     Self.validateCompilationConditionArgs(&parsedOptions, diagnosticEngine: diagnosticEngine)
     Self.validateFrameworkSearchPathArgs(&parsedOptions, diagnosticEngine: diagnosticEngine)
     Self.validateCoverageArgs(&parsedOptions, diagnosticsEngine: diagnosticEngine)
@@ -2089,6 +2090,14 @@ extension Driver {
           diagnosticEngine.emit(Error.missingProfilingData(profilingData))
         }
       }
+    }
+  }
+
+  static func validateParseableOutputArgs(_ parsedOptions: inout ParsedOptions,
+                                          diagnosticEngine: DiagnosticsEngine) {
+    if parsedOptions.contains(.parseableOutput) &&
+        parsedOptions.contains(.useFrontendParseableOutput) {
+      diagnosticEngine.emit(Error.conflictingOptions(.parseableOutput, .useFrontendParseableOutput))
     }
   }
 

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -242,6 +242,11 @@ extension Driver {
       commandLine.appendFlags("-module-name", moduleOutputInfo.name)
     }
 
+    // Enable frontend Parseable-output, if needed.
+    if parsedOptions.contains(.useFrontendParseableOutput) {
+      commandLine.appendFlag("-frontend-parseable-output")
+    }
+
     try toolchain.addPlatformSpecificCommonFrontendOptions(commandLine: &commandLine,
                                                            inputs: &inputs,
                                                            frontendTargetInfo: frontendTargetInfo)

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -13,8 +13,9 @@ extension Option {
   public static let driverPrintGraphviz: Option = Option("-driver-print-graphviz", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Write the job graph as a graphviz file", group: .internalDebug)
   public static let driverExplicitModuleBuild: Option = Option("-experimental-explicit-module-build", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
   public static let driverScanDependenciesNonLib: Option = Option("-nonlib-dependency-scanner", .flag, attributes: [.helpHidden], helpText: "Use calls to `swift-frontend -scan-dependencies` instead of dedicated dependency scanning library")
-  public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver.")
+  public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver")
   public static let emitModuleSeparately: Option = Option("-experimental-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job")
+  public static let useFrontendParseableOutput: Option = Option("-use-frontend-parseable-output", .flag, attributes: [.helpHidden], helpText: "Emit parseable-output from swift-frontend jobs instead of from the driver")
 
   public static var extraOptions: [Option] {
     return [
@@ -22,7 +23,8 @@ extension Option {
       Option.driverExplicitModuleBuild,
       Option.driverScanDependenciesNonLib,
       Option.driverWarnUnusedOptions,
-      Option.emitModuleSeparately
+      Option.emitModuleSeparately,
+      Option.useFrontendParseableOutput
     ]
   }
 }


### PR DESCRIPTION

Resolves rdar://75787629