### PR TITLE
Re-enable `testLitDriverDependenciesTests` when run on Apple Silicon

### DIFF
--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -127,11 +127,6 @@ final class IntegrationTests: IntegrationTestCase {
   }
 
   func testLitDriverDependenciesTests() throws {
-    #if os(macOS) && arch(arm64)
-      // Disabled on Apple Silicon
-      // rdar://76609781
-      throw XCTSkip()
-    #endif
     try runLitTests(suite: "test", "Driver", "Dependencies")
   }
 


### PR DESCRIPTION
This test was previously failing in `swift` CI.
I cannot trigger the failure locally so re-enabling here to test with cross-repository PR testing. 