### PR TITLE
[5.5] New Driver: do not generate a dSYM bundle for static archives

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -469,8 +469,18 @@ extension Driver {
 
     let linkJ = try linkJob(inputs: linkerInputs)
     addJob(linkJ)
-    guard targetTriple.isDarwin, debugInfo.level != nil
-    else {return }
+    guard targetTriple.isDarwin
+    else { return }
+
+    switch linkerOutputType {
+    case .none, .some(.staticLibrary):
+      // Cannot generate a dSYM bundle for a non-image target.
+      return
+
+    case .some(.dynamicLibrary), .some(.executable):
+      guard debugInfo.level != nil
+      else { return }
+    }
 
     let dsymJob = try generateDSYMJob(inputs: linkJ.outputs)
     addJob(dsymJob)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3021,7 +3021,7 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: [
         "swiftc", "-target", "x86_64-apple-macosx10.15", "-g", "-emit-library",
         "-static", "-o", "library.a", "library.swift"
-      ])
+      ], env: env)
       let jobs = try driver.planBuild()
 
       XCTAssertEqual(jobs.count, 3)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3011,6 +3011,24 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
+      var env = ProcessEnv.vars
+      // As per Unix conventions, /var/empty is expected to exist and be empty.
+      // This gives us a non-existent path that we can use for libtool which
+      // allows us to run this this on non-Darwin platforms.
+      env["SWIFT_DRIVER_LIBTOOL_EXEC"] = "/var/empty/libtool"
+
+      // No dSYM generation (-g -emit-library -static)
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-apple-macosx10.15", "-g", "-emit-library",
+        "-static", "-o", "library.a", "library.swift"
+      ])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 3)
+      XCTAssertFalse(jobs.contains { $0.kind == .generateDSYM })
+    }
+
+    do {
       // dSYM generation (-g)
       var driver = try Driver(args: commonArgs + ["-g"])
       let plannedJobs = try driver.planBuild()


### PR DESCRIPTION
This is the new driver version of apple/swift#37539.

rdar://78334766

----

Explanation: When emitting a static library, the driver attempts to run dsymutil on it. dsymutil is not supposed to be run on archives so it fails. As a result, one cannot compile static libraries with debug info at all. This patch just fixes the behavior by checking when adding the dsymutil job if we are emitting a static library and in such a case, do not add the dsymutil job.
Scope: Small. Just ensures that if we are compiling a static library we do not add a dsymutil job in the driver.
Risk: Low.
Testing: Adding a compiler test that validates the behavior.
Issue: rdar://78271443
Reviewer: @artemcm 
