### PR TITLE
Temporarily disable tests that fail on Apple Silicon CI.

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -754,6 +754,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
 // We only care about prebuilt modules in macOS.
 #if os(macOS)
   func testPrebuiltModuleGenerationJobs() throws {
+    #if arch(arm64)
+      // Disabled on Apple Silicon
+      // rdar://76609781
+      throw XCTSkip()
+    #endif
+
     func getInputModules(_ job: Job) -> [String] {
       return job.inputs.map { input in
         return input.file.absolutePath!.parentDirectory.basenameWithoutExt

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -131,6 +131,11 @@ final class IntegrationTests: IntegrationTestCase {
   }
 
   func testLitDriverValidationTests() throws {
+    #if os(macOS) && arch(arm64)
+      // Disabled on Apple Silicon
+      // rdar://76609781
+      throw XCTSkip()
+    #endif
     guard ProcessEnv.vars.keys.contains("SWIFT_DRIVER_ENABLE_FAILING_INTEGRATION_TESTS") else {
       throw XCTSkip("Not all Driver validation-tests supported")
     }

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -90,7 +90,13 @@ extension DarwinToolchain {
 
 final class JobExecutorTests: XCTestCase {
   func testDarwinBasic() throws {
-#if os(macOS)
+  #if os(macOS)
+    #if arch(arm64)
+      // Disabled on Apple Silicon
+      // rdar://76609781
+      throw XCTSkip()
+    #endif
+
     let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
                                            processSet: ProcessSet(),
                                            fileSystem: localFileSystem,
@@ -362,6 +368,12 @@ final class JobExecutorTests: XCTestCase {
   }
 
   func testSaveTemps() throws {
+    #if os(macOS) && arch(arm64)
+      // Disabled on Apple Silicon
+      // rdar://76609781
+      throw XCTSkip()
+    #endif
+
     do {
       try withTemporaryDirectory { path in
         let main = path.appending(component: "main.swift")


### PR DESCRIPTION
The following tests currently fail on Apple Silicon:
```
testDarwinBasic
testSaveTemps
testPrebuiltModuleGenerationJobs
testLitDriverDependenciesTests
```
e.g. https://ci.swift.org/job/oss-swift-incremental-RA-macos-apple-silicon/433/consoleText

For the most part, the test code just does not account for the fact that macOS can run on anything other than x86. 
These tests are going to be disabled on Apple Silicon for the time being to unblock CI, while we go and fix the test code. 