### PR TITLE
Revert "Bump required CMake version to 3.17"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.15.1)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 


### PR DESCRIPTION
Reverts apple/swift-driver#624

This is breaking many Linux bots as they only have CMake 3.16.5. Reverting until the bots are updated.

rdar://77440032