### PR TITLE
[rdar://77619051] implement sanitize-recover validation

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2232,7 +2232,6 @@ extension Driver {
       if sanitizer != .address {
         diagnosticEngine.emit(
           .error_unsupported_argument(argument: arg, option: .sanitizeRecoverEQ))
-//          .error_unsupported_argument(argument: arg, arg: Option.sanitizeRecoverEQ))
         continue
       }
       

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -567,6 +567,8 @@ public struct Driver {
       diagnosticEngine: diagnosticEngine,
       toolchain: toolchain,
       targetInfo: frontendTargetInfo)
+    
+    Self.validateSanitizerRecoverArgValues(&parsedOptions, diagnosticEngine: diagnosticsEngine, enabledSanitizers: enabledSanitizers)
 
     Self.validateSanitizerCoverageArgs(&parsedOptions,
                                        anySanitizersEnabled: !enabledSanitizers.isEmpty,
@@ -1795,6 +1797,10 @@ extension Diagnostic.Message {
   static var verify_debug_info_requires_debug_option: Diagnostic.Message {
     .warning("ignoring '-verify-debug-info'; no debug info is being generated")
   }
+  
+  static func warning_option_requires_sanitizer(currentOption: Option, currentOptionValue: String, sanitizerRequired: Sanitizer) -> Diagnostic.Message {
+      .warning("option '\(currentOption.spelling)\(currentOptionValue)' has no effect when '\(sanitizerRequired)' sanitizer is disabled. Use \(Option.sanitizeEQ.spelling)\(sanitizerRequired) to enable the sanitizer")
+  }
 }
 
 // Module computation.
@@ -2193,6 +2199,46 @@ extension Driver {
       let parts = value.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
       if parts.count != 2 {
         diagnosticsEngine.emit(.error_opt_invalid_mapping(option: coveragePrefixMap.option, value: value))
+      }
+    }
+  }
+  
+  
+  /// Validates the set of `-sanitize-recover={sanitizer}` arguments
+  private static func validateSanitizerRecoverArgValues(
+    _ parsedOptions: inout ParsedOptions,
+    diagnosticEngine: DiagnosticsEngine,
+    enabledSanitizers: Set<Sanitizer>
+  ){
+    let args = parsedOptions
+      .filter { $0.option == .sanitizeRecoverEQ }
+      .flatMap { $0.argument.asMultiple }
+
+    // No sanitizer args found, we could return.
+    if args.isEmpty {
+      return
+    }
+
+    // Find the sanitizer kind.
+    for arg in args {
+      guard let sanitizer = Sanitizer(rawValue: arg) else {
+        // Unrecognized sanitizer option
+        diagnosticEngine.emit(
+          .error_invalid_arg_value(arg: .sanitizeRecoverEQ, value: arg))
+        continue
+      }
+      
+      // only -sanitize-recover=address is supported
+      if sanitizer != .address {
+        diagnosticEngine.emit(
+          .error_unsupported_argument(argument: arg, option: .sanitizeRecoverEQ))
+//          .error_unsupported_argument(argument: arg, arg: Option.sanitizeRecoverEQ))
+        continue
+      }
+      
+      if !enabledSanitizers.contains(sanitizer) {
+        diagnosticEngine.emit(
+          .warning_option_requires_sanitizer(currentOption: .sanitizeRecoverEQ, currentOptionValue: arg, sanitizerRequired: sanitizer))
       }
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1584,6 +1584,70 @@ final class SwiftDriverTests: XCTestCase {
       #endif
     }
   }
+  
+  func testSanitizerRecoverArgs() throws {
+    let commonArgs = ["swiftc", "foo.swift", "bar.swift",]
+    do {
+      // address sanitizer + address sanitizer recover
+      var driver = try Driver(args: commonArgs + ["-sanitize=address", "-sanitize-recover=address"])
+      let plannedJobs = try driver.planBuild()
+
+      XCTAssertEqual(plannedJobs.count, 3)
+
+      let compileJob = plannedJobs[0]
+      let compileCmd = compileJob.commandLine
+      XCTAssertTrue(compileCmd.contains(.flag("-sanitize=address")))
+      XCTAssertTrue(compileCmd.contains(.flag("-sanitize-recover=address")))
+    }
+    do {
+      // invalid sanitize recover arg
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize-recover=foo"]) {
+        $1.expect(.error("invalid value 'foo' in '-sanitize-recover='"))
+      }
+    }
+    do {
+      // only address is supported
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize-recover=thread"]) {
+        $1.expect(.error("unsupported argument 'thread' to option '-sanitize-recover='"))
+      }
+    }
+    do {
+      // only address is supported
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize-recover=scudo"]) {
+        $1.expect(.error("unsupported argument 'scudo' to option '-sanitize-recover='"))
+      }
+    }
+    do {
+      // invalid sanitize recover arg
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize-recover=undefined"]) {
+        $1.expect(.error("unsupported argument 'undefined' to option '-sanitize-recover='"))
+      }
+    }
+    do {
+      // no sanitizer + address sanitizer recover
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize-recover=address"]) {
+        $1.expect(.warning("option '-sanitize-recover=address' has no effect when 'address' sanitizer is disabled. Use -sanitize=address to enable the sanitizer"))
+      }
+    }
+    do {
+      // thread sanitizer + address sanitizer recover
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=thread", "-sanitize-recover=address"]) {
+        $1.expect(.warning("option '-sanitize-recover=address' has no effect when 'address' sanitizer is disabled. Use -sanitize=address to enable the sanitizer"))
+      }
+    }
+    do {
+      // multiple sanitizers separately
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=undefined", "-sanitize=address", "-sanitize-recover=address"]) {
+        $1.forbidUnexpected(.error, .warning)
+      }
+    }
+    do {
+      // comma sanitizer + address sanitizer recover together
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=undefined,address", "-sanitize-recover=address"]) {
+        $1.forbidUnexpected(.error, .warning)
+      }
+    }
+  }
 
   func testSanitizerArgs() throws {
   // FIXME: This doesn't work on Linux.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1635,18 +1635,21 @@ final class SwiftDriverTests: XCTestCase {
         $1.expect(.warning("option '-sanitize-recover=address' has no effect when 'address' sanitizer is disabled. Use -sanitize=address to enable the sanitizer"))
       }
     }
+    // "-sanitize=undefined" is not available on x86_64-unknown-linux-gnu
+    #if os(macOS)
     do {
       // multiple sanitizers separately
-      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=thread", "-sanitize=address", "-sanitize-recover=address"]) {
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=undefined", "-sanitize=address", "-sanitize-recover=address"]) {
         $1.forbidUnexpected(.error, .warning)
       }
     }
     do {
       // comma sanitizer + address sanitizer recover together
-      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=thread,address", "-sanitize-recover=address"]) {
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=undefined,address", "-sanitize-recover=address"]) {
         $1.forbidUnexpected(.error, .warning)
       }
     }
+    #endif
   }
 
   func testSanitizerArgs() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1590,8 +1590,8 @@ final class SwiftDriverTests: XCTestCase {
     do {
       // address sanitizer + address sanitizer recover
       var driver = try Driver(args: commonArgs + ["-sanitize=address", "-sanitize-recover=address"])
-      let plannedJobs = try driver.planBuild()
-
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      
       XCTAssertEqual(plannedJobs.count, 3)
 
       let compileJob = plannedJobs[0]

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1637,13 +1637,13 @@ final class SwiftDriverTests: XCTestCase {
     }
     do {
       // multiple sanitizers separately
-      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=undefined", "-sanitize=address", "-sanitize-recover=address"]) {
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=thread", "-sanitize=address", "-sanitize-recover=address"]) {
         $1.forbidUnexpected(.error, .warning)
       }
     }
     do {
       // comma sanitizer + address sanitizer recover together
-      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=undefined,address", "-sanitize-recover=address"]) {
+      try assertDriverDiagnostics(args: commonArgs + ["-sanitize=thread,address", "-sanitize-recover=address"]) {
         $1.forbidUnexpected(.error, .warning)
       }
     }


### PR DESCRIPTION
port validation for `-sanitize-recover` over from the c swift driver

rdar://77619051