### PR TITLE
[5.5][Incremental Imports] Recover from input map failure

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -677,8 +677,9 @@ public struct Driver {
         moduleName: moduleOutputInfo.name)
   }
 
-  public mutating func planBuild() throws -> [Job] {
-    let (jobs, incrementalCompilationState) = try planPossiblyIncrementalBuild()
+  public mutating func planBuild( simulateGetInputFailure: Bool = false ) throws -> [Job] {
+    let (jobs, incrementalCompilationState) = try planPossiblyIncrementalBuild(
+      simulateGetInputFailure: simulateGetInputFailure)
     self.incrementalCompilationState = incrementalCompilationState
     return jobs
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -486,6 +486,9 @@ extension IncrementalCompilationState {
     /// that reads the dependency graph from a serialized format on disk instead
     /// of reading O(N) swiftdeps files.
     public static let readPriorsFromModuleDependencyGraph    = Options(rawValue: 1 << 5)
+    /// Causes `getInput` to fail, in order to allow testing.
+    /// No need to come from a command-line option.
+    public static let simulateGetInputFailure                = Options(rawValue: 1 << 6)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -33,7 +33,8 @@ extension IncrementalCompilationState {
     @_spi(Testing) public let isCrossModuleIncrementalBuildEnabled: Bool
     @_spi(Testing) public let verifyDependencyGraphAfterEveryImport: Bool
     @_spi(Testing) public let emitDependencyDotFileAfterEveryImport: Bool
-    
+    @_spi(Testing) public let simulateGetInputFailure: Bool
+
     /// Options, someday
     @_spi(Testing) public let dependencyDotFilesIncludeExternals: Bool = true
     @_spi(Testing) public let dependencyDotFilesIncludeAPINotes: Bool = false
@@ -73,6 +74,7 @@ extension IncrementalCompilationState {
       self.isCrossModuleIncrementalBuildEnabled = options.contains(.enableCrossModuleIncrementalBuild)
       self.verifyDependencyGraphAfterEveryImport = options.contains(.verifyDependencyGraphAfterEveryImport)
       self.emitDependencyDotFileAfterEveryImport = options.contains(.emitDependencyDotFileAfterEveryImport)
+      self.simulateGetInputFailure = options.contains(.simulateGetInputFailure)
       self.buildStartTime = maybeBuildRecord?.buildStartTime ?? .distantPast
       self.buildEndTime = maybeBuildRecord?.buildEndTime ?? .distantFuture
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InitialStateComputer.swift
@@ -157,8 +157,11 @@ extension IncrementalCompilationState.InitialStateComputer {
     // recompilation. Thus, `ChangedOrAdded`.
     let nodesDirectlyInvalidatedByExternals = graph.collectNodesInvalidatedByChangedOrAddedExternals()
     // Wait till the last minute to do the transitive closure as an optimization.
-    let inputsInvalidatedByExternals = graph.collectInputsUsingInvalidated(
+    guard let inputsInvalidatedByExternals = graph.collectInputsUsingInvalidated(
       nodes: nodesDirectlyInvalidatedByExternals)
+    else {
+      return nil
+    }
     return (graph, inputsInvalidatedByExternals)
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -70,10 +70,13 @@ import SwiftOptions
   }
 
   @_spi(Testing) public func getInput(for source: DependencySource) -> TypedVirtualPath? {
-    guard let input = inputDependencySourceMap[source]
+    guard let input =
+            info.simulateGetInputFailure ? nil
+            : inputDependencySourceMap[source]
     else {
-      info.diagnosticEngine.emit(warning: "incremental import failure; recovering with a full rebuild. Next build will be incremental.")
-      info.reporter?.report("Input not found in inputDependencySourceMap; created for: \(creationPhase), now: \(phase): \(source.file.basename)")
+      info.diagnosticEngine.emit(warning: "Failed to find source file for '\(source.file.basename)', recovering with a full rebuild. Next build will be incremental.")
+      info.reporter?.report(
+        "\(info.simulateGetInputFailure ? "Simulating i" : "I")nput not found in inputDependencySourceMap; created for: \(creationPhase), now: \(phase)")
       return nil
     }
     return input

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -364,11 +364,11 @@ final class IncrementalCompilationTests: XCTestCase {
       "Incremental compilation: Queuing Extracting autolink information for module \(module)",
     ]
   }
-  var autolinkLifecycleExpectations: [String] {
+  var autolinkLifecycleExpectations: [Diagnostic.Message] {
     [
       "Starting Extracting autolink information for module \(module)",
       "Finished Extracting autolink information for module \(module)",
-    ]
+    ].map {.remark($0)}
   }
   var commonArgs: [String] {
     [
@@ -412,14 +412,16 @@ extension IncrementalCompilationTests {
                 checkDiagnostics: Bool,
                 extraArguments: [String],
                 expectingRemarks texts: [String],
-                whenAutolinking: [String]
+                whenAutolinking autolinkExpectations: [Diagnostic.Message],
+                simulateGetInputFailure: Bool = false
   ) throws -> Driver? {
     try doABuild(
       message,
       checkDiagnostics: checkDiagnostics,
       extraArguments: extraArguments,
       expecting: texts.map {.remark($0)},
-      expectingWhenAutolinking: whenAutolinking.map {.remark($0)})
+      whenAutolinking: autolinkExpectations,
+      simulateGetInputFailure: simulateGetInputFailure)
   }
 
   @discardableResult
@@ -427,12 +429,13 @@ extension IncrementalCompilationTests {
                 checkDiagnostics: Bool,
                 extraArguments: [String],
                 expecting expectations: [Diagnostic.Message],
-                expectingWhenAutolinking autolinkExpectations: [Diagnostic.Message]
+                whenAutolinking autolinkExpectations: [Diagnostic.Message],
+                simulateGetInputFailure: Bool = false
   ) throws -> Driver? {
     print("*** starting build \(message) ***", to: &stderrStream); stderrStream.flush()
 
     func doTheCompile(_ driver: inout Driver) {
-      let jobs = try! driver.planBuild()
+      let jobs = try! driver.planBuild(simulateGetInputFailure: simulateGetInputFailure)
       try? driver.run(jobs: jobs)
     }
 
@@ -553,6 +556,16 @@ extension IncrementalCompilationTests {
       DependencyGraphDotFileWriter.moduleDependencyGraphBasename,
     ])
   }
+
+  func testGetInputFailureRecovery() throws {
+#if !os(Linux)
+    try tryInitial(checkDiagnostics: true)
+    tryNoChange(checkDiagnostics: true)
+    try tryChangingMainWithGetInputFailure()
+    try tryRecoveringFromGetInputFailure()
+#endif
+  }
+
 
   func expectNoDotFiles() {
     guard localFileSystem.exists(derivedDataDir) else { return }
@@ -803,6 +816,67 @@ extension IncrementalCompilationTests {
         "Finished Compiling main.swift, other.swift",
         "Starting Linking theModule",
         "Finished Linking theModule",
+      ],
+      whenAutolinking: autolinkLifecycleExpectations)
+  }
+
+  func tryChangingMainWithGetInputFailure() throws {
+    replace(contentsOf: "main", with: "let foo = \"hello\"")
+    try doABuild(
+      "simulating getInput failure",
+      checkDiagnostics: true,
+      extraArguments: [],
+      expecting: [
+        .remark("Incremental compilation: Read dependency graph "),
+        .remark("Incremental compilation: Enabling incremental cross-module building"),
+        .remark("Incremental compilation: Scheduing changed input  {compile: main.o <= main.swift}"),
+        .remark("Incremental compilation: May skip current input:  {compile: other.o <= other.swift}"),
+        .remark("Incremental compilation: Queuing (initial):  {compile: main.o <= main.swift}"),
+        .remark("Incremental compilation: not scheduling dependents of main.swift; unknown changes"),
+        .remark("Incremental compilation: Skipping input:  {compile: other.o <= other.swift}"),
+        .remark("Found 1 batchable job"),
+        .remark("Forming into 1 batch"),
+        .remark("Adding {compile: main.swift} to batch 0"),
+        .remark("Forming batch job from 1 constituents: main.swift"),
+        .remark("Starting Compiling main.swift"),
+        .remark("Finished Compiling main.swift"),
+        .remark("Incremental compilation: Fingerprint changed for interface of source file main.swiftdeps in main.swiftdeps"),
+        .remark("Incremental compilation: Fingerprint changed for implementation of source file main.swiftdeps in main.swiftdeps"),
+        .remark("Incremental compilation: Traced: interface of source file main.swiftdeps in main.swift -> interface of top-level name 'foo' in main.swift -> implementation of source file other.swiftdeps in other.swift"),
+        .warning("Failed to find source file for '"),
+        .remark("Simulating input not found in inputDependencySourceMap; created for: updatingFromAPrior, now: updatingAfterCompilation"),
+        .remark("Incremental compilation: Failed to read some dependencies source; compiling everything  {compile: main.o <= main.swift}"),
+        .remark("Incremental compilation: Queuing because of dependencies discovered later:  {compile: other.o <= other.swift}"),
+        .remark("Incremental compilation: Scheduling invalidated  {compile: other.o <= other.swift}"),
+        .remark("Found 1 batchable job"),
+        .remark("Forming into 1 batch"),
+        .remark("Adding {compile: other.swift} to batch 0"),
+        .remark("Forming batch job from 1 constituents: other.swift"),
+        .remark("Starting Compiling other.swift"),
+        .remark("Finished Compiling other.swift"),
+        .remark("Incremental compilation: Scheduling all post-compile jobs because something was compiled"),
+        .remark("Starting Linking theModule"),
+        .remark("Finished Linking theModule"),
+      ],
+      whenAutolinking: autolinkLifecycleExpectations,
+      simulateGetInputFailure: true)
+  }
+
+  func tryRecoveringFromGetInputFailure() throws {
+    try! doABuild(
+      "recovering from getInput failure",
+      checkDiagnostics: true,
+      extraArguments: [],
+      expectingRemarks: [
+        "Incremental compilation: Read dependency graph ",
+        "Incremental compilation: Enabling incremental cross-module building",
+        "Incremental compilation: May skip current input:  {compile: main.o <= main.swift}",
+        "Incremental compilation: May skip current input:  {compile: other.o <= other.swift}",
+        "Incremental compilation: Skipping input:  {compile: other.o <= other.swift}",
+        "Incremental compilation: Skipping input:  {compile: main.o <= main.swift}",
+        "Incremental compilation: Skipping job: Linking theModule; oldest output is current",
+        "Skipped Compiling main.swift",
+        "Skipped Compiling other.swift",
       ],
       whenAutolinking: autolinkLifecycleExpectations)
   }


### PR DESCRIPTION
rdar://76284047

1. Recover from a missing inputSourceDependency map entry with a clean build.
2. Add a test for this.