### PR TITLE
Note file type for -emit-irgen.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1490,7 +1490,7 @@ extension Driver {
       case .emitSibgen:
         compilerOutputType = .raw_sib
 
-      case .emitIr:
+      case .emitIrgen, .emitIr:
         compilerOutputType = .llvmIR
 
       case .emitBc:


### PR DESCRIPTION
Forgot to do this earlier when I added `-emit-irgen`.