### PR TITLE
Provide swift-frontend path when running integration tests

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2427,9 +2427,9 @@ extension Driver {
 
     var appliesToFetchingTargetInfo: Bool {
       guard let path = overridePath else { return true }
-      return path.basename != "Python" &&
-        // starts(with:) to handle both python3 and point versions (Ex: python3.9)
-        !path.basename.starts(with: "python3")
+      // lowercased() to handle Python
+      // starts(with:) to handle both python3 and point versions (Ex: python3.9). Also future versions (Ex: Python4).
+      return !path.basename.lowercased().starts(with: "python")
     }
     func setUpForTargetInfo(_ toolchain: Toolchain) {
       if !appliesToFetchingTargetInfo {

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2426,8 +2426,10 @@ extension Driver {
     }
 
     var appliesToFetchingTargetInfo: Bool {
-      return overridePath?.basename != "Python" &&
-             overridePath?.basename != "python3"
+      guard let path = overridePath else { return true }
+      return path.basename != "Python" &&
+        // starts(with:) to handle both python3 and point versions (Ex: python3.9)
+        !path.basename.starts(with: "python3")
     }
     func setUpForTargetInfo(_ toolchain: Toolchain) {
       if !appliesToFetchingTargetInfo {

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -184,8 +184,11 @@ final class IntegrationTests: IntegrationTestCase {
       /// The e.g. swift-macosx-x86_64 directory.
       let swiftBuildDir = litConfigDir.parentDirectory
 
-      /// The path to the real frontend we should use.
-      let frontendFile = swiftBuildDir.appending(components: "bin", "swift")
+      /// The path to the real frontend (swift) we should use.
+      let swiftFile = swiftBuildDir.appending(components: "bin", "swift")
+
+      /// The path to the real frontend (swift-frontend) we should use.
+      let frontendFile = swiftBuildDir.appending(components: "bin", "swift-frontend")
 
       /// The path to lit.py.
       let litFile = swiftRootDir.appending(components: "llvm-project", "llvm", "utils", "lit",
@@ -196,7 +199,7 @@ final class IntegrationTests: IntegrationTestCase {
         $0.appending(component: $1)
       }
 
-      for path in [litFile, litConfigFile, frontendFile, testDir] {
+      for path in [litFile, litConfigFile, swiftFile, frontendFile, testDir] {
         guard localFileSystem.exists(path) else {
           XCTFail("Lit tests enabled, but path doesn't exist: \(path)")
           return
@@ -211,6 +214,7 @@ final class IntegrationTests: IntegrationTestCase {
       let args = [
         litFile.pathString, "-svi", "--time-tests",
         "--param", "copy_env=SWIFT_DRIVER_SWIFT_EXEC",
+        "--param", "copy_env=SWIFT_DRIVER_SWIFT_FRONTEND_EXEC",
         "--param", "swift_site_config=\(litConfigFile.pathString)",
         "--param", "swift_driver",
         testDir.pathString
@@ -220,7 +224,8 @@ final class IntegrationTests: IntegrationTestCase {
       let extraEnv = [
         "SWIFT": swift.pathString,
         "SWIFTC": swiftc.pathString,
-        "SWIFT_DRIVER_SWIFT_EXEC": frontendFile.pathString,
+        "SWIFT_DRIVER_SWIFT_EXEC": swiftFile.pathString,
+        "SWIFT_DRIVER_SWIFT_FRONTEND_EXEC": frontendFile.pathString,
         "LC_ALL": "en_US.UTF-8"
       ]
 


### PR DESCRIPTION
Fixes the issues I was running into: https://forums.swift.org/t/lots-of-errors-running-swift-driver-integration-tests/47986

Still 90 failing tests, which is more than the 50 from March 27: https://github.com/apple/swift-driver/pull/365/commits/dadb0a3707f979dedd72d984bbd6b21dea33829d

A lot of Dependencies tests failing with similar looking errors, but first step is actually being able to run the tests :)
This is an example error snippet if anyone is curious:
```
            8: Failed to read dependency file
check:12'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            9: Traceback (most recent call last):
check:12'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           10:  File "SOURCE_DIR/test/Driver/Dependencies/Inputs/update-dependencies.py", line 53, in <module>
check:12'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           11:  shutil.copyfile(primaryFile, depsFile)
check:12'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           12:  File "/usr/local/Cellar/python@3.9/3.9.1_7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/shutil.py", line 264, in copyfile
check:12'0     
```