### PR TITLE
[Incremental] Skip post-compile jobs only if no compiles ran, and all the outputs are up-to-date.

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -167,7 +167,8 @@ import SwiftOptions
         compilationInputModificationDates: compilationInputModificationDates,
         actualSwiftVersion: actualSwiftVersion,
         argsHash: currentArgsHash,
-        timeBeforeFirstJob: timeBeforeFirstJob)
+        timeBeforeFirstJob: timeBeforeFirstJob,
+        timeAfterLastJob: Date())
     }
 
     guard let contents = buildRecord.encode(currentArgsHash: currentArgsHash,

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -38,7 +38,8 @@ extension IncrementalCompilationState {
     @_spi(Testing) public let dependencyDotFilesIncludeExternals: Bool = true
     @_spi(Testing) public let dependencyDotFilesIncludeAPINotes: Bool = false
 
-    @_spi(Testing) public let buildTime: Date
+    @_spi(Testing) public let buildStartTime: Date
+    @_spi(Testing) public let buildEndTime: Date
 
     @_spi(Testing) public init(
       _ options: IncrementalCompilationState.Options,
@@ -72,7 +73,8 @@ extension IncrementalCompilationState {
       self.isCrossModuleIncrementalBuildEnabled = options.contains(.enableCrossModuleIncrementalBuild)
       self.verifyDependencyGraphAfterEveryImport = options.contains(.verifyDependencyGraphAfterEveryImport)
       self.emitDependencyDotFileAfterEveryImport = options.contains(.emitDependencyDotFileAfterEveryImport)
-      self.buildTime = maybeBuildRecord?.buildTime ?? .distantPast
+      self.buildStartTime = maybeBuildRecord?.buildStartTime ?? .distantPast
+      self.buildEndTime = maybeBuildRecord?.buildEndTime ?? .distantFuture
     }
 
     func compute(batchJobFormer: inout Driver)
@@ -102,7 +104,9 @@ extension IncrementalCompilationState {
 
       return InitialState(graph: graph,
                           skippedCompileGroups: skippedCompileGroups,
-                          mandatoryJobsInOrder: mandatoryJobsInOrder)
+                          mandatoryJobsInOrder: mandatoryJobsInOrder,
+                          buildStartTime: buildStartTime,
+                          buildEndTime: buildEndTime)
     }
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -330,7 +330,7 @@ extension ModuleDependencyGraph {
       return true
     }
     let fileModTime = (try? info.fileSystem.lastModificationTime(for: depFile)) ?? .distantFuture
-    let hasChanged = fileModTime >= info.buildTime
+    let hasChanged = fileModTime >= info.buildStartTime
     externalDependencyModTimeCache[externalDependency] = hasChanged
     return hasChanged
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -189,8 +189,6 @@ extension ModuleDependencyGraph.Integrator {
     }
   }
 
-  private var buildTime: Date { destination.info.buildTime }
-
   // A `moduleGraphUseNode` is used by an externalDependency key being integrated.
   // Remember the dependency for later processing in externalDependencies, and
   // also return it in results.

--- a/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
+++ b/Tests/SwiftDriverTests/Helpers/AssertDiagnostics.swift
@@ -15,17 +15,18 @@ import SwiftDriver
 import TSCBasic
 import TestUtilities
 
-func assertDriverDiagnostics(
+@discardableResult
+func assertDriverDiagnostics<Result> (
   args: [String],
   env: [String: String] = ProcessEnv.vars,
   file: StaticString = #file, line: UInt = #line,
-  do body: (inout Driver, DiagnosticVerifier) throws -> Void
-) throws {
+  do body: (inout Driver, DiagnosticVerifier) throws -> Result
+) throws -> Result {
   let matcher = DiagnosticVerifier()
   defer { matcher.verify(file: file, line: line) }
 
   var driver = try Driver(args: args, env: env, diagnosticsEngine: DiagnosticsEngine(handlers: [matcher.emit(_:)]))
-  try body(&driver, matcher)
+  return try body(&driver, matcher)
 }
 
 /// Asserts that the `Driver` it instantiates will only emit warnings and errors

--- a/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
@@ -17,7 +17,8 @@ enum Inputs {
     """
         version: "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
         options: "abbbfbcaf36b93e58efaadd8271ff142"
-        build_time: [1570318779, 32358000]
+        build_start_time: [1570318779, 32358000]
+        build_end_time: [1570318779, 32358010]
         inputs:
           "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift": !dirty [1570318778, 0]
           "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift": [1570083660, 0]
@@ -27,7 +28,8 @@ enum Inputs {
   static var buildRecordWithoutOptions: String {
     """
         version: "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
-        build_time: [1570318779, 32358000]
+        build_start_time: [1570318779, 32358000]
+        build_end_time: [1570318779, 32358010]
         inputs:
           "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift": !dirty [1570318778, 0]
           "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift": [1570083660, 0]


### PR DESCRIPTION
If the merge-modules step fails or is cancelled, all the compile steps may be skipped, yet the post-compile jobs still must run.
Improve the logic that was skipping the post-compile jobs whenever there are no compile jobs.
When the compile jobs would otherwise be skipped, check their outputs against the time the previous build finished.
In order to perform the check, enhance the build record to store the end time as well as the start time of the prior build.

rdar://76127929