### PR TITLE
Generalize disabled tests to also work on Apple Silicon 

### DIFF
--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/A.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/A.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A
+import Swift
+public func FuncA() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/E.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/E.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name E
+import Swift
+public func FuncE() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/G.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/G.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name G
+import Swift
+import E
+public func FuncG() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/H.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/H.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name H
+import Swift
+import A
+import E
+import F
+import G
+public func FuncH() { }

--- a/TestInputs/mock-sdk.sdk/usr/lib/swift/Swift.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/TestInputs/mock-sdk.sdk/usr/lib/swift/Swift.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,2 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib -module-name Swift

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -95,13 +95,8 @@ extension DarwinToolchain {
 
 final class JobExecutorTests: XCTestCase {
   func testDarwinBasic() throws {
-  #if os(macOS)
-    #if arch(arm64)
-      // Disabled on Apple Silicon
-      // rdar://76609781
-      throw XCTSkip()
-    #endif
-
+    #if os(macOS)
+    let hostTriple = try Driver(args: ["swiftc", "test.swift"]).hostTriple
     let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
                                            processSet: ProcessSet(),
                                            fileSystem: localFileSystem,
@@ -142,7 +137,7 @@ final class JobExecutorTests: XCTestCase {
           "-primary-file",
           .path(inputs[ "foo"]!.file),
           .path(inputs["main"]!.file),
-          "-target", "x86_64-apple-darwin18.7.0",
+          "-target", .flag(hostTriple.triple),
           "-enable-objc-interop",
           "-sdk",
           .path(.absolute(try toolchain.sdk.get())),
@@ -164,7 +159,7 @@ final class JobExecutorTests: XCTestCase {
           .path(.relative(RelativePath("foo.swift"))),
           "-primary-file",
           .path(inputs["main"]!.file),
-          "-target", "x86_64-apple-darwin18.7.0",
+          "-target", .flag(hostTriple.triple),
           "-enable-objc-interop",
           "-sdk",
           .path(.absolute(try toolchain.sdk.get())),
@@ -185,9 +180,7 @@ final class JobExecutorTests: XCTestCase {
           .path(.temporary(RelativePath("main.o"))),
           .path(.absolute(try toolchain.clangRT.get())),
           "-syslibroot", .path(.absolute(try toolchain.sdk.get())),
-          "-lobjc", "-lSystem", "-arch", "x86_64",
-          "-force_load", .path(.absolute(try toolchain.compatibility50.get())),
-          "-force_load", .path(.absolute(try toolchain.compatibilityDynamicReplacements.get())),
+          "-lobjc", "-lSystem", "-arch", .flag(hostTriple.archName),
           "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
           "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),
           "-rpath", "/usr/lib/swift", "-macosx_version_min", "10.14.0", "-no_objc_category_merging", "-o",
@@ -200,7 +193,6 @@ final class JobExecutorTests: XCTestCase {
         primaryInputs: [],
         outputs: [.init(file: VirtualPath.relative(RelativePath("main")).intern(), type: .image)]
       )
-
       let delegate = JobCollectingDelegate()
       let executor = MultiJobExecutor(workload: .all([compileFoo, compileMain, link]),
                                       resolver: resolver, executorDelegate: delegate, diagnosticsEngine: DiagnosticsEngine())


### PR DESCRIPTION
https://github.com/apple/swift-driver/pull/599 and https://github.com/apple/swift-driver/pull/602 disabled the following tests:
- `testDarwinBasic`
- `testSaveTemps`
- `testInputForwarding`
- `testPrebuiltModuleGenerationJobs`
This PR generalizes those tests to be agnostic to the macOS architecture and re-enables them on Apple Silicon. 

The only remaining Apple Silicon-disabled test after this is:
- `testLitDriverDependenciesTests `