### PR TITLE
Disable output file map diagnostic for non-incremental mode

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -592,6 +592,7 @@ public struct Driver {
       fileSystem: fileSystem,
       moduleOutputInfo: moduleOutputInfo,
       outputFileMap: outputFileMap,
+      incremental: self.shouldAttemptIncrementalCompilation,
       parsedOptions: parsedOptions,
       recordedInputModificationDates: recordedInputModificationDates)
 

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -74,12 +74,14 @@ import SwiftOptions
     fileSystem: FileSystem,
     moduleOutputInfo: ModuleOutputInfo,
     outputFileMap: OutputFileMap?,
+    incremental: Bool,
     parsedOptions: ParsedOptions,
     recordedInputModificationDates: [TypedVirtualPath: Date]
   ) {
     // Cannot write a buildRecord without a path.
     guard let buildRecordPath = Self.computeBuildRecordPath(
             outputFileMap: outputFileMap,
+            incremental: incremental,
             compilerOutputType: compilerOutputType,
             workingDirectory: workingDirectory,
             diagnosticEngine: diagnosticEngine)
@@ -124,6 +126,7 @@ import SwiftOptions
   /// Determine the input and output path for the build record
   private static func computeBuildRecordPath(
     outputFileMap: OutputFileMap?,
+    incremental: Bool,
     compilerOutputType: FileType?,
     workingDirectory: AbsolutePath?,
     diagnosticEngine: DiagnosticsEngine
@@ -136,7 +139,9 @@ import SwiftOptions
     guard let partialBuildRecordPath =
             ofm.existingOutputForSingleInput(outputType: .swiftDeps)
     else {
-      diagnosticEngine.emit(.warning_incremental_requires_build_record_entry)
+      if incremental {
+        diagnosticEngine.emit(.warning_incremental_requires_build_record_entry)
+      }
       return nil
     }
     return workingDirectory


### PR DESCRIPTION
This re-implements this logic https://github.com/apple/swift/blob/3116eed2e465a2688f070b3b87adc106cbbaf09f/lib/Driver/Driver.cpp#L414-L417 to not warn when output file maps don't have a main entry when using WMO