### PR TITLE
[Incremental] Harness immutability to make `inputDependencySourceMap` robust

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/BidirectionalMap.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BidirectionalMap.swift
@@ -12,10 +12,6 @@
 
 /// Like a two-way dictionary
 ///
-// FIXME: The current use of this abstraction in the driver is
-// fundamentally broken. This data structure should be retired ASAP.
-// See the extended FIXME in its use in
-// `ModuleDependencyGraph.inputDependencySourceMap`
 public struct BidirectionalMap<T1: Hashable, T2: Hashable>: Equatable, Sequence {
   private var map1: [T1: T2] = [:]
   private var map2: [T2: T1] = [:]
@@ -74,6 +70,20 @@ public struct BidirectionalMap<T1: Hashable, T2: Hashable>: Equatable, Sequence 
   public func contains(key: T2) -> Bool {
     map2.keys.contains(key)
   }
+
+  public mutating func updateValue(_ newValue: T2, forKey key: T1) -> T2? {
+    let oldValue = map1.updateValue(newValue, forKey: key)
+    _ = oldValue.map {map2.removeValue(forKey: $0)}
+    map2[newValue] = key
+    return oldValue
+  }
+  public mutating func updateValue(_ newValue: T1, forKey key: T2) -> T1? {
+    let oldValue = map2.updateValue(newValue, forKey: key)
+   _ = oldValue.map {map1.removeValue(forKey: $0)}
+    map1[newValue] = key
+    return oldValue
+  }
+
   public mutating func removeValue(forKey t1: T1) {
     if let t2 = map1[t1] {
       map2.removeValue(forKey: t2)

--- a/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
@@ -19,7 +19,7 @@ public struct Directly {}
 public struct InvalidatedSet<ClosureLevel, Element: Hashable>: Sequence {
   var contents: Set<Element>
 
-  init(_ s: Set<Element> = Set()) {
+  @_spi(Testing) public init(_ s: Set<Element> = Set()) {
     self.contents = s
   }
   init<Elements: Sequence>(_ elements: Elements)

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -256,7 +256,6 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     else {
       return nil
     }
-    
     var inputsInvalidatedByChangedExternals = TransitivelyInvalidatedInputSet()
     for input in sourceFiles.currentInOrder {
        guard let invalidatedInputs =

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -227,9 +227,6 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     else {
       return buildInitialGraphFromSwiftDepsAndCollectInputsInvalidatedByChangedExternals()
     }
-    guard graph.populateInputDependencySourceMap(for: .inputsAddedSincePriors) else {
-      return nil
-    }
     graph.dotFileWriter?.write(graph)
 
     // Any externals not already in graph must be additions which should trigger
@@ -255,13 +252,11 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   private func buildInitialGraphFromSwiftDepsAndCollectInputsInvalidatedByChangedExternals()
   -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet)?
   {
-    let graph = ModuleDependencyGraph(self, .buildingWithoutAPrior)
-    assert(outputFileMap.onlySourceFilesHaveSwiftDeps())
-    
-    guard graph.populateInputDependencySourceMap(for: .buildingFromSwiftDeps) else {
+    guard let graph = ModuleDependencyGraph(self, .buildingWithoutAPrior)
+    else {
       return nil
     }
-
+    
     var inputsInvalidatedByChangedExternals = TransitivelyInvalidatedInputSet()
     for input in sourceFiles.currentInOrder {
        guard let invalidatedInputs =

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InputDependencySourceMap.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InputDependencySourceMap.swift
@@ -45,6 +45,36 @@ extension InputDependencySourceMap {
     _ eachFn: (TypedVirtualPath, DependencySource) -> Void
   ) {
     biMap.forEach(eachFn)
+
+extension OutputFileMap {
+  @_spi(Testing) public func getDependencySource(
+    for sourceFile: TypedVirtualPath
+  ) -> DependencySource? {
+    assert(sourceFile.type == FileType.swift)
+    guard let swiftDepsPath = existingOutput(inputFile: sourceFile.fileHandle,
+                                             outputType: .swiftDeps)
+    else {
+      return nil
+   }
+    assert(VirtualPath.lookup(swiftDepsPath).extension == FileType.swiftDeps.rawValue)
+    let typedSwiftDepsFile = TypedVirtualPath(file: swiftDepsPath, type: .swiftDeps)
+    return DependencySource(typedSwiftDepsFile)
+  }
+}
+
+extension OutputFileMap {
+  @_spi(Testing) public func getDependencySource(
+    for sourceFile: TypedVirtualPath
+  ) -> DependencySource? {
+    assert(sourceFile.type == FileType.swift)
+    guard let swiftDepsPath = existingOutput(inputFile: sourceFile.fileHandle,
+                                             outputType: .swiftDeps)
+    else {
+      return nil
+   }
+    assert(VirtualPath.lookup(swiftDepsPath).extension == FileType.swiftDeps.rawValue)
+    let typedSwiftDepsFile = TypedVirtualPath(file: swiftDepsPath, type: .swiftDeps)
+    return DependencySource(typedSwiftDepsFile)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InputDependencySourceMap.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InputDependencySourceMap.swift
@@ -66,12 +66,6 @@ extension InputDependencySourceMap {
   @_spi(Testing) public func inputIfKnown(for source: DependencySource) -> TypedVirtualPath? {
     biMap[source]
   }
-
-  @_spi(Testing) public func enumerateToSerializePriors(
-    _ eachFn: (TypedVirtualPath, DependencySource) -> Void
-  ) {
-    biMap.forEach(eachFn)
-  }
 }
 
 extension OutputFileMap {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InputDependencySourceMap.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InputDependencySourceMap.swift
@@ -22,9 +22,10 @@ import TSCBasic
   public typealias BiMap = BidirectionalMap<TypedVirtualPath, DependencySource>
   @_spi(Testing) public let biMap: BiMap
 
-  /// Create the reverse map to map swiftdeps -> input (source) file from the `OutputFileMap`
-   ///
-   /// - Returns: the map, or nil if error
+  /// Based on entries in the `OutputFileMap`, create the bidirectional map to map each source file
+  /// path to- and from- the corresponding swiftdeps file path.
+  ///
+  /// - Returns: the map, or nil if error
   init?(_ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup) {
     let outputFileMap = info.outputFileMap
     let diagnosticEngine = info.diagnosticEngine

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @_spi(Testing) import SwiftDriver
 import TSCBasic
 
-class DependencyGraphSerializationTests: XCTestCase {
+class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker {
+  static let mockGraphCreator = MockModuleDependencyGraphCreator(maxIndex: 12)
+
   func roundTrip(_ graph: ModuleDependencyGraph) throws {
     let mockPath = VirtualPath.absolute(AbsolutePath("/module-dependency-graph"))
     let fs = InMemoryFileSystem()
@@ -216,8 +218,7 @@ class DependencyGraphSerializationTests: XCTestCase {
     ]
 
     for fixture in fixtures {
-      let de = DiagnosticsEngine()
-      let graph = ModuleDependencyGraph(mock: de)
+      let graph = Self.mockGraphCreator.mockUpAGraph()
       for loadCommand in fixture.commands {
         switch loadCommand {
         case .load(index: let index, nodes: let nodes, fingerprint: let fingerprint):

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -161,7 +161,7 @@ struct MockModuleDependencyGraphCreator {
   }
 
   func mockUpAGraph() -> ModuleDependencyGraph {
-    ModuleDependencyGraph(info, .buildingWithoutAPrior)
+    ModuleDependencyGraph(info, .buildingWithoutAPrior)!
   }
 }
 

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -13,6 +13,7 @@
 @_spi(Testing) import SwiftDriver
 import TSCBasic
 import Foundation
+import XCTest
 
 // MARK: - utilities for unit testing
 extension ModuleDependencyGraph {
@@ -119,13 +120,15 @@ extension BuildRecordInfo {
 extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   static func mock(
     options: IncrementalCompilationState.Options = [.verifyDependencyGraphAfterEveryImport],
-    diagnosticEngine: DiagnosticsEngine = DiagnosticsEngine(),
-    fileSystem: FileSystem = localFileSystem) -> Self {
+    outputFileMap: OutputFileMap = OutputFileMap(),
+    fileSystem: FileSystem = localFileSystem,
+    diagnosticEngine: DiagnosticsEngine = DiagnosticsEngine()
+  ) -> Self {
     let diagnosticsEngine = DiagnosticsEngine()
-    let outputFileMap = OutputFileMap()
     return Self(options, outputFileMap,
                 BuildRecordInfo.mock(diagnosticsEngine, outputFileMap),
-                nil, nil, [], fileSystem, diagnosticsEngine)
+                nil, nil, [], fileSystem,
+                diagnosticsEngine)
   }
 }
 
@@ -137,5 +140,40 @@ func `is`<S: StringProtocol>(dotFileName a: S, lessThan b: S) -> Bool {
 extension Collection where Element: StringProtocol {
   func sortedByDotFileSequenceNumbers() -> [Element] {
     sorted(by: `is`(dotFileName:lessThan:))
+  }
+}
+
+// MARK: - Mocking up a ModuleDependencyGraph
+protocol ModuleDependencyGraphMocker {
+  static var mockGraphCreator: MockModuleDependencyGraphCreator {get}
+}
+
+struct MockModuleDependencyGraphCreator {
+  let maxIndex: Int
+  let info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
+
+  /// maxIndex must be larger than any index used
+  init(maxIndex: Int) {
+    let outputFileMap = OutputFileMap.mock(maxIndex: maxIndex)
+    self.info = IncrementalCompilationState.IncrementalDependencyAndInputSetup
+      .mock(outputFileMap: outputFileMap)
+    self.maxIndex = maxIndex
+  }
+
+  func mockUpAGraph() -> ModuleDependencyGraph {
+    ModuleDependencyGraph(info, .buildingWithoutAPrior)
+  }
+}
+
+
+extension OutputFileMap {
+  fileprivate static func mock(maxIndex: Int) -> Self {
+    OutputFileMap( entries: (0...maxIndex) .reduce(into: [:]) {
+      entries, index in
+      let inputHandle = TypedVirtualPath(mockInput: index).file.intern()
+      let swiftDepsHandle = DependencySource(mock: index).file.intern()
+      entries[inputHandle] = [.swiftDeps: swiftDepsHandle]
+    }
+    )
   }
 }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -14,13 +14,11 @@ import XCTest
 @_spi(Testing) import SwiftDriver
 import TSCBasic
 
-class ModuleDependencyGraphTests: XCTestCase {
-  static let OFM = OutputFileMap()
-
-  let de = DiagnosticsEngine()
+class ModuleDependencyGraphTests: XCTestCase, ModuleDependencyGraphMocker {
+  static let mockGraphCreator = MockModuleDependencyGraphCreator(maxIndex: 12)
 
   func testBasicLoad() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a->", "b->"]])
 
@@ -38,7 +36,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testIndependentNodes() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a0", "a->"]])
     graph.simulateLoad(1, [.topLevel: ["b0", "b->"]])
@@ -67,7 +65,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testIndependentDepKinds() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a", "a->"]])
     graph.simulateLoad(1, [.topLevel: ["a", "b->"]])
@@ -78,7 +76,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testIndependentDepKinds2() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a->", "b"]])
     graph.simulateLoad(1, [.topLevel: ["b->", "a"]])
@@ -89,7 +87,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testIndependentMembers() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.member: ["a,aa"]])
     graph.simulateLoad(1, [.member: ["a,bb->"]])
@@ -106,7 +104,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependent() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad(1, [.topLevel: ["x->", "b->", "z->"]])
@@ -124,7 +122,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependentReverse() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a->", "b->", "c->"]])
     graph.simulateLoad(1, [.topLevel: ["x", "b", "z"]])
@@ -143,7 +141,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependent2() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a", "b", "c"]])
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "z->"]])
@@ -162,7 +160,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependent3() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a"], .topLevel: ["a"]])
     graph.simulateLoad(1, [.nominal: ["a->"]])
@@ -181,7 +179,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependent4() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a"]])
     graph.simulateLoad(1,
@@ -201,7 +199,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependent5() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0,
                        [.nominal: ["a"], .topLevel: ["a"]])
@@ -223,7 +221,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependent6() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.dynamicLookup: ["a", "b", "c"]])
     graph.simulateLoad(1,
@@ -242,7 +240,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleDependentMember() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.member: ["a,aa", "b,bb", "c,cc"]])
     graph.simulateLoad(1,
@@ -262,7 +260,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMultipleDependentsSame() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a", "b", "c"]])
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "z->"]])
@@ -285,7 +283,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMultipleDependentsDifferent() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a", "b", "c"]])
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "z->"]])
@@ -308,7 +306,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testChainedDependents() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a", "b", "c"]])
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "z"]])
@@ -331,7 +329,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testChainedNoncascadingDependents() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a", "b", "c"]])
     graph.simulateLoad(1, [.nominal: ["x->", "b->", "#z"]])
@@ -354,7 +352,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testChainedNoncascadingDependents2() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad( 1, [.topLevel: ["x->", "#b->"], .nominal: ["z"]])
@@ -371,7 +369,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMarkTwoNodes() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a", "b"]])
     graph.simulateLoad(1, [.topLevel: ["a->", "z"]])
@@ -409,7 +407,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMarkOneNodeTwice() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a"]])
     graph.simulateLoad(1, [.nominal: ["a->"]])
@@ -435,7 +433,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMarkOneNodeTwice2() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a"]])
     graph.simulateLoad(1, [.nominal: ["a->"]])
@@ -461,7 +459,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testReloadDetectsChange() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a"]])
     graph.simulateLoad(1, [.nominal: ["a->"]])
@@ -488,7 +486,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testNotTransitiveOnceMarked() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["a"]])
     graph.simulateLoad(1, [.nominal: ["a->"]])
@@ -516,7 +514,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testDependencyLoops() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c", "a->"]])
     graph.simulateLoad(1,
@@ -543,7 +541,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMarkIntransitive() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad(1, [.topLevel: ["x->", "b->", "z->"]])
@@ -561,7 +559,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMarkIntransitiveTwice() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad(1, [.topLevel: ["x->", "b->", "z->"]])
@@ -571,7 +569,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMarkIntransitiveThenIndirect() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.topLevel: ["a", "b", "c"]])
     graph.simulateLoad(1, [.topLevel: ["x->", "b->", "z->"]])
@@ -590,7 +588,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleExternal() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0,
                        [.externalDepend: ["/foo->", "/bar->"]])
@@ -611,7 +609,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testSimpleExternal2() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0,
                        [.externalDepend: ["/foo->", "/bar->"]])
@@ -624,7 +622,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testChainedExternal() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(
       0,
@@ -654,7 +652,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testChainedExternalReverse() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(
       0,
@@ -685,7 +683,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testChainedExternalPreMarked() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(
       0,
@@ -705,7 +703,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testMutualInterfaceHash() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     graph.simulateLoad(0, [.topLevel: ["a", "b->"]])
     graph.simulateLoad(1, [.topLevel: ["a->", "b"]])
 
@@ -714,7 +712,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testEnabledTypeBodyFingerprints() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     graph.simulateLoad(0, [.nominal: ["B2->"]])
     graph.simulateLoad(1, [.nominal: ["B1", "B2"]])
@@ -730,7 +728,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testBaselineForPrintsAndCrossType() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     // Because when A1 changes, B1 and not B2 is affected, only jobs1 and 2
     // should be recompiled, except type fingerprints is off!
@@ -751,14 +749,14 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testLoadPassesWithFingerprint() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     _ = graph.getInvalidatedNodesForSimulatedLoad(
       0,
       [MockDependencyKind.nominal: ["A@1"]])
   }
 
   func testUseFingerprints() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
 
     // Because when A1 changes, B1 and not B2 is affected, only jobs1 and 2
     // should be recompiled, except type fingerprints is off!
@@ -781,7 +779,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testUseFingerprintsPingPong() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     // Because of the cross-type dependency, A->B,
     // when A changes, only B is dirtied in 1.
 
@@ -810,7 +808,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testUseFingerprintsPingPong2() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     // Because of the cross-type dependency, A->B,
     // when A changes, only B is dirtied in 1.
 
@@ -840,7 +838,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testCrossTypeDependencyBaseline() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     graph.simulateLoad(0, [.nominal: ["A"]])
     graph.simulateLoad(1, [.nominal: ["B", "C", "A->"]])
     graph.simulateLoad(2, [.nominal: ["B->"]])
@@ -854,7 +852,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testCrossTypeDependency() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     // Because of the cross-type dependency, A->B,
     // when A changes, only B is dirtied in 1.
 
@@ -871,7 +869,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testCrossTypeDependencyBaselineWithFingerprints() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     graph.simulateLoad(0, [.nominal: ["A1@1", "A2@2"]])
     graph.simulateLoad(1, [.nominal: ["B1", "C1", "A1->"]])
     graph.simulateLoad(2, [.nominal: ["B1->"]])
@@ -892,7 +890,7 @@ class ModuleDependencyGraphTests: XCTestCase {
   }
 
   func testCrossTypeDependencyWithFingerprints() {
-    let graph = ModuleDependencyGraph(mock: de)
+    let graph = Self.mockGraphCreator.mockUpAGraph()
     // Because of the cross-type dependency, A->B,
     // when A changes, only B is dirtied in 1.
 
@@ -934,17 +932,7 @@ enum MockDependencyKind {
   }
 }
 
-
 extension ModuleDependencyGraph {
-
-  convenience init(
-    mock diagnosticEngine: DiagnosticsEngine,
-    options: IncrementalCompilationState.Options = [ .verifyDependencyGraphAfterEveryImport ]
-  ) {
-    self.init(IncrementalCompilationState.IncrementalDependencyAndInputSetup.mock(), .buildingWithoutAPrior)
-  }
-
-
   func simulateLoad(
     _ swiftDepsIndex: Int,
     _ dependencyDescriptions: [MockDependencyKind: [String]],
@@ -986,10 +974,12 @@ extension ModuleDependencyGraph {
     includePrivateDeps: Bool = true,
     hadCompilationError: Bool = false
   ) -> DirectlyInvalidatedNodeSet {
-    let dependencySource = DependencySource(mock: swiftDepsIndex)
-    // Only needed for serialization testing:
-    mockMapEntry(TypedVirtualPath.init(mockInput: swiftDepsIndex),
-                    dependencySource)
+    let inputPath = TypedVirtualPath(mockInput: swiftDepsIndex)
+    guard let dependencySource = info.outputFileMap.getDependencySource(for: inputPath)
+    else {
+      XCTFail("maxIndex is too small")
+      return DirectlyInvalidatedNodeSet()
+    }
     let interfaceHash =
       interfaceHashIfPresent ?? dependencySource.interfaceHashForMockDependencySource
 


### PR DESCRIPTION
Make the `inputDependencyMap` immutable, solely reflecting the `OutputFileMap`.
Do not include it in the priors.

In a previous PR, @CodaFi uncovered and explained issues with the `inputDependencySourceMap:
```
   // FIXME: The map between swiftdeps and swift files is absolutely *not*`
   // a bijection. In particular, more than one swiftdeps file can be encountered
   // in the course of deserializing priors *and* reading the output file map
   // *and* re-reading swiftdeps files after frontends complete
   // that correspond to the same swift file. These cause two problems:
   // - overwrites in this data structure that lose data and
   // - cache misses in `getInput(for:)` that cause the incremental build to
   // turn over when e.g. entries in the output file map change. This should be
   // replaced by a multi-map from swift files to dependency sources,
   // and a regular map from dependency sources to swift files -
   // since that direction really is one-to-one.
```

This PR solves the problem in a simpler way. The key insight is that the output file map contains the information linking a source file to the swiftdeps file for any build. Thus, the output file map should just determine the entries in the `inputDependencySourceMap`, just as it did before the introduction of incremental imports. Then the map in question does become a true bijection. It can also be made immutable, which greatly eases reasoning about the code.

It will also make it easy to cull removed file nodes from priors in a future PR.
