### PR TITLE
Re-enable `testStubProcessProtocol` on non-macOS platforms.

### DIFF
--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -288,11 +288,6 @@ final class JobExecutorTests: XCTestCase {
   }
 
   func testStubProcessProtocol() throws {
-    // This test fails intermittently on Linux
-    // rdar://70067844
-    #if !os(macOS)
-      throw XCTSkip()
-    #endif
     let job = Job(
       moduleName: "main",
       kind: .compile,


### PR DESCRIPTION
I ran this test 150,000 times on Ubuntu 20.04 and 150,000 times on Ubuntu 16.04 and saw no failures.
Let's see how things go with the test enabled.