### PR TITLE
Only output serialized diagnostics for verify jobs if explicitly requested in the output file map

### DIFF
--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -19,13 +19,11 @@ extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
-    // Compute the serialized diagnostics output file
-    let outputFile: TypedVirtualPath
-    if let output = serializedDiagnosticsFilePath {
-      outputFile = TypedVirtualPath(file: output, type: .diagnostics)
-    } else {
-      outputFile = TypedVirtualPath(file: interfaceInput.file.replacingExtension(with: .diagnostics).intern(),
-                                    type: .diagnostics)
+    // Output serialized diagnostics for this job, if specifically requested
+    var outputs: [TypedVirtualPath] = []
+    if let outputPath = outputFileMap?.existingOutput(inputFile: interfaceInput.fileHandle,
+                                                      outputType: .diagnostics) {
+      outputs.append(TypedVirtualPath(file: outputPath, type: .diagnostics))
     }
 
     return Job(
@@ -36,7 +34,7 @@ extension Driver {
       displayInputs: [interfaceInput],
       inputs: inputs,
       primaryInputs: [],
-      outputs: [outputFile]
+      outputs: outputs
     )
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3563,6 +3563,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(verifyJob.kind, .verifyModuleInterface)
       XCTAssertTrue(verifyJob.inputs.count == 1)
       XCTAssertTrue(verifyJob.inputs[0] == mergeInterfaceOutputs[0])
+      XCTAssertTrue(verifyJob.outputs.isEmpty)
       XCTAssertTrue(verifyJob.commandLine.contains(.path(mergeInterfaceOutputs[0].file)))
     }
     // No Evolution


### PR DESCRIPTION
Otherwise, today, we are always emitting these serialized diagnostic files incorrectly.
We use either:
   - `ModuleName` + `.dia` for both plain and private module interfaces (which is wrong because we have multiple producers of an identical file).
   - `InterfaceFileBasename` + `.dia` for both plain and private module interfaces (which is wrong for the plain interface, for example, because it may conflict with a compile job emitting an identically-named `.dia` file).

Looking at the legacy driver, we don't actually emit these most of the time, even when `-serialize-diagnostics` is specified on the invocation, because that refers to the overall build, not the verification. Which leads me to believe there aren't any consumers for these specific serialized diagnostics.

Resolves rdar://76122268