### PR TITLE
test SymbolGraph/EmitWhileBuilding when a lit dir is available

### DIFF
--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -155,6 +155,10 @@ final class IntegrationTests: IntegrationTestCase {
     }
     try self.runLitTests(suite: "test", "stdlib")
   }
+  
+  func testLitSymbolGraphFrontendTest() throws {
+    try runLitTests(suite: "test", "SymbolGraph", "EmitWhileBuilding.swift")
+  }
 
   func runLitTests(suite: String...) throws {
   #if os(macOS)


### PR DESCRIPTION
As part of rdar://76815547, i want to make sure the symbol-graph's integration into the frontend is properly flexed with both the old driver and the new driver.