### PR TITLE
[NFC, Incremental] Refactoring to facilitate replacing the inputDependencySourceMap with the right thing

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(SwiftDriver
   Execution/ParsableOutput.swift
   Execution/ProcessProtocol.swift
 
+  "IncrementalCompilation/ModuleDependencyGraphParts/InputDependencySourceMap.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/Node.swift"
   "IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift"


### PR DESCRIPTION
Redoing reverted https://github.com/apple/swift-driver/pull/664, which was missing a CMakeLists.txt entry.