### PR TITLE
[Integrated Tests] Invoke `lit.py` using python3

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2338,7 +2338,8 @@ extension Driver {
     }
 
     var appliesToFetchingTargetInfo: Bool {
-      return overridePath?.basename != "Python"
+      return overridePath?.basename != "Python" &&
+             overridePath?.basename != "python3"
     }
     func setUpForTargetInfo(_ toolchain: Toolchain) {
       if !appliesToFetchingTargetInfo {

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -215,7 +215,7 @@ final class IntegrationTests: IntegrationTestCase {
       printCommand(args: commandArgs, extraEnv: extraEnv)
 
       let process = TSCBasic.Process(
-        arguments: args,
+        arguments: commandArgs,
         environment: ProcessEnv.vars.merging(extraEnv) { $1 },
         outputRedirection: .none
       )

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -23,6 +23,10 @@ private func bundleRoot() -> AbsolutePath {
 
 private let packageDirectory = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
 
+// The "default" here means lit.py will be invoked as an executable, while otherwise let's use
+// python 3 explicitly.
+private let pythonExec = ProcessEnv.vars.keys.contains("SWIFT_DRIVER_INTEGRATION_TESTS_USE_PYTHON_DEFAULT") ? "" : "python3"
+
 func makeDriverSymlinks(
   in tempDir: AbsolutePath,
   with swiftBuildDir: AbsolutePath? = nil
@@ -199,6 +203,7 @@ final class IntegrationTests: IntegrationTestCase {
         "--param", "swift_driver",
         testDir.pathString
       ]
+      let commandArgs = pythonExec.isEmpty ? args : [pythonExec] + args
 
       let extraEnv = [
         "SWIFT": swift.pathString,
@@ -207,7 +212,7 @@ final class IntegrationTests: IntegrationTestCase {
         "LC_ALL": "en_US.UTF-8"
       ]
 
-      printCommand(args: args, extraEnv: extraEnv)
+      printCommand(args: commandArgs, extraEnv: extraEnv)
 
       let process = TSCBasic.Process(
         arguments: args,


### PR DESCRIPTION
Also provides an escape hatch to invoke with the system default (just launching `lit.py` as a standalone script executable)

LLVM is transitioning its script infrastructure to python3 and we may run into issues if we continue using the system-default python2 on some platforms.
Resolves rdar://75848017