### PR TITLE
[DNM] Revert disabling tests on Apple Silicon

### DIFF
--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -607,6 +607,13 @@ class ExecuteJobRule: LLBuildRule {
       let result = try process.waitUntilExit()
       let success = result.exitStatus == .terminated(code: EXIT_SUCCESS)
 
+
+      if !success {
+        print("Job failure: \(job)")
+        print("Output: \(try result.utf8Output())")
+        print("Err Output: \(try result.utf8stderrOutput())")
+      }
+
       if !success {
         switch result.exitStatus {
         case let .terminated(code):

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -96,12 +96,6 @@ extension DarwinToolchain {
 final class JobExecutorTests: XCTestCase {
   func testDarwinBasic() throws {
   #if os(macOS)
-    #if arch(arm64)
-      // Disabled on Apple Silicon
-      // rdar://76609781
-      throw XCTSkip()
-    #endif
-
     let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
                                            processSet: ProcessSet(),
                                            fileSystem: localFileSystem,
@@ -221,11 +215,6 @@ final class JobExecutorTests: XCTestCase {
   /// Ensure the executor is capable of forwarding its standard input to the compile job that requires it.
   func testInputForwarding() throws {
 #if os(macOS)
-    #if arch(arm64)
-      // Disabled on Apple Silicon
-      // rdar://76609781
-      throw XCTSkip()
-    #endif      
     let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(),
                                            processSet: ProcessSet(),
                                            fileSystem: localFileSystem,
@@ -456,12 +445,6 @@ final class JobExecutorTests: XCTestCase {
   }
 
   func testSaveTemps() throws {
-    #if os(macOS) && arch(arm64)
-      // Disabled on Apple Silicon
-      // rdar://76609781
-      throw XCTSkip()
-    #endif
-
     do {
       try withTemporaryDirectory { path in
         let main = path.appending(component: "main.swift")


### PR DESCRIPTION
`testDarwinBasic`
`testInputForwarding`
`testSaveTemps`

I am not able to reproduce the original failures anymore on a local machine so experimenting with CI to try and see what the differences are. 