### PR TITLE
Verify emitted module interfaces by default (Take 2)

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -405,7 +405,7 @@ extension Driver {
        parsedOptions.hasArgument(.enableLibraryEvolution),
        parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
                              negative: .noVerifyEmittedModuleInterface,
-                             default: false)
+                             default: true)
     else { return }
 
     func addVerifyJob(forPrivate: Bool) throws {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -405,7 +405,14 @@ extension Driver {
        parsedOptions.hasArgument(.enableLibraryEvolution),
        parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
                              negative: .noVerifyEmittedModuleInterface,
-                             default: true)
+                             default: true),
+
+      // Don't verify by default modules emitted from a merge-module job
+      // as it's more likely to be invalid
+      shouldCreateEmitModuleJob || compilerMode == .singleCompile ||
+        parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
+                              negative: .noVerifyEmittedModuleInterface,
+                              default: false)
     else { return }
 
     func addVerifyJob(forPrivate: Bool) throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3948,11 +3948,20 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 2)
     }
 
+    // Explicitly disabled
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
+                                     "foo", "-emit-module-interface",
+                                     "-enable-library-evolution",
+                                     "-no-verify-emitted-module-interface"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 2)
+    }
+
     // Emit-module separately
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
                                      "foo", "-emit-module-interface",
-                                     "-verify-emitted-module-interface",
                                      "-enable-library-evolution",
                                      "-experimental-emit-module-separately"])
       let plannedJobs = try driver.planBuild()
@@ -3973,7 +3982,6 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
                                      "foo", "-emit-module-interface",
-                                     "-verify-emitted-module-interface",
                                      "-enable-library-evolution",
                                      "-whole-module-optimization"])
       let plannedJobs = try driver.planBuild()

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3958,6 +3958,16 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 2)
     }
 
+    // Disabled by default in merge-module
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
+                                     "foo", "-emit-module-interface",
+                                     "-enable-library-evolution",
+                                     "-no-emit-module-separately"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 2)
+    }
+
     // Emit-module separately
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",


### PR DESCRIPTION
Verifying swiftinterface files after they are emitted will detect framework breaking issues much earlier. It can be turned off in offending projects with `-no-verify-emitted-module-interface`.

Only swiftinterfaces emitted from non-merge-module builds at verified by default. Merge-module builds are more likely to generate broken swiftinterfaces even when a whole-module or emit-module-separately build generates a valid one.

rdar://77534863