### PR TITLE
Fix quadratic COW copies in DictionaryOfDictionaries

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/TwoDMap.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/TwoDMap.swift
@@ -21,8 +21,6 @@ public struct TwoDMap<Key1: Hashable, Key2: Hashable, Value: Equatable>: Mutable
   public typealias Element = (Key, Value)
   public typealias Index = DictionaryOfDictionaries<Key1, Key2, Value>.Index
 
-
-
   public init() {}
 
   public subscript(position: Index) -> Element {


### PR DESCRIPTION
Cherry pick #654 

----------------

DictioanryOfDictionaries implemented its subscript in terms of updateValue
and removeValue, both of which keep track of and return the old value, and then
threw away the old value.

Instead, flip it so removeValue and updateValue are implemented in terms of the
subscript, and make the subscript modify the dictionary in-place.

This ended up being a 700x speedup on an Intel Mac and a 180x speedup on an M1.

Fixes rdar://77882768