### PR TITLE
Small fix to `emitModuleJob` for compatibility with <=5.3 compilers.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -185,9 +185,9 @@ extension Driver {
 
   private mutating func addEmitModuleJob(addJobBeforeCompiles: (Job) -> Void, addJobAfterCompiles: (Job) -> Void) throws {
     if shouldCreateEmitModuleJob {
-      let emitModuleJob = try emitModuleJob()
-      addJobBeforeCompiles(emitModuleJob)
-      try addVerifyJobs(emitModuleJob: emitModuleJob, addJob: addJobAfterCompiles)
+      let emitJob = try emitModuleJob()
+      addJobBeforeCompiles(emitJob)
+      try addVerifyJobs(emitModuleJob: emitJob, addJob: addJobAfterCompiles)
     }
   }
 


### PR DESCRIPTION
SwiftCI is using a 5.3 compiler and errors out on trying to build this code with:
```
swift-driver/Sources/SwiftDriver/Jobs/Planning.swift:188:31: error: variable used within its own initial value
               let emitModuleJob = try emitModuleJob()
```