### PR TITLE
Add Docc Support and Some Preliminary Articles

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 import PackageDescription
 import class Foundation.ProcessInfo
 
@@ -41,18 +41,25 @@ let package = Package(
   targets: [
 
     /// C modules wrapper for _InternalLibSwiftScan.
-    .target(name: "CSwiftScan"),
+    .target(name: "CSwiftScan",
+            exclude: [ "CMakeLists.txt" ]),
 
     /// The driver library.
     .target(
       name: "SwiftDriver",
-      dependencies: ["SwiftOptions", "SwiftToolsSupport-auto",
-                     "CSwiftScan", "Yams"]),
+      dependencies: [
+        "SwiftOptions",
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+        "CSwiftScan", "Yams"
+      ]),
 
     /// The execution library.
     .target(
       name: "SwiftDriverExecution",
-      dependencies: ["SwiftDriver", "SwiftToolsSupport-auto"]),
+      dependencies: [
+        "SwiftDriver",
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+      ]),
 
     /// Driver tests.
     .testTarget(
@@ -63,7 +70,11 @@ let package = Package(
     /// IncrementalImport tests
     .testTarget(
       name: "IncrementalImportTests",
-      dependencies: ["IncrementalTestFramework", "TestUtilities", "SwiftToolsSupport-auto"]),
+      dependencies: [
+        "IncrementalTestFramework",
+        "TestUtilities",
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ]),
 
     .target(
       name: "IncrementalTestFramework",
@@ -81,28 +92,34 @@ let package = Package(
     /// The options library.
     .target(
       name: "SwiftOptions",
-      dependencies: ["SwiftToolsSupport-auto"]),
+      dependencies: [
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ]),
     .testTarget(
       name: "SwiftOptionsTests",
       dependencies: ["SwiftOptions"]),
 
     /// The primary driver executable.
-    .target(
+    .executableTarget(
       name: "swift-driver",
       dependencies: ["SwiftDriverExecution", "SwiftDriver"]),
 
     /// The help executable.
-    .target(
+    .executableTarget(
       name: "swift-help",
-      dependencies: ["SwiftOptions", "ArgumentParser", "SwiftToolsSupport-auto"]),
+      dependencies: [
+        "SwiftOptions",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      ]),
 
     /// The help executable.
-    .target(
+    .executableTarget(
       name: "swift-build-sdk-interfaces",
       dependencies: ["SwiftDriver", "SwiftDriverExecution"]),
 
     /// The `makeOptions` utility (for importing option definitions).
-    .target(
+    .executableTarget(
       name: "makeOptions",
       dependencies: []),
   ],
@@ -121,7 +138,9 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
             .package(path: "../llbuild"),
         ]
     }
-    package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += ["llbuildSwift"]
+    package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
+      .product(name: "llbuildSwift", package: "swift-llbuild"),
+    ]
 }
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -1,6 +1,6 @@
-// swift-tools-version:5.5
-// In order to support users running on legacy Xcodes, please ensure that
-// Package@swift-5.4.swift is kept in sync with this file.
+// swift-tools-version:5.1
+// In order to support users running on the latest Xcodes, please ensure that
+// Package.swift is kept in sync with this file.
 import PackageDescription
 import class Foundation.ProcessInfo
 
@@ -43,25 +43,18 @@ let package = Package(
   targets: [
 
     /// C modules wrapper for _InternalLibSwiftScan.
-    .target(name: "CSwiftScan",
-            exclude: [ "CMakeLists.txt" ]),
+    .target(name: "CSwiftScan"),
 
     /// The driver library.
     .target(
       name: "SwiftDriver",
-      dependencies: [
-        "SwiftOptions",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        "CSwiftScan", "Yams"
-      ]),
+      dependencies: ["SwiftOptions", "SwiftToolsSupport-auto",
+                     "CSwiftScan", "Yams"]),
 
     /// The execution library.
     .target(
       name: "SwiftDriverExecution",
-      dependencies: [
-        "SwiftDriver",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
-      ]),
+      dependencies: ["SwiftDriver", "SwiftToolsSupport-auto"]),
 
     /// Driver tests.
     .testTarget(
@@ -72,11 +65,7 @@ let package = Package(
     /// IncrementalImport tests
     .testTarget(
       name: "IncrementalImportTests",
-      dependencies: [
-        "IncrementalTestFramework",
-        "TestUtilities",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ]),
+      dependencies: ["IncrementalTestFramework", "TestUtilities", "SwiftToolsSupport-auto"]),
 
     .target(
       name: "IncrementalTestFramework",
@@ -94,34 +83,28 @@ let package = Package(
     /// The options library.
     .target(
       name: "SwiftOptions",
-      dependencies: [
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ]),
+      dependencies: ["SwiftToolsSupport-auto"]),
     .testTarget(
       name: "SwiftOptionsTests",
       dependencies: ["SwiftOptions"]),
 
     /// The primary driver executable.
-    .executableTarget(
+    .target(
       name: "swift-driver",
       dependencies: ["SwiftDriverExecution", "SwiftDriver"]),
 
     /// The help executable.
-    .executableTarget(
+    .target(
       name: "swift-help",
-      dependencies: [
-        "SwiftOptions",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ]),
+      dependencies: ["SwiftOptions", "ArgumentParser", "SwiftToolsSupport-auto"]),
 
     /// The help executable.
-    .executableTarget(
+    .target(
       name: "swift-build-sdk-interfaces",
       dependencies: ["SwiftDriver", "SwiftDriverExecution"]),
 
     /// The `makeOptions` utility (for importing option definitions).
-    .executableTarget(
+    .target(
       name: "makeOptions",
       dependencies: []),
   ],
@@ -140,9 +123,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
             .package(path: "../llbuild"),
         ]
     }
-    package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
-      .product(name: "llbuildSwift", package: "swift-llbuild"),
-    ]
+    package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += ["llbuildSwift"]
 }
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -13,6 +13,8 @@
 import TSCBasic
 import Foundation
 
+/// A type that is capable of executing compilation jobs on some underlying
+/// build service.
 public protocol DriverExecutor {
   var resolver: ArgsResolver { get }
 

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -63,7 +63,7 @@ extension SwiftVersion: Codable {
 
 /// Describes information about the target as provided by the Swift frontend.
 @dynamicMemberLookup
-@_spi(Testing) public struct FrontendTargetInfo: Codable {
+public struct FrontendTargetInfo: Codable {
   struct CompatibilityLibrary: Codable {
     enum Filter: String, Codable {
       case all

--- a/Sources/SwiftDriver/SwiftDriver.docc/ExplicitModuleBuilds.md
+++ b/Sources/SwiftDriver/SwiftDriver.docc/ExplicitModuleBuilds.md
@@ -1,0 +1,79 @@
+# Explicit Module Builds
+
+Fast scanning and reporting of modular dependencies.
+
+## Introduction
+
+The Swift driver provides facilities for quickly scanning the Swift source files
+to identify explicit dependencies on other Swift modules, C headers, frameworks,
+modulemaps, and other inputs that may affect the structure and contents of a 
+module. This information is used to proactively build a complete picture of
+the entire set of dependencies of a module which will enable build systems to
+perform faster, more robust rebuilds.
+
+## Fast Dependency Scanning
+
+The dependency information for a module can come from a variety of sources:
+
+- Serialized swift module files, by reading the module header
+- Swift interface files, by parsing the source code to find imports
+- Swift source files, by parsing the source code to find imports
+- Clang modules, using Clang's fast dependency scanning tool
+- Bridging headers, including the source files and modules they depend on
+
+Each of these does not require more work than parsing or module loading
+to discover dependencies, making them ideal candidates for rapidly sourcing
+dependency information.
+
+The Swift Driver schedules a special frontend job to perform all of this
+dependency scanning up front. The information is then reported back to any
+clients that wish to determine the jobs they need to run to rebuild dependent
+modules *before* they rebuild the current Swift module.
+
+## What's So Bad About Implicit Module Builds?
+
+One of the primary tasks of a build system is determining the number, order, and
+kind of dependencies between different build products. This information helps
+the build system determine which tools it needs to invoke to regenerate these
+products when changes occur. Make-style build systems require an explicit
+declaration of targets and their dependencies that makes this kind of analysis
+relatively straightforward. But some build systems try to be intelligent about
+the kinds of dependencies they can search for without explicit declarations.
+
+Sometimes, even the tools themselves try to be intelligent about build 
+dependencies. For example, the Swift Driver reports back a curious thing to 
+build systems that care to ask for make-style dependencies: every file depends
+upon every other file. This dense dependency graph allows the driver to take
+control of rebuilding Swift files, and ensures that 
+[incremental builds](doc://SwiftDriver/IncrementalBuilds) work with these
+systems out of the box.
+
+Further implicit build schemes are implemented by both Clang and Swift to 
+rebuild their respective notion of modules when metadata mismatches are 
+detected. Both compilers maintain a cache of these implicitly-built modules to
+speed up future queries for the same module. As these caches are rebuilt on
+demand, the dependency on the rebuild is *not* reported to the build system -
+it happens *implicitly*.
+
+Implicit module builds complicate the compilers in a number of interesting
+ways. Each compiler and its associated driver must become a miniature module
+build system to accomodate requests to rebuild modules (which may, itself, 
+involve rebuilding yet more modules), which comes with lots of maintenance 
+overhead. What's more, as these rebuilds are hidden from both the user and the
+build tools, certain compilations may appear to take an inordinate amount of
+time as caches are repopulated, then appear to take no time at all at a later
+point. Because the same module may be requested many times during the parallel
+rebuild of targets, the caches are constantly under heavy contention from
+multiple processes that are trying to both read and write into them, which leads
+to incredibly subtle problems when file systems, locks, and concurrency bugs 
+conspire together. Finally, the build system will generally have some 
+user-derived knowledge of the amount of parallelism needed to accomplish
+a given task. The compilers performing implicit module builds, by contrast, are
+not given this information. This can lead to an explosion of tasks to rebuild 
+and repopulate the module cache that can and do quickly overwhelm a 
+user's machine.
+
+All of these problems could be avoided by returning to a more declarative
+model where dependencies on modules being rebuilt is provided to the build
+systems up front.
+

--- a/Sources/SwiftDriver/SwiftDriver.docc/IncrementalBuilds.md
+++ b/Sources/SwiftDriver/SwiftDriver.docc/IncrementalBuilds.md
@@ -1,0 +1,146 @@
+# Incremental Builds
+
+A compilation mode that tries to schedule the rebuilding of Swift files with
+changes and their dependents.
+
+## Overview
+
+An *incremental build* is a resource-saving compilation mode that attempts
+to detect and rebuild only those files that have changed between successive
+invocations of the driver. By communicating with the frontends it spawns to
+determine their dependencies, the driver is able to intelligently schedule
+minimal rebuilds of Swift modules. 
+
+## Introduction
+
+The finest unit of scheduling the Swift driver is concerned about is an 
+individual file. When the driver is invoked, every file in the module is passed
+to it as an input. It is up to the incremental build to sort these inputs into
+jobs that should be run, and jobs that should be skipped.
+
+The Swift compilation model includes one more wrinkle: the compilation of one
+file may introduce dependencies on another file that needs to rebuild afterward.
+Therefore, the incremental build state can be continuously queried to both
+integrate new dependencies and discover additional compilation jobs to run. This
+implies that the incremental build must be run *to a fixpoint* in order for
+it to complete.
+
+## Communicating Dependencies
+
+The Swift driver includes built-in facilities for reading incremental dependnecy
+information produced by the Swift frontend called `.swiftdeps` files. These
+files contain serialized dependency information on both a per-file and 
+per-declaration basis. The format of swiftdeps files is an implementation detail
+of the driver and frontends, and version mismatches will cause the incremental
+build to be cancelled and a full rebuild to be performed in its place.
+
+Generally, a `.swiftdeps` file contains the names of dependencies that the file
+exports to other files - called *provides* - and dependencies that the file
+imports from other files - called *depends*. To see this system in abstract,
+consider the following "file" of Swift declarations:
+
+```
+public struct Foo { // (1)
+  var bar: Bar // (3)
+}
+
+public struct Bar { // (2)
+  var baz: Int // (4)
+}
+```
+
+This file *provides* the types `Foo` and `Bar` as well as their members
+`Foo.bar` and `Bar.baz`. There are also dependencies between `Foo` and `Bar`
+because the type of `Foo.bar` depends upon `Bar`, and a dependency between
+`Bar` and Swift's `Int` type because of `Bar.baz`.
+ 
+Notably, the provides of a file need not be limited to the declarations it 
+contains. Provides are often composed transitively from other provided 
+declarations used in the file. For example,
+
+```
+class B : A {} // This file provides both A and B
+```
+
+This may seem odd at first blush as this file only declares the class type `B`,
+not the superclass `A`. But consider that any file that uses the subclass `B`
+also *implicitly uses the superclass A*. If `A` were to change in a way that
+required a rebuild, we would want those transitive dependencies to rebuild as 
+well!
+
+In general, after collecting all of the provides and depends for a file, the
+result is an enormous [multi-graph](https://en.wikipedia.org/wiki/Multigraph)
+of dependency edges between Swift files. The Swift driver integrates each
+`.swiftdeps` file that corresponds to a `.swift` file into a 
+``SwiftDriver/ModuleDependencyGraph`` that then forms the backbone of 
+the dependency analysis procedures that power the incremental build.
+
+## Constructing the Incremental Build
+
+Computing the set of files that must be rebuilt is a continuous process of
+dynamically discovering, integrating, and scheduling dependencies. A high-level
+summary of the incremental build state machine is provided in the following
+diagram:
+
+```
+                                                                              ┌─────────────────────────────────────────────────┐
+                                                                              │                                                 │
+                            ┌──────┐                     ┌──────────┐         ▼                                                 │
+                            │ Yes! │   ┏━━━━━━━━━━━━━┓   │ Success! │   ┏━━━━━━━━━━━┓                                           │
+                        ┌───┴──────┴──▶┃ Read Priors ┃─┬─┴──────────┴──▶┃ Integrate ┃                                           │
+                        │              ┗━━━━━━━━━━━━━┛ │                ┗━━━━━━━━━━━┛                                           │
+                        │                              │                      │                                                 │
+            ┌─────────┐ │                              ├────────┐             ├──────────────┐                                  │
+┏━━━━━━━━┓  │ Priors? │ │                              │ Error! │             │  Discovered  │                                  │
+┃ Start! ┃──┴─────────┴─┴─┐                            ├────────┘             │Dependencies? │                                  │
+┗━━━━━━━━┛                │                            │                      ├──────────────┘┌──────┐                          │
+                          │                            │                      │               │ Yes! │  ┏━━━━━━━━━━━━━━━━━━━━┓  │
+                          │    ┌──────┐                ▼                      └────────────┬──┴──────┴─▶┃ Schedule Next Wave ┃──┘
+                          │    │ Nope │    ┏━━━━━━━━━━━━━━━━━━━━━━━┓                ┌──────┤            ┗━━━━━━━━━━━━━━━━━━━━┛   
+                          └────┴──────┴───▶┃ Schedule Full Rebuild ┃─────────┐      │ Nope │                                     
+                                           ┗━━━━━━━━━━━━━━━━━━━━━━━┛         │      └──────┤                                     
+                                                                             │             │                                     
+                                                                             │             │                                     
+                                                                             │             ▼                                     
+                                                                             │         ┏━━━━━━━┓                                 
+                                                                             └────────▶┃ Done! ┃                                 
+                                                                                       ┗━━━━━━━┛                                 
+```
+
+The build begins by examining "priors" - data left behind by the last compilation
+session. If no data is found, the Driver considers the incremental build to be
+a lost cause and schedules a full rebuild in order to gather `.swiftdeps` files
+it can use to reconstruct this prior data.
+
+Assuming priors are present, they are deserialized and any dependency 
+information they contain is integrated into the driver's dependency graph. Next,
+the modification time of any files is examined. If these modification times do
+not match the driver's last expected modification time, those files are 
+immediately scheduled for rebuilding. Using the information from the prior build,
+we can also determine the files that directly depend upon those modified files
+and pull them in for rebuilding. The set of modified files and their direct
+dependents is colloquially referred to as the *first wave* of compilation jobs.
+
+As the name *first wave* implies, additional discovered dependencies in the
+modified files can cause the formation of further waves of compilation. As
+each frontend job finishes compiling a swift file, it lays down a new 
+`.swiftdeps` file that the driver picks up and integrates into the module 
+dependency graph. New edges are added, and old edges removed, thus keeping
+the module dependency graph up to date with the current state of the user's code
+at that moment in time.
+
+Eventually, the incremental build either exhausts the set of input files it
+must rebuild, or runs into an error during compilation that requires the build
+to halt. Either way, the driver writes down the state of the build, then flushes
+the module dependency graph to disk so the entire process can begin anew.
+
+## Topics
+
+### State Management
+
+- <doc:SwiftDriver/IncrementalCompilationState>
+
+### Dependency Graphs
+
+- <doc:SwiftDriver/ModuleDependencyGraph>
+- <doc:SwiftDriver/SourceFileDependencyGraph>

--- a/Sources/SwiftDriver/SwiftDriver.docc/Info.plist
+++ b/Sources/SwiftDriver/SwiftDriver.docc/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>SwiftDriver</string>
+	<key>CFBundleDisplayName</key>
+	<string>SwiftDriver</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.apple.swift-driver</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIconFile</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundleIconName</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundlePackageType</key>
+	<string>DOCS</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+	<key>CDAppleDefaultAvailability</key>
+	<dict>
+		<key>SwiftDriver</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>macOS</string>
+				<key>version</key>
+				<string>10.15</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Sources/SwiftDriver/SwiftDriver.docc/SwiftDriver.md
+++ b/Sources/SwiftDriver/SwiftDriver.docc/SwiftDriver.md
@@ -1,0 +1,44 @@
+# ``SwiftDriver``
+
+A native compiler driver for the Swift language.
+
+## Overview
+
+The `SwiftDriver` framework coordinates the compilation of Swift source code
+into various compiled results: executables, libraries, object files, Swift 
+modules and interfaces, etc. It is the program one invokes from the command line
+to build Swift code (i.e., swift or swiftc) and is often invoked on the 
+developer's behalf by a build system such as the 
+[Swift Package Manager](https://github.com/apple/swift-package-manager)
+or Xcode's build system.
+
+## Topics
+
+### Fundamentals
+
+- <doc:SwiftDriver/Driver>
+- <doc:SwiftDriver/DriverExecutor>
+
+### Toolchains
+
+- <doc:SwiftDriver/Toolchain>
+- <doc:SwiftDriver/DarwinToolchain>
+- <doc:SwiftDriver/GenericUnixToolchain>
+- <doc:SwiftDriver/WebAssemblyToolchain>
+
+### Incremental Builds
+
+- <doc:SwiftDriver/IncrementalBuilds>
+
+### Explicit Module Builds
+
+- <doc:SwiftDriver/ExplicitModuleBuilds>
+
+### Utilities
+
+- <doc:TSCBasic/DiagnosticsEngine>
+- <doc:SwiftDriver/Triple>
+- <doc:SwiftDriver/FileType>
+- <doc:SwiftDriver/VirtualPath>
+- <doc:SwiftDriver/TypedVirtualPath>
+

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -17,7 +17,7 @@ import SwiftOptions
 /// Toolchain for Darwin-based platforms, such as macOS and iOS.
 ///
 /// FIXME: This class is not thread-safe.
-@_spi(Testing) public final class DarwinToolchain: Toolchain {
+public final class DarwinToolchain: Toolchain {
   public let env: [String: String]
 
   /// Doubles as path cache and point for overriding normal lookup

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -12,7 +12,7 @@
 import TSCBasic
 
 /// Toolchain for Unix-like systems.
-@_spi(Testing) public final class GenericUnixToolchain: Toolchain {
+public final class GenericUnixToolchain: Toolchain {
   public let env: [String: String]
 
   /// The executor used to run processes used to find tools and retrieve target info.

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -28,7 +28,7 @@ public enum Tool: Hashable {
 
 /// Describes a toolchain, which includes information about compilers, linkers
 /// and other tools required to build Swift code.
-@_spi(Testing) public protocol Toolchain {
+public protocol Toolchain {
   init(env: [String: String], executor: DriverExecutor, fileSystem: FileSystem, compilerExecutableDir: AbsolutePath?, toolDirectory: AbsolutePath?)
 
   var env: [String: String] { get }

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -13,7 +13,7 @@ import TSCBasic
 import SwiftOptions
 
 /// Toolchain for WebAssembly-based systems.
-@_spi(Testing) public final class WebAssemblyToolchain: Toolchain {
+public final class WebAssemblyToolchain: Toolchain {
   @_spi(Testing) public enum Error: Swift.Error, DiagnosticData {
     case interactiveModeUnsupportedForTarget(String)
     case dynamicLibrariesUnsupportedForTarget(String)


### PR DESCRIPTION
This provides a model for what integrating Docc documentation would look like for the Swift driver. A few articles are included to get a feel for the basics of what we can provide here.