### PR TITLE
Ensure that verbose (`-v`) mode applies to in-place execution.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1053,6 +1053,13 @@ extension Driver {
         stderrStream <<< "swift-driver version: " <<< Driver.driverSourceVersion <<< " "
         stderrStream.flush()
       }
+      // In verbose mode, print out the job
+      if parsedOptions.contains(.v) {
+        let arguments: [String] = try executor.resolver.resolveArgumentList(for: inPlaceJob,
+                                                                            forceResponseFiles: forceResponseFiles)
+        stdoutStream <<< arguments.map { $0.spm_shellEscaped() }.joined(separator: " ") <<< "\n"
+        stdoutStream.flush()
+      }
       try executor.execute(job: inPlaceJob,
                            forceResponseFiles: forceResponseFiles,
                            recordedInputModificationDates: recordedInputModificationDates)

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -14,7 +14,7 @@ import TSCBasic
 
 
 #if os(macOS)
-private func bundleRoot() -> AbsolutePath {
+internal func bundleRoot() -> AbsolutePath {
     for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
         return AbsolutePath(bundle.bundlePath).parentDirectory
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3643,6 +3643,30 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testVerboseImmediateMode() throws {
+// There is nothing particularly macOS-specific about this test other than
+// the use of some macOS-specific XCTest functionality to determine the
+// test bundle that contains the swift-driver executable.
+#if os(macOS)
+    try withTemporaryDirectory { path in
+      let input = path.appending(component: "ImmediateTest.swift")
+      try localFileSystem.writeFileContents(input) { $0 <<< "print(\"Hello, World\")" }
+      let binDir = bundleRoot()
+      let driver = binDir.appending(component: "swift-driver")
+      let args = [driver.description, "--driver-mode=swift", "-v", input.description]
+      // Immediate mode takes over the process with `exec` so we need to create
+      // a separate process to capture its output here
+      let result = try TSCBasic.Process.checkNonZeroExit(
+        arguments: args,
+        environment: ProcessEnv.vars
+      )
+      // Make sure the interpret job description was printed
+      XCTAssertTrue(result.contains("-frontend -interpret \(input.description)"))
+      XCTAssertTrue(result.contains("Hello, World"))
+    }
+#endif
+  }
+
   func testDiagnosticOptions() throws {
     do {
       var driver = try Driver(args: ["swift", "-no-warnings-as-errors", "-warnings-as-errors", "foo.swift"])


### PR DESCRIPTION
For compiles which fall under our "in-place execution" flow, ensure that we print the in-place job before executing it if `-v` was specified.

Resolves rdar://79295614