### PR TITLE
Add `free()` workaround that causes error when built with some compiler versions.

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -360,5 +360,5 @@ func withArrayOfCStrings(_ strings: [String],
   let _ = unsafeCStrings.withUnsafeBufferPointer {
     action(UnsafeMutablePointer(mutating: $0.baseAddress))
   }
-  for ptr in cstrings { free(ptr) }
+  for ptr in cstrings { if let ptr = ptr { free(ptr) } }
 }


### PR DESCRIPTION
Otherwise some building compilers will see errors:
```
error: value of optional type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') must be unwrapped to a value of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>')
  for ptr in cstrings { free(ptr) }
```