### PR TITLE
In WMO, treat all inputs as `displayInputs` for parsable-output

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -366,12 +366,20 @@ extension Driver {
       let pchInput = TypedVirtualPath(file: pchPath, type: .pch)
       inputs.append(pchInput)
     }
+
+    let displayInputs : [TypedVirtualPath]
+    if case .singleCompile = compilerMode {
+      displayInputs = inputs
+    } else {
+      displayInputs = primaryInputs
+    }
+
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .compile,
       tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
       commandLine: commandLine,
-      displayInputs: primaryInputs,
+      displayInputs: displayInputs,
       inputs: inputs,
       primaryInputs: primaryInputs,
       outputs: outputs,


### PR DESCRIPTION
Otherwise these jobs today have input-less parsable-output:
```
  "command_executable" : "\/usr\/bin\/swift-frontend",
  "inputs" : [

  ],
  "kind" : "began",
```

Resolves rdar://78321174