### PR TITLE
Driver: do not create a dSYM bundle for static archives

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -472,8 +472,18 @@ extension Driver {
 
     let linkJ = try linkJob(inputs: linkerInputs)
     addJob(linkJ)
-    guard targetTriple.isDarwin, debugInfo.level != nil
-    else {return }
+    guard targetTriple.isDarwin
+    else { return }
+
+    switch linkerOutputType {
+    case .none, .some(.staticLibrary):
+      // Cannot generate a dSYM bundle for a non-image target.
+      return
+
+    case .some(.dynamicLibrary), .some(.executable):
+      guard debugInfo.level != nil
+      else { return }
+    }
 
     let dsymJob = try generateDSYMJob(inputs: linkJ.outputs)
     addJob(dsymJob)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3077,7 +3077,7 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: [
         "swiftc", "-target", "x86_64-apple-macosx10.15", "-g", "-emit-library",
         "-static", "-o", "library.a", "library.swift"
-      ])
+      ], env: env)
       let jobs = try driver.planBuild()
 
       XCTAssertEqual(jobs.count, 3)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3067,6 +3067,24 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
+      var env = ProcessEnv.vars
+      // As per Unix conventions, /var/empty is expected to exist and be empty.
+      // This gives us a non-existent path that we can use for libtool which
+      // allows us to run this this on non-Darwin platforms.
+      env["SWIFT_DRIVER_LIBTOOL_EXEC"] = "/var/empty/libtool"
+
+      // No dSYM generation (-g -emit-library -static)
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-apple-macosx10.15", "-g", "-emit-library",
+        "-static", "-o", "library.a", "library.swift"
+      ])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 3)
+      XCTAssertFalse(jobs.contains { $0.kind == .generateDSYM })
+    }
+
+    do {
       // dSYM generation (-g)
       var driver = try Driver(args: commonArgs + ["-g"])
       let plannedJobs = try driver.planBuild()


### PR DESCRIPTION
Creation of a dSYM bundle for a static library is not supported.  Do not
create a job to create a dSYM bundle for a static library.