### PR TITLE
[5.5] [NFC] Small fix to `emitModuleJob` for compatibility with <=5.3 compilers.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -177,9 +177,9 @@ extension Driver {
 
   private mutating func addEmitModuleJob(addJobBeforeCompiles: (Job) -> Void, addJobAfterCompiles: (Job) -> Void) throws {
     if shouldCreateEmitModuleJob {
-      let emitModuleJob = try emitModuleJob()
-      addJobBeforeCompiles(emitModuleJob)
-      try addVerifyJobs(emitModuleJob: emitModuleJob, addJob: addJobAfterCompiles)
+      let emitJob = try emitModuleJob()
+      addJobBeforeCompiles(emitJob)
+      try addVerifyJobs(emitModuleJob: emitJob, addJob: addJobAfterCompiles)
     }
   }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/617
---------------------------------------------------
Some SwiftCI bots are using a 5.3 compiler and errors out on this code with:
```
swift-driver/Sources/SwiftDriver/Jobs/Planning.swift:188:31: error: variable used within its own initial value
               let emitModuleJob = try emitModuleJob()
```