### PR TITLE
Verify emitted module interfaces by default

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -409,7 +409,7 @@ extension Driver {
        parsedOptions.hasArgument(.enableLibraryEvolution),
        parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
                              negative: .noVerifyEmittedModuleInterface,
-                             default: false)
+                             default: true)
     else { return }
 
     func addVerifyJob(forPrivate: Bool) throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3637,7 +3637,6 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
                                      "foo", "-emit-module-interface",
-                                     "-verify-emitted-module-interface",
                                      "-enable-library-evolution"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 3)
@@ -3664,11 +3663,20 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 2)
     }
 
+    // Explicitly disabled
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
+                                     "foo", "-emit-module-interface",
+                                     "-enable-library-evolution",
+                                     "-no-verify-emitted-module-interface"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 2)
+    }
+
     // Emit-module separately
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
                                      "foo", "-emit-module-interface",
-                                     "-verify-emitted-module-interface",
                                      "-enable-library-evolution",
                                      "-experimental-emit-module-separately"])
       let plannedJobs = try driver.planBuild()
@@ -3689,7 +3697,6 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
                                      "foo", "-emit-module-interface",
-                                     "-verify-emitted-module-interface",
                                      "-enable-library-evolution",
                                      "-whole-module-optimization"])
       let plannedJobs = try driver.planBuild()


### PR DESCRIPTION
Verifying swiftinterface files after they are emitted will detect framework breaking issues much earlier. It can be turned off in offending projects with `-no-verify-emitted-module-interface`.

rdar://77534863