### PR TITLE
Implement swift_build_sdk_interfaces.py using libSwiftDriver

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,9 @@ let package = Package(
     .executable(
       name: "swift-help",
       targets: ["swift-help"]),
+    .executable(
+      name: "swift-build-sdk-interfaces",
+      targets: ["swift-build-sdk-interfaces"]),
     .library(
       name: "SwiftDriver",
       targets: ["SwiftDriver"]),
@@ -92,6 +95,11 @@ let package = Package(
     .target(
       name: "swift-help",
       dependencies: ["SwiftOptions", "ArgumentParser", "SwiftToolsSupport-auto"]),
+
+    /// The help executable.
+    .target(
+      name: "swift-build-sdk-interfaces",
+      dependencies: ["SwiftDriver", "SwiftDriverExecution"]),
 
     /// The `makeOptions` utility (for importing option definitions).
     .target(

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(SwiftDriver
   Jobs/VerifyDebugInfoJob.swift
   Jobs/VerifyModuleInterfaceJob.swift
   Jobs/WebAssemblyToolchain+LinkerSupport.swift
+  Jobs/PrebuiltModulesJob.swift
 
   Toolchains/DarwinToolchain.swift
   Toolchains/GenericUnixToolchain.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -312,6 +312,23 @@ public struct Driver {
   /// A global queue for emitting non-interrupted messages into stderr
   public static let stdErrQueue = DispatchQueue(label: "org.swift.driver.emit-to-stderr")
 
+
+  lazy var sdkPath: VirtualPath? = {
+    guard let rawSdkPath = frontendTargetInfo.sdkPath?.path else {
+      return nil
+    }
+    return VirtualPath.lookup(rawSdkPath)
+  } ()
+
+  lazy var iosMacFrameworksSearchPath: VirtualPath = {
+    sdkPath!
+      .appending(component: "System")
+      .appending(component: "iOSSupport")
+      .appending(component: "System")
+      .appending(component: "Library")
+      .appending(component: "Frameworks")
+  } ()
+
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in
     stdErrQueue.sync {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -496,7 +496,7 @@ extension Driver {
     return try explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
   }
 
-  private mutating func gatherModuleDependencies()
+  mutating func gatherModuleDependencies()
   throws -> InterModuleDependencyGraph {
     var dependencyGraph = try performDependencyScan()
 
@@ -550,6 +550,7 @@ extension Driver {
   }
 
 }
+
 
 /// MARK: Planning
 extension Driver {

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -1,0 +1,297 @@
+//===----- PrebuiltModulesJob.swift - Swit prebuilt module Planning -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TSCBasic
+import SwiftOptions
+
+public struct PrebuiltModuleInput {
+  // The path to the input/output of the a module building task.
+  let path: TypedVirtualPath
+  // The arch infered from the file name.
+  let arch: Triple.Arch
+  init(_ path: TypedVirtualPath) {
+    let baseName = path.file.basename
+    let arch = baseName.prefix(upTo: baseName.firstIndex(where: { $0 == "-" || $0 == "." })!)
+    self.init(path, Triple.Arch.parse(arch)!)
+  }
+  init(_ path: TypedVirtualPath, _ arch: Triple.Arch) {
+    self.path = path
+    self.arch = arch
+  }
+}
+
+typealias PrebuiltModuleOutput = PrebuiltModuleInput
+
+public struct SDKPrebuiltModuleInputsCollector {
+  let sdkPath: AbsolutePath
+  let nonFrameworkDirs = [RelativePath("usr/lib/swift"),
+                          RelativePath("System/iOSSupport/usr/lib/swift")]
+  let frameworkDirs = [RelativePath("System/Library/Frameworks"),
+                      RelativePath("System/iOSSupport/System/Library/Frameworks")]
+  let sdkInfo: DarwinToolchain.DarwinSDKInfo
+  let diagEngine: DiagnosticsEngine
+  public init(_ sdkPath: AbsolutePath, _ diagEngine: DiagnosticsEngine) {
+    self.sdkPath = sdkPath
+    self.sdkInfo = DarwinToolchain.readSDKInfo(localFileSystem,
+                                               VirtualPath.absolute(sdkPath).intern())!
+    self.diagEngine = diagEngine
+  }
+
+  public var versionString: String {
+    return sdkInfo.versionString
+  }
+
+  // Returns a target triple that's proper to use with the given SDK path.
+  public var targetTriple: String {
+    let canonicalName = sdkInfo.canonicalName
+    func extractVersion(_ platform: String) -> Substring? {
+      if canonicalName.starts(with: platform) {
+        return canonicalName.suffix(from: canonicalName.index(canonicalName.startIndex,
+                                                              offsetBy: platform.count))
+      }
+      return nil
+    }
+
+    if let version = extractVersion("macosx") {
+      return "arm64-apple-macosx\(version)"
+    } else if let version = extractVersion("iphoneos") {
+      return "arm64-apple-ios\(version)"
+    } else if let version = extractVersion("iphonesimulator") {
+      return "arm64-apple-ios\(version)-simulator"
+    } else if let version = extractVersion("watchos") {
+      return "armv7k-apple-watchos\(version)"
+    } else if let version = extractVersion("watchsimulator") {
+      return "arm64-apple-watchos\(version)-simulator"
+    } else if let version = extractVersion("appletvos") {
+      return "arm64-apple-tvos\(version)"
+    } else if let version = extractVersion("appletvsimulator") {
+      return "arm64-apple-tvos\(version)-simulator"
+    } else {
+      diagEngine.emit(error: "unhandled platform name: \(canonicalName)")
+      return ""
+    }
+  }
+
+  private func sanitizeInterfaceMap(_ map: [String: [PrebuiltModuleInput]]) -> [String: [PrebuiltModuleInput]] {
+    return map.filter {
+      // Remove modules without associated .swiftinterface files and diagnose.
+      if $0.value.isEmpty {
+        diagEngine.emit(warning: "\($0.key) has no associated .swiftinterface files")
+        return false
+      }
+      return true
+    }
+  }
+
+  public func collectSwiftInterfaceMap() throws -> [String: [PrebuiltModuleInput]] {
+    var results: [String: [PrebuiltModuleInput]] = [:]
+
+    func updateResults(_ dir: AbsolutePath) throws {
+      if !localFileSystem.exists(dir) {
+        return
+      }
+      let moduleName = dir.basenameWithoutExt
+      if results[moduleName] == nil {
+        results[moduleName] = []
+      }
+
+      // Search inside a .swiftmodule directory for any .swiftinterface file, and
+      // add the files into the dictionary.
+      // Duplicate entries are discarded, otherwise llbuild will complain.
+      try localFileSystem.getDirectoryContents(dir).forEach {
+        let currentFile = AbsolutePath(dir, try VirtualPath(path: $0).relativePath!)
+        if currentFile.extension == "swiftinterface" {
+          let currentBaseName = currentFile.basenameWithoutExt
+          let interfacePath = TypedVirtualPath(file: VirtualPath.absolute(currentFile).intern(),
+                                               type: .swiftInterface)
+          if !results[moduleName]!.contains(where: { $0.path.file.basenameWithoutExt == currentBaseName }) {
+            results[moduleName]!.append(PrebuiltModuleInput(interfacePath))
+          }
+        }
+        if currentFile.extension == "swiftmodule" {
+          diagEngine.emit(warning: "found \(currentFile)")
+        }
+      }
+    }
+    // Search inside framework dirs in an SDK to find .swiftmodule directories.
+    for dir in frameworkDirs {
+      let frameDir = AbsolutePath(sdkPath, dir)
+      if !localFileSystem.exists(frameDir) {
+        continue
+      }
+      try localFileSystem.getDirectoryContents(frameDir).forEach {
+        let frameworkPath = try VirtualPath(path: $0)
+        if frameworkPath.extension != "framework" {
+          return
+        }
+        let moduleName = frameworkPath.basenameWithoutExt
+        let swiftModulePath = frameworkPath
+          .appending(component: "Modules")
+          .appending(component: moduleName + ".swiftmodule").relativePath!
+        try updateResults(AbsolutePath(frameDir, swiftModulePath))
+      }
+    }
+    // Search inside lib dirs in an SDK to find .swiftmodule directories.
+    for dir in nonFrameworkDirs {
+      let swiftModuleDir = AbsolutePath(sdkPath, dir)
+      if !localFileSystem.exists(swiftModuleDir) {
+        continue
+      }
+      try localFileSystem.getDirectoryContents(swiftModuleDir).forEach {
+        if $0.hasSuffix(".swiftmodule") {
+          try updateResults(AbsolutePath(swiftModuleDir, $0))
+        }
+      }
+    }
+    return sanitizeInterfaceMap(results)
+  }
+}
+
+extension Driver {
+
+  private mutating func generateSingleModuleBuildingJob(_ moduleName: String,  _ prebuiltModuleDir: AbsolutePath,
+                                                        _ inputPath: PrebuiltModuleInput, _ outputPath: PrebuiltModuleOutput,
+                                                        _ dependencies: [TypedVirtualPath]) throws -> Job {
+    assert(inputPath.path.file.basenameWithoutExt == outputPath.path.file.basenameWithoutExt)
+    func isIosMac(_ path: TypedVirtualPath) -> Bool {
+      // Infer macabi interfaces by the file name.
+      // FIXME: more robust way to do this.
+      return path.file.basenameWithoutExt.contains("macabi")
+    }
+    var commandLine: [Job.ArgTemplate] = []
+    commandLine.appendFlag(.compileModuleFromInterface)
+    commandLine.appendFlag(.sdk)
+    commandLine.append(.path(sdkPath!))
+    commandLine.appendFlag(.prebuiltModuleCachePath)
+    commandLine.appendPath(prebuiltModuleDir)
+    commandLine.appendFlag(.moduleName)
+    commandLine.appendFlag(moduleName)
+    commandLine.appendFlag(.o)
+    commandLine.appendPath(outputPath.path.file)
+    commandLine.appendPath(inputPath.path.file)
+    if moduleName == "Swift" {
+      commandLine.appendFlag(.parseStdlib)
+    }
+    // Add macabi-specific search path.
+    if isIosMac(inputPath.path) {
+      commandLine.appendFlag(.Fsystem)
+      commandLine.append(.path(iosMacFrameworksSearchPath))
+    }
+    commandLine.appendFlag(.serializeParseableModuleInterfaceDependencyHashes)
+    return Job(
+      moduleName: moduleName,
+      kind: .compile,
+      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      commandLine: commandLine,
+      inputs: dependencies,
+      primaryInputs: [],
+      outputs: [outputPath.path]
+    )
+  }
+
+  public mutating func generatePrebuitModuleGenerationJobs(_ inputMap: [String: [PrebuiltModuleInput]],
+                                                           _ prebuiltModuleDir: AbsolutePath) throws -> ([Job], [Job]) {
+    assert(sdkPath != nil)
+    // Run the dependency scanner and update the dependency oracle with the results
+    let dependencyGraph = try gatherModuleDependencies()
+    var jobs: [Job] = []
+    var danglingJobs: [Job] = []
+    var inputCount = 0
+    // Create directories for each Swift module
+    try inputMap.forEach {
+      assert(!$0.value.isEmpty)
+      try localFileSystem.createDirectory(prebuiltModuleDir
+        .appending(RelativePath($0.key + ".swiftmodule")))
+    }
+
+    // Generate an outputMap from the inputMap for easy reference.
+    let outputMap: [String: [PrebuiltModuleOutput]] =
+      Dictionary.init(uniqueKeysWithValues: inputMap.map { key, value in
+      let outputPaths: [PrebuiltModuleInput] = value.map {
+        let path = prebuiltModuleDir.appending(RelativePath(key + ".swiftmodule"))
+          .appending(RelativePath($0.path.file.basenameWithoutExt + ".swiftmodule"))
+        return PrebuiltModuleOutput(TypedVirtualPath(file: VirtualPath.absolute(path).intern(),
+                                                     type: .swiftModule), $0.arch)
+      }
+      inputCount += outputPaths.count
+      return (key, outputPaths)
+    })
+
+    func getDependenciesPaths(_ module: String, _ arch: Triple.Arch) throws -> [TypedVirtualPath] {
+      var results: [TypedVirtualPath] = []
+      let info = dependencyGraph.modules[.swift(module)]!
+      guard let dependencies = info.directDependencies else {
+        return results
+      }
+
+      for dep in dependencies {
+        if case let .swift(moduleName) = dep {
+          if let outputs = outputMap[moduleName] {
+            // Depending only those .swiftmodule files with the same arch kind.
+            // FIXME: handling arm64 and arm64e specifically.
+            let selectOutputs = outputs.filter ({ $0.arch == arch }).map { $0.path }
+            results.append(contentsOf: selectOutputs)
+          }
+        }
+      }
+      return results
+    }
+
+    func forEachInputOutputPair(_ moduleName: String,
+                                _ action: (PrebuiltModuleInput, PrebuiltModuleOutput) throws -> ()) throws {
+      if let inputPaths = inputMap[moduleName] {
+        let outputPaths = outputMap[moduleName]!
+        assert(inputPaths.count == outputPaths.count)
+        assert(!inputPaths.isEmpty)
+        for i in 0..<inputPaths.count {
+          try action(inputPaths[i], outputPaths[i])
+        }
+      }
+    }
+    // Keep track of modules that are not handled.
+    var unhandledModules = Set<String>(inputMap.keys)
+    let moduleInfo = dependencyGraph.mainModule
+    if let dependencies = moduleInfo.directDependencies {
+      for dep in dependencies {
+        switch dep {
+        case .swift(let moduleName):
+          // Removed moduleName from the list.
+          unhandledModules.remove(moduleName)
+          try forEachInputOutputPair(moduleName) {
+            jobs.append(try generateSingleModuleBuildingJob(moduleName,
+              prebuiltModuleDir, $0, $1,
+              try getDependenciesPaths(moduleName, $0.arch)))
+          }
+        default:
+          continue
+        }
+      }
+    }
+
+    // For each unhandled module, generate dangling jobs for each associated
+    // interfaces.
+    // The only known usage of this so for is in macosx SDK where some collected
+    // modules are only for macabi. The file under scanning is using a target triple
+    // of mac native so those macabi-only modules cannot be found by the scanner.
+    // We have to handle those modules separately without any dependency info.
+    try unhandledModules.forEach { moduleName in
+      diagnosticEngine.emit(warning: "handle \(moduleName) as dangling jobs")
+      try forEachInputOutputPair(moduleName) { input, output in
+        danglingJobs.append(try generateSingleModuleBuildingJob(moduleName,
+          prebuiltModuleDir, input, output, []))
+      }
+    }
+
+    // check we've generated jobs for all inputs
+    assert(inputCount == jobs.count + danglingJobs.count)
+    return (jobs, danglingJobs)
+  }
+}

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -422,6 +422,8 @@ extension Triple {
     case armeb
     /// AArch64 (little endian): aarch64
     case aarch64
+    /// AArch64e (little endian): aarch64e
+    case aarch64e
     /// AArch64 (big endian): aarch64_be
     case aarch64_be
     // AArch64 (little endian) ILP32: aarch64_32
@@ -517,7 +519,7 @@ extension Triple {
     // 64-bit RenderScript
     case renderscript64
 
-    fileprivate static func parse(_ archName: Substring) -> Triple.Arch? {
+    static func parse(_ archName: Substring) -> Triple.Arch? {
       switch archName {
       case "i386", "i486", "i586", "i686":
         return .x86
@@ -545,6 +547,8 @@ extension Triple {
         return .arc
       case "arm64":
         return .aarch64
+      case "arm64e":
+        return .aarch64e
       case "arm64_32":
         return .aarch64_32
       case "arm":
@@ -817,7 +821,7 @@ extension Triple {
            .shave, .wasm32, .renderscript32, .aarch64_32:
         return 32
 
-      case .aarch64, .aarch64_be, .amdgcn, .bpfel, .bpfeb, .le64, .mips64,
+      case .aarch64, .aarch64e, .aarch64_be, .amdgcn, .bpfel, .bpfeb, .le64, .mips64,
            .mips64el, .nvptx64, .ppc64, .ppc64le, .riscv64, .sparcv9, .systemz,
            .x86_64, .amdil64, .hsail64, .spir64,  .wasm64, .renderscript64:
         return 64
@@ -1363,7 +1367,7 @@ extension Triple {
 
     fileprivate static func infer(arch: Triple.Arch?, os: Triple.OS?) -> Triple.ObjectFormat {
       switch arch {
-        case nil, .aarch64, .aarch64_32, .arm, .thumb, .x86, .x86_64:
+        case nil, .aarch64, .aarch64e, .aarch64_32, .arm, .thumb, .x86, .x86_64:
           if os?.isDarwin ?? false {
             return .macho
           } else if os?.isWindows ?? false {

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -1,0 +1,142 @@
+import SwiftDriverExecution
+import SwiftDriver
+import TSCLibc
+import TSCBasic
+import TSCUtility
+
+let diagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
+
+guard let sdkPathRaw = ProcessEnv.vars["SDKROOT"] else {
+  diagnosticsEngine.emit(.error("need to set SDKROOT"))
+  exit(1)
+}
+
+var rawOutputDir = ""
+if let oid = CommandLine.arguments.firstIndex(of: "-o") {
+  let dirId = oid.advanced(by: 1)
+  if dirId < CommandLine.arguments.count {
+    rawOutputDir = CommandLine.arguments[dirId]
+  }
+}
+if rawOutputDir.isEmpty {
+  diagnosticsEngine.emit(.error("need to specify -o"))
+  exit(1)
+}
+
+class PrebuitGenDelegate: JobExecutionDelegate {
+  var failingModules = Set<String>()
+  var commandMap: [Int: String] = [:]
+  func jobStarted(job: Job, arguments: [String], pid: Int) {
+    commandMap[pid] = arguments.reduce("") { return $0 + " " + $1 }
+  }
+
+  var hasStdlibFailure: Bool {
+    return failingModules.contains("Swift") || failingModules.contains("_Concurrency")
+  }
+
+  func jobFinished(job: Job, result: ProcessResult, pid: Int) {
+    switch result.exitStatus {
+    case .terminated(code: let code):
+      if code != 0 {
+        failingModules.insert(job.moduleName)
+        Driver.stdErrQueue.sync {
+          stderrStream <<< "failed: " <<< commandMap[pid]! <<< "\n"
+          stderrStream.flush()
+        }
+      }
+    case .signalled:
+      diagnosticsEngine.emit(.remark("\(job.moduleName) interrupted"))
+    }
+  }
+
+  func jobSkipped(job: Job) {
+    diagnosticsEngine.emit(.error("\(job.moduleName) skipped"))
+  }
+}
+do {
+  let sdkPath = try VirtualPath(path: sdkPathRaw).absolutePath!
+  if !localFileSystem.exists(sdkPath) {
+    diagnosticsEngine.emit(error: "cannot find sdk: \(sdkPath.pathString)")
+    exit(1)
+  }
+  let collector = SDKPrebuiltModuleInputsCollector(sdkPath, diagnosticsEngine)
+  var outputDir = try VirtualPath(path: rawOutputDir).absolutePath!
+  // if the given output dir ends with 'prebuilt-modules', we should
+  // append the SDK version number so all modules will built into
+  // the SDK-versioned sub-directory.
+  if outputDir.basename == "prebuilt-modules" {
+    outputDir = outputDir.appending(RelativePath(collector.versionString))
+  }
+  if !localFileSystem.exists(outputDir) {
+    try localFileSystem.createDirectory(outputDir)
+  }
+  let swiftcPathRaw = ProcessEnv.vars["SWIFT_EXEC"]
+  var swiftcPath: AbsolutePath
+  if let swiftcPathRaw = swiftcPathRaw {
+    swiftcPath = try VirtualPath(path: swiftcPathRaw).absolutePath!
+  } else {
+    swiftcPath = sdkPath.parentDirectory.parentDirectory.parentDirectory
+      .parentDirectory.parentDirectory.appending(RelativePath("Toolchains"))
+      .appending(RelativePath("XcodeDefault.xctoolchain")).appending(RelativePath("usr"))
+      .appending(RelativePath("bin")).appending(RelativePath("swiftc"))
+  }
+  if !localFileSystem.exists(swiftcPath) {
+    diagnosticsEngine.emit(error: "cannot find swift compiler: \(swiftcPath.pathString)")
+    exit(1)
+  }
+
+  let sysVersionFile = outputDir.appending(component: "SystemVersion.plist")
+  if localFileSystem.exists(sysVersionFile) {
+    try localFileSystem.removeFileTree(sysVersionFile)
+  }
+  // Copy $SDK/System/Library/CoreServices/SystemVersion.plist file from the SDK
+  // into the prebuilt module file to keep track of which SDK build we are generating
+  // the modules from.
+  try localFileSystem.copy(from: sdkPath.appending(component: "System")
+                              .appending(component: "Library")
+                              .appending(component: "CoreServices")
+                              .appending(component: "SystemVersion.plist"),
+                           to: sysVersionFile)
+  let processSet = ProcessSet()
+  let inputMap = try collector.collectSwiftInterfaceMap()
+  let allModules = inputMap.keys
+  try withTemporaryFile(suffix: ".swift") {
+    let tempPath = $0.path
+    try localFileSystem.writeFileContents(tempPath, body: {
+      for module in allModules {
+        $0 <<< "import " <<< module <<< "\n"
+      }
+    })
+    let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
+                                           processSet: processSet,
+                                           fileSystem: localFileSystem,
+                                           env: ProcessEnv.vars)
+    var driver = try Driver(args: ["swiftc",
+                                   "-target", collector.targetTriple,
+                                   tempPath.description,
+                                   "-sdk", sdkPathRaw],
+                            diagnosticsEngine: diagnosticsEngine,
+                            executor: executor,
+                            compilerExecutableDir: swiftcPath.parentDirectory)
+    let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(inputMap, outputDir)
+    let delegate = PrebuitGenDelegate()
+    do {
+      try executor.execute(workload: DriverExecutorWorkload.init(jobs, nil, continueBuildingAfterErrors: true),
+                           delegate: delegate, numParallelJobs: 128)
+    } catch {
+      // Only fail the process if stdlib failed
+      if delegate.hasStdlibFailure {
+        exit(1)
+      }
+    }
+    do {
+      try executor.execute(workload: DriverExecutorWorkload.init(danglingJobs, nil, continueBuildingAfterErrors: true), delegate: delegate, numParallelJobs: 128)
+    } catch {
+      // Failing of dangling jobs don't fail the process.
+      exit(0)
+    }
+  }
+} catch {
+  print("error: \(error)")
+  exit(1)
+}

--- a/TestInputs/mock-sdk.sdk/SDKSettings.json
+++ b/TestInputs/mock-sdk.sdk/SDKSettings.json
@@ -1,0 +1,8 @@
+{
+	"Version": "10.15",
+	"VersionMap": {
+		"macOS_iOSMac": {},
+		"iOSMac_macOS": {}
+	},
+	"CanonicalName": "macosx10.15"
+}

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/A.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/A.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A
+import Swift
+public func FuncA() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/A.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/A.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A
+import Swift
+public func FuncA() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/E.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/E.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name E
+import Swift
+public func FuncE() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/E.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/E.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name E
+import Swift
+public func FuncE() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/F.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/F.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name F
+import Swift
+import A
+public func FuncF() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/F.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/F.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name F
+import Swift
+import A
+public func FuncF() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/G.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/G.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name G
+import Swift
+import E
+public func FuncG() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/G.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/G.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name G
+import Swift
+import E
+public func FuncG() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/H.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/H.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name H
+import Swift
+import A
+import E
+import F
+import G
+public func FuncH() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/H.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/H.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name H
+import Swift
+import A
+import E
+import F
+import G
+public func FuncH() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/Swift.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/Swift.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,2 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib -module-name Swift

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,2 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib -module-name Swift

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -567,39 +567,38 @@ final class ExplicitModuleBuildTests: XCTestCase {
     #endif
   }
 
+  func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath) {
+    let toolchainRootPath: AbsolutePath = try driver.toolchain.getToolPath(.swiftCompiler)
+                                                            .parentDirectory // bin
+                                                            .parentDirectory // toolchain root
+    if driver.targetTriple.isDarwin {
+      let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
+                                             processSet: ProcessSet(),
+                                             fileSystem: localFileSystem,
+                                             env: ProcessEnv.vars)
+      let sdkPath = try executor.checkNonZeroExit(
+        args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
+      let stdLibPath = AbsolutePath(sdkPath).appending(component: "usr")
+        .appending(component: "lib")
+        .appending(component: "swift")
+      return (stdLibPath, stdLibPath.appending(component: "shims"))
+    } else {
+      return (toolchainRootPath.appending(component: "lib")
+                .appending(component: "swift")
+                .appending(component: driver.targetTriple.osNameUnversioned),
+              toolchainRootPath.appending(component: "lib")
+                .appending(component: "swift")
+                .appending(component: "shims"))
+    }
+  }
+
   /// Test the libSwiftScan dependency scanning.
   func testDependencyScanning() throws {
     // Just instantiating to get at the toolchain path
     let driver = try Driver(args: ["swiftc", "-experimental-explicit-module-build",
                                    "-module-name", "testDependencyScanning",
                                    "test.swift"])
-    let toolchainRootPath: AbsolutePath = try driver.toolchain.getToolPath(.swiftCompiler)
-                                                            .parentDirectory // bin
-                                                            .parentDirectory // toolchain root
-
-    let stdLibPath: AbsolutePath
-    let shimsPath: AbsolutePath
-    // On Darwin, use the SDK's stdlib, to make sure the test is more likely to actually
-    // find one.
-    if driver.targetTriple.isDarwin {
-      let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers:         [Driver.stderrDiagnosticsHandler]),
-                                             processSet: ProcessSet(),
-                                             fileSystem: localFileSystem,
-                                             env: ProcessEnv.vars)
-      let sdkPath = try executor.checkNonZeroExit(
-        args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
-      stdLibPath = AbsolutePath(sdkPath).appending(component: "usr")
-                                        .appending(component: "lib")
-                                        .appending(component: "swift")
-      shimsPath = stdLibPath.appending(component: "shims")
-    } else {
-      stdLibPath = toolchainRootPath.appending(component: "lib")
-        .appending(component: "swift")
-        .appending(component: driver.targetTriple.osNameUnversioned)
-      shimsPath = toolchainRootPath.appending(component: "lib")
-        .appending(component: "swift")
-        .appending(component: "shims")
-    }
+    let (stdLibPath, shimsPath) = try getStdlibShimsPaths(driver)
 
     XCTAssertTrue(localFileSystem.exists(stdLibPath),
                   "expected Swift StdLib at: \(stdLibPath.description)")
@@ -732,4 +731,80 @@ final class ExplicitModuleBuildTests: XCTestCase {
     XCTAssertEqual(moduleMap[1].sourceInfoPath!.path.description, "B.swiftsourceinfo")
     XCTAssertEqual(moduleMap[1].isFramework, false)
   }
+// We only care about prebuilt modules in macOS.
+#if os(macOS)
+  func testPrebuiltModuleGenerationJobs() throws {
+    func getInputModules(_ job: Job) -> [String] {
+      return job.inputs.map { input in
+        return input.file.absolutePath!.parentDirectory.basenameWithoutExt
+      }.sorted()
+    }
+
+    func getOutputName(_ job: Job) -> String {
+      XCTAssertTrue(job.outputs.count == 1)
+      return job.outputs[0].file.basename
+    }
+
+    func checkInputOutputIntegrity(_ job: Job) {
+      let name = job.outputs[0].file.basename
+      job.inputs.forEach { input in
+        XCTAssertTrue(input.file.basename == name)
+      }
+    }
+    try withTemporaryDirectory { path in
+      let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
+      try localFileSystem.writeFileContents(main) {
+        $0 <<< "import A\n"
+        $0 <<< "import E\n"
+        $0 <<< "import F\n"
+        $0 <<< "import G\n"
+        $0 <<< "import H\n"
+        $0 <<< "import Swift\n"
+      }
+      let packageRootPath = URL(fileURLWithPath: #file).pathComponents
+        .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
+      let testInputsPath = packageRootPath + "/TestInputs"
+      let mockSDKPath : String = testInputsPath + "/mock-sdk.sdk"
+      var driver = try Driver(args: ["swiftc", main.pathString,
+                                     "-sdk", mockSDKPath,
+                                    ])
+
+      let diagnosticEnging = DiagnosticsEngine()
+      let collector = try SDKPrebuiltModuleInputsCollector(VirtualPath(path: mockSDKPath).absolutePath!, diagnosticEnging)
+      let interfaceMap = try collector.collectSwiftInterfaceMap()
+      XCTAssertTrue(interfaceMap["Swift"]!.count == 2)
+      XCTAssertTrue(interfaceMap["A"]!.count == 2)
+      XCTAssertTrue(interfaceMap["E"]!.count == 2)
+      XCTAssertTrue(interfaceMap["F"]!.count == 2)
+      XCTAssertTrue(interfaceMap["G"]!.count == 2)
+      XCTAssertTrue(interfaceMap["H"]!.count == 2)
+
+      let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(interfaceMap,
+                                                                VirtualPath(path: "/tmp/").absolutePath!)
+
+      XCTAssertTrue(danglingJobs.count == 2)
+      XCTAssertTrue(danglingJobs.allSatisfy { job in
+        job.moduleName == "MissingKit"
+      })
+      XCTAssertTrue(jobs.count == 12)
+      XCTAssertTrue(jobs.allSatisfy {$0.outputs.count == 1})
+      XCTAssertTrue(jobs.allSatisfy {$0.kind == .compile})
+      XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-compile-module-from-interface"))})
+      let HJobs = jobs.filter { $0.moduleName == "H"}
+      XCTAssertTrue(HJobs.count == 2)
+      XCTAssertTrue(getInputModules(HJobs[0]) == ["A", "E", "F", "G", "Swift"])
+      XCTAssertTrue(getInputModules(HJobs[1]) == ["A", "E", "F", "G", "Swift"])
+      XCTAssertTrue(getOutputName(HJobs[0]) != getOutputName(HJobs[1]))
+      checkInputOutputIntegrity(HJobs[0])
+      checkInputOutputIntegrity(HJobs[1])
+      let GJobs = jobs.filter { $0.moduleName == "G"}
+      XCTAssertTrue(GJobs.count == 2)
+      XCTAssertTrue(getInputModules(GJobs[0]) == ["E", "Swift"])
+      XCTAssertTrue(getInputModules(GJobs[1]) == ["E", "Swift"])
+      XCTAssertTrue(getOutputName(GJobs[0]) != getOutputName(GJobs[1]))
+      checkInputOutputIntegrity(GJobs[0])
+      checkInputOutputIntegrity(GJobs[1])
+    }
+  }
+#endif
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2531,6 +2531,7 @@ final class SwiftDriverTests: XCTestCase {
         $0 <<< """
         {
           "Version":"10.15",
+          "CanonicalName": "macosx10.15",
           "VersionMap" : {
               "macOS_iOSMac" : {
                   "10.15" : "13.1",
@@ -2550,6 +2551,7 @@ final class SwiftDriverTests: XCTestCase {
         $0 <<< """
         {
           "Version":"10.15.4",
+          "CanonicalName": "macosx10.15.4",
           "VersionMap" : {
               "macOS_iOSMac" : {
                   "10.14.4" : "12.4",


### PR DESCRIPTION
This PR is an implementation of swift_build_sdk_interfaces.py using
libSwiftDriver. The tool is used to traverse an entire SDK to find
Swift interface files and to generate prebuilt module cache for each one
of them. Comparing to the python implementation, this implementation generates
the prebuilt modules in the dependency order so that:

(1) It's more performant than the python counterpart. Several preliminary
experiments showed an average of 40% less CPU time spent on generating modules in an SDK.

(2) It fails fast. If an interface is broken in the SDK, this new implementation
won't schedule jobs for building other modules depending on this interface. It should help us avoid
issues like rdar://76201633