### PR TITLE
[5.5] Change branch dependencies on TSC and LLBuild from `main` to `release/5.5`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -112,7 +112,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("main")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("release/5.5")),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools
@@ -126,7 +126,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("release/5.5")),
     .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "4.0.0")),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate


### PR DESCRIPTION
This switches the branch dependencies for `swift-tools-support-core` and `swift-llbuild`, as we do for every release branch.  This is needed in order for SwiftPM to make the switch (since it has a dependency on `swift-driver`).