### PR TITLE
[Incremental, Testing] Implement 7 more removal tests.

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -797,6 +797,7 @@ extension IncrementalCompilationTests {
     graph.verifyGraph()
     if removeInputFromInvocation {
       if afterRestoringBadPriors {
+        // FIXME: Fix the driver
         print("*** WARNING: skipping checks, driver fails to cleaned out the graph ***",
               to: &stderrStream); stderrStream.flush()
         return graph

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -71,6 +71,7 @@ final class IncrementalCompilationTests: XCTestCase {
       //        "-v",
       "-save-temps",
       "-incremental",
+      "-no-color-diagnostics",
     ]
     + inputPathsAndContents.map {$0.0.pathString} .sorted()
   }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -353,7 +353,7 @@ fileprivate enum RemovalTestOption: String, CaseIterable, Comparable, Hashable, 
   }
   var mask: Int { 1 << intValue}
   static let maxIntValue = allCases.map {$0.intValue} .max()!
-  static let maxCombinedValue = (1 << maxIntValue) - 1
+  static let maxCombinedValue = (1 << (maxIntValue + 1)) - 1
 
   var description: String { rawValue }
 }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -703,7 +703,7 @@ extension IncrementalCompilationTests {
     switch (removeInputFromInvocation, removeSwiftDepsFile) {
     case (false, false):
       expectations = [
-        .readGraphAndSkipAll("main", "other", "another")
+        .readGraphAndSkipAll("main", "other", removedInput)
       ]
     case
       (true, false),
@@ -718,11 +718,11 @@ extension IncrementalCompilationTests {
       expectations = [
         .readGraph,
         .enablingCrossModule,
-        .maySkip("main", "other", "another"),
-        .missing("another"),
-        .queuingInitial("another"),
+        .maySkip("main", "other", removedInput),
+        .missing(removedInput),
+        .queuingInitial(removedInput),
         .skipping("main", "other"),
-        .findingBatchingCompiling("another"),
+        .findingBatchingCompiling(removedInput),
         .schedulingPostCompileJobs,
         .linking,
         .skipped("main", "other"),
@@ -798,6 +798,16 @@ extension IncrementalCompilationTests {
     if removeInputFromInvocation {
       if afterRestoringBadPriors {
         // FIXME: Fix the driver
+        // If you incrementally compile with a.swift and b.swift,
+        // at the end, the driver saves a serialized `ModuleDependencyGraph`
+        // contains nodes for declarations defined in both files.
+        // If you then later remove b.swift and recompile, the driver will
+        // see that a file was removed (via comparisons with the saved `BuildRecord`
+        // and will delete the saved priors. However, if for some reason the
+        // saved priors are not deleted, the driver will read saved priors
+        // containing entries for the deleted file. This test simulates that
+        // condition by restoring the deleted priors. The driver ought to be fixed
+        // to cull any entries for removed files from the deserialized priors.
         print("*** WARNING: skipping checks, driver fails to cleaned out the graph ***",
               to: &stderrStream); stderrStream.flush()
         return graph


### PR DESCRIPTION
Tests all combinations of `removeInputFromInvocation`,  `removeSwiftDepsFile`, & `restoreBadPriors`.
The last condition simulates a case where a file is removed but somehow the driver does not get to remove the priors, which has entries for the removed file.
For that condition, the test passes but prints out a warning.
A subsequent PR will fix this issue.