### PR TITLE
[Dependency Scanning] Add ability to use the dependency scanner's import-prescan mode

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -266,3 +266,7 @@ public struct InterModuleDependencyGraph: Codable {
   /// Information about the main module.
   public var mainModule: ModuleInfo { modules[.swift(mainModuleName)]! }
 }
+
+public struct InterModuleDependencyImports: Codable {
+  public var imports: [String]
+}

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -52,6 +52,16 @@ public class InterModuleDependencyOracle {
     }
   }
 
+  @_spi(Testing) public func getImports(workingDirectory: AbsolutePath,
+                                             commandLine: [String])
+  throws -> InterModuleDependencyImports {
+    precondition(hasScannerInstance)
+    return try queue.sync {
+      return try swiftScanLibInstance!.preScanImports(workingDirectory: workingDirectory,
+                                                      invocationCommand: commandLine)
+    }
+  }
+
   /// Given a specified toolchain path, locate and instantiate an instance of the SwiftScan library
   /// Returns True if a library instance exists (either verified or newly-created).
   @_spi(Testing) public func verifyOrCreateScannerInstance(fileSystem: FileSystem,

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -42,6 +42,16 @@ internal extension SwiftScan {
     return resultGraph
   }
 
+  /// From a reference to a binary-format set of module imports return by libSwiftScan pre-scan query,
+  /// construct an instance of an `InterModuleDependencyImports` set
+  func constructImportSet(from importSetRef: swiftscan_import_set_t) throws
+  -> InterModuleDependencyImports {
+    guard let importsRef = api.swiftscan_import_set_get_imports(importSetRef) else {
+      throw DependencyScanningError.missingField("import_set.imports")
+    }
+    return InterModuleDependencyImports(imports: try toSwiftStringArray(importsRef.pointee))
+  }
+
   /// From a reference to a binary-format dependency graph collection returned by libSwiftScan batch scan query,
   /// corresponding to the specified batch scan input (`BatchScanModuleInfo`), construct instances of
   /// `InterModuleDependencyGraph` for each result.


### PR DESCRIPTION
An ability to do a simple import pre-scan was added to the dependency scanner in https://github.com/apple/swift/pull/34028, with a corresponding libSwiftScan API added later. It parses input files looking for `import` statements and outputs an array of module names imported in the provided input source files.

This PR adds the ability to invoke this import pre-scan from the driver.