### PR TITLE
Add some additional directives for OpenBSD.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2335,7 +2335,7 @@ extension Triple {
       return DarwinToolchain.self
     case .linux:
       return GenericUnixToolchain.self
-    case .freeBSD, .haiku:
+    case .freeBSD, .haiku, .openbsd:
       return GenericUnixToolchain.self
     case .wasi:
       return WebAssemblyToolchain.self

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -14,6 +14,10 @@ import SwiftOptions
 
 extension GenericUnixToolchain {
   private func defaultLinker(for targetTriple: Triple) -> String? {
+    if targetTriple.os == .openbsd {
+      return "lld"
+    }
+
     switch targetTriple.arch {
     case .arm, .aarch64, .armeb, .thumb, .thumbeb:
       // BFD linker has issues wrt relocation of the protocol conformance

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -274,6 +274,8 @@ extension Triple {
       return environment == .android ? "android" : "linux"
     case .freeBSD:
       return "freebsd"
+    case .openbsd:
+      return "openbsd"
     case .win32:
       switch environment {
       case .cygnus:
@@ -295,9 +297,8 @@ extension Triple {
     // Explicitly spell out the remaining cases to force a compile error when
     // Triple updates
     case .ananas, .cloudABI, .dragonFly, .fuchsia, .kfreebsd, .lv2, .netbsd,
-         .openbsd, .solaris, .minix, .rtems, .nacl, .cnk, .aix, .cuda, .nvcl,
-         .amdhsa, .elfiamcu, .mesa3d, .contiki, .amdpal, .hermitcore, .hurd,
-         .emscripten:
+         .solaris, .minix, .rtems, .nacl, .cnk, .aix, .cuda, .nvcl, .amdhsa,
+         .elfiamcu, .mesa3d, .contiki, .amdpal, .hermitcore, .hurd, .emscripten:
       return nil
     }
   }


### PR DESCRIPTION
These are needed for the swift-driver to work correctly on this
platform.

OpenBSD has the lld linker in the base system, so just default to using
it over bfd, as suggested by the comments.