### PR TITLE
Support subcommands when querying for help

### DIFF
--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -55,7 +55,11 @@ enum Subcommand: String, CaseIterable {
 }
 
 struct SwiftHelp: ParsableCommand {
-  @Argument var topic: HelpTopic = .driver(.interactive)
+  @Argument(help: "The topic to display help for.")
+  var topic: HelpTopic = .driver(.interactive)
+
+  @Argument(help: "The help subtopics, if applicable.")
+  var subtopics: [String] = []
 
   @Flag(name: .customLong("show-hidden", withSingleDash: true),
         help: "List hidden (unsupported) options")
@@ -89,7 +93,11 @@ struct SwiftHelp: ParsableCommand {
       }
 
       // Execute the subcommand with --help.
-      try exec(path: path.pathString, args: [execName, "--help"])
+      if subtopics.isEmpty {
+        try exec(path: path.pathString, args: [execName, "--help"])
+      } else {
+        try exec(path: path.pathString, args: [execName, "help"] + subtopics)
+      }
     }
   }
 }


### PR DESCRIPTION
Currently, running `swift help package` (when the `swift-help` from this package is installed) prints the help screen for the `swift package` command. However, subcommands and sub-subcommands are not accessible:

```
$ swift help package clean
Error: Unexpected argument 'clean'
Usage: swift-help [<topic>] [-show-hidden]
  See 'swift-help --help' for more information.
```

This adds an array that captures additional subcommands and passes them along to the matched command:

```
$ swift help package clean
OVERVIEW: Delete build artifacts

USAGE: swift package clean [<options>] --enable-index-store

OPTIONS:
  -Xcc <Xcc>              Pass flag through to all C compiler invocations 
  -Xswiftc <Xswiftc>      Pass flag through to all Swift compiler invocations 
  -Xlinker <Xlinker>      Pass flag through to all linker invocations 
  ....
```