### PR TITLE
[Incremental] Only warn if cannot write prior module dependencies, and print more error info

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1057,11 +1057,15 @@ extension Driver {
     // A mitigation to rdar://76359678.
     // If the write fails, import incrementality is lost, but it is not a fatal error.
     if let incrementalCompilationState = self.incrementalCompilationState {
-      let hadError = incrementalCompilationState.writeDependencyGraph()
-      /// Ensure that a bogus dependency graph is not used next time.
-      guard !hadError else {
-        buildRecordInfo?.removeBuildRecord()
-        return
+      do {
+        try incrementalCompilationState.writeDependencyGraph()
+      }
+      catch {
+        diagnosticEngine.emit(
+          .warning("next compile won't be incremental; could not write dependency graph: \(error.localizedDescription)"))
+          /// Ensure that a bogus dependency graph is not used next time.
+          buildRecordInfo?.removeBuildRecord()
+          return
       }
     }
     buildRecordInfo?.writeBuildRecord(

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1053,9 +1053,12 @@ extension Driver {
   }
 
   private func writeIncrementalBuildInformation(_ jobs: [Job]) {
+    // In case the write fails, don't crash the build.
+    // A mitigation to rdar://76359678.
+    // If the write fails, import incrementality is lost, but it is not a fatal error.
     if let incrementalCompilationState = self.incrementalCompilationState {
       let hadError = incrementalCompilationState.writeDependencyGraph()
-      /// Ensure that a bogus dependency graph is not used next time
+      /// Ensure that a bogus dependency graph is not used next time.
       guard !hadError else {
         buildRecordInfo?.removeBuildRecord()
         return

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -184,6 +184,13 @@ import SwiftOptions
     }
   }
 
+  func removeBuildRecord() {
+    guard let absPath = buildRecordPath.absolutePath else {
+      return
+    }
+    try? fileSystem.removeFileTree(absPath)
+  }
+
   /// Before writing to the dependencies file path, preserve any previous file
   /// that may have been there. No error handling -- this is just a nicety, it
   /// doesn't matter if it fails.

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -496,23 +496,26 @@ extension IncrementalCompilationState {
 // MARK: - Serialization
 
 extension IncrementalCompilationState {
-  @_spi(Testing) public func writeDependencyGraph() {
+  @_spi(Testing) public func writeDependencyGraph() -> Bool {
     // If the cross-module build is not enabled, the status quo dictates we
     // not emit this file.
     guard moduleDependencyGraph.info.isCrossModuleIncrementalBuildEnabled else {
-      return
+      return false
     }
 
     guard
       let recordInfo = self.driver.buildRecordInfo
     else {
+      // It's OK to silently fail because no build record will be written
+      // so there will be no attempt to use the saved module dependency graph
+      // next time.
       self.driver.diagnosticEngine.emit(
         .warning_could_not_write_dependency_graph)
-      return
+      return true
     }
-    self.moduleDependencyGraph.write(to: recordInfo.dependencyGraphPath,
-                                     on: self.driver.fileSystem,
-                                     compilerVersion: recordInfo.actualSwiftVersion)
+    return self.moduleDependencyGraph.write(to: recordInfo.dependencyGraphPath,
+                                            on: self.driver.fileSystem,
+                                            compilerVersion: recordInfo.actualSwiftVersion)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -674,8 +674,8 @@ extension ModuleDependencyGraph {
       try fileSystem.writeFileContents(path,
                                        bytes: data,
                                        atomically: true)
-    } catch let e {
-      info.diagnosticEngine.emit(.error_could_not_write_dep_graph(to: path, error: e))
+    } catch {
+      info.diagnosticEngine.emit(.warning_could_not_write_dep_graph(to: path, error: error))
     }
   }
 
@@ -1035,11 +1035,11 @@ fileprivate extension DependencyKey.Designator {
 }
 
 extension Diagnostic.Message {
-  fileprivate static func error_could_not_write_dep_graph(
+  fileprivate static func warning_could_not_write_dep_graph(
     to path: VirtualPath,
-    error: Swift.Error
+    error: Error
   ) -> Diagnostic.Message {
-      .error("could not write driver dependency graph to \(path). Returned error was: \(error)")
+    .warning("could not write driver dependency graph to \(path), Returned error was: \(error.localizedDescription)")
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -663,19 +663,22 @@ extension ModuleDependencyGraph {
   ///   - fileSystem: The file system for this location.
   ///   - compilerVersion: A string containing version information for the
   ///                      driver used to create this file.
+  /// - Returns: true if had error
   @_spi(Testing) public func write(
     to path: VirtualPath,
     on fileSystem: FileSystem,
     compilerVersion: String
-  ) {
+  ) -> Bool {
     let data = ModuleDependencyGraph.Serializer.serialize(self, compilerVersion)
 
     do {
       try fileSystem.writeFileContents(path,
                                        bytes: data,
                                        atomically: true)
+      return false
     } catch {
       info.diagnosticEngine.emit(.warning_could_not_write_dep_graph(to: path, error: error))
+      return true
     }
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -668,17 +668,16 @@ extension ModuleDependencyGraph {
     to path: VirtualPath,
     on fileSystem: FileSystem,
     compilerVersion: String
-  ) -> Bool {
+  ) throws {
     let data = ModuleDependencyGraph.Serializer.serialize(self, compilerVersion)
 
     do {
       try fileSystem.writeFileContents(path,
                                        bytes: data,
                                        atomically: true)
-      return false
     } catch {
-      info.diagnosticEngine.emit(.warning_could_not_write_dep_graph(to: path, error: error))
-      return true
+      throw IncrementalCompilationState.WriteDependencyGraphError.couldNotWrite(
+        path: path, error: error)
     }
   }
 
@@ -1034,15 +1033,6 @@ fileprivate extension DependencyKey.Designator {
     case .sourceFileProvide(name: _):
       return 6
     }
-  }
-}
-
-extension Diagnostic.Message {
-  fileprivate static func warning_could_not_write_dep_graph(
-    to path: VirtualPath,
-    error: Error
-  ) -> Diagnostic.Message {
-    .warning("could not write driver dependency graph to \(path), Returned error was: \(error.localizedDescription)")
   }
 }
 

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -18,7 +18,7 @@ class DependencyGraphSerializationTests: XCTestCase {
   func roundTrip(_ graph: ModuleDependencyGraph) throws {
     let mockPath = VirtualPath.absolute(AbsolutePath("/module-dependency-graph"))
     let fs = InMemoryFileSystem()
-    graph.write(to: mockPath, on: fs, compilerVersion: "Swift 99")
+    try graph.write(to: mockPath, on: fs, compilerVersion: "Swift 99")
 
     let deserializedGraph = try ModuleDependencyGraph.read(from: mockPath,
                                                            info: .mock(fileSystem: fs))!


### PR DESCRIPTION
A mitigation to rdar://76359678.
If the write fails, import incrementality is lost, but it is not a fatal error.
@CodaFi , what do you think?