### PR TITLE
[Incremental] When reading priors filter out nodes from removed inputs.

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -786,7 +786,7 @@ extension IncrementalCompilationTests {
         fingerprintChanged(.interface, "main")
         fingerprintChanged(.implementation, "main")
 
-        let affectedInputs = removeInputFromInvocation && !afterRestoringBadPriors
+        let affectedInputs = removeInputFromInvocation
         ? ["other"]
         : [removedInput, "other"]
         for input in affectedInputs {
@@ -797,10 +797,6 @@ extension IncrementalCompilationTests {
                       input == removedInput && afterRestoringBadPriors
                       ? nil : input)
           }
-        }
-        if removeInputFromInvocation && afterRestoringBadPriors {
-          failedToFindSource(removedInput)
-          failedToReadSomeSource(compiling: "main")
         }
         let affectedInputsInBuild = affectedInputs.filter(inputs.contains)
         queuingLater(affectedInputsInBuild)
@@ -814,22 +810,6 @@ extension IncrementalCompilationTests {
     let graph = try driver.moduleDependencyGraph()
     graph.verifyGraph()
     if removeInputFromInvocation {
-      if afterRestoringBadPriors {
-        // FIXME: Fix the driver
-        // If you incrementally compile with a.swift and b.swift,
-        // at the end, the driver saves a serialized `ModuleDependencyGraph`
-        // contains nodes for declarations defined in both files.
-        // If you then later remove b.swift and recompile, the driver will
-        // see that a file was removed (via comparisons with the saved `BuildRecord`
-        // and will delete the saved priors. However, if for some reason the
-        // saved priors are not deleted, the driver will read saved priors
-        // containing entries for the deleted file. This test simulates that
-        // condition by restoring the deleted priors. The driver ought to be fixed
-        // to cull any entries for removed files from the deserialized priors.
-        print("*** WARNING: skipping checks, driver fails to cleaned out the graph ***",
-              to: &stderrStream); stderrStream.flush()
-        return graph
-      }
       graph.ensureOmits(sourceBasenameWithoutExt: removedInput)
       graph.ensureOmits(name: topLevelName)
     }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -372,27 +372,10 @@ extension RemovalTestOptions {
 }
 
 extension IncrementalCompilationTests {
-  /// While all cases are being made to work, just test for now in known good cases
-  func testRemovalInPassingCases() throws {
-    try testRemoval(includeFailingCombos: false)
-  }
-
-  func testRemovalInAllCases() throws {
-    try testRemoval(includeFailingCombos: true)
-  }
-
-  func testRemoval(includeFailingCombos: Bool) throws {
+  func testRemoval() throws {
 #if !os(Linux)
-    let knownGoodCombos: [[RemovalTestOption]] = [
-      [.removeInputFromInvocation],
-    ]
     for optionsToTest in RemovalTestOptions.allCombinations {
-      if knownGoodCombos.contains(optionsToTest) {
-        try testRemoval(optionsToTest)
-      }
-      else if includeFailingCombos {
-          try testRemoval(optionsToTest)
-      }
+      try testRemoval(optionsToTest)
     }
 #endif
   }


### PR DESCRIPTION
If a source file was part of the build but is no longer, it is possible to read a prior `ModuleDependencyGraph` node that corresponds to a definition in the removed file. Filter those out on deserialization in order to remove a potential source of bugs and bloat.