### PR TITLE
PrebuiltModuleGen: Allow arm64 interfaces to depend on arm64e interfaces

### DIFF
--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/F.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/F.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name F
+import Swift
+import A
+public func FuncF() { }
+


### PR DESCRIPTION
 Prebuit modules of arm64e interfaces can be loaded to help building arm64 interfaces.