### PR TITLE
Use unique temporary file names

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1924,7 +1924,7 @@ extension Driver {
         moduleOutputPath = try .init(path: moduleFilename)
       }
     } else {
-      moduleOutputPath = .temporary(RelativePath(moduleName.appendingFileTypeExtension(.swiftModule)))
+      moduleOutputPath = VirtualPath.createUniqueTemporaryFile(RelativePath(moduleName.appendingFileTypeExtension(.swiftModule)))
     }
 
     // Use working directory if specified
@@ -2037,13 +2037,12 @@ extension Driver {
       return outputPath
     }
 
-    // FIXME: should have '-.*' at the end of the filename, similar to llvm::sys::fs::createTemporaryFile
     let inputFile = VirtualPath.lookup(input)
     let pchFileName = inputFile.basenameWithoutExt.appendingFileTypeExtension(.pch)
     if let outputDirectory = parsedOptions.getLastArgument(.pchOutputDir)?.asSingle {
       return try VirtualPath(path: outputDirectory).appending(component: pchFileName).intern()
     } else {
-      return VirtualPath.temporary(RelativePath(pchFileName)).intern()
+      return VirtualPath.createUniqueTemporaryFile(RelativePath(pchFileName)).intern()
     }
   }
 }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -484,8 +484,8 @@ public struct Driver {
     self.shouldUseInputFileList = inputFiles.count > fileListThreshold
     if shouldUseInputFileList {
       let swiftInputs = inputFiles.filter(\.type.isPartOfSwiftCompilation)
-      let path = RelativePath(createTemporaryFileName(prefix: "sources"))
-      self.allSourcesFileList = .fileList(path, .list(swiftInputs.map(\.file)))
+      self.allSourcesFileList = VirtualPath.createUniqueFilelist(RelativePath("sources"),
+                                                                 .list(swiftInputs.map(\.file)))
     } else {
       self.allSourcesFileList = nil
     }

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -39,7 +39,7 @@ public struct OutputFileMap: Hashable, Codable {
     }
 
     // Form the virtual path.
-    return VirtualPath.temporary(RelativePath(inputFile.basenameWithoutExt.appendingFileTypeExtension(outputType))).intern()
+    return VirtualPath.createUniqueTemporaryFile(RelativePath(inputFile.basenameWithoutExt.appendingFileTypeExtension(outputType))).intern()
   }
 
   public func existingOutput(inputFile: VirtualPath.Handle, outputType: FileType) -> VirtualPath.Handle? {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -377,7 +377,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(dependencyArtifacts)
-    return .temporaryWithKnownContents(.init("\(moduleId.moduleName)-dependencies.json"), contents)
+    return VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("\(moduleId.moduleName)-dependencies.json"), contents)
   }
 
   private func getPCMHashParts(pcmArgs: [String]) -> [String] {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -90,8 +90,8 @@ internal extension Driver {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(placeholderArtifacts)
-    return .temporaryWithKnownContents(.init("\(moduleOutputInfo.name)-placeholder-modules.json"),
-                                       contents)
+    return VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("\(moduleOutputInfo.name)-placeholder-modules.json"),
+                                                                  contents)
   }
 
   mutating func performDependencyScan() throws -> InterModuleDependencyGraph {
@@ -281,8 +281,8 @@ internal extension Driver {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     let contents = try encoder.encode(moduleInfos)
-    return .temporaryWithKnownContents(.init("\(moduleOutputInfo.name)-batch-module-scan.json"),
-                                       contents)
+    return VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("\(moduleOutputInfo.name)-batch-module-scan.json"),
+                                                                  contents)
   }
 
   fileprivate func itemizedJobCommand(of job: Job, forceResponseFiles: Bool,

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -33,7 +33,7 @@ extension Driver {
     // Go through a bit of extra rigmarole to keep the "./" out of the name for
     // the sake of the tests.
     let output: VirtualPath = dir == .temporary(RelativePath("."))
-      ? .temporary(RelativePath(outputBasename))
+      ? VirtualPath.createUniqueTemporaryFile(RelativePath(outputBasename))
       : dir.appending(component: outputBasename)
 
     commandLine.append(contentsOf: inputs.map { .path($0.file) })

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -15,6 +15,7 @@ import Foundation
 extension Driver {
   /// Form a backend job.
   mutating func backendJob(input: TypedVirtualPath,
+                           baseInput: TypedVirtualPath?,
                            addJobOutputs: ([TypedVirtualPath]) -> Void)
   throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
@@ -55,7 +56,9 @@ extension Driver {
 
     // Add the output file argument if necessary.
     if let compilerOutputType = compilerOutputType {
-      let output = computePrimaryOutput(for: input,
+      // If there is no baseInput (singleCompileMode), primary output computation
+      // is not input-specific, therefore it does not matter which input is passed.
+      let output = computePrimaryOutput(for: baseInput ?? input,
                                         outputType: compilerOutputType,
                                         isTopLevel: isTopLevelOutput(type: compilerOutputType))
       commandLine.appendFlag(.o)

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -64,7 +64,7 @@ extension Driver {
     }
 
     if !isTopLevel {
-      return TypedVirtualPath(file: VirtualPath.temporary(.init(baseName.appendingFileTypeExtension(outputType))).intern(),
+      return TypedVirtualPath(file: VirtualPath.createUniqueTemporaryFile(.init(baseName.appendingFileTypeExtension(outputType))).intern(),
                               type: outputType)
     }
     return TypedVirtualPath(file: useWorkingDirectory(.init(baseName.appendingFileTypeExtension(outputType))).intern(), type: outputType)

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -121,8 +121,9 @@ extension Driver {
     if usePrimaryInputFileList {
       // primary file list
       commandLine.appendFlag(.primaryFilelist)
-      let path = RelativePath(createTemporaryFileName(prefix: "primaryInputs"))
-      commandLine.appendPath(.fileList(path, .list(primaryInputs.map(\.file))))
+      let fileList = VirtualPath.createUniqueFilelist(RelativePath("primaryInputs"),
+                                                      .list(primaryInputs.map(\.file)))
+      commandLine.appendPath(fileList)
     }
 
     let isTopLevel = isTopLevelOutput(type: outputType)
@@ -296,8 +297,9 @@ extension Driver {
     // Add primary outputs.
     if primaryOutputs.count > fileListThreshold {
       commandLine.appendFlag(.outputFilelist)
-      let path = RelativePath(createTemporaryFileName(prefix: "outputs"))
-      commandLine.appendPath(.fileList(path, .list(primaryOutputs.map { $0.file })))
+      let fileList = VirtualPath.createUniqueFilelist(RelativePath("outputs"),
+                                                      .list(primaryOutputs.map { $0.file }))
+      commandLine.appendPath(fileList)
     } else {
       for primaryOutput in primaryOutputs {
         commandLine.appendFlag(.o)
@@ -309,8 +311,9 @@ extension Driver {
     if !primaryIndexUnitOutputs.isEmpty {
       if primaryIndexUnitOutputs.count > fileListThreshold {
         commandLine.appendFlag(.indexUnitOutputPathFilelist)
-        let path = RelativePath(createTemporaryFileName(prefix: "index-unit-outputs"))
-        commandLine.appendPath(.fileList(path, .list(primaryIndexUnitOutputs.map { $0.file })))
+        let fileList = VirtualPath.createUniqueFilelist(RelativePath("index-unit-outputs"),
+                                                        .list(primaryIndexUnitOutputs.map { $0.file }))
+        commandLine.appendPath(fileList)
       } else {
         for primaryIndexUnitOutput in primaryIndexUnitOutputs {
           commandLine.appendFlag(.indexUnitOutputPath)

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -251,7 +251,6 @@ extension DarwinToolchain {
     // inputs LinkFileList
     if shouldUseInputFileList {
       commandLine.appendFlag(.filelist)
-      let path = RelativePath(createTemporaryFileName(prefix: "inputs", suffix: "LinkFileList"))
       var inputPaths = [VirtualPath]()
       var inputModules = [VirtualPath]()
       for input in inputs {
@@ -264,7 +263,9 @@ extension DarwinToolchain {
           inputPaths.append(input.file)
         }
       }
-      commandLine.appendPath(.fileList(path, .list(inputPaths)))
+      let fileList = VirtualPath.createUniqueFilelist(RelativePath("inputs.LinkFileList"),
+                                                      .list(inputPaths))
+      commandLine.appendPath(fileList)
       if linkerOutputType != .staticLibrary {
         for module in inputModules {
           commandLine.append(.flag("-add_ast_path"))

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -30,8 +30,9 @@ extension Toolchain {
     // This action does not require any input files, but all frontend actions require
     // at least one so we fake it.
     // FIXME: Teach -emit-supported-features to not expect any inputs, like -print-target-info does.
-    let dummyInputPath = VirtualPath.temporaryWithKnownContents(.init("dummyInput.swift"),
-                                                                "".data(using: .utf8)!)
+    let dummyInputPath =
+      VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("dummyInput.swift"),
+                                                             "".data(using: .utf8)!)
     commandLine.appendPath(dummyInputPath)
     inputs.append(TypedVirtualPath(file: dummyInputPath.intern(), type: .swift))
     

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -284,7 +284,7 @@ extension Driver {
           // Alongside primary output
           outputPath = output.file.replacingExtension(with: outputType).intern()
         } else {
-          outputPath = VirtualPath.temporary(RelativePath(input.file.basenameWithoutExt.appendingFileTypeExtension(outputType))).intern()
+          outputPath = VirtualPath.createUniqueTemporaryFile(RelativePath(input.file.basenameWithoutExt.appendingFileTypeExtension(outputType))).intern()
         }
 
         // Update the input-output file map.
@@ -394,7 +394,8 @@ extension Driver {
         // Alongside primary output
         remapOutputPath = output.file.replacingExtension(with: .remap)
       } else {
-        remapOutputPath = .temporary(RelativePath(input.file.basenameWithoutExt.appendingFileTypeExtension(.remap)))
+        remapOutputPath =
+          VirtualPath.createUniqueTemporaryFile(RelativePath(input.file.basenameWithoutExt.appendingFileTypeExtension(.remap)))
       }
 
       flaggedInputOutputPairs.append((flag: "-emit-remap-file-path",

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -437,9 +437,10 @@ extension Driver {
         entries[indexFilePath.fileHandle] = [.indexData: idxOutput.fileHandle]
       }
       let outputFileMap = OutputFileMap(entries: entries)
-      let path = RelativePath(createTemporaryFileName(prefix: "supplementaryOutputs"))
+      let fileList = VirtualPath.createUniqueFilelist(RelativePath("supplementaryOutputs"),
+                                                      .outputFileMap(outputFileMap))
       commandLine.appendFlag(.supplementaryOutputFileMap)
-      commandLine.appendPath(.fileList(path, .outputFileMap(outputFileMap)))
+      commandLine.appendPath(fileList)
     } else {
       for flaggedPair in flaggedInputOutputPairs {
         // Add the appropriate flag.
@@ -476,11 +477,4 @@ extension Driver {
   public func isExplicitMainModuleJob(job: Job) -> Bool {
     return job.moduleName == moduleOutputInfo.name
   }
-}
-
-var id: Int = 0
-// I don't like this as a global function, but it needs to be used by both Driver and Toolchain
-func createTemporaryFileName(prefix: String, suffix: String? = nil) -> String {
-  id += 1
-  return prefix + "-\(id)" + (suffix.map { "." + $0 } ?? "")
 }

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -39,8 +39,9 @@ extension Driver {
         let outputName = input.file.basenameWithoutExt + "-" + String(code, radix: 36)
         path = try VirtualPath(path: outputDirectory).appending(component: outputName.appendingFileTypeExtension(.diagnostics))
       } else {
-        // FIXME: should have '-.*' at the end of the filename, similar to llvm::sys::fs::createTemporaryFile
-        path = .temporary(RelativePath(input.file.basenameWithoutExt.appendingFileTypeExtension(.diagnostics)))
+        path =
+          VirtualPath.createUniqueTemporaryFile(
+            RelativePath(input.file.basenameWithoutExt.appendingFileTypeExtension(.diagnostics)))
       }
       commandLine.appendPath(path)
       outputs.append(.init(file: path.intern(), type: .diagnostics))

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -26,8 +26,9 @@ extension Driver {
     // Input file list.
     if shouldUseInputFileList {
       commandLine.appendFlag(.filelist)
-      let path = RelativePath(createTemporaryFileName(prefix: "inputs"))
-      commandLine.appendPath(.fileList(path, .list(inputsFromOutputs.map { $0.file })))
+      let fileList = VirtualPath.createUniqueFilelist(RelativePath("inputs"),
+                                                      .list(inputsFromOutputs.map { $0.file }))
+      commandLine.appendPath(fileList)
       inputs.append(contentsOf: inputsFromOutputs)
       
       for input in providedInputs {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -266,7 +266,7 @@ extension Driver {
       addJob(compile)
       let backendJobs = try compile.outputs.compactMap { output in
         output.type == .llvmBitcode
-          ? try backendJob(input: output, addJobOutputs: addJobOutputs)
+          ? try backendJob(input: output, baseInput: nil, addJobOutputs: addJobOutputs)
           : nil
       }
       backendJobs.forEach(addJob)
@@ -367,7 +367,7 @@ extension Driver {
                                    emitModuleTrace: emitModuleTrace)
       let backendJobs = try compile.outputs.compactMap { output in
         output.type == .llvmBitcode
-          ? try backendJob(input: output, addJobOutputs: addJobOutputs)
+          ? try backendJob(input: output, baseInput: primaryInput, addJobOutputs: addJobOutputs)
           : nil
       }
       assert(backendJobs.count <= 1)

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -20,6 +20,8 @@ import Darwin
 public enum VirtualPath: Hashable {
   private static var pathCache = PathCache()
 
+  private static var temporaryFileStore = TemporaryFileStore()
+
   /// A relative path that has not been resolved based on the current working
   /// directory.
   case relative(RelativePath)
@@ -33,12 +35,14 @@ public enum VirtualPath: Hashable {
   /// Standard output
   case standardOutput
 
+  /// We would like to direct clients to use the temporary file creation utilities `createUniqueTemporaryFile`, etc.
+  /// To ensure temporary files are unique.
+  /// TODO: If/When Swift gains enum access control, we can prohibit direct instantiation of temporary file cases,
+  /// e.g. `private(init) case temporary(RelativePath)`.
   /// A temporary file with the given name.
   case temporary(RelativePath)
-
   /// A temporary file with the given name and contents.
   case temporaryWithKnownContents(RelativePath, Data)
-
   /// A temporary file that holds a list of paths.
   case fileList(RelativePath, FileList)
 
@@ -400,6 +404,70 @@ extension VirtualPath {
         }
       }
     }
+  }
+}
+
+// MARK: Temporary File Creation
+
+/// Most client contexts require temporary files they request to be unique (e.g. auxiliary compile outputs).
+/// This extension provides a set of utilities to create unique (within driver context) relative paths to temporary files.
+/// Clients are still allowed to instantiate `.temporary` `VirtualPath` values directly because of our inability to specify
+/// enum case access control, but are discouraged from doing so.
+extension VirtualPath {
+  public static func createUniqueTemporaryFile(_ path: RelativePath) -> VirtualPath {
+    let uniquedRelativePath = getUniqueTemporaryPath(for: path)
+    return .temporary(uniquedRelativePath)
+  }
+
+  public static func createUniqueTemporaryFileWithKnownContents(_ path: RelativePath, _ data: Data)
+  -> VirtualPath {
+    let uniquedRelativePath = getUniqueTemporaryPath(for: path)
+    return .temporaryWithKnownContents(uniquedRelativePath, data)
+  }
+
+  private static func getUniqueTemporaryPath(for path: RelativePath) -> RelativePath {
+    let uniquedBaseName = Self.temporaryFileStore.getUniqueFilename(for: path.basenameWithoutExt)
+    // Avoid introducing the the leading dot
+    let dirName = path.dirname == "." ? "" : path.dirname
+    let fileExtension = path.extension.map { ".\($0)" } ?? ""
+    return RelativePath(dirName + uniquedBaseName + fileExtension)
+  }
+
+  /// A cache of created temporary files
+  private final class TemporaryFileStore {
+    private var uniqueFileCountDict: [String: Int]
+    private var queue: DispatchQueue
+
+    init() {
+      self.uniqueFileCountDict = [String: Int]()
+      self.queue = DispatchQueue(label: "com.apple.swift.driver.temp-file-store",
+                                 qos: .userInteractive)
+    }
+
+    fileprivate func getUniqueFilename(for temporaryPathStr: String) -> String {
+      return self.queue.sync() {
+        let newCount: Int
+        if let previouslySeenCount = uniqueFileCountDict[temporaryPathStr] {
+          newCount = previouslySeenCount + 1
+        } else {
+          newCount = 1
+        }
+        uniqueFileCountDict[temporaryPathStr] = newCount
+        return "\(temporaryPathStr)-\(newCount)"
+      }
+    }
+
+    // Used for testing purposes only
+    fileprivate func reset() {
+      return self.queue.sync() {
+        uniqueFileCountDict.removeAll()
+      }
+    }
+  }
+
+  // Reset the temporary file store, for testing purposes only
+  @_spi(Testing) public static func resetTemporaryFileStore() {
+    Self.temporaryFileStore.reset()
   }
 }
 

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -425,6 +425,12 @@ extension VirtualPath {
     return .temporaryWithKnownContents(uniquedRelativePath, data)
   }
 
+  public static func createUniqueFilelist(_ path: RelativePath, _ fileList: FileList)
+  -> VirtualPath {
+    let uniquedRelativePath = getUniqueTemporaryPath(for: path)
+    return .fileList(uniquedRelativePath, fileList)
+  }
+
   private static func getUniqueTemporaryPath(for path: RelativePath) -> RelativePath {
     let uniquedBaseName = Self.temporaryFileStore.getUniqueFilename(for: path.basenameWithoutExt)
     // Avoid introducing the the leading dot

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -15,6 +15,7 @@ import TSCUtility
 
 @_spi(Testing) import SwiftDriver
 import SwiftDriverExecution
+import TestUtilities
 
 extension Job.ArgTemplate: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) {
@@ -384,7 +385,7 @@ final class JobExecutorTests: XCTestCase {
         XCTAssertEqual(jobs.removingAutolinkExtractJobs().map(\.kind), [.compile, .link])
         XCTAssertEqual(jobs[0].outputs.count, 1)
         let compileOutput = jobs[0].outputs[0].file
-        guard case .temporary(.init("main.o")) = compileOutput else {
+        guard matchTemporary(compileOutput, "main.o") else {
           XCTFail("unexpected output")
           return
         }
@@ -422,7 +423,7 @@ final class JobExecutorTests: XCTestCase {
         XCTAssertEqual(jobs.removingAutolinkExtractJobs().map(\.kind), [.compile, .link])
         XCTAssertEqual(jobs[0].outputs.count, 1)
         let compileOutput = jobs[0].outputs[0].file
-        guard case .temporary(.init("main.o")) = compileOutput else {
+        guard matchTemporary(compileOutput, "main.o") else {
           XCTFail("unexpected output")
           return
         }
@@ -460,7 +461,7 @@ final class JobExecutorTests: XCTestCase {
         XCTAssertEqual(jobs.removingAutolinkExtractJobs().map(\.kind), [.compile, .link])
         XCTAssertEqual(jobs[0].outputs.count, 1)
         let compileOutput = jobs[0].outputs[0].file
-        guard case .temporary(.init("main.o")) = compileOutput else {
+        guard matchTemporary(compileOutput, "main.o") else {
           XCTFail("unexpected output")
           return
         }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -384,7 +384,6 @@ final class SwiftDriverTests: XCTestCase {
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-debug-prefix-map", "foo=bar=baz", "-debug-prefix-map", "qux=") { driver in
         let jobs = try driver.planBuild()
-      print(jobs[0].commandLine)
         XCTAssertTrue(jobs[0].commandLine.contains(.flag("-debug-prefix-map")))
         XCTAssertTrue(jobs[0].commandLine.contains(.flag("foo=bar=baz")))
         XCTAssertTrue(jobs[0].commandLine.contains(.flag("-debug-prefix-map")))

--- a/Tests/TestUtilities/Fixture.swift
+++ b/Tests/TestUtilities/Fixture.swift
@@ -1,4 +1,4 @@
-//===-------- DriverExtensions.swift - Driver Testing Extensions ----------===//
+//===------------ Fixture.swift - Driver Testing Extensions --------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/Tests/TestUtilities/TemporaryFileMatching.swift
+++ b/Tests/TestUtilities/TemporaryFileMatching.swift
@@ -1,0 +1,78 @@
+//===-------- TemporaryFileMatch.swift - Driver Testing Extensions --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCBasic
+import SwiftDriver
+
+
+public func matchTemporary(_ path: VirtualPath, basename: String, fileExtension: String?) -> Bool {
+  let relativePath: RelativePath
+  switch path {
+    case .temporary(let tempPath):
+      relativePath = tempPath
+    case .temporaryWithKnownContents(let tempPath, _):
+      relativePath = tempPath
+    default:
+      return false
+  }
+  return relativePath.basenameWithoutExt.hasPrefix(basename) &&
+         fileExtension == relativePath.extension
+}
+
+public func matchTemporary(_ path: VirtualPath, _ filename: String) -> Bool {
+  let components = filename.components(separatedBy: ".")
+  if components.count == 1 {
+    return matchTemporary(path, basename: filename, fileExtension: nil)
+  } else if components.count == 2 {
+    return matchTemporary(path, basename: components[0], fileExtension: components[1])
+  } else {
+    let basename = components[0 ..< components.count - 1].joined()
+    return matchTemporary(path, basename: basename, fileExtension: components.last)
+  }
+}
+
+public func commandContainsFlagTemporaryPathSequence(_ cmd: [Job.ArgTemplate],
+                                                     flag: Job.ArgTemplate,
+                                                     filename: String)
+-> Bool {
+  for (index, element) in cmd.enumerated() {
+    if element == flag,
+       (index + 1) < cmd.count {
+      guard case .path(let relativePath) = cmd[index + 1] else {
+        continue
+      }
+      if matchTemporary(relativePath, filename) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+public func commandContainsTemporaryPath(_ cmd: [Job.ArgTemplate],
+                                         _ filename: String)
+-> Bool {
+  return cmd.contains {
+    guard case .path(let path) = $0 else { return false }
+    return matchTemporary(path, filename)
+  }
+}
+
+public func commandContainsTemporaryResponsePath(_ cmd: [Job.ArgTemplate],
+                                                 _ filename: String)
+-> Bool {
+  return cmd.contains {
+    guard case .responseFilePath(let path) = $0 else { return false }
+    return matchTemporary(path, filename)
+  }
+}
+


### PR DESCRIPTION
This PR augments `VirtualPath` with an ability to create a temporary file that is unique a given driver execution context: `createUniqueTemporaryFile`. i.e. if a temporary file with the same filename as one being requested has been created before, using this API, then the newly-created file will have a suffix appended to the base name to distinguish it.

This brings swift-driver closer to the legacy driver's behavior, which generates unique temporary files by-default, using LLVM's `llvm::sys::fs::createTemporaryFile`.

Doing so is necessary to resolve several kinds of problems, for example: 
Compiling a module `Foo` consisting of two source files `Foo.swift` and `Bar.swift` will result in a temporary partial module `Foo.swiftmodule` being produced from building `Foo.swift` and a full `Foo.swiftmodule` produced from the merge-modules job. If the full module does not need to be exposed to the user as the output of compilation, it will be a temporary file, in which case it will conflict with the partial `Foo.swiftmodule` causing the downstream executor to rightly complain about potential cycles in the build.

I entertained the idea of instead resolving `.temporary` paths to unique files at argument resolution time, but that proved troublesome because in that case a specific unique file has to be tracked via a unique `VirtualPath.handle`, where different such handles may refer to the same `VirtualPath`, which is an opaque distinction to many path clients in the driver, and would be really hard to enforce throughout the code-base. Instead, this approach relies on the file's creator to make sure it is unique.

Having enum case access control would be super useful here in order to prohibit clients from instantiating `.temporary` paths explicitly, instead of via the new API. This is left for future work once Swift has such a feature.

Resolves rdar://76123509