### PR TITLE
Update `isSDKTooOld` to be compatible with older compilers.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2040,8 +2040,8 @@ extension Driver {
 extension Driver {
   static func isSDKTooOld(sdkPath: AbsolutePath, fileSystem: FileSystem,
                           diagnosticsEngine: DiagnosticsEngine) -> Bool {
-    let sdkInfo = DarwinToolchain.readSDKInfo(fileSystem, VirtualPath.absolute(sdkPath).intern())
-    guard let sdkInfo = sdkInfo else {
+    let sdkInfoReadAttempt = DarwinToolchain.readSDKInfo(fileSystem, VirtualPath.absolute(sdkPath).intern())
+    guard let sdkInfo = sdkInfoReadAttempt else {
       diagnosticsEngine.emit(.warning_no_sdksettings_json(sdkPath.pathString))
       return false
     }


### PR DESCRIPTION
5.3 and ealier compilers may hit:
```
swift-driver/Sources/SwiftDriver/Driver/Driver.swift:2044:15: error: definition conflicts with previous value
    guard let sdkInfo = sdkInfo else {
```
e.g.
https://ci.swift.org/job/swift-PR-toolchain-osx/949/console