### PR TITLE
Expose supportedFrontendFlags

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -307,7 +307,7 @@ public struct Driver {
   @_spi(Testing) public var externalBuildArtifacts: ExternalBuildArtifacts? = nil
 
   /// A collection of all the flags the selected toolchain's `swift-frontend` supports
-  @_spi(Testing) public let supportedFrontendFlags: Set<String>
+  public let supportedFrontendFlags: Set<String>
 
   /// A global queue for emitting non-interrupted messages into stderr
   public static let stdErrQueue = DispatchQueue(label: "org.swift.driver.emit-to-stderr")


### PR DESCRIPTION
SwiftPM needs this to check what compiler flags are available.

Currently it is possible to use a version of SwiftPM, `5.5`, that attempts to use flags that do not currently exist on any publicly available version of `swiftc` 