### PR TITLE
Locate "arclite" library relative to the Clang in the active Xcode

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -14,6 +14,15 @@ import TSCUtility
 import SwiftOptions
 
 extension DarwinToolchain {
+  internal func findXcodeClangPath() throws -> AbsolutePath? {
+    let result = try executor.checkNonZeroExit(
+      args: "xcrun", "-toolchain", "default", "-f", "clang",
+      environment: env
+    ).spm_chomp()
+
+    return result.isEmpty ? nil : AbsolutePath(result)
+  }
+
   internal func findXcodeClangLibPath(_ additionalPath: String) throws -> AbsolutePath? {
     let path = try getToolPath(.swiftCompiler)
       .parentDirectory // 'swift'
@@ -24,7 +33,7 @@ extension DarwinToolchain {
 
     // If we don't have a 'lib/arc/' directory, find the "arclite" library
     // relative to the Clang in the active Xcode.
-    if let clangPath = try? getToolPath(.clang) {
+    if let clangPath = try? findXcodeClangPath() {
       return clangPath
         .parentDirectory // 'clang'
         .parentDirectory // 'bin'

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -165,7 +165,8 @@ import SwiftOptions
                            targetTriple: Triple,
                            targetVariantTriple: Triple?,
                            diagnosticsEngine: DiagnosticsEngine) throws {
-    // On non-darwin hosts, libArcLite is not relevant
+    // On non-darwin hosts, libArcLite won't be found and a warning will be emitted
+    // Guard for the sake of tests runnin on all platforms
     #if os(macOS)
     // Validating arclite library path when link-objc-runtime.
     validateLinkObjcRuntimeARCLiteLib(&parsedOptions,

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -165,10 +165,13 @@ import SwiftOptions
                            targetTriple: Triple,
                            targetVariantTriple: Triple?,
                            diagnosticsEngine: DiagnosticsEngine) throws {
+    // On non-darwin hosts, libArcLite is not relevant
+    #if os(macOS)
     // Validating arclite library path when link-objc-runtime.
     validateLinkObjcRuntimeARCLiteLib(&parsedOptions,
                                       targetTriple: targetTriple,
                                       diagnosticsEngine: diagnosticsEngine)
+    #endif
     // Validating apple platforms deployment targets.
     try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple)
     if let targetVariantTriple = targetVariantTriple,


### PR DESCRIPTION
Instead of locating it in the current toolchain that the driver belongs to.
This will match the behaviour in the legacy driver:
https://github.com/apple/swift/blob/main/lib/Driver/DarwinToolChains.cpp#L287

Resolves rdar://76035286