### PR TITLE
[5.5] Validate that `-static-executable` is not supported on Darwin.

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -181,7 +181,11 @@ import SwiftOptions
     }
     // Validating darwin unsupported -static-stdlib argument.
     if parsedOptions.hasArgument(.staticStdlib) {
-        throw ToolchainValidationError.argumentNotSupported("-static-stdlib")
+      throw ToolchainValidationError.argumentNotSupported("-static-stdlib")
+    }
+    // Validating darwin unsupported -static-executable argument.
+    if parsedOptions.hasArgument(.staticExecutable) {
+      throw ToolchainValidationError.argumentNotSupported("-static-executable")
     }
     // If a C++ standard library is specified, it has to be libc++.
     if let cxxLib = parsedOptions.getLastArgument(.experimentalCxxStdlib) {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2385,6 +2385,14 @@ final class SwiftDriverTests: XCTestCase {
         return
       }
     }
+
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-static-executable", "-target", "x86_64-apple-macosx10.14",
+                                           "foo.swift"])) { error in
+      guard case DarwinToolchain.ToolchainValidationError.argumentNotSupported("-static-executable") = error else {
+        XCTFail()
+        return
+      }
+    }
     
     XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-macosx10.14", "-experimental-cxx-stdlib", "libstdc++",
                                            "foo.swift"])) { error in


### PR DESCRIPTION
This is a cherry-pick of the change merged in: https://github.com/apple/swift-driver/pull/635 on `main`. 

Resolves rdar://77631444