### PR TITLE
use `BUILD_RPATH` to make the build more portable

### DIFF
--- a/Sources/swift-driver/CMakeLists.txt
+++ b/Sources/swift-driver/CMakeLists.txt
@@ -25,5 +25,6 @@ if(CMAKE_VERSION VERSION_LESS 3.17)
   get_target_property(ARGPARSE_LIB ArgumentParser LOCATION)
   get_filename_component(ARGPARSE_LIB_DIR ${ARGPARSE_LIB} DIRECTORY)
 
-  target_link_options(swift-driver PUBLIC "LINKER:-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY},-rpath,${TSC_LIB_DIR},-rpath,${LLBUILD_LIB_DIR},-rpath,${ARGPARSE_LIB_DIR}")
+  set_target_properties(swift-driver PROPERTEIS
+    BUILD_RPATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${TSC_LIB_DIR};${LLBUILD_LIB_DIR};${ARGPARSE_LIB_DIR})
 endif()

--- a/Sources/swift-help/CMakeLists.txt
+++ b/Sources/swift-help/CMakeLists.txt
@@ -19,9 +19,10 @@ target_link_libraries(swift-help PUBLIC
 if(CMAKE_VERSION VERSION_LESS 3.17)
   get_target_property(TSC_UTIL_LIB TSCUtility LOCATION)
   get_filename_component(TSC_LIB_DIR ${TSC_UTIL_LIB} DIRECTORY)
-  
+
   get_target_property(ARGPARSE_LIB ArgumentParser LOCATION)
   get_filename_component(ARGPARSE_LIB_DIR ${ARGPARSE_LIB} DIRECTORY)
-  
-  target_link_options(swift-help PUBLIC "LINKER:-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY},-rpath,${TSC_LIB_DIR},-rpath,${ARGPARSE_LIB_DIR}")
+
+  set_target_properties(swift-help PROPERTIES
+    BUILD_RPATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${TSC_LIB_DIR};${ARGPARSE_LIB_DIR})
 endif()


### PR DESCRIPTION
The `-rpath` linker options are not portable and persist into
installation providing an attack vector.  This uses CMake to control the
RPATH for testing and ensures that the paths are erased at install time.
This is more secure and portable.