### PR TITLE
[5.5] Produce an error when multiple `-o` options are specified in multi-threading mode

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -24,6 +24,7 @@ public struct Driver {
     case relativeFrontendPath(String)
     case subcommandPassedToDriver
     case integratedReplRemoved
+    case cannotSpecify_OForMultipleOutputs
     case conflictingOptions(Option, Option)
     case unableToLoadOutputFileMap(String)
     case unableToDecodeFrontendTargetInfo(String?, [String], String)
@@ -57,6 +58,8 @@ public struct Driver {
         return "subcommand passed to driver"
       case .integratedReplRemoved:
         return "Compiler-internal integrated REPL has been removed; use the LLDB-enhanced REPL instead."
+      case .cannotSpecify_OForMultipleOutputs:
+        return "cannot specify -o when generating multiple output files"
       case .conflictingOptions(let one, let two):
         return "conflicting options '\(one.spelling)' and '\(two.spelling)'"
       case let .unableToDecodeFrontendTargetInfo(outputString, arguments, errorDesc):
@@ -679,6 +682,8 @@ public struct Driver {
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
+
+    try verifyOutputOptions()
   }
 
   public mutating func planBuild( simulateGetInputFailure: Bool = false ) throws -> [Job] {
@@ -762,6 +767,29 @@ extension Driver {
       return nil
     }
     return kind
+  }
+}
+
+extension Driver {
+  // Detect mis-use of multi-threading and output file options
+  private func verifyOutputOptions() throws {
+    if compilerOutputType != .swiftModule,
+       parsedOptions.hasArgument(.o),
+       linkerOutputType == nil {
+      let shouldComplain: Bool
+      if numThreads > 0 {
+        // Multi-threading compilation has multiple outputs unless there's only
+        // one input.
+        shouldComplain = self.inputFiles.count > 1
+      } else {
+        // Single-threaded compilation is a problem if we're compiling more than
+        // one file.
+        shouldComplain = self.inputFiles.filter { $0.type.isPartOfSwiftCompilation }.count > 1 && .singleCompile != compilerMode
+      }
+      if shouldComplain {
+        diagnosticEngine.emit(Error.cannotSpecify_OForMultipleOutputs)
+      }
+    }
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -85,7 +85,6 @@ extension Driver {
   -> ([Job], IncrementalCompilationState?) {
     precondition(compilerMode.isStandardCompilationForPlanning,
                  "compiler mode \(compilerMode) is handled elsewhere")
-
     // Determine the initial state for incremental compilation that is required during
     // the planning process. This state contains the module dependency graph and
     // cross-module dependency information.

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -191,7 +191,8 @@ public final class MultiJobExecutor {
                                     to producerMap: inout [VirtualPath.Handle: Int]
     ) {
       for output in job.outputs {
-        if let otherJobIndex = producerMap.updateValue(index, forKey: output.fileHandle) {
+        if output.file != .standardOutput,
+           let otherJobIndex = producerMap.updateValue(index, forKey: output.fileHandle) {
           fatalError("multiple producers for output \(output.file): \(job) & \(knownJobs[otherJobIndex])")
         }
         producerMap[output.fileHandle] = index

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -314,6 +314,16 @@ final class SwiftDriverTests: XCTestCase {
       }
   }
 
+  func testMultiThreadingOutputs() throws {
+    try assertDriverDiagnostics(args: "swiftc", "-c", "foo.swift", "bar.swift", "-o", "bar.ll", "-o", "foo.ll", "-num-threads", "2", "-whole-module-optimization") {
+      $1.expect(.error("cannot specify -o when generating multiple output files"))
+    }
+
+    try assertDriverDiagnostics(args: "swiftc", "-c", "foo.swift", "bar.swift", "-o", "bar.ll", "-o", "foo.ll", "-num-threads", "0") {
+      $1.expect(.error("cannot specify -o when generating multiple output files"))
+    }
+  }
+
   func testBaseOutputPaths() throws {
     // Test the combination of -c and -o includes the base output path.
     do {


### PR DESCRIPTION
5.5 Cherry-pick of https://github.com/apple/swift-driver/pull/711
-----------------------------------------
Causing the behavior to be analagous to the Legacy driver's here:
https://github.com/apple/swift/blob/main/lib/Driver/Driver.cpp#L2415

Otherwise, this isn't a supported flow and leads to driver crashes downstream.

Resolves rdar://79171618