### PR TITLE
[Incremental] Add first file removal test

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -500,6 +500,7 @@ extension IncrementalCompilationState {
       }
     }
   }
+
   @_spi(Testing) public func writeDependencyGraph() throws {
     // If the cross-module build is not enabled, the status quo dictates we
     // not emit this file.
@@ -514,6 +515,12 @@ extension IncrementalCompilationState {
     try self.moduleDependencyGraph.write(to: recordInfo.dependencyGraphPath,
                                          on: self.driver.fileSystem,
                                          compilerVersion: recordInfo.actualSwiftVersion)
+  }
+
+  @_spi(Testing) public static func removeDependencyGraphFile(_ driver: Driver) {
+    if let path = driver.buildRecordInfo?.dependencyGraphPath {
+      try? driver.fileSystem.removeFileTree(path)
+    }
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -59,6 +59,7 @@ extension IncrementalCompilationState {
           driver.diagnosticEngine
         ).compute()
     else {
+      Self.removeDependencyGraphFile(driver)
       return nil
     }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -466,7 +466,7 @@ extension ModuleDependencyGraph {
 // MARK: - verification
 extension ModuleDependencyGraph {
   @discardableResult
-  func verifyGraph() -> Bool {
+  @_spi(Testing) public func verifyGraph() -> Bool {
     nodeFinder.verify()
   }
 }

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -707,6 +707,12 @@ extension TSCBasic.FileSystem {
     }
   }
 
+  func removeFileTree(_ path: VirtualPath) throws {
+    try resolvingVirtualPath(path) { absolutePath in
+      try self.removeFileTree(absolutePath)
+    }
+  }
+
   func getFileInfo(_ path: VirtualPath) throws -> TSCBasic.FileInfo {
     try resolvingVirtualPath(path, apply: getFileInfo)
   }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -362,12 +362,12 @@ extension RemovalTestOptions {
 
 extension IncrementalCompilationTests {
   /// While all cases are being made to work, just test for now in known good cases
-  func testRemovalOfPassingCases() throws {
+  func testRemovalInPassingCases() throws {
     try testRemoval(includeFailingCombos: false)
   }
 
   /// Someday, turn this test on and test all cases
-  func testRemovalOfAllCases() throws {
+  func testRemovalInAllCases() throws {
     throw XCTSkip("unimplemented")
     try testRemoval(includeFailingCombos: true)
   }
@@ -384,9 +384,7 @@ extension IncrementalCompilationTests {
         try testRemoval(optionsToTest)
       }
       else if includeFailingCombos {
-        try XCTExpectFailure("\(optionsToTest) should fail") {
           try testRemoval(optionsToTest)
-        }
       }
     }
 #endif

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -326,7 +326,7 @@ fileprivate enum RemovalTestOption: String, CaseIterable, Comparable, Hashable, 
   case
   removeInputFromInvocation,
   removeSourceFile,
-  removeEntryFromOutputFileMap,
+  removePreviouslyAddedInputFromOutputFileMap,
   removeSwiftDepsFile,
   restoreBadPriors
 
@@ -376,8 +376,6 @@ extension IncrementalCompilationTests {
 #if !os(Linux)
     let knownGoodCombos: [[RemovalTestOption]] = [
       [.removeInputFromInvocation],
-      // next up:
-      // [.removeInputFromInvocation, .restoreBadPriors],
     ]
     for optionsToTest in RemovalTestOptions.allCombinations {
       if knownGoodCombos.contains(optionsToTest) {
@@ -403,7 +401,7 @@ extension IncrementalCompilationTests {
     if options.contains(.removeSwiftDepsFile) {
       removeSwiftDeps(newInput)
     }
-    if options.contains(.removeEntryFromOutputFileMap) {
+    if options.contains(.removePreviouslyAddedInputFromOutputFileMap) {
       // FACTOR
       OutputFileMapCreator.write(module: module,
                                  inputPaths: inputPathsAndContents.map {$0.0},


### PR DESCRIPTION
- Adds a bunch of removal test options
- A facility for testing all combinations of them
- The first, most basic removal test,
- A fix for that test, that removes priors if incremental setup fails