### PR TITLE
[NFC: Incremental] Clarifications and typo fixes

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -375,16 +375,10 @@ extension ModuleDependencyGraph {
   /// Collects the nodes invalidated by a change to the given external
   /// dependency after integrating it into the dependency graph.
   ///
-  /// This function does not to the transitive closure; that is left to the
+  /// This function does not do the transitive closure; that is left to the
   /// callers.
   ///
-  /// - Parameters:
-  ///   - integrand: The external dependency to integrate.
-  ///   - isKnown: If `true`, the caller is aware of this node and
-  ///              integration should assume it is a known external.
-  ///              If `false`, and the external has not been
-  ///              integrated before, it is treated as a freshly-
-  ///              added external dependency.
+  /// - Parameter integrand: The external dependency to integrate.
   /// - Returns: The set of module dependency graph nodes invalidated by integration.
   func integrateExternal(
     _ integrand: ExternalIntegrand

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -177,8 +177,10 @@ extension ModuleDependencyGraph.Integrator {
     _ moduleUseNode: Graph.Node
   ) {
     sourceGraph.forEachDefDependedUpon(by: sourceFileUseNode) { def in
+      let isNewUse = destination.nodeFinder.record(def: def.key,
+                                                   use: moduleUseNode)
       guard
-        destination.nodeFinder.record(def: def.key, use: moduleUseNode),
+        isNewUse,
         let externalDependency = def.key.designator.externalDependency
       else {
         return
@@ -197,12 +199,17 @@ extension ModuleDependencyGraph.Integrator {
     from externalDependency: FingerprintedExternalDependency
   ) {
     let invalidated = destination.integrateExternal(.unknown(externalDependency))
-    invalidatedNodes.formUnion(invalidated)
+    recordUsesOfSomeExternal(invalidated)
   }
 }
 
 // MARK: - Results {
 extension ModuleDependencyGraph.Integrator {
+  /*@_spi(Testing)*/
+    mutating func recordUsesOfSomeExternal(_ invalidated: DirectlyInvalidatedNodeSet)
+    {
+      invalidatedNodes.formUnion(invalidated)
+    }
   mutating func addDisappeared(_ node: Graph.Node) {
     assert(isUpdating)
     invalidatedNodes.insert(node)


### PR DESCRIPTION
A recent PR, https://github.com/apple/swift-driver/pull/666, nicely cleaned up some of the external dependency code by reifying the notion of a known vs unknown external dependency. 

Fix a couple of typos from that PR.

Add some clarity to that PR for the sake of those to come who are not as familiar with this, somewhat tricky, code:
- Add a named local variable, `isNew`, in order to make the meaning result of a call to `record` more salient, and
- Restore the intension-revealing function, `recordUsesOfSomeExternal` to make the intention, i.e. the remembering of *uses* of an external dependency salient.