### PR TITLE
[5.5] Use `stat` Instead of `lstat`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,7 +14,7 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "main",
+          "branch": "release/5.5",
           "revision": "b7b4c5eaa798708d6233ca07908a7cab75620040",
           "version": null
         }
@@ -23,7 +23,7 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "main",
+          "branch": "release/5.5",
           "revision": "435a2708a6e486d69ea7d7aaa3f4ad243bc3b408",
           "version": null
         }


### PR DESCRIPTION
Cherry pick of #697 

---------

Using `lstat` here will do the wrong thing when the input path is a symlink since it's going to give us mod time info on the symlink instead of the file it references. Since mod time updates are intentionally not propagated across links, this has the potential to cause us to miscompile if a file's contents change on disk but the symlink passed as input hasn't actually changed. It also has the potential to defeat the incremental build when build systems that generate symlinks on every build interact with the driver.

On Darwin (and, technically, other UNIX-likes) the fix is simple: use stat instead of lstat which will resolve symlinks for us. On Windows the answer is... complicated. Instead, on the fallback path, resolve symlinks before retrieving the modification time of the file.

rdar://78828871