### PR TITLE
[Incremental] Gracefully recover from when an input cannot be found in the inputDependencySourceMap.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -691,8 +691,9 @@ public struct Driver {
         moduleName: moduleOutputInfo.name)
   }
 
-  public mutating func planBuild() throws -> [Job] {
-    let (jobs, incrementalCompilationState) = try planPossiblyIncrementalBuild()
+  public mutating func planBuild( simulateGetInputFailure: Bool = false ) throws -> [Job] {
+    let (jobs, incrementalCompilationState) = try planPossiblyIncrementalBuild(
+      simulateGetInputFailure: simulateGetInputFailure)
     self.incrementalCompilationState = incrementalCompilationState
     return jobs
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -468,6 +468,9 @@ extension IncrementalCompilationState {
     /// that reads the dependency graph from a serialized format on disk instead
     /// of reading O(N) swiftdeps files.
     public static let readPriorsFromModuleDependencyGraph    = Options(rawValue: 1 << 5)
+    /// Causes `getInput` to fail, in order to allow testing.
+    /// No need to come from a command-line option.
+    public static let simulateGetInputFailure                = Options(rawValue: 1 << 6)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -15,12 +15,15 @@ import TSCBasic
 
 // Initial incremental state computation
 extension IncrementalCompilationState {
-  static func computeIncrementalStateForPlanning(driver: inout Driver)
+  static func computeIncrementalStateForPlanning(
+    driver: inout Driver,
+    simulateGetInputFailure: Bool)
     throws -> IncrementalCompilationState.InitialStateForPlanning?
   {
     guard driver.shouldAttemptIncrementalCompilation else { return nil }
 
-    let options = computeIncrementalOptions(driver: &driver)
+    let options = computeIncrementalOptions(driver: &driver,
+                                            simulateGetInputFailure: simulateGetInputFailure)
 
     guard let outputFileMap = driver.outputFileMap else {
       driver.diagnosticEngine.emit(.warning_incremental_requires_output_file_map)
@@ -66,7 +69,10 @@ extension IncrementalCompilationState {
   }
 
   // Extract options relevant to incremental builds
-  static func computeIncrementalOptions(driver: inout Driver) -> IncrementalCompilationState.Options {
+  static func computeIncrementalOptions(
+    driver: inout Driver,
+    simulateGetInputFailure: Bool)
+  -> IncrementalCompilationState.Options {
     var options: IncrementalCompilationState.Options = []
     if driver.parsedOptions.contains(.driverAlwaysRebuildDependents) {
       options.formUnion(.alwaysRebuildDependents)
@@ -87,6 +93,9 @@ extension IncrementalCompilationState {
                                   default: true) {
       options.formUnion(.enableCrossModuleIncrementalBuild)
       options.formUnion(.readPriorsFromModuleDependencyGraph)
+    }
+    if simulateGetInputFailure {
+      options.formUnion(.simulateGetInputFailure)
     }
     return options
   }
@@ -131,6 +140,10 @@ extension IncrementalCompilationState {
     @_spi(Testing) public var emitDependencyDotFileAfterEveryImport: Bool {
       options.contains(.emitDependencyDotFileAfterEveryImport)
     }
+    @_spi(Testing) public var simulateGetInputFailure: Bool {
+      options.contains(.simulateGetInputFailure)
+    }
+
 
     @_spi(Testing) public init(
       _ options: Options,

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -236,8 +236,11 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     let nodesDirectlyInvalidatedByExternals =
       graph.collectNodesInvalidatedByChangedOrAddedExternals()
     // Wait till the last minute to do the transitive closure as an optimization.
-    let inputsInvalidatedByExternals = graph.collectInputsUsingInvalidated(
+    guard let inputsInvalidatedByExternals = graph.collectInputsUsingInvalidated(
       nodes: nodesDirectlyInvalidatedByExternals)
+    else {
+      return nil
+    }
     return (graph, inputsInvalidatedByExternals)
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -69,7 +69,10 @@ import SwiftOptions
     return source
   }
   @_spi(Testing) public func getInput(for source: DependencySource) -> TypedVirtualPath? {
-    guard let input = inputDependencySourceMap[source] else {
+    guard let input =
+            info.simulateGetInputFailure ? nil
+            : inputDependencySourceMap[source]
+    else {
       info.diagnosticEngine.emit(
         warning: "\(source.file.basename) not found in inputDependencySourceMap; created for: \(creationPhase), now: \(phase)")
       return nil
@@ -274,7 +277,8 @@ extension ModuleDependencyGraph {
   }
 
   /// Given nodes that are invalidated, find all the affected inputs that must be recompiled.
-  /// Return nil if the input could not be found, which should not happen, but somehow does.
+  /// Return nil if the input could not be found, which should not happen, but can happen when
+  /// the prior graph is read inconsistently.
   func collectInputsUsingInvalidated(
     nodes directlyInvalidatedNodes: DirectlyInvalidatedNodeSet
   ) -> TransitivelyInvalidatedInputSet? {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -37,6 +37,9 @@ import SwiftOptions
 
   @_spi(Testing) public var phase: Phase
 
+  /// The phase when the graph was created. Used to help diagnose later failures
+  let creationPhase: Phase
+
   /// Minimize the number of file system modification-time queries.
   private var externalDependencyModTimeCache = [ExternalDependency: Bool]()
 
@@ -48,6 +51,7 @@ import SwiftOptions
     ? DependencyGraphDotFileWriter(info)
     : nil
     self.phase = phase
+    self.creationPhase = phase
   }
 
   private func addMapEntry(_ input: TypedVirtualPath, _ dependencySource: DependencySource) {
@@ -60,13 +64,15 @@ import SwiftOptions
                                        file: String = #file,
                                        line: Int = #line) -> DependencySource {
     guard let source = inputDependencySourceMap[input] else {
-      fatalError("\(input.file) not found in map: \(inputDependencySourceMap), \(file):\(line) in \(function)")
+      fatalError("\(input.file.basename) not found in inputDependencySourceMap, \(file):\(line) in \(function)")
     }
     return source
   }
-  @_spi(Testing) public func getInput(for source: DependencySource) -> TypedVirtualPath {
+  @_spi(Testing) public func getInput(for source: DependencySource) -> TypedVirtualPath? {
     guard let input = inputDependencySourceMap[source] else {
-      fatalError("\(source.file) not found in map: \(inputDependencySourceMap)")
+      info.diagnosticEngine.emit(
+        warning: "\(source.file.basename) not found in inputDependencySourceMap; created for: \(creationPhase), now: \(phase)")
+      return nil
     }
     return input
   }
@@ -268,13 +274,19 @@ extension ModuleDependencyGraph {
   }
 
   /// Given nodes that are invalidated, find all the affected inputs that must be recompiled.
+  /// Return nil if the input could not be found, which should not happen, but somehow does.
   func collectInputsUsingInvalidated(
     nodes directlyInvalidatedNodes: DirectlyInvalidatedNodeSet
-  ) -> TransitivelyInvalidatedInputSet {
-    collectSwiftDepsUsingInvalidated(nodes: directlyInvalidatedNodes)
-      .reduce(into: TransitivelyInvalidatedInputSet()) { invalidatedInputs, invalidatedSwiftDeps in
-        invalidatedInputs.insert(getInput(for: invalidatedSwiftDeps))
+  ) -> TransitivelyInvalidatedInputSet? {
+    var invalidatedInputs = TransitivelyInvalidatedInputSet()
+    for invalidatedSwiftDeps in collectSwiftDepsUsingInvalidated(nodes: directlyInvalidatedNodes) {
+      guard let invalidatedInput = getInput(for: invalidatedSwiftDeps)
+      else {
+        return nil
       }
+      invalidatedInputs.insert(invalidatedInput)
+    }
+    return invalidatedInputs
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -77,7 +77,8 @@ struct CompileJobGroup {
 extension Driver {
   /// Plan a standard compilation, which produces jobs for compiling separate
   /// primary files.
-  private mutating func planStandardCompile() throws
+  private mutating func planStandardCompile(
+    simulateGetInputFailure: Bool = false) throws
   -> ([Job], IncrementalCompilationState?) {
     precondition(compilerMode.isStandardCompilationForPlanning,
                  "compiler mode \(compilerMode) is handled elsewhere")
@@ -86,7 +87,9 @@ extension Driver {
     // the planning process. This state contains the module dependency graph and
     // cross-module dependency information.
     let initialIncrementalState =
-      try IncrementalCompilationState.computeIncrementalStateForPlanning(driver: &self)
+    try IncrementalCompilationState.computeIncrementalStateForPlanning(
+      driver: &self,
+      simulateGetInputFailure: simulateGetInputFailure)
 
     // Compute the set of all jobs required to build this module
     let jobsInPhases = try computeJobsForPhasedStandardBuild()
@@ -603,7 +606,8 @@ extension Driver {
 
   /// Plan a build by producing a set of jobs to complete the build.
   /// Should be private, but compiler bug
-  /*private*/ mutating func planPossiblyIncrementalBuild() throws
+  /*private*/ mutating func planPossiblyIncrementalBuild(
+    simulateGetInputFailure: Bool = false) throws
   -> ([Job], IncrementalCompilationState?) {
 
     if let job = try immediateForwardingJob() {
@@ -634,7 +638,7 @@ extension Driver {
       return (jobs, nil)
 
     case .standardCompile, .batchCompile, .singleCompile:
-      return try planStandardCompile()
+      return try planStandardCompile(simulateGetInputFailure: simulateGetInputFailure)
 
     case .compilePCM:
       if inputFiles.count != 1 {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -364,11 +364,11 @@ final class IncrementalCompilationTests: XCTestCase {
       "Incremental compilation: Queuing Extracting autolink information for module \(module)",
     ]
   }
-  var autolinkLifecycleExpectations: [String] {
+  var autolinkLifecycleExpectations: [Diagnostic.Message] {
     [
       "Starting Extracting autolink information for module \(module)",
       "Finished Extracting autolink information for module \(module)",
-    ]
+    ].map {.remark($0)}
   }
   var commonArgs: [String] {
     [
@@ -412,14 +412,16 @@ extension IncrementalCompilationTests {
                 checkDiagnostics: Bool,
                 extraArguments: [String],
                 expectingRemarks texts: [String],
-                whenAutolinking: [String]
+                whenAutolinking autolinkExpectations: [Diagnostic.Message],
+                simulateGetInputFailure: Bool = false
   ) throws -> Driver? {
     try doABuild(
       message,
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expecting: texts.map {.remark($0)},
-      expectingWhenAutolinking: whenAutolinking.map {.remark($0)})
+      whenAutolinking: autolinkExpectations,
+      simulateGetInputFailure: simulateGetInputFailure)
   }
 
   @discardableResult
@@ -427,12 +429,13 @@ extension IncrementalCompilationTests {
                 checkDiagnostics: Bool,
                 extraArguments: [String],
                 expecting expectations: [Diagnostic.Message],
-                expectingWhenAutolinking autolinkExpectations: [Diagnostic.Message]
+                whenAutolinking autolinkExpectations: [Diagnostic.Message],
+                simulateGetInputFailure: Bool = false
   ) throws -> Driver? {
     print("*** starting build \(message) ***", to: &stderrStream); stderrStream.flush()
 
     func doTheCompile(_ driver: inout Driver) {
-      let jobs = try! driver.planBuild()
+      let jobs = try! driver.planBuild(simulateGetInputFailure: simulateGetInputFailure)
       try? driver.run(jobs: jobs)
     }
 
@@ -553,6 +556,16 @@ extension IncrementalCompilationTests {
       DependencyGraphDotFileWriter.moduleDependencyGraphBasename,
     ])
   }
+
+  func testGetInputFailureRecovery() throws {
+#if !os(Linux)
+    try tryInitial(checkDiagnostics: true)
+    tryNoChange(checkDiagnostics: true)
+    try tryChangingMainWithGetInputFailure()
+    try tryRecoveringFromGetInputFailure()
+#endif
+  }
+
 
   func expectNoDotFiles() {
     guard localFileSystem.exists(derivedDataDir) else { return }
@@ -803,6 +816,66 @@ extension IncrementalCompilationTests {
         "Finished Compiling main.swift, other.swift",
         "Starting Linking theModule",
         "Finished Linking theModule",
+      ],
+      whenAutolinking: autolinkLifecycleExpectations)
+  }
+
+  func tryChangingMainWithGetInputFailure() throws {
+    replace(contentsOf: "main", with: "let foo = \"hello\"")
+    try doABuild(
+      "simulating getInput failure",
+      checkDiagnostics: true,
+      extraArguments: [],
+      expecting: [
+        .remark("Incremental compilation: Read dependency graph "),
+        .remark("Incremental compilation: Enabling incremental cross-module building"),
+        .remark("Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}"),
+        .remark("Incremental compilation: May skip current input:  {compile: other.o <= other.swift}"),
+        .remark("Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}"),
+        .remark("Incremental compilation: not scheduling dependents of main.swift; unknown changes"),
+        .remark("Incremental compilation: Skipping input:  {compile: other.o <= other.swift}"),
+        .remark("Found 1 batchable job"),
+        .remark("Forming into 1 batch"),
+        .remark("Adding {compile: main.swift} to batch 0"),
+        .remark("Forming batch job from 1 constituents: main.swift"),
+        .remark("Starting Compiling main.swift"),
+        .remark("Finished Compiling main.swift"),
+        .remark("Incremental compilation: Fingerprint changed for interface of source file main.swiftdeps in main.swiftdeps"),
+        .remark("Incremental compilation: Fingerprint changed for implementation of source file main.swiftdeps in main.swiftdeps"),
+        .remark("Incremental compilation: Traced: interface of source file main.swiftdeps in main.swift -> interface of top-level name 'foo' in main.swift -> implementation of source file other.swiftdeps in other.swift"),
+        .warning("other.swiftdeps not found in inputDependencySourceMap; created for: updatingFromAPrior, now: updatingAfterCompilation"),
+        .remark("Incremental compilation: Failed to read some dependencies source; compiling everything  {compile: main.o <= main.swift}"),
+        .remark("Incremental compilation: Queuing because of dependencies discovered later:  {compile: other.o <= other.swift}"),
+        .remark("Incremental compilation: Scheduling invalidated  {compile: other.o <= other.swift}"),
+        .remark("Found 1 batchable job"),
+        .remark("Forming into 1 batch"),
+        .remark("Adding {compile: other.swift} to batch 0"),
+        .remark("Forming batch job from 1 constituents: other.swift"),
+        .remark("Starting Compiling other.swift"),
+        .remark("Finished Compiling other.swift"),
+        .remark("Incremental compilation: Scheduling all post-compile jobs because something was compiled"),
+        .remark("Starting Linking theModule"),
+        .remark("Finished Linking theModule"),
+      ],
+      whenAutolinking: autolinkLifecycleExpectations,
+      simulateGetInputFailure: true)
+  }
+
+  func tryRecoveringFromGetInputFailure() throws {
+    try! doABuild(
+      "recovering from getInput failure",
+      checkDiagnostics: true,
+      extraArguments: [],
+      expectingRemarks: [
+        "Incremental compilation: Read dependency graph ",
+        "Incremental compilation: Enabling incremental cross-module building",
+        "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
+        "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
+        "Incremental compilation: Skipping input:  {compile: other.o <= other.swift}",
+        "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
+        "Incremental compilation: Skipping job: Linking theModule; oldest output is current",
+        "Skipped Compiling main.swift",
+        "Skipped Compiling other.swift",
       ],
       whenAutolinking: autolinkLifecycleExpectations)
   }


### PR DESCRIPTION
Normally the inputDependencySourceMap bidirectionally maps .swift files to .swiftdeps files. However, we have seen failures when no .swift file can be found, from issues reading the prior module dependency graph. Instead of crashing, fall back to a non-incremental build.

Also adds a test to ensure that after such a fall-back, the next build will work incrementally.