### PR TITLE
Intro a flag to disable emit-module-separately

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -103,7 +103,9 @@ extension Driver {
 
   /// Returns true if the -emit-module-separately is active.
   mutating func shouldEmitModuleSeparately() -> Bool {
-    return parsedOptions.hasArgument(.emitModuleSeparately)
+    return parsedOptions.hasFlag(positive: .emitModuleSeparately,
+                                 negative: .noEmitModuleSeparately,
+                                 default: false)
            && !parsedOptions.hasFlag(positive: .wholeModuleOptimization,
                                      negative: .noWholeModuleOptimization,
                                      default: false)

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -15,6 +15,7 @@ extension Option {
   public static let driverScanDependenciesNonLib: Option = Option("-nonlib-dependency-scanner", .flag, attributes: [.helpHidden], helpText: "Use calls to `swift-frontend -scan-dependencies` instead of dedicated dependency scanning library")
   public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver")
   public static let emitModuleSeparately: Option = Option("-experimental-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job")
+  public static let noEmitModuleSeparately: Option = Option("-no-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Force using merge-module as the incremental build mode")
   public static let useFrontendParseableOutput: Option = Option("-use-frontend-parseable-output", .flag, attributes: [.helpHidden], helpText: "Emit parseable-output from swift-frontend jobs instead of from the driver")
 
   public static var extraOptions: [Option] {
@@ -24,6 +25,7 @@ extension Option {
       Option.driverScanDependenciesNonLib,
       Option.driverWarnUnusedOptions,
       Option.emitModuleSeparately,
+      Option.noEmitModuleSeparately,
       Option.useFrontendParseableOutput
     ]
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2064,6 +2064,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .link]))
     }
+
+    do {
+      // Specifying -no-emit-module-separately uses a mergeModule job.
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", "/foo/bar/Test.swiftmodule", "-experimental-emit-module-separately", "-no-emit-module-separately" ])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 3)
+      XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .mergeModule]))
+    }
   }
 
   func testModuleWrapJob() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1955,6 +1955,7 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module", "-disable-bridging-pch", "-import-objc-header", "TestInputHeader.h", "-emit-dependencies", "-emit-module-source-info-path", "/foo/bar/Test.swiftsourceinfo"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 3)
+      XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .mergeModule]))
       XCTAssertEqual(plannedJobs[0].outputs.count, 4)
 
       XCTAssertTrue(matchTemporary(plannedJobs[0].outputs[0].file, "foo.swiftmodule"))
@@ -2032,6 +2033,7 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", "/foo/bar/Test.swiftmodule", "-experimental-emit-module-separately", "-emit-library", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 4)
+      XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .emitModule, .link]))
       XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
       XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-parse-as-library")))
       XCTAssertEqual(plannedJobs[0].outputs.count, 3)
@@ -2046,6 +2048,7 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", "/foo/bar/Test.swiftmodule", "-experimental-emit-module-separately"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.emitModule]))
       XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
       XCTAssertEqual(plannedJobs[0].outputs.count, 3)
       XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath("/foo/bar/Test.swiftmodule")))
@@ -2059,6 +2062,7 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "-emit-library", "foo.swift", "-whole-module-optimization", "-emit-module-path", "foo.swiftmodule", "-experimental-emit-module-separately", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 2)
+      XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .link]))
     }
   }
 


### PR DESCRIPTION
We want to make emit-module-separately the default incremental build mode soon. Let's first add a flag to disable it to be safe. Once emit-module-separately is the default, passing this flag will force the driver to revert to using the merge-module incremental build mode.