### PR TITLE
Revert "Conditionally pass musttail checking flag to frontend."

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -224,11 +224,6 @@ extension Driver {
       }
     }
 
-    if !parsedOptions.hasArgument(.skipSwifttailccMusttailCheck) {
-      commandLine.appendFlag("-Xllvm")
-      commandLine.appendFlag("-enable-swifttailcc-musttail-check")
-    }
-
     // Pass through any subsystem flags.
     try commandLine.appendAll(.Xllvm, from: &parsedOptions)
     try commandLine.appendAll(.Xcc, from: &parsedOptions)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -499,7 +499,6 @@ extension Option {
   public static let silVerifyAll: Option = Option("-sil-verify-all", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Verify SIL after each transform")
   public static let silVerifyNone: Option = Option("-sil-verify-none", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Completely disable SIL verification")
   public static let skipInheritedDocs: Option = Option("-skip-inherited-docs", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Skip emitting doc comments for members inherited through classes or default implementations")
-  public static let skipSwifttailccMusttailCheck: Option = Option("-skip-swifttailcc-musttail-check", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Skip additional LLVM verification that all tail calls from swifttailcc->swifttailcc are marked musttail.")
   public static let skipSynthesizedMembers: Option = Option("-skip-synthesized-members", .flag, attributes: [.noDriver], helpText: "Skip members inherited through classes or default implementations")
   public static let solverDisableShrink: Option = Option("-solver-disable-shrink", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable the shrink phase of expression type checking")
   public static let solverExpressionTimeThresholdEQ: Option = Option("-solver-expression-time-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver])
@@ -1084,7 +1083,6 @@ extension Option {
       Option.silVerifyAll,
       Option.silVerifyNone,
       Option.skipInheritedDocs,
-      Option.skipSwifttailccMusttailCheck,
       Option.skipSynthesizedMembers,
       Option.solverDisableShrink,
       Option.solverExpressionTimeThresholdEQ,


### PR DESCRIPTION
This reverts commit 0acbbbd001887bf8be842065928df037b457f88c.

Using this flag caused breakage when trying to use upstream LLVM
as well as Clang/LLVM from Xcode 12.5. See SR-14714.