### PR TITLE
Set dsym-job's output to be the primary output file + `.dSYM`

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -11,10 +11,18 @@
 //===----------------------------------------------------------------------===//
 
 extension Driver {
-  func generateDSYMJob(inputs: [TypedVirtualPath]) throws -> Job {
+  mutating func generateDSYMJob(inputs: [TypedVirtualPath]) throws -> Job {
     assert(inputs.count == 1)
     let input = inputs[0]
-    let outputPath = input.file.replacingExtension(with: .dSYM)
+
+    // Output is final output file + `.dSYM`
+    let outputFile: VirtualPath
+    if let output = parsedOptions.getLastArgument(.o) {
+      outputFile = try VirtualPath(path: output.asSingle)
+    } else {
+      outputFile = outputFileForImage
+    }
+    let outputPath = try VirtualPath(path: outputFile.description.appendingFileTypeExtension(.dSYM))
 
     var commandLine = [Job.ArgTemplate]()
     commandLine.appendPath(input.file)

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -12,7 +12,7 @@
 import TSCBasic
 
 extension Driver {
-  private var relativeOutputFileForImage: RelativePath {
+  internal var relativeOutputFileForImage: RelativePath {
     if inputFiles.count == 1 && moduleOutputInfo.nameIsFallback && inputFiles[0].file != .standardInput {
       return RelativePath(inputFiles[0].file.basenameWithoutExt)
     }
@@ -24,7 +24,7 @@ extension Driver {
   }
 
   /// Compute the output file for an image output.
-  private var outputFileForImage: VirtualPath {
+  internal var outputFileForImage: VirtualPath {
     return useWorkingDirectory(relativeOutputFileForImage)
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2859,6 +2859,17 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertTrue(cmd.contains(.path(try VirtualPath(path: "Test"))))
     }
+
+    do {
+      // dSYM generation (-g) with specified output file name with an extension
+      var driver = try Driver(args: commonArgs + ["-g", "-o", "a.out"])
+      let plannedJobs = try driver.planBuild()
+      let generateDSYMJob = plannedJobs.last!
+      if driver.targetTriple.isDarwin {
+        XCTAssertEqual(plannedJobs.count, 5)
+        XCTAssertEqual(generateDSYMJob.outputs.last?.file, try VirtualPath(path: "a.out.dSYM"))
+      }
+    }
   }
 
   func testEmitModuleTrace() throws {


### PR DESCRIPTION
Instead of taking the input file and replacing its extension with `.dSYM`.
This change causes the behavior to match what the C++ driver does and what LLDB expects.

Resolves rdar://76073797