### PR TITLE
Remove target `x86_64` specialization from `testExplicitModuleBuildEndToEnd`

### DIFF
--- a/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/G.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name G -swift-version 5 -target x86_64-apple-macosx10.9
+// swift-module-flags: -module-name G -swift-version 5
 #if swift(>=5.0)
 @_exported import G
 import Swift

--- a/TestInputs/ExplicitModuleBuilds/Swift/Swift.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/Swift.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
 // swift-compiler-version: Swift version 5.4-dev (LLVM bd2476a8056e227, Swift 68ac381af6ca0e3)
-// swift-module-flags: -disable-objc-attr-requires-foundation-module -target x86_64-apple-macosx10.9 -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -enable-experimental-concise-pound-file -module-name Swift
+// swift-module-flags: -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -enable-experimental-concise-pound-file -module-name Swift
 import SwiftShims

--- a/TestInputs/ExplicitModuleBuilds/Swift/SwiftOnoneSupport.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/SwiftOnoneSupport.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
 // swift-compiler-version: Swift version 5.4-dev (LLVM bd2476a8056e227, Swift 68ac381af6ca0e3)
-// swift-module-flags: -disable-objc-attr-requires-foundation-module -target x86_64-apple-macosx10.9 -enable-objc-interop -enable-library-evolution -module-link-name swiftSwiftOnoneSupport -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -module-name SwiftOnoneSupport
+// swift-module-flags: -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-library-evolution -module-link-name swiftSwiftOnoneSupport -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -module-name SwiftOnoneSupport
 import Swift


### PR DESCRIPTION
This explicit specifier causes these modules to get built for `x86_64` even on `Apple Silicon` hosts:
e.g. https://ci.swift.org/job/oss-swift-incremental-RA-macos-apple-silicon/490/console