### PR TITLE
Add workaround for building executables with older CMake versions.

### DIFF
--- a/Sources/swift-driver/CMakeLists.txt
+++ b/Sources/swift-driver/CMakeLists.txt
@@ -12,4 +12,18 @@ target_link_libraries(swift-driver PUBLIC
   SwiftDriver
   SwiftDriverExecution)
 
+# This is a fairly egregious workaround for the fact that in versions < 3.17,
+# executables do not get `-rpath` linker arguments for their linked library
+# dependencies (direct and transitive)
+if(CMAKE_VERSION VERSION_LESS 3.17)
+  get_target_property(TSC_UTIL_LIB TSCUtility LOCATION)
+  get_filename_component(TSC_LIB_DIR ${TSC_UTIL_LIB} DIRECTORY)
 
+  get_target_property(LLBUILD_LIB llbuildSwift LOCATION)
+  get_filename_component(LLBUILD_LIB_DIR ${LLBUILD_LIB} DIRECTORY)
+
+  get_target_property(ARGPARSE_LIB ArgumentParser LOCATION)
+  get_filename_component(ARGPARSE_LIB_DIR ${ARGPARSE_LIB} DIRECTORY)
+
+  target_link_options(swift-driver PUBLIC "LINKER:-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY},-rpath,${TSC_LIB_DIR},-rpath,${LLBUILD_LIB_DIR},-rpath,${ARGPARSE_LIB_DIR}")
+endif()

--- a/Sources/swift-help/CMakeLists.txt
+++ b/Sources/swift-help/CMakeLists.txt
@@ -13,3 +13,15 @@ target_link_libraries(swift-help PUBLIC
   ArgumentParser
   TSCBasic)
 
+# This is a fairly egregious workaround for the fact that in versions < 3.17,
+# executables do not get `-rpath` linker arguments for their linked library
+# dependencies (direct and transitive)
+if(CMAKE_VERSION VERSION_LESS 3.17)
+  get_target_property(TSC_UTIL_LIB TSCUtility LOCATION)
+  get_filename_component(TSC_LIB_DIR ${TSC_UTIL_LIB} DIRECTORY)
+  
+  get_target_property(ARGPARSE_LIB ArgumentParser LOCATION)
+  get_filename_component(ARGPARSE_LIB_DIR ${ARGPARSE_LIB} DIRECTORY)
+  
+  target_link_options(swift-help PUBLIC "LINKER:-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY},-rpath,${TSC_LIB_DIR},-rpath,${ARGPARSE_LIB_DIR}")
+endif()


### PR DESCRIPTION
Some time between CMake 3.16 and 3.17 the default behaviour seems to have changed as follows:
For a project which will build an executable, e.g.:
```
add_executable(exe_target
    main.swift)
target_link_libraries(exe_target PUBLIC
    libA
    libB)
```
In 3.17, the invocation command to create the `exe_target` executable includes `-Xlinker -rpath -Xlinkier <libA_path/lib>` and so forth for the linked libraries and their dependencies.
In 3.16, the linker is not passed the rpath flags, so the executable ends up without the `LC_RPATH` required for it to run.
This affects executable targets only, libraries do still have rpaths propagated correctly.

The correct solution (which will hopefully happen soon) is to bump the compiler's minimum CMake version to 3.18.
This is under discussion now here: https://forums.swift.org/t/bump-cmake-version-to-3-18