### PR TITLE
[5.5] Pass down `-Xlinker` flags to the underlying clang linker call using `-Xlinker` prefix

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -268,10 +268,15 @@ extension GenericUnixToolchain {
       try commandLine.append(
         contentsOf: parsedOptions.arguments(in: .linkerOption)
       )
-      try commandLine.appendAllArguments(.Xlinker, from: &parsedOptions)
+      // Because we invoke `clang` as the linker executable, we must still
+      // use `-Xlinker` for linker-specific arguments.
+      for linkerOpt in parsedOptions.arguments(for: .Xlinker) {
+        commandLine.appendFlag(.Xlinker)
+        commandLine.appendFlag(linkerOpt.argument.asSingle)
+      }
       try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
 
-        // This should be the last option, for convenience in checking output.
+      // This should be the last option, for convenience in checking output.
       commandLine.appendFlag(.o)
       commandLine.appendPath(outputFile)
       return clangPath

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1085,6 +1085,21 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(cmd.contains(.flag("-shared")))
     }
 
+    #if os(Linux)
+    do {
+      // Xlinker flags
+      // Ensure that Xlinker flags are passed as such to the clang linker invocation.
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-L", "/tmp", "-Xlinker", "-w",
+                                                  "-Xlinker", "-rpath=$ORIGIN",
+                                                  "-target", "x86_64-unknown-linux"], env: env)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 4)
+      let linkJob = plannedJobs[3]
+      let cmd = linkJob.commandLine
+      XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("-rpath=$ORIGIN")]))
+    }
+    #endif
+
     do {
       // Object file inputs
       var driver = try Driver(args: commonArgs + ["baz.o", "-emit-library", "-target", "x86_64-apple-macosx10.15"], env: env)


### PR DESCRIPTION
Passing them in as-is is not valid when invoking the linker using the clang executable as `clang -fuse-ld=gold`.

This is a 5.5 cherry-pick of a change merged on `main` in: https://github.com/apple/swift-driver/pull/644