### PR TITLE
Drop the Failure Simulation Paths from the Incremental Build

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -695,9 +695,8 @@ public struct Driver {
         moduleName: moduleOutputInfo.name)
   }
 
-  public mutating func planBuild( simulateGetInputFailure: Bool = false ) throws -> [Job] {
-    let (jobs, incrementalCompilationState) = try planPossiblyIncrementalBuild(
-      simulateGetInputFailure: simulateGetInputFailure)
+  public mutating func planBuild() throws -> [Job] {
+    let (jobs, incrementalCompilationState) = try planPossiblyIncrementalBuild()
     self.incrementalCompilationState = incrementalCompilationState
     return jobs
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -482,9 +482,6 @@ extension IncrementalCompilationState {
     /// that reads the dependency graph from a serialized format on disk instead
     /// of reading O(N) swiftdeps files.
     public static let readPriorsFromModuleDependencyGraph    = Options(rawValue: 1 << 5)
-    /// Causes `getInput` to fail, in order to allow testing.
-    /// No need to come from a command-line option.
-    public static let simulateGetInputFailure                = Options(rawValue: 1 << 6)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -15,15 +15,12 @@ import TSCBasic
 
 // Initial incremental state computation
 extension IncrementalCompilationState {
-  static func computeIncrementalStateForPlanning(
-    driver: inout Driver,
-    simulateGetInputFailure: Bool)
+  static func computeIncrementalStateForPlanning(driver: inout Driver)
     throws -> IncrementalCompilationState.InitialStateForPlanning?
   {
     guard driver.shouldAttemptIncrementalCompilation else { return nil }
 
-    let options = computeIncrementalOptions(driver: &driver,
-                                            simulateGetInputFailure: simulateGetInputFailure)
+    let options = computeIncrementalOptions(driver: &driver)
 
     guard let outputFileMap = driver.outputFileMap else {
       driver.diagnosticEngine.emit(.warning_incremental_requires_output_file_map)
@@ -69,10 +66,7 @@ extension IncrementalCompilationState {
   }
 
   // Extract options relevant to incremental builds
-  static func computeIncrementalOptions(
-    driver: inout Driver,
-    simulateGetInputFailure: Bool)
-  -> IncrementalCompilationState.Options {
+  static func computeIncrementalOptions(driver: inout Driver) -> IncrementalCompilationState.Options {
     var options: IncrementalCompilationState.Options = []
     if driver.parsedOptions.contains(.driverAlwaysRebuildDependents) {
       options.formUnion(.alwaysRebuildDependents)
@@ -93,9 +87,6 @@ extension IncrementalCompilationState {
                                   default: true) {
       options.formUnion(.enableCrossModuleIncrementalBuild)
       options.formUnion(.readPriorsFromModuleDependencyGraph)
-    }
-    if simulateGetInputFailure {
-      options.formUnion(.simulateGetInputFailure)
     }
     return options
   }
@@ -140,10 +131,6 @@ extension IncrementalCompilationState {
     @_spi(Testing) public var emitDependencyDotFileAfterEveryImport: Bool {
       options.contains(.emitDependencyDotFileAfterEveryImport)
     }
-    @_spi(Testing) public var simulateGetInputFailure: Bool {
-      options.contains(.simulateGetInputFailure)
-    }
-
 
     @_spi(Testing) public init(
       _ options: Options,

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -313,15 +313,23 @@ extension ModuleDependencyGraph {
     return collectInputsUsingInvalidated(nodes: invalidatedNodes)
   }
 
-  /// Given nodes that are invalidated, find all the affected inputs that must be recompiled.
-  /// Return nil if the input could not be found, which should not happen, but somehow does.
+  /// Computes the set of inputs that must be recompiled as a result of the
+  /// invalidation of the given list of nodes.
+  ///
+  /// If the set of invalidated nodes could not be computed because of a failure
+  /// to match a swiftdeps file to its corresponding input file, this function
+  /// return `nil`. This can happen when e.g. the build system changes the
+  /// entries in the output file map out from under us.
+  ///
+  /// - Parameter directlyInvalidatedNodes: The set of invalidated nodes.
+  /// - Returns: The set of inputs that were transitively invalidated, if
+  ///            possible. Or `nil` if such a set could not be computed.
   func collectInputsUsingInvalidated(
     nodes directlyInvalidatedNodes: DirectlyInvalidatedNodeSet
   ) -> TransitivelyInvalidatedInputSet? {
     var invalidatedInputs = TransitivelyInvalidatedInputSet()
     for invalidatedSwiftDeps in collectSwiftDepsUsingInvalidated(nodes: directlyInvalidatedNodes) {
-      guard let invalidatedInput = getInput(for: invalidatedSwiftDeps)
-      else {
+      guard let invalidatedInput = getInput(for: invalidatedSwiftDeps) else {
         return nil
       }
       invalidatedInputs.insert(invalidatedInput)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -81,13 +81,8 @@ import SwiftOptions
     return source
   }
   @_spi(Testing) public func getInput(for source: DependencySource) -> TypedVirtualPath? {
-    guard let input =
-            info.simulateGetInputFailure ? nil
-            : inputDependencySourceMap[source]
-    else {
+    guard let input = inputDependencySourceMap[source] else {
       info.diagnosticEngine.emit(warning: "Failed to find source file for '\(source.file.basename)', recovering with a full rebuild. Next build will be incremental.")
-      info.reporter?.report(
-        "\(info.simulateGetInputFailure ? "Simulating i" : "I")nput not found in inputDependencySourceMap; created for: \(creationPhase), now: \(phase)")
       return nil
     }
     return input
@@ -319,8 +314,7 @@ extension ModuleDependencyGraph {
   }
 
   /// Given nodes that are invalidated, find all the affected inputs that must be recompiled.
-  /// Return nil if the input could not be found, which should not happen, but can happen when
-  /// the prior graph is read inconsistently.
+  /// Return nil if the input could not be found, which should not happen, but somehow does.
   func collectInputsUsingInvalidated(
     nodes directlyInvalidatedNodes: DirectlyInvalidatedNodeSet
   ) -> TransitivelyInvalidatedInputSet? {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -77,8 +77,7 @@ struct CompileJobGroup {
 extension Driver {
   /// Plan a standard compilation, which produces jobs for compiling separate
   /// primary files.
-  private mutating func planStandardCompile(
-    simulateGetInputFailure: Bool = false) throws
+  private mutating func planStandardCompile() throws
   -> ([Job], IncrementalCompilationState?) {
     precondition(compilerMode.isStandardCompilationForPlanning,
                  "compiler mode \(compilerMode) is handled elsewhere")
@@ -87,9 +86,7 @@ extension Driver {
     // the planning process. This state contains the module dependency graph and
     // cross-module dependency information.
     let initialIncrementalState =
-    try IncrementalCompilationState.computeIncrementalStateForPlanning(
-      driver: &self,
-      simulateGetInputFailure: simulateGetInputFailure)
+      try IncrementalCompilationState.computeIncrementalStateForPlanning(driver: &self)
 
     // Compute the set of all jobs required to build this module
     let jobsInPhases = try computeJobsForPhasedStandardBuild()
@@ -616,8 +613,7 @@ extension Driver {
 
   /// Plan a build by producing a set of jobs to complete the build.
   /// Should be private, but compiler bug
-  /*private*/ mutating func planPossiblyIncrementalBuild(
-    simulateGetInputFailure: Bool = false) throws
+  /*private*/ mutating func planPossiblyIncrementalBuild() throws
   -> ([Job], IncrementalCompilationState?) {
 
     if let job = try immediateForwardingJob() {
@@ -648,7 +644,7 @@ extension Driver {
       return (jobs, nil)
 
     case .standardCompile, .batchCompile, .singleCompile:
-      return try planStandardCompile(simulateGetInputFailure: simulateGetInputFailure)
+      return try planStandardCompile()
 
     case .compilePCM:
       if inputFiles.count != 1 {


### PR DESCRIPTION
We no longer need the simulated failure path since we can reproduce this
as of #662