### PR TITLE
[Merge Modules] Omit merge-modules job when only one input is given.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -392,6 +392,16 @@ extension Driver {
           !(moduleInputs.isEmpty && moduleInputsFromJobOutputs.isEmpty),
           compilerMode.usesPrimaryFileInputs
     else { return nil }
+
+    // If there is only 1 module input to this job and its path matches that which we intend
+    // to produce with this merge-modules job, skip it
+    let mergeOutput = moduleOutputInfo.output!.outputPath
+    if moduleInputs.count + moduleInputsFromJobOutputs.count == 1,
+       let soleInput = moduleInputs.first == nil ? moduleInputsFromJobOutputs.first : moduleInputs.first,
+       soleInput.fileHandle == mergeOutput {
+      return nil
+    }
+
     return try mergeModuleJob(inputs: moduleInputs, inputsFromOutputs: moduleInputsFromJobOutputs)
   }
 


### PR DESCRIPTION
And said input matches the expected output path.

Otherwise both the `.compile` and the `.mergeModule` jobs have an identical output:
`.temporary(<module_name>.swiftmodule)` which will trigger a fatal error in the MultiJobExecutor because it may cause LLBuild cycles downstream. 