### PR TITLE
[5.5] Add support for `-dump-pcm` compiler mode

### DIFF
--- a/Sources/SwiftDriver/Driver/CompilerMode.swift
+++ b/Sources/SwiftDriver/Driver/CompilerMode.swift
@@ -29,6 +29,9 @@
 
   /// Compile a Clang module (.pcm).
   case compilePCM
+
+  /// Dump information about a precompiled Clang module
+  case dumpPCM
 }
 
 /// Information about batch mode, which is used to determine how to form
@@ -43,7 +46,7 @@ extension CompilerMode {
   /// Whether this compilation mode uses -primary-file to specify its inputs.
   public var usesPrimaryFileInputs: Bool {
     switch self {
-    case .immediate, .repl, .singleCompile, .compilePCM:
+    case .immediate, .repl, .singleCompile, .compilePCM, .dumpPCM:
       return false
 
     case .standardCompile, .batchCompile:
@@ -57,14 +60,14 @@ extension CompilerMode {
     case .immediate, .repl, .standardCompile, .batchCompile:
       return false
 
-    case .singleCompile, .compilePCM:
+    case .singleCompile, .compilePCM, .dumpPCM:
       return true
     }
   }
 
   public var isStandardCompilationForPlanning: Bool {
     switch self {
-      case .immediate, .repl, .compilePCM:
+      case .immediate, .repl, .compilePCM, .dumpPCM:
         return false
       case .batchCompile, .standardCompile, .singleCompile:
         return true
@@ -88,7 +91,7 @@ extension CompilerMode {
   // headers.
   public var supportsBridgingPCH: Bool {
     switch self {
-    case .batchCompile, .singleCompile, .standardCompile, .compilePCM:
+    case .batchCompile, .singleCompile, .standardCompile, .compilePCM, .dumpPCM:
       return true
     case .immediate, .repl:
       return false
@@ -111,6 +114,8 @@ extension CompilerMode: CustomStringConvertible {
         return "immediate compilation"
       case .compilePCM:
         return "compile Clang module (.pcm)"
+      case .dumpPCM:
+        return "dump Clang module (.pcm)"
       }
   }
 }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1296,6 +1296,9 @@ extension Driver {
       case .emitPcm:
         return .compilePCM
 
+      case .dumpPcm:
+        return .dumpPCM
+
       default:
         // Output flag doesn't determine the compiler mode.
         break
@@ -1487,6 +1490,9 @@ extension Driver {
 
       case .emitPcm:
         compilerOutputType = .pcm
+
+      case .dumpPcm:
+        compilerOutputType = nil
 
       case .emitImportedModules:
         compilerOutputType = .importedModules

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -180,7 +180,7 @@ fileprivate extension CompilerMode {
   var supportsIncrementalCompilation: Bool {
     switch self {
     case .standardCompile, .immediate, .repl, .batchCompile: return true
-    case .singleCompile, .compilePCM: return false
+    case .singleCompile, .compilePCM, .dumpPCM: return false
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -55,7 +55,7 @@ extension Driver {
     // Only pass -target to the REPL or immediate modes if it was explicitly
     // specified on the command line.
     switch compilerMode {
-    case .standardCompile, .singleCompile, .batchCompile, .compilePCM:
+    case .standardCompile, .singleCompile, .batchCompile, .compilePCM, .dumpPCM:
       commandLine.appendFlag(.target)
       commandLine.appendFlag(targetTriple.triple)
 

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -27,6 +27,7 @@ public struct Job: Codable, Equatable, Hashable {
 
     /// Generate a compiled Clang module.
     case generatePCM = "generate-pcm"
+    case dumpPCM = "dump-pcm"
     case interpret
     case repl
     case verifyDebugInfo = "verify-debug-info"
@@ -187,6 +188,9 @@ extension Job : CustomStringConvertible {
     case .generatePCM:
         return "Compiling Clang module \(moduleName)"
 
+    case .dumpPCM:
+        return "Dump information about Clang module \(displayInputs.first?.file.name ?? "")"
+
     case .interpret:
         return "Interpreting \(displayInputs.first?.file.name ?? "")"
 
@@ -234,7 +238,7 @@ extension Job.Kind {
   public var isSwiftFrontend: Bool {
     switch self {
     case .backend, .compile, .mergeModule, .emitModule, .generatePCH,
-        .generatePCM, .interpret, .repl, .printTargetInfo,
+        .generatePCM, .dumpPCM, .interpret, .repl, .printTargetInfo,
         .versionRequest, .emitSupportedFeatures, .scanDependencies, .verifyModuleInterface:
         return true
 
@@ -249,7 +253,7 @@ extension Job.Kind {
     case .compile:
       return true
     case .backend, .mergeModule, .emitModule, .generatePCH,
-         .generatePCM, .interpret, .repl, .printTargetInfo,
+         .generatePCM, .dumpPCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
          .help, .link, .verifyDebugInfo, .scanDependencies,
          .emitSupportedFeatures, .moduleWrap, .verifyModuleInterface:

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -16,6 +16,7 @@ import SwiftOptions
 public enum PlanningError: Error, DiagnosticData {
   case replReceivedInput
   case emitPCMWrongInputFiles
+  case dumpPCMWrongInputFiles
 
   public var description: String {
     switch self {
@@ -24,6 +25,9 @@ public enum PlanningError: Error, DiagnosticData {
 
     case .emitPCMWrongInputFiles:
       return "Clang module emission requires exactly one input file (the module map)"
+
+    case .dumpPCMWrongInputFiles:
+      return "Emitting information about Clang module requires exactly one input file (pre-compiled module)"
     }
   }
 }
@@ -650,7 +654,13 @@ extension Driver {
       if inputFiles.count != 1 {
         throw PlanningError.emitPCMWrongInputFiles
       }
-      return ([try generatePCMJob(input: inputFiles.first!)], nil)
+      return ([try generateEmitPCMJob(input: inputFiles.first!)], nil)
+
+    case .dumpPCM:
+      if inputFiles.count != 1 {
+        throw PlanningError.dumpPCMWrongInputFiles
+      }
+      return ([try generateDumpPCMJob(input: inputFiles.first!)], nil)
     }
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4056,6 +4056,19 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testPCMDump() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-dump-pcm", "module.pcm"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+
+      XCTAssertEqual(plannedJobs[0].kind, .dumpPCM)
+      XCTAssertEqual(plannedJobs[0].inputs.count, 1)
+      XCTAssertEqual(plannedJobs[0].inputs[0].file, .relative(RelativePath("module.pcm")))
+      XCTAssertEqual(plannedJobs[0].outputs.count, 0)
+    }
+  }
+
   func testIndexFilePathHandling() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-index-file", "-index-file-path",


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/691
-----------------------------------------------------------------------
This gets lowered into a `-dump-pcm` `swift-frontend` job that outputs a bunch of information about the module to standard output.

Resolves rdar://78739383