### PR TITLE
Add support for compile jobs that read source input from standard input.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
+          "version": "0.3.2"
         }
       },
       {
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "main",
-          "revision": "53e245a2cf429e0d97633c633ca9968f5eb21b15",
+          "revision": "b7b4c5eaa798708d6233ca07908a7cab75620040",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": "main",
-          "revision": "207f9c6bc5e33eb8383266c0cd3129c1276f534b",
+          "revision": "435a2708a6e486d69ea7d7aaa3f4ad243bc3b408",
           "version": null
         }
       },
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "1bce5b89a11912fb8a8c48bd404bd24979472f27",
-          "version": "4.0.3"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -51,8 +51,14 @@ public final class SwiftDriverExecutor: DriverExecutor {
     } else {
       var childEnv = env
       childEnv.merge(job.extraEnvironment, uniquingKeysWith: { (_, new) in new })
-
-      let process = try Process.launchProcess(arguments: arguments, env: childEnv)
+      let process : ProcessProtocol
+      if job.inputs.contains(TypedVirtualPath(file: .standardInput, type: .swift)) {
+        process = try Process.launchProcessAndWriteInput(
+          arguments: arguments, env: childEnv, inputFileHandle: FileHandle.standardInput
+        )
+      } else {
+        process = try Process.launchProcess(arguments: arguments, env: childEnv)
+      }
       return try process.waitUntilExit()
     }
   }

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -29,6 +29,11 @@ class JobCollectingDelegate: JobExecutionDelegate {
       return .init()
     }
 
+    static func launchProcessAndWriteInput(arguments: [String], env: [String : String],
+                                           inputFileHandle: FileHandle) throws -> StubProcess {
+      return .init()
+    }
+
     var processID: TSCBasic.Process.ProcessID { .init(-1) }
 
     func waitUntilExit() throws -> ProcessResult {
@@ -203,6 +208,84 @@ final class JobExecutorTests: XCTestCase {
       XCTAssertTrue(localFileSystem.exists(AbsolutePath(fooObject)), "expected foo.o to be present in the temporary directory")
       try resolver.removeTemporaryDirectory()
       XCTAssertFalse(localFileSystem.exists(AbsolutePath(fooObject)), "expected foo.o to be removed from the temporary directory")
+    }
+#endif
+  }
+
+  /// Ensure the executor is capable of forwarding its standard input to the compile job that requires it.
+  func testInputForwarding() throws {
+#if os(macOS)
+    let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
+                                           processSet: ProcessSet(),
+                                           fileSystem: localFileSystem,
+                                           env: ProcessEnv.vars)
+    let toolchain = DarwinToolchain(env: ProcessEnv.vars, executor: executor)
+    try withTemporaryDirectory { path in
+      let exec = path.appending(component: "main")
+      let compile = Job(
+        moduleName: "main",
+        kind: .compile,
+        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        commandLine: [
+          "-frontend",
+          "-c",
+          "-primary-file",
+          // This compile job must read the input from STDIN
+          "-",
+          "-target", "x86_64-apple-darwin18.7.0",
+          "-enable-objc-interop",
+          "-sdk",
+          .path(.absolute(try toolchain.sdk.get())),
+          "-module-name", "main",
+          "-o", .path(.temporary(RelativePath("main.o"))),
+        ],
+        inputs: [TypedVirtualPath(file: .standardInput, type: .swift )],
+        primaryInputs: [TypedVirtualPath(file: .standardInput, type: .swift )],
+        outputs: [.init(file: VirtualPath.temporary(RelativePath("main.o")).intern(),
+                        type: .object)]
+      )
+      let link = Job(
+        moduleName: "main",
+        kind: .link,
+        tool: .absolute(try toolchain.getToolPath(.dynamicLinker)),
+        commandLine: [
+          .path(.temporary(RelativePath("main.o"))),
+          .path(.absolute(try toolchain.clangRT.get())),
+          "-syslibroot", .path(.absolute(try toolchain.sdk.get())),
+          "-lobjc", "-lSystem", "-arch", "x86_64",
+          "-force_load", .path(.absolute(try toolchain.compatibility50.get())),
+          "-force_load", .path(.absolute(try toolchain.compatibilityDynamicReplacements.get())),
+          "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
+          "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),
+          "-rpath", "/usr/lib/swift", "-macosx_version_min", "10.14.0", "-no_objc_category_merging",
+          "-o", .path(.absolute(exec)),
+        ],
+        inputs: [
+          .init(file: VirtualPath.temporary(RelativePath("main.o")).intern(), type: .object),
+        ],
+        primaryInputs: [],
+        outputs: [.init(file: VirtualPath.relative(RelativePath("main")).intern(), type: .image)]
+      )
+
+      // Create a file with inpuit
+      let inputFile = path.appending(component: "main.swift")
+      try localFileSystem.writeFileContents(inputFile) {
+        $0 <<< "print(\"Hello, World\")"
+      }
+      // We are going to override he executors standard input FileHandle to the above
+      // input file, to simulate it being piped over standard input to this compilation.
+      let testFile: FileHandle = FileHandle(forReadingAtPath: inputFile.description)!
+      let delegate = JobCollectingDelegate()
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
+      let executor = MultiJobExecutor(workload: .all([compile, link]),
+                                      resolver: resolver, executorDelegate: delegate,
+                                      diagnosticsEngine: DiagnosticsEngine(),
+                                      inputHandleOverride: testFile)
+      try executor.execute(env: toolchain.env, fileSystem: localFileSystem)
+
+      // Execute the resulting program
+      let output = try TSCBasic.Process.checkNonZeroExit(args: exec.pathString)
+      XCTAssertEqual(output, "Hello, World\n")
     }
 #endif
   }


### PR DESCRIPTION
This change uses `Process` input handling added in https://github.com/apple/swift-tools-support-core/pull/208 to allow forwarding of the driver's Standard Input to a frontend job.

Resolves rdar://76454784