### PR TITLE
PrebuiltModuleGen: consider failures of Foundation and anything below critical

### DIFF
--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -112,7 +112,7 @@ do {
       try executor.execute(workload: DriverExecutorWorkload.init(jobs, nil, continueBuildingAfterErrors: true),
                            delegate: delegate, numParallelJobs: 128)
     } catch {
-      // Only fail the process if stdlib failed
+      // Only fail when critical failures happened.
       if delegate.hasCriticalFailure {
         exit(1)
       }

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -107,13 +107,13 @@ do {
                             executor: executor,
                             compilerExecutableDir: swiftcPath.parentDirectory)
     let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: inputMap, into: outputDir, exhaustive: !coreMode)
-    let delegate = PrebuitModuleGenerationDelegate(diagnosticsEngine, verbose)
+    let delegate = PrebuitModuleGenerationDelegate(jobs, diagnosticsEngine, verbose)
     do {
       try executor.execute(workload: DriverExecutorWorkload.init(jobs, nil, continueBuildingAfterErrors: true),
                            delegate: delegate, numParallelJobs: 128)
     } catch {
       // Only fail the process if stdlib failed
-      if delegate.hasStdlibFailure {
+      if delegate.hasCriticalFailure {
         exit(1)
       }
     }


### PR DESCRIPTION
Foundation failures can lead to noticeable slowness in compilation, so we should
consider them critical.