### PR TITLE
[Parsable Output] Break down batch compile jobs into constituent messages

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1018,6 +1018,7 @@ extension Driver {
       buildRecordInfo: buildRecordInfo,
       incrementalCompilationState: incrementalCompilationState,
       showJobLifecycle: showJobLifecycle,
+      argsResolver: executor.resolver,
       diagnosticEngine: diagnosticEngine)
   }
 

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -24,6 +24,15 @@ import Glibc
 
 /// Delegate for printing execution information on the command-line.
 final class ToolExecutionDelegate: JobExecutionDelegate {
+  /// Quasi-PIDs are _negative_ PID-like unique keys used to
+  /// masquerade batch job constituents as (quasi)processes, when writing
+  /// parseable output to consumers that don't understand the idea of a batch
+  /// job. They are negative in order to avoid possibly colliding with real
+  /// PIDs (which are always positive). We start at -1000 here as a crude but
+  /// harmless hedge against colliding with an errno value that might slip
+  /// into the stream of real PIDs (say, due to a TaskQueue bug).
+  static let QUASI_PID_START = -1000
+
   public enum Mode {
     case verbose
     case parsableOutput
@@ -35,19 +44,25 @@ final class ToolExecutionDelegate: JobExecutionDelegate {
   public let incrementalCompilationState: IncrementalCompilationState?
   public let showJobLifecycle: Bool
   public let diagnosticEngine: DiagnosticsEngine
-
   public var anyJobHadAbnormalExit: Bool = false
+
+  private var nextBatchQuasiPID: Int
+  private let argsResolver: ArgsResolver
+  private var batchJobInputQuasiPIDMap = DictionaryOfDictionaries<Job, TypedVirtualPath, Int>()
 
   init(mode: ToolExecutionDelegate.Mode,
        buildRecordInfo: BuildRecordInfo?,
        incrementalCompilationState: IncrementalCompilationState?,
        showJobLifecycle: Bool,
+       argsResolver: ArgsResolver,
        diagnosticEngine: DiagnosticsEngine) {
     self.mode = mode
     self.buildRecordInfo = buildRecordInfo
     self.incrementalCompilationState = incrementalCompilationState
     self.showJobLifecycle = showJobLifecycle
     self.diagnosticEngine = diagnosticEngine
+    self.argsResolver = argsResolver
+    self.nextBatchQuasiPID = ToolExecutionDelegate.QUASI_PID_START
   }
 
   public func jobStarted(job: Job, arguments: [String], pid: Int) {
@@ -61,23 +76,124 @@ final class ToolExecutionDelegate: JobExecutionDelegate {
       stdoutStream <<< arguments.map { $0.spm_shellEscaped() }.joined(separator: " ") <<< "\n"
       stdoutStream.flush()
     case .parsableOutput:
-
-      // Compute the outputs for the message.
-      let outputs: [BeganMessage.Output] = job.outputs.map {
-        .init(path: $0.file.name, type: $0.type.description)
+      let beganMessages = constructJobBeganMessages(job: job, arguments: arguments, pid: pid)
+      for beganMessage in beganMessages {
+        let message = ParsableMessage(name: job.kind.rawValue, kind: .began(beganMessage))
+        emit(message)
       }
-
-      let beganMessage = BeganMessage(
-        pid: pid,
-        inputs: job.displayInputs.map{ $0.file.name },
-        outputs: outputs,
-        commandExecutable: arguments[0],
-        commandArguments: arguments[1...].map { String($0) }
-      )
-
-      let message = ParsableMessage(name: job.kind.rawValue, kind: .began(beganMessage))
-      emit(message)
     }
+  }
+
+  public func constructJobBeganMessages(job: Job, arguments: [String], pid: Int) -> [BeganMessage] {
+    let result : [BeganMessage]
+    if job.kind == .compile {
+      if job.primaryInputs.count == 1 {
+        result = [constructSingleBeganMessage(inputs: job.displayInputs,
+                                              outputs: job.outputs,
+                                              arguments: arguments,
+                                              pid: pid,
+                                              realPid: pid)]
+      } else {
+        // Batched compile jobs need to be broken up into multiple messages, one per constituent.
+        result = constructBatchCompileBeginMessages(job: job, arguments: arguments, pid: pid,
+                                                        quasiPIDBase: nextBatchQuasiPID)
+        nextBatchQuasiPID -= result.count
+      }
+    } else {
+      result = [constructSingleBeganMessage(inputs: job.displayInputs,
+                                            outputs: job.outputs,
+                                            arguments: arguments,
+                                            pid: pid,
+                                            realPid: pid)]
+    }
+
+    return result
+  }
+
+  public func constructBatchCompileBeginMessages(job: Job, arguments: [String],
+                                                 pid: Int, quasiPIDBase: Int) -> [BeganMessage] {
+    precondition(job.kind == .compile && job.primaryInputs.count > 1)
+    var quasiPID = quasiPIDBase
+    var result : [BeganMessage] = []
+    for input in job.primaryInputs {
+      let outputs = job.getCompileInputOutputs(for: input) ?? []
+      let outputPaths = outputs.map {
+        TypedVirtualPath(file: try! VirtualPath.intern(path: argsResolver.resolve(.path($0.file))),
+                         type: $0.type)
+      }
+      result.append(
+        constructSingleBeganMessage(inputs: [input],
+                                    outputs: outputPaths,
+                                    arguments: Self.filterPrimaryArguments(in: arguments,
+                                                                           input: input,
+                                                                           outputs: outputPaths),
+                                    pid: quasiPID,
+                                    realPid: pid))
+      // Save the quasiPID of this job/input combination in order to generate the correct
+      // `finished` message
+      batchJobInputQuasiPIDMap[(job, input)] = quasiPID
+      quasiPID -= 1
+    }
+    return result
+  }
+
+  public func constructSingleBeganMessage(inputs: [TypedVirtualPath],
+                                          outputs: [TypedVirtualPath],
+                                          arguments: [String],
+                                          pid: Int,
+                                          realPid: Int) -> BeganMessage {
+
+    let outputs: [BeganMessage.Output] = outputs.map {
+      .init(path: $0.file.name, type: $0.type.description)
+    }
+
+    return BeganMessage(
+      pid: pid,
+      realPid: realPid,
+      inputs: inputs.map{ $0.file.name },
+      outputs: outputs,
+      commandExecutable: arguments[0],
+      commandArguments: arguments[1...].map { String($0) }
+    )
+  }
+
+
+  /// Best-effort attempt to "fix-up" the individual swift-frontend invocation command line, to pretend
+  /// it is an individual single-primary compile job, rather than a batch mode compile with multiple primaries
+  private static func filterPrimaryArguments(in arguments: [String],
+                                             input: TypedVirtualPath,
+                                             outputs: [TypedVirtualPath]) -> [String] {
+    // We must have only one `-primary-file` option specified, the one that corresponds
+    // to the primary file whose job this message is faking.
+    var result = arguments.enumerated().compactMap() { index, element -> String? in
+      if element == "-primary-file" {
+        assert(arguments.count > index + 1)
+        return arguments[index + 1].hasSuffix(input.file.basename) ? element : nil
+      }
+      return element
+    }
+
+    // We must have only one `-o` option specified, the one that corresponds
+    // to the primary output file for the current input, whose job this message is faking.
+    let outputPathStrings = outputs.map { $0.file.description }
+    var pathsToRemove : [String] = []
+    result = result.enumerated().compactMap() { index, element -> String? in
+      if element == "-o" {
+        assert(result.count > index + 1)
+        if outputPathStrings.contains(result[index + 1]) {
+          return element
+        } else {
+          pathsToRemove.append(result[index + 1])
+          return nil
+        }
+      }
+      if pathsToRemove.contains(element) {
+        return nil
+      }
+      return element
+    }
+
+    return result
   }
 
   public func jobFinished(job: Job, result: ProcessResult, pid: Int) {

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -23,14 +23,14 @@ import Glibc
 #endif
 
 /// Delegate for printing execution information on the command-line.
-final class ToolExecutionDelegate: JobExecutionDelegate {
+@_spi(Testing) public final class ToolExecutionDelegate: JobExecutionDelegate {
   /// Quasi-PIDs are _negative_ PID-like unique keys used to
   /// masquerade batch job constituents as (quasi)processes, when writing
   /// parseable output to consumers that don't understand the idea of a batch
   /// job. They are negative in order to avoid possibly colliding with real
   /// PIDs (which are always positive). We start at -1000 here as a crude but
   /// harmless hedge against colliding with an errno value that might slip
-  /// into the stream of real PIDs (say, due to a TaskQueue bug).
+  /// into the stream of real PIDs.
   static let QUASI_PID_START = -1000
 
   public enum Mode {
@@ -50,12 +50,12 @@ final class ToolExecutionDelegate: JobExecutionDelegate {
   private let argsResolver: ArgsResolver
   private var batchJobInputQuasiPIDMap = DictionaryOfDictionaries<Job, TypedVirtualPath, Int>()
 
-  init(mode: ToolExecutionDelegate.Mode,
-       buildRecordInfo: BuildRecordInfo?,
-       incrementalCompilationState: IncrementalCompilationState?,
-       showJobLifecycle: Bool,
-       argsResolver: ArgsResolver,
-       diagnosticEngine: DiagnosticsEngine) {
+  @_spi(Testing) public init(mode: ToolExecutionDelegate.Mode,
+                             buildRecordInfo: BuildRecordInfo?,
+                             incrementalCompilationState: IncrementalCompilationState?,
+                             showJobLifecycle: Bool,
+                             argsResolver: ArgsResolver,
+                             diagnosticEngine: DiagnosticsEngine) {
     self.mode = mode
     self.buildRecordInfo = buildRecordInfo
     self.incrementalCompilationState = incrementalCompilationState

--- a/Sources/SwiftDriver/Execution/ParsableOutput.swift
+++ b/Sources/SwiftDriver/Execution/ParsableOutput.swift
@@ -110,22 +110,24 @@ import Foundation
 @_spi(Testing) public struct FinishedMessage: Encodable {
   let exitStatus: Int
   let pid: Int
+  let process: ActualProcess
   let output: String?
-
-  // proc-info
 
   public init(
     exitStatus: Int,
+    output: String?,
     pid: Int,
-    output: String?
+    realPid: Int
   ) {
     self.exitStatus = exitStatus
     self.pid = pid
+    self.process = ActualProcess(realPid: realPid)
     self.output = output
   }
 
   private enum CodingKeys: String, CodingKey {
     case pid
+    case process
     case output
     case exitStatus = "exit-status"
   }
@@ -133,12 +135,14 @@ import Foundation
 
 @_spi(Testing) public struct SignalledMessage: Encodable {
   let pid: Int
+  let process: ActualProcess
   let output: String?
   let errorMessage: String
   let signal: Int
 
-  public init(pid: Int, output: String?, errorMessage: String, signal: Int) {
+  public init(pid: Int, realPid: Int, output: String?, errorMessage: String, signal: Int) {
     self.pid = pid
+    self.process = ActualProcess(realPid: realPid)
     self.output = output
     self.errorMessage = errorMessage
     self.signal = signal
@@ -146,6 +150,7 @@ import Foundation
 
   private enum CodingKeys: String, CodingKey {
     case pid
+    case process
     case output
     case errorMessage = "error-message"
     case signal

--- a/Sources/SwiftDriver/Execution/ParsableOutput.swift
+++ b/Sources/SwiftDriver/Execution/ParsableOutput.swift
@@ -39,6 +39,18 @@ import Foundation
   }
 }
 
+@_spi(Testing) public struct ActualProcess: Encodable {
+  public let realPid: Int
+
+  public init(realPid: Int) {
+    self.realPid = realPid
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case realPid = "real_pid"
+  }
+}
+
 @_spi(Testing) public struct BeganMessage: Encodable {
   public struct Output: Encodable {
     public let type: String
@@ -50,6 +62,7 @@ import Foundation
     }
   }
 
+  public let process: ActualProcess
   public let pid: Int
   public let inputs: [String]
   public let outputs: [Output]
@@ -58,12 +71,14 @@ import Foundation
 
   public init(
     pid: Int,
+    realPid: Int,
     inputs: [String],
     outputs: [Output],
     commandExecutable: String,
     commandArguments: [String]
   ) {
     self.pid = pid
+    self.process = ActualProcess(realPid: realPid)
     self.inputs = inputs
     self.outputs = outputs
     self.commandExecutable = commandExecutable
@@ -72,6 +87,7 @@ import Foundation
 
   private enum CodingKeys: String, CodingKey {
     case pid
+    case process
     case inputs
     case outputs
     case commandExecutable = "command_executable"

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -104,7 +104,7 @@ extension Driver {
   mutating func addCompileInputs(primaryInputs: [TypedVirtualPath],
                                  indexFilePath: TypedVirtualPath?,
                                  inputs: inout [TypedVirtualPath],
-                                 inputOutputMap: inout [TypedVirtualPath: TypedVirtualPath],
+                                 inputOutputMap: inout [TypedVirtualPath: [TypedVirtualPath]],
                                  outputType: FileType?,
                                  commandLine: inout [Job.ArgTemplate])
   -> ([TypedVirtualPath], [TypedVirtualPath]) {
@@ -178,7 +178,7 @@ extension Driver {
                                           outputType: outputType,
                                           isTopLevel: isTopLevel)
         primaryOutputs.append(output)
-        inputOutputMap[input] = output
+        inputOutputMap[input] = [output]
 
         if let indexUnitOut = computeIndexUnitOutput(for: input, outputType: outputType, topLevel: isTopLevel) {
           indexUnitOutputDiffers = true
@@ -197,7 +197,7 @@ extension Driver {
                                         outputType: outputType,
                                         isTopLevel: isTopLevel)
       primaryOutputs.append(output)
-      inputOutputMap[input] = output
+      inputOutputMap[input] = [output]
 
       if let indexUnitOut = computeIndexUnitOutput(for: input, outputType: outputType, topLevel: isTopLevel) {
         indexUnitOutputDiffers = true
@@ -226,7 +226,7 @@ extension Driver {
     var inputs: [TypedVirtualPath] = []
     var outputs: [TypedVirtualPath] = []
     // Used to map primaryInputs to primaryOutputs
-    var inputOutputMap = [TypedVirtualPath: TypedVirtualPath]()
+    var inputOutputMap = [TypedVirtualPath: [TypedVirtualPath]]()
 
     commandLine.appendFlag("-frontend")
     addCompileModeOption(outputType: outputType, commandLine: &commandLine)
@@ -265,7 +265,7 @@ extension Driver {
       commandLine: &commandLine,
       primaryInputs: primaryInputs,
       inputsGeneratingCodeCount: inputsGeneratingCodeCount,
-      inputOutputMap: inputOutputMap,
+      inputOutputMap: &inputOutputMap,
       includeModuleTracePath: emitModuleTrace,
       indexFilePath: indexFilePath)
 
@@ -372,6 +372,7 @@ extension Driver {
       inputs: inputs,
       primaryInputs: primaryInputs,
       outputs: outputs,
+      inputOutputMap: inputOutputMap,
       supportsResponseFiles: true
     )
   }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -94,6 +94,9 @@ public struct Job: Codable, Equatable, Hashable {
   /// The kind of job.
   public var kind: Kind
 
+  /// A map from a primary input to all of its corresponding outputs
+  private var compileInputOutputMap: [TypedVirtualPath : [TypedVirtualPath]]
+
   public init(
     moduleName: String,
     kind: Kind,
@@ -103,6 +106,7 @@ public struct Job: Codable, Equatable, Hashable {
     inputs: [TypedVirtualPath],
     primaryInputs: [TypedVirtualPath],
     outputs: [TypedVirtualPath],
+    inputOutputMap: [TypedVirtualPath : [TypedVirtualPath]] = [:],
     extraEnvironment: [String: String] = [:],
     requiresInPlaceExecution: Bool = false,
     supportsResponseFiles: Bool = false
@@ -115,6 +119,7 @@ public struct Job: Codable, Equatable, Hashable {
     self.inputs = inputs
     self.primaryInputs = primaryInputs
     self.outputs = outputs
+    self.compileInputOutputMap = inputOutputMap
     self.extraEnvironment = extraEnvironment
     self.requiresInPlaceExecution = requiresInPlaceExecution
     self.supportsResponseFiles = supportsResponseFiles
@@ -140,6 +145,15 @@ extension Job {
         throw InputError.inputUnexpectedlyModified(input)
       }
     }
+  }
+}
+
+extension Job {
+  // If the job's kind is `.compile`, serve a collection of Outputs corresponding
+  // to a given primary input.
+  public func getCompileInputOutputs(for input: TypedVirtualPath) -> [TypedVirtualPath]? {
+    assert(self.kind == .compile)
+    return compileInputOutputMap[input]
   }
 }
 

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -20,6 +20,7 @@ final class ParsableMessageTests: XCTestCase {
   func testBeganMessage() throws {
     let message = BeganMessage(
       pid: 1,
+      realPid: 1,
       inputs: ["/path/to/foo.swift"],
       outputs: [
       .init(path: "/path/to/foo.o", type: "object")
@@ -57,7 +58,7 @@ final class ParsableMessageTests: XCTestCase {
   }
 
   func testFinishedMessage() throws {
-    let message = FinishedMessage(exitStatus: 1, pid: 1, output: "hello")
+    let message = FinishedMessage(exitStatus: 1, output: "hello", pid: 1, realPid: 1)
     let finishedMessage = ParsableMessage(name: "compile", kind: .finished(message))
     let encoded = try finishedMessage.toJSON()
     let string = String(data: encoded, encoding: .utf8)!
@@ -74,7 +75,8 @@ final class ParsableMessageTests: XCTestCase {
   }
 
     func testSignalledMessage() throws {
-      let message = SignalledMessage(pid: 2, output: "sig", errorMessage: "err", signal: 3)
+      let message = SignalledMessage(pid: 2, realPid: 2, output: "sig",
+                                     errorMessage: "err", signal: 3)
       let signalledMessage = ParsableMessage(name: "compile", kind: .signalled(message))
       let encoded = try signalledMessage.toJSON()
       let string = String(data: encoded, encoding: .utf8)!

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -308,8 +308,6 @@ final class ParsableMessageTests: XCTestCase {
           let errorOutput = try localFileSystem.readFileContents(errorBuffer).description
           XCTAssertTrue(errorOutput.contains(
           """
-          {
-            \"error-message\" : \"Killed: 9\",
             \"kind\" : \"signalled\",
             \"name\" : \"compile\",
             \"pid\" : -1000,
@@ -321,8 +319,6 @@ final class ParsableMessageTests: XCTestCase {
           """))
           XCTAssertTrue(errorOutput.contains(
           """
-          {
-            \"error-message\" : \"Killed: 9\",
             \"kind\" : \"signalled\",
             \"name\" : \"compile\",
             \"pid\" : -1001,
@@ -334,8 +330,6 @@ final class ParsableMessageTests: XCTestCase {
           """))
           XCTAssertTrue(errorOutput.contains(
           """
-          {
-            \"error-message\" : \"Killed: 9\",
             \"kind\" : \"signalled\",
             \"name\" : \"compile\",
             \"pid\" : -1002,

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -151,13 +151,6 @@ final class ParsableMessageTests: XCTestCase {
           /// One per primary
           XCTAssertTrue(errorOutput.contains(
           """
-              \"-primary-file\",
-              \"\\/WorkDir\\/main.swift\",
-              \"\\/WorkDir\\/test1.swift\",
-              \"\\/WorkDir\\/test2.swift\",
-          """))
-          XCTAssertTrue(errorOutput.contains(
-          """
             "pid" : -1000,
           """))
           XCTAssertTrue(errorOutput.contains(
@@ -168,13 +161,6 @@ final class ParsableMessageTests: XCTestCase {
           """))
           XCTAssertTrue(errorOutput.contains(
           """
-              \"\\/WorkDir\\/main.swift\",
-              \"-primary-file\",
-              \"\\/WorkDir\\/test1.swift\",
-              \"\\/WorkDir\\/test2.swift\",
-          """))
-          XCTAssertTrue(errorOutput.contains(
-          """
             "pid" : -1001,
           """))
           XCTAssertTrue(errorOutput.contains(
@@ -182,13 +168,6 @@ final class ParsableMessageTests: XCTestCase {
             \"inputs\" : [
               \"\\/WorkDir\\/test1.swift\"
             ],
-          """))
-          XCTAssertTrue(errorOutput.contains(
-          """
-              \"\\/WorkDir\\/main.swift\",
-              \"\\/WorkDir\\/test1.swift\",
-              \"-primary-file\",
-              \"\\/WorkDir\\/test2.swift\",
           """))
           XCTAssertTrue(errorOutput.contains(
           """

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -52,7 +52,10 @@ final class ParsableMessageTests: XCTestCase {
             "type" : "object"
           }
         ],
-        "pid" : 1
+        "pid" : 1,
+        "process" : {
+          "real_pid" : 1
+        }
       }
       """)
   }
@@ -69,7 +72,10 @@ final class ParsableMessageTests: XCTestCase {
       "kind" : "finished",
       "name" : "compile",
       "output" : "hello",
-      "pid" : 1
+      "pid" : 1,
+      "process" : {
+        "real_pid" : 1
+      }
     }
     """)
   }
@@ -88,6 +94,9 @@ final class ParsableMessageTests: XCTestCase {
         "name" : "compile",
         "output" : "sig",
         "pid" : 2,
+        "process" : {
+          "real_pid" : 2
+        },
         "signal" : 3
       }
       """)


### PR DESCRIPTION
We have, historically, treated batch mode as an implementation detail of the compiler. As a consequence, we have been lying to clients of parsable-output by emitting multiple `began`, `finished`, `signalled` messages for each batch job - one message per primary input. The time has come to teach swift-driver to tell the same old lies. 

Emulating existing C++ driver behavior:
    - Cargo-cult the concept of a `quasiPID`
    (https://github.com/apple/swift/blob/main/include/swift/Basic/ParseableOutput.h#L36)
    - Break up one compile job with multiple primaries into multiple `[Began|Finished|Signalled]Message` messages
    - Collect `((job, primaryInput) -> quasiPID)` information to generate correct `Finished` messages
    - Fixup individual command lines of each `Began` message (w.r.t. `-o` and `-primary-input` options)
    - Make `InputOutputMap` a part of a `.compile` `Job`'s state so that we can later query which of its many outputs correspond to a specific primary

Resolves rdar://75636235
