### PR TITLE
[5.5] Pass `.tbd` inputs down to the linker invocation.

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -268,6 +268,8 @@ extension DarwinToolchain {
           inputModules.append(input.file)
         } else if input.type == .object {
           inputPaths.append(input.file)
+        } else if input.type == .tbd {
+          inputPaths.append(input.file)
         } else if input.type == .llvmBitcode {
           inputPaths.append(input.file)
         }
@@ -290,6 +292,8 @@ extension DarwinToolchain {
         if path.type == .swiftModule && linkerOutputType != .staticLibrary {
           return [.flag("-add_ast_path"), .path(path.file)]
         } else if path.type == .object {
+          return [.path(path.file)]
+        } else if path.type == .tbd {
           return [.path(path.file)]
         } else if path.type == .llvmBitcode {
           return [.path(path.file)]

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -330,7 +330,7 @@ extension Driver {
                                       addCompileJobGroup: addCompileJobGroup,
                                       addJobOutputs: addJobOutputs)
 
-    case .object, .autolink, .llvmBitcode:
+    case .object, .autolink, .llvmBitcode, .tbd:
       if linkerOutputType != nil {
         addLinkerInput(input)
       } else {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1019,6 +1019,17 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
+      // .tbd inputs are passed down to the linker.
+      var driver = try Driver(args: commonArgs + ["foo.dylib", "foo.tbd", "-target", "x86_64-apple-macosx10.15"], env: env)
+      let plannedJobs = try driver.planBuild()
+      let linkJob = plannedJobs[2]
+      XCTAssertEqual(linkJob.kind, .link)
+      let cmd = linkJob.commandLine
+      XCTAssertTrue(cmd.contains(.path(try VirtualPath(path: "foo.tbd"))))
+      XCTAssertTrue(cmd.contains(.path(try VirtualPath(path: "foo.dylib"))))
+    }
+
+    do {
       // iOS target
       var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "arm64-apple-ios10.0"], env: env)
       let plannedJobs = try driver.planBuild()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/701 for the `release/5.5` branch.
--------------------------------------
Instead of passing them as inputs to the `swift-frontend` invocations, which does not make sense as they are not source-code.

Part of rdar://78881502