### PR TITLE
Bump required CMake version to 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-cmake_minimum_required(VERSION 3.15.1)
+cmake_minimum_required(VERSION 3.17)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 


### PR DESCRIPTION
There are several key livability fixes in 3.17 for building Swift code.
This should prevent scenarios like this:
https://github.com/apple/swift/pull/37114

Where CMake `<3.17` missed setting up rpaths on the `swift-driver` executable.