### PR TITLE
Delay most tool lookup until after build planning

### DIFF
--- a/Sources/SwiftDriver/Driver/LinkKind.swift
+++ b/Sources/SwiftDriver/Driver/LinkKind.swift
@@ -23,7 +23,7 @@ public enum LinkOutputType {
 }
 
 /// Describes the kind of link-time-optimization we expect to perform.
-public enum LTOKind: String, Hashable {
+public enum LTOKind: String, Hashable, Codable {
   /// Perform LLVM ThinLTO.
   case llvmThin = "llvm-thin"
   /// Perform LLVM full LTO.

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -44,16 +44,20 @@ public final class ArgsResolver {
     }
   }
 
-  public func resolveArgumentList(for job: Job, forceResponseFiles: Bool,
+  public func resolveArgumentList(for job: Job, toolPath: AbsolutePath, forceResponseFiles: Bool,
                                   quotePaths: Bool = false) throws -> [String] {
-    let (arguments, _) = try resolveArgumentList(for: job, forceResponseFiles: forceResponseFiles,
+    let (arguments, _) = try resolveArgumentList(for: job,
+                                                 toolPath: toolPath,
+                                                 forceResponseFiles: forceResponseFiles,
                                                  quotePaths: quotePaths)
     return arguments
   }
 
-  public func resolveArgumentList(for job: Job, forceResponseFiles: Bool,
+  public func resolveArgumentList(for job: Job,
+                                  toolPath: AbsolutePath,
+                                  forceResponseFiles: Bool,
                                   quotePaths: Bool = false) throws -> ([String], usingResponseFile: Bool) {
-    let tool = try resolve(.path(job.tool), quotePaths: quotePaths)
+    let tool = try resolve(.path(.absolute(toolPath)), quotePaths: quotePaths)
     var arguments = [tool] + (try job.commandLine.map { try resolve($0, quotePaths: quotePaths) })
     let usingResponseFile = try createResponseFileIfNeeded(for: job, resolvedArguments: &arguments,
                                                            forceResponseFiles: forceResponseFiles)

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -165,7 +165,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
       jobs.append(Job(
         moduleName: moduleId.moduleName,
         kind: .emitModule,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        tool: .swiftCompiler,
         commandLine: commandLine,
         inputs: inputs,
         primaryInputs: [],
@@ -228,7 +228,7 @@ public typealias ExternalBuildArtifacts = (ExternalTargetModulePathMap, ModuleIn
         jobs.append(Job(
           moduleName: moduleId.moduleName,
           kind: .generatePCM,
-          tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+          tool: .swiftCompiler,
           commandLine: commandLine,
           inputs: inputs,
           primaryInputs: [],

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -29,7 +29,7 @@ internal extension Driver {
     // Construct the scanning job.
     return Job(moduleName: moduleOutputInfo.name,
                kind: .scanDependencies,
-               tool: VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler)),
+               tool: .swiftCompiler,
                commandLine: commandLine,
                displayInputs: inputs,
                inputs: inputs,
@@ -132,6 +132,7 @@ internal extension Driver {
       // `swift-frontend -scan-dependencies`
       dependencyGraph =
         try self.executor.execute(job: scannerJob,
+                                  toolPath: try toolchain.getToolPath(scannerJob.tool),
                                   capturingJSONOutputAs: InterModuleDependencyGraph.self,
                                   forceResponseFiles: forceResponseFiles,
                                   recordedInputModificationDates: recordedInputModificationDates)
@@ -192,6 +193,7 @@ internal extension Driver {
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     let batchScanResult =
       try self.executor.execute(job: batchScanningJob,
+                                toolPath: try toolchain.getToolPath(batchScanningJob.tool),
                                 forceResponseFiles: forceResponseFiles,
                                 recordedInputModificationDates: recordedInputModificationDates)
     let success = batchScanResult.exitStatus == .terminated(code: EXIT_SUCCESS)
@@ -266,7 +268,7 @@ internal extension Driver {
     // Construct the scanning job.
     return Job(moduleName: moduleOutputInfo.name,
                kind: .scanDependencies,
-               tool: VirtualPath.absolute(try toolchain.getToolPath(.swiftCompiler)),
+               tool: .swiftCompiler,
                commandLine: commandLine,
                displayInputs: inputs,
                inputs: inputs,
@@ -288,6 +290,7 @@ internal extension Driver {
   fileprivate func itemizedJobCommand(of job: Job, forceResponseFiles: Bool,
                                       using resolver: ArgsResolver) throws -> [String] {
     let (args, _) = try resolver.resolveArgumentList(for: job,
+                                                     toolPath: toolchain.getToolPath(job.tool),
                                                      forceResponseFiles: forceResponseFiles,
                                                      quotePaths: true)
     return args

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -43,7 +43,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .autolinkExtract,
-      tool: .absolute(try toolchain.getToolPath(.swiftAutolinkExtract)),
+      tool: .swiftAutolinkExtract,
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -71,7 +71,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .backend,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       displayInputs: inputs,
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -369,7 +369,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .compile,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       displayInputs: primaryInputs,
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -205,7 +205,7 @@ extension DarwinToolchain {
     lto: LTOKind?,
     sanitizers: Set<Sanitizer>,
     targetInfo: FrontendTargetInfo
-  ) throws -> AbsolutePath {
+  ) throws -> Tool {
     // Set up for linking.
     let linkerTool: Tool
     switch linkerOutputType {
@@ -250,7 +250,7 @@ extension DarwinToolchain {
     commandLine.appendFlag("-o")
     commandLine.appendPath(outputFile)
 
-    return try getToolPath(linkerTool)
+    return linkerTool
   }
 
   private func addLinkInputs(shouldUseInputFileList: Bool,

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -84,7 +84,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .emitModule,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -39,7 +39,7 @@ extension Toolchain {
     return Job(
       moduleName: "",
       kind: .emitSupportedFeatures,
-      tool: .absolute(try getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,
@@ -80,6 +80,7 @@ extension Driver {
                                                       frontendOverride.prefixArgsForTargetInfo)
     let decodedSupportedFlagList = try executor.execute(
       job: frontendFeaturesJob,
+      toolPath: try toolchain.getToolPath(frontendFeaturesJob.tool),
       capturingJSONOutputAs: SupportedCompilerFeatures.self,
       forceResponseFiles: false,
       recordedInputModificationDates: [:]).SupportedArguments

--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -33,7 +33,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .generateDSYM,
-      tool: .absolute(try toolchain.getToolPath(.dsymutil)),
+      tool: .dsymutil,
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -65,7 +65,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .generatePCH,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -55,7 +55,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .generatePCM,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -43,7 +43,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .interpret,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -59,7 +59,7 @@ public struct Job: Codable, Equatable, Hashable {
   public var moduleName: String
 
   /// The tool to invoke.
-  public var tool: VirtualPath
+  public var tool: Tool
 
   /// The command-line arguments of the job.
   public var commandLine: [ArgTemplate]
@@ -100,7 +100,7 @@ public struct Job: Codable, Equatable, Hashable {
   public init(
     moduleName: String,
     kind: Kind,
-    tool: VirtualPath,
+    tool: Tool,
     commandLine: [ArgTemplate],
     displayInputs: [TypedVirtualPath]? = nil,
     inputs: [TypedVirtualPath],

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -52,7 +52,7 @@ extension Driver {
     }
 
     // Defer to the toolchain for platform-specific linking
-    let toolPath = try toolchain.addPlatformSpecificLinkerArgs(
+    let tool = try toolchain.addPlatformSpecificLinkerArgs(
       to: &commandLine,
       parsedOptions: &parsedOptions,
       linkerOutputType: linkerOutputType!,
@@ -68,7 +68,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .link,
-      tool: .absolute(toolPath),
+      tool: tool,
       commandLine: commandLine,
       displayInputs: inputs,
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -78,7 +78,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .mergeModule,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
+++ b/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
@@ -29,7 +29,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .moduleWrap,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       inputs: [moduleInput],
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -584,7 +584,7 @@ extension Driver {
       return Job(
         moduleName: moduleOutputInfo.name,
         kind: .versionRequest,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        tool: .swiftCompiler,
         commandLine: [.flag("--version")],
         inputs: [],
         primaryInputs: [],
@@ -600,7 +600,7 @@ extension Driver {
       return Job(
         moduleName: moduleOutputInfo.name,
         kind: .help,
-        tool: .absolute(try toolchain.getToolPath(.swiftHelp)),
+        tool: .swiftHelp,
         commandLine: commandLine,
         inputs: [],
         primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -275,7 +275,7 @@ extension Driver {
     return Job(
       moduleName: moduleName,
       kind: .compile,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       inputs: dependencies,
       primaryInputs: [],
@@ -285,7 +285,7 @@ extension Driver {
 
   public mutating func generatePrebuitModuleGenerationJobs(with inputMap: [String: [PrebuiltModuleInput]],
                                                            into prebuiltModuleDir: AbsolutePath,
-                                                           exhaustive: Bool) throws -> ([Job], [Job]) {
+                                                           exhaustive: Bool) throws -> ([Job], [Job], AbsolutePath) {
     assert(sdkPath != nil)
     // Run the dependency scanner and update the dependency oracle with the results
     // We only need Swift dependencies here, so we don't need to invoke gatherModuleDependencies,
@@ -396,7 +396,7 @@ extension Driver {
 
     // We are done if we don't need to handle all inputs exhaustively.
     if !exhaustive {
-      return (jobs, [])
+      return (jobs, [], try toolchain.getToolPath(.swiftCompiler))
     }
     // For each unhandled module, generate dangling jobs for each associated
     // interfaces.
@@ -414,6 +414,6 @@ extension Driver {
 
     // check we've generated jobs for all inputs
     assert(inputCount == jobs.count + danglingJobs.count)
-    return (jobs, danglingJobs)
+    return (jobs, danglingJobs, try toolchain.getToolPath(.swiftCompiler))
   }
 }

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -163,7 +163,7 @@ extension Toolchain {
     return Job(
       moduleName: "",
       kind: .printTargetInfo,
-      tool: .absolute(try getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       displayInputs: [],
       inputs: [],

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -26,7 +26,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .repl,
-      tool: .absolute(try toolchain.getToolPath(.lldb)),
+      tool: .lldb,
       commandLine: lldbCommandLine,
       inputs: inputs,
       primaryInputs: [],

--- a/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyDebugInfoJob.swift
@@ -23,7 +23,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .verifyDebugInfo,
-      tool: .absolute(try toolchain.getToolPath(.dwarfdump)),
+      tool: .dwarfdump,
       commandLine: commandLine,
       displayInputs: [],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -29,7 +29,7 @@ extension Driver {
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .verifyModuleInterface,
-      tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+      tool: .swiftCompiler,
       commandLine: commandLine,
       displayInputs: [interfaceInput],
       inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -23,7 +23,7 @@ extension WebAssemblyToolchain {
     lto: LTOKind?,
     sanitizers: Set<Sanitizer>,
     targetInfo: FrontendTargetInfo
-  ) throws -> AbsolutePath {
+  ) throws -> Tool {
     let targetTriple = targetInfo.target.triple
     switch linkerOutputType {
     case .dynamicLibrary:
@@ -56,15 +56,11 @@ extension WebAssemblyToolchain {
       // Windows rather than msvcprt).  When C++ interop is enabled, we will need to
       // surface this via a driver flag.  For now, opt for the simpler approach of
       // just using `clang` and avoid a dependency on the C++ runtime.
-      var clangPath = try getToolPath(.clang)
-      if let toolsDirPath = parsedOptions.getLastArgument(.toolsDirectory) {
-        // FIXME: What if this isn't an absolute path?
-        let toolsDir = try AbsolutePath(validating: toolsDirPath.asSingle)
-
-        // If there is a clang in the toolchain folder, use that instead.
-        if let tool = lookupExecutablePath(filename: "clang", searchPaths: [toolsDir]) {
-          clangPath = tool
-        }
+      if let toolsDirPath = self.toolDirectory {
+        // The toolchain will ensure clang is looked up in the tools directory.
+        // Here, we just need to ensure we look for binutils in the toolchain folder.
+        commandLine.appendFlag("-B")
+        commandLine.appendPath(toolsDirPath)
       }
 
       guard !parsedOptions.hasArgument(.noStaticStdlib, .noStaticExecutable) else {
@@ -148,14 +144,14 @@ extension WebAssemblyToolchain {
         // This should be the last option, for convenience in checking output.
       commandLine.appendFlag(.o)
       commandLine.appendPath(outputFile)
-      return clangPath
+      return .clang
     case .staticLibrary:
       // We're using 'ar' as a linker
       commandLine.appendFlag("crs")
       commandLine.appendPath(outputFile)
 
       commandLine.append(contentsOf: inputs.map { .path($0.file) })
-      return try getToolPath(.staticLinker(lto))
+      return .staticLinker(lto)
     }
   }
 }

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -69,7 +69,10 @@ import TSCBasic
          .staticLinker(.llvmThin):
       return try lookup(executable: "llvm-ar")
     case .dynamicLinker:
-      // FIXME: This needs to look in the tools_directory first.
+      if let toolsDirectory = toolDirectory,
+         let clangPath = lookupExecutablePath(filename: "clang", searchPaths: [toolsDirectory]) {
+        return clangPath
+      }
       return try lookup(executable: "clang")
     case .clang:
       return try lookup(executable: "clang")

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -25,6 +25,73 @@ public enum Tool: Hashable {
   case swiftHelp
 }
 
+extension Tool: Codable {
+  enum CodingKeys: CodingKey {
+    case swiftCompiler
+    case staticLinker
+    case dynamicLinker
+    case clang
+    case swiftAutolinkExtract
+    case dsymutil
+    case lldb
+    case dwarfdump
+    case swiftHelp
+  }
+
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    guard let key = values.allKeys.first(where: values.contains) else {
+      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Did not find a matching key"))
+    }
+    switch key {
+    case .swiftCompiler:
+      self = .swiftCompiler
+    case .staticLinker:
+      var container = try values.nestedUnkeyedContainer(forKey: .staticLinker)
+      self = .staticLinker(try container.decode(LTOKind?.self))
+    case .dynamicLinker:
+      self = .dynamicLinker
+    case .clang:
+      self = .clang
+    case .swiftAutolinkExtract:
+      self = .swiftAutolinkExtract
+    case .dsymutil:
+      self = .dsymutil
+    case .lldb:
+      self = .lldb
+    case .dwarfdump:
+      self = .dwarfdump
+    case .swiftHelp:
+      self = .swiftHelp
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case .swiftCompiler:
+      _ = container.nestedUnkeyedContainer(forKey: .swiftCompiler)
+    case .staticLinker(let ltoKind):
+      var nestedContainer = container.nestedUnkeyedContainer(forKey: .staticLinker)
+      try nestedContainer.encode(ltoKind)
+    case .dynamicLinker:
+      _ = container.nestedUnkeyedContainer(forKey: .dynamicLinker)
+    case .clang:
+      _ = container.nestedUnkeyedContainer(forKey: .clang)
+    case .swiftAutolinkExtract:
+      _ = container.nestedUnkeyedContainer(forKey: .swiftAutolinkExtract)
+    case .dsymutil:
+      _ = container.nestedUnkeyedContainer(forKey: .dsymutil)
+    case .lldb:
+      _ = container.nestedUnkeyedContainer(forKey: .lldb)
+    case .dwarfdump:
+      _ = container.nestedUnkeyedContainer(forKey: .dwarfdump)
+    case .swiftHelp:
+      _ = container.nestedUnkeyedContainer(forKey: .swiftHelp)
+    }
+  }
+}
+
 /// Describes a toolchain, which includes information about compilers, linkers
 /// and other tools required to build Swift code.
 @_spi(Testing) public protocol Toolchain {
@@ -77,7 +144,7 @@ public enum Tool: Hashable {
     lto: LTOKind?,
     sanitizers: Set<Sanitizer>,
     targetInfo: FrontendTargetInfo
-  ) throws -> AbsolutePath
+  ) throws -> Tool
 
   func runtimeLibraryName(
     for sanitizer: Sanitizer,

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -200,14 +200,6 @@ extension Toolchain {
     return "SWIFT_DRIVER_\(lookupName)_EXEC"
   }
 
-  /// Use this property only for testing purposes, for example,
-  /// to enable cross-compiling tests that depends on macOS tooling such as `dsymutil`.
-  ///
-  /// Returns true if `SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK` is set to `1`.
-  private var fallbackToExecutableDefaultPath: Bool {
-    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] == "1"
-  }
-
   /// Looks for the executable in the `SWIFT_DRIVER_TOOLNAME_EXEC` environment variable, if found nothing,
   /// looks in the `executableDir`, `xcrunFind` or in the `searchPaths`.
   /// - Parameter executable: executable to look for [i.e. `swift`].
@@ -234,8 +226,6 @@ extension Toolchain {
     } else if executable == "swift-frontend" {
       // Temporary shim: fall back to looking for "swift" before failing.
       return try lookup(executable: "swift")
-    } else if fallbackToExecutableDefaultPath {
-      return AbsolutePath("/usr/bin/" + executable)
     } else {
       throw ToolchainError.unableToFind(tool: executable)
     }

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -93,7 +93,10 @@ import SwiftOptions
          .staticLinker(.llvmThin):
       return try lookup(executable: "llvm-ar")
     case .dynamicLinker:
-      // FIXME: This needs to look in the tools_directory first.
+      if let toolsDirectory = toolDirectory,
+         let clangPath = lookupExecutablePath(filename: "clang", searchPaths: [toolsDirectory]) {
+        return clangPath
+      }
       return try lookup(executable: "clang")
     case .clang:
       return try lookup(executable: "clang")

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -91,6 +91,9 @@ public final class MultiJobExecutor {
     /// The value of the option
     let continueBuildingAfterErrors: Bool
 
+    /// The locations of tools used to run jobs.
+    let toolLocations: [SwiftDriver.Tool: AbsolutePath]
+
 
     init(
       argsResolver: ArgsResolver,
@@ -126,6 +129,7 @@ public final class MultiJobExecutor {
       self.diagnosticsEngine = diagnosticsEngine
       self.processType = processType
       self.testInputHandle = inputHandleOverride
+      self.toolLocations = workload.toolLocations
     }
 
     private static func fillInJobsAndProducers(_ workload: DriverExecutorWorkload
@@ -575,6 +579,7 @@ class ExecuteJobRule: LLBuildRule {
     var pid = 0
     do {
       let arguments: [String] = try resolver.resolveArgumentList(for: job,
+                                                                 toolPath: context.toolLocations[job.tool]!,
                                                                  forceResponseFiles: context.forceResponseFiles)
 
 

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -33,9 +33,11 @@ public final class SwiftDriverExecutor: DriverExecutor {
   }
 
   public func execute(job: Job,
+                      toolPath: AbsolutePath,
                       forceResponseFiles: Bool = false,
                       recordedInputModificationDates: [TypedVirtualPath: Date] = [:]) throws -> ProcessResult {
     let arguments: [String] = try resolver.resolveArgumentList(for: job,
+                                                               toolPath: toolPath,
                                                                forceResponseFiles: forceResponseFiles)
 
     try job.verifyInputsNotModified(since: recordedInputModificationDates,
@@ -86,8 +88,10 @@ public final class SwiftDriverExecutor: DriverExecutor {
     return try Process.checkNonZeroExit(arguments: args, environment: environment)
   }
 
-  public func description(of job: Job, forceResponseFiles: Bool) throws -> String {
-    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, forceResponseFiles: forceResponseFiles)
+  public func description(of job: Job, toolPath: AbsolutePath, forceResponseFiles: Bool) throws -> String {
+    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job,
+                                                                    toolPath: toolPath,
+                                                                    forceResponseFiles: forceResponseFiles)
     var result = args.map { $0.spm_shellEscaped() }.joined(separator: " ")
 
     if usedResponseFile {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -816,9 +816,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-sdk", mockSDKPath,
                                      "-module-cache-path", moduleCachePath
                                     ])
-      let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
-                                                                                into: VirtualPath(path: "/tmp/").absolutePath!,
-                                                                                exhaustive: true)
+      let (jobs, danglingJobs, compilerPath) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
+                                                                                              into: VirtualPath(path: "/tmp/").absolutePath!,
+                                                                                              exhaustive: true)
 
       XCTAssertTrue(danglingJobs.count == 2)
       XCTAssertTrue(danglingJobs.allSatisfy { job in
@@ -862,9 +862,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
-      let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
-                                                                                into: VirtualPath(path: "/tmp/").absolutePath!,
-                                                                                exhaustive: false)
+      let (jobs, danglingJobs, compilerPath) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
+                                                                                              into: VirtualPath(path: "/tmp/").absolutePath!,
+                                                                                              exhaustive: false)
 
       XCTAssertTrue(danglingJobs.isEmpty)
       XCTAssertTrue(jobs.count == 18)
@@ -900,9 +900,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
-      let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
-                                                                                into: VirtualPath(path: "/tmp/").absolutePath!,
-                                                                                exhaustive: false)
+      let (jobs, danglingJobs, compilerPath) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
+                                                                                              into: VirtualPath(path: "/tmp/").absolutePath!,
+                                                                                              exhaustive: false)
 
       XCTAssertTrue(danglingJobs.isEmpty)
       XCTAssert(jobs.count == 3)
@@ -916,9 +916,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
-      let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
-                                                                                into: VirtualPath(path: "/tmp/").absolutePath!,
-                                                                                exhaustive: false)
+      let (jobs, danglingJobs, compilerPath) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
+                                                                                              into: VirtualPath(path: "/tmp/").absolutePath!,
+                                                                                              exhaustive: false)
 
       XCTAssertTrue(danglingJobs.isEmpty)
       XCTAssertTrue(jobs.count == 9)
@@ -936,7 +936,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
-      let (jobs, _) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
+      let (jobs, _, _) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
                                                                                 into: VirtualPath(path: "/tmp/").absolutePath!,
                                                                                 exhaustive: false)
       let F = findJob(jobs, "F", "arm64-apple-macos")!

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -827,15 +827,9 @@ extension IncrementalCompilationTests {
   /// autolink job.
   /// Much of the code below is taking from testLinking(), but uses the output file map code here.
   func testAutolinkOutputPath() {
-    var env = ProcessEnv.vars
-    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
-    env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
-    env["SWIFT_DRIVER_DSYMUTIL_EXEC"] = "/garbage/dsymutil"
-
     var driver = try! Driver(
       args: commonArgs
-        + ["-emit-library", "-target", "x86_64-unknown-linux"],
-      env: env)
+        + ["-emit-library", "-target", "x86_64-unknown-linux"])
     let plannedJobs = try! driver.planBuild()
     let autolinkExtractJob = try! XCTUnwrap(
       plannedJobs

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1421,7 +1421,7 @@ extension Job {
                                       type: .swift)
     try! self.init(moduleName: "nothing",
                    kind: .compile,
-                   tool: VirtualPath(path: ""),
+                   tool: .swiftCompiler,
                    commandLine: [],
                    inputs:  [input],
                    primaryInputs: [input],

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -129,7 +129,9 @@ final class ParsableMessageTests: XCTestCase {
                                          "-working-directory", "/WorkDir"])
           let jobs = try driver.planBuild()
           let compileJob = jobs[0]
-          let args : [String] = try resolver.resolveArgumentList(for: compileJob, forceResponseFiles: false)
+          let args : [String] = try resolver.resolveArgumentList(for: compileJob,
+                                                                 toolPath: .init("/path/to/swift-frontent"),
+                                                                 forceResponseFiles: false)
           let toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                    buildRecordInfo: nil,
                                                    incrementalCompilationState: nil,
@@ -207,7 +209,9 @@ final class ParsableMessageTests: XCTestCase {
                                          "-working-directory", "/WorkDir"])
           let jobs = try driver.planBuild()
           compileJob = jobs[0]
-          args = try resolver.resolveArgumentList(for: compileJob!, forceResponseFiles: false)
+          args = try resolver.resolveArgumentList(for: compileJob!,
+                                                  toolPath: .init("/path/to/swift-frontent"),
+                                                  forceResponseFiles: false)
           toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                buildRecordInfo: nil,
                                                incrementalCompilationState: nil,
@@ -285,6 +289,7 @@ final class ParsableMessageTests: XCTestCase {
           let jobs = try driver.planBuild()
           compileJob = jobs[0]
           args  = try resolver.resolveArgumentList(for: compileJob!,
+                                                   toolPath: .init("/path/to/swift-frontend"),
                                                    forceResponseFiles: false)
           toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                buildRecordInfo: nil,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -996,15 +996,10 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testLinking() throws {
-    var env = ProcessEnv.vars
-    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
-    env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
-    env["SWIFT_DRIVER_DSYMUTIL_EXEC"] = "/garbage/dsymutil"
-
     let commonArgs = ["swiftc", "foo.swift", "bar.swift",  "-module-name", "Test"]
     do {
       // macOS target
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(3, plannedJobs.count)
@@ -1026,7 +1021,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // iOS target
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "arm64-apple-ios10.0"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "arm64-apple-ios10.0"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(3, plannedJobs.count)
@@ -1048,7 +1043,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // macOS catalyst target
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-ios13.0-macabi"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-ios13.0-macabi"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(3, plannedJobs.count)
@@ -1071,7 +1066,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // Xlinker flags
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-L", "/tmp", "-Xlinker", "-w", "-target", "x86_64-apple-macosx10.15"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-L", "/tmp", "-Xlinker", "-w", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(3, plannedJobs.count)
@@ -1091,24 +1086,22 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(cmd.contains(.flag("-shared")))
     }
 
-    #if os(Linux)
     do {
       // Xlinker flags
       // Ensure that Xlinker flags are passed as such to the clang linker invocation.
       var driver = try Driver(args: commonArgs + ["-emit-library", "-L", "/tmp", "-Xlinker", "-w",
                                                   "-Xlinker", "-rpath=$ORIGIN",
-                                                  "-target", "x86_64-unknown-linux"], env: env)
+                                                  "-target", "x86_64-unknown-linux"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 4)
       let linkJob = plannedJobs[3]
       let cmd = linkJob.commandLine
       XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("-rpath=$ORIGIN")]))
     }
-    #endif
 
     do {
       // Object file inputs
-      var driver = try Driver(args: commonArgs + ["baz.o", "-emit-library", "-target", "x86_64-apple-macosx10.15"], env: env)
+      var driver = try Driver(args: commonArgs + ["baz.o", "-emit-library", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(3, plannedJobs.count)
@@ -1128,7 +1121,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // static linking
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-L", "/tmp", "-Xlinker", "-w", "-target", "x86_64-apple-macosx10.15"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-L", "/tmp", "-Xlinker", "-w", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(plannedJobs.count, 3)
@@ -1158,7 +1151,7 @@ final class SwiftDriverTests: XCTestCase {
       // static linking
       // Locating relevant libraries is dependent on being a macOS host
       #if os(macOS)
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-L", "/tmp", "-Xlinker", "-w", "-target", "x86_64-apple-macosx10.9", "-lto=llvm-full"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-L", "/tmp", "-Xlinker", "-w", "-target", "x86_64-apple-macosx10.9", "-lto=llvm-full"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(plannedJobs.count, 3)
@@ -1192,7 +1185,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // executable linking
-      var driver = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-apple-macosx10.15"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(3, plannedJobs.count)
       XCTAssertFalse(plannedJobs.contains { $0.kind == .autolinkExtract })
@@ -1215,7 +1208,7 @@ final class SwiftDriverTests: XCTestCase {
       // lto linking
       // Locating relevant libraries is dependent on being a macOS host
       #if os(macOS)
-      var driver1 = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-apple-macosx10.15", "-lto=llvm-thin"], env: env)
+      var driver1 = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-apple-macosx10.15", "-lto=llvm-thin"])
       let plannedJobs1 = try driver1.planBuild()
       XCTAssertFalse(plannedJobs1.contains(where: { $0.kind == .autolinkExtract }))
       let linkJob1 = try XCTUnwrap(plannedJobs1.first(where: { $0.kind == .link }))
@@ -1223,14 +1216,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(linkJob1.commandLine.contains(.flag("-lto_library")))
       #endif
 
-      var driver2 = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-unknown-linux", "-lto=llvm-thin"], env: env)
+      var driver2 = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-unknown-linux", "-lto=llvm-thin"])
       let plannedJobs2 = try driver2.planBuild()
       XCTAssertFalse(plannedJobs2.contains(where: { $0.kind == .autolinkExtract }))
       let linkJob2 = try XCTUnwrap(plannedJobs2.first(where: { $0.kind == .link }))
       XCTAssertTrue(try driver2.toolchain.getToolPath(linkJob2.tool).basename.hasPrefix("clang"))
       XCTAssertTrue(linkJob2.commandLine.contains(.flag("-flto=thin")))
 
-      var driver3 = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-unknown-linux", "-lto=llvm-full"], env: env)
+      var driver3 = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-unknown-linux", "-lto=llvm-full"])
       let plannedJobs3 = try driver3.planBuild()
       XCTAssertFalse(plannedJobs3.contains(where: { $0.kind == .autolinkExtract }))
       
@@ -1243,7 +1236,7 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      var driver = try Driver(args: commonArgs + ["-emit-executable", "-emit-module", "-g", "-target", "x86_64-apple-macosx10.15"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-executable", "-emit-module", "-g", "-target", "x86_64-apple-macosx10.15"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(5, plannedJobs.count)
       XCTAssertEqual(plannedJobs.map(\.kind), [.compile, .compile, .mergeModule, .link, .generateDSYM])
@@ -1265,7 +1258,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // linux target
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-unknown-linux"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-unknown-linux"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(plannedJobs.count, 4)
@@ -1294,7 +1287,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // static linux linking
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-target", "x86_64-unknown-linux"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-target", "x86_64-unknown-linux"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(plannedJobs.count, 4)
@@ -1328,7 +1321,7 @@ final class SwiftDriverTests: XCTestCase {
     #if os(Linux)
     do {
       // executable linking linux static stdlib
-      var driver = try Driver(args: commonArgs + ["-emit-executable", "-static-stdlib", "-target", "x86_64-unknown-linux"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-executable", "-static-stdlib", "-target", "x86_64-unknown-linux"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(plannedJobs.count, 4)
@@ -1358,7 +1351,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // static WASM linking
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-target", "wasm32-unknown-wasi"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-static", "-target", "wasm32-unknown-wasi"])
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(plannedJobs.count, 4)
@@ -1393,7 +1386,7 @@ final class SwiftDriverTests: XCTestCase {
         var driver = try Driver(args: commonArgs + ["-emit-executable",
                                                     "-target", "wasm32-unknown-wasi",
                                                     "-resource-dir", path.pathString,
-                                                    "-sdk", "/sdk/path"], env: env)
+                                                    "-sdk", "/sdk/path"])
         let plannedJobs = try driver.planBuild()
 
         XCTAssertEqual(plannedJobs.count, 4)
@@ -1424,10 +1417,8 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testWebAssemblyUnsupportedFeatures() throws {
-    var env = ProcessEnv.vars
-    env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
     do {
-      var driver = try Driver(args: ["swift", "-target", "wasm32-unknown-wasi", "foo.swift"], env: env)
+      var driver = try Driver(args: ["swift", "-target", "wasm32-unknown-wasi", "foo.swift"])
       XCTAssertThrowsError(try driver.planBuild()) {
         guard case WebAssemblyToolchain.Error.interactiveModeUnsupportedForTarget("wasm32-unknown-wasi") = $0 else {
           XCTFail()
@@ -1437,7 +1428,7 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      var driver = try Driver(args: ["swiftc", "-target", "wasm32-unknown-wasi", "-emit-library", "foo.swift"], env: env)
+      var driver = try Driver(args: ["swiftc", "-target", "wasm32-unknown-wasi", "-emit-library", "foo.swift"])
       XCTAssertThrowsError(try driver.planBuild()) {
         guard case WebAssemblyToolchain.Error.dynamicLibrariesUnsupportedForTarget("wasm32-unknown-wasi") = $0 else {
           XCTFail()
@@ -1447,7 +1438,7 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      var driver = try Driver(args: ["swiftc", "-target", "wasm32-unknown-wasi", "-no-static-executable", "foo.swift"], env: env)
+      var driver = try Driver(args: ["swiftc", "-target", "wasm32-unknown-wasi", "-no-static-executable", "foo.swift"])
       XCTAssertThrowsError(try driver.planBuild()) {
         guard case WebAssemblyToolchain.Error.dynamicLibrariesUnsupportedForTarget("wasm32-unknown-wasi") = $0 else {
           XCTFail()
@@ -1457,7 +1448,7 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      XCTAssertThrowsError(try Driver(args: ["swiftc", "-target", "wasm32-unknown-wasi", "foo.swift", "-sanitize=thread"], env: env)) {
+      XCTAssertThrowsError(try Driver(args: ["swiftc", "-target", "wasm32-unknown-wasi", "foo.swift", "-sanitize=thread"])) {
         guard case WebAssemblyToolchain.Error.sanitizersUnsupportedForTarget("wasm32-unknown-wasi") = $0 else {
           XCTFail()
           return
@@ -1480,7 +1471,6 @@ final class SwiftDriverTests: XCTestCase {
 
   func testCompatibilityLibs() throws {
     var env = ProcessEnv.vars
-    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     try withTemporaryDirectory { path in
       let path5_0Mac = path.appending(components: "macosx", "libswiftCompatibility50.a")
       let path5_1Mac = path.appending(components: "macosx", "libswiftCompatibility51.a")
@@ -3085,17 +3075,11 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      var env = ProcessEnv.vars
-      // As per Unix conventions, /var/empty is expected to exist and be empty.
-      // This gives us a non-existent path that we can use for libtool which
-      // allows us to run this this on non-Darwin platforms.
-      env["SWIFT_DRIVER_LIBTOOL_EXEC"] = "/var/empty/libtool"
-
       // No dSYM generation (-g -emit-library -static)
       var driver = try Driver(args: [
         "swiftc", "-target", "x86_64-apple-macosx10.15", "-g", "-emit-library",
         "-static", "-o", "library.a", "library.swift"
-      ], env: env)
+      ])
       let jobs = try driver.planBuild()
 
       XCTAssertEqual(jobs.count, 3)
@@ -3410,18 +3394,6 @@ final class SwiftDriverTests: XCTestCase {
       try? toolchain.getToolPath(.swiftCompiler).parentDirectory,
       try? toolchain.getToolPath(.clang).parentDirectory
     )
-  }
-
-  func testExecutableFallbackPath() throws {
-    let driver1 = try Driver(args: ["swift", "main.swift"])
-    if !driver1.targetTriple.isDarwin {
-      XCTAssertThrowsError(try driver1.toolchain.getToolPath(.dsymutil))
-    }
-
-    var env = ProcessEnv.vars
-    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
-    let driver2 = try Driver(args: ["swift", "main.swift"], env: env)
-    XCTAssertNoThrow(try driver2.toolchain.getToolPath(.dsymutil))
   }
 
   func testVersionRequest() throws {


### PR DESCRIPTION
This makes testing easier because fewer tools need to be present locally to plan builds for various targets, and in theory it simplifies distributed builds a little. 

I'd be interested in hearing thoughts on the approach used here. The main change here is that `Job` now has a `Tool` instead of the `AbsolutePath` to a tool, and the `DriverExecutor` entry points now accept the locations of the tools needed to run their workload. I thought about moving the tool lookup operations into `ArgsResolver`, but since they require a `Toolchain` I thought it made sense to keep them in `Driver` for now.