### PR TITLE
[NFC, Incremental] Test effect of a minor version number change on the priors

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -207,7 +207,7 @@ public struct Driver {
   /// Info needed to write and maybe read the build record.
   /// Only present when the driver will be writing the record.
   /// Only used for reading when compiling incrementally.
-  let buildRecordInfo: BuildRecordInfo?
+  @_spi(Testing) public let buildRecordInfo: BuildRecordInfo?
 
   /// A build-record-relative path to the location of a serialized copy of the
   /// driver's dependency graph.

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -36,7 +36,7 @@ import SwiftOptions
   let buildRecordPath: VirtualPath
   let fileSystem: FileSystem
   let currentArgsHash: String
-  let actualSwiftVersion: String
+  @_spi(Testing) public let actualSwiftVersion: String
   let timeBeforeFirstJob: Date
   let diagnosticEngine: DiagnosticsEngine
   let compilationInputModificationDates: [TypedVirtualPath: Date]

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -218,9 +218,9 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     do {
       graphIfPresent = try ModuleDependencyGraph.read( from: dependencyGraphPath, info: self)
     }
-    catch ModuleDependencyGraph.ReadError.mismatchedSerializedGraphVersion {
+    catch let ModuleDependencyGraph.ReadError.mismatchedSerializedGraphVersion(expected, read) {
       diagnosticEngine.emit(
-        warning: "Will not do cross-module incremental builds, wrong version of priors at '\(dependencyGraphPath)'")
+        warning: "Will not do cross-module incremental builds, wrong version of priors; expected \(expected) but read \(read) at '\(dependencyGraphPath)'")
       graphIfPresent = nil
     }
     catch {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -218,9 +218,14 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     do {
       graphIfPresent = try ModuleDependencyGraph.read( from: dependencyGraphPath, info: self)
     }
+    catch ModuleDependencyGraph.ReadError.mismatchedSerializedGraphVersion {
+      diagnosticEngine.emit(
+        warning: "Will not do cross-module incremental builds, wrong version of priors at '\(dependencyGraphPath)'")
+      graphIfPresent = nil
+    }
     catch {
       diagnosticEngine.emit(
-        warning: "Could not read \(dependencyGraphPath), will not do cross-module incremental builds")
+        warning: "Will not do cross-module incremental builds, could not read priors at '\(dependencyGraphPath)'")
       graphIfPresent = nil
     }
     guard let graph = graphIfPresent

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -447,7 +447,9 @@ extension ModuleDependencyGraph {
   ///
   /// - WARNING: You *must* increment the minor version number when making any
   ///            changes to the underlying serialization format.
-  fileprivate static let version = Version(1, 0, 0)
+  ///
+  /// - Minor number 1: Don't serialize the `inputDepedencySourceMap`
+  @_spi(Testing) public static let serializedGraphVersion = Version(1, 1, 0)
 
   /// The IDs of the records used by the module dependency graph.
   fileprivate enum RecordID: UInt64 {
@@ -481,10 +483,11 @@ extension ModuleDependencyGraph {
     }
   }
 
-  fileprivate enum ReadError: Error {
+  @_spi(Testing) public enum ReadError: Error {
     case badMagic
     case noRecordBlock
     case malformedMetadataRecord
+    case mismatchedSerializedGraphVersion
     case unexpectedMetadataRecord
     case malformedFingerprintRecord
     case malformedIdentifierRecord
@@ -666,9 +669,9 @@ extension ModuleDependencyGraph {
     guard let major = visitor.majorVersion,
           let minor = visitor.minorVersion,
           visitor.compilerVersionString != nil,
-          Version(Int(major), Int(minor), 0) == Self.version
+          Version(Int(major), Int(minor), 0) == Self.serializedGraphVersion
     else {
-      throw ReadError.malformedMetadataRecord
+      throw ReadError.mismatchedSerializedGraphVersion
     }
     let graph = visitor.finalizeGraph()
     info.reporter?.report("Read dependency graph", path)
@@ -691,13 +694,17 @@ extension ModuleDependencyGraph {
   ///   - fileSystem: The file system for this location.
   ///   - compilerVersion: A string containing version information for the
   ///                      driver used to create this file.
+  ///   - mockSerializedGraphVersion: Overrides the standard version for testing
   /// - Returns: true if had error
   @_spi(Testing) public func write(
     to path: VirtualPath,
     on fileSystem: FileSystem,
-    compilerVersion: String
+    compilerVersion: String,
+    mockSerializedGraphVersion: Version? = nil
   ) throws {
-    let data = ModuleDependencyGraph.Serializer.serialize(self, compilerVersion)
+    let data = ModuleDependencyGraph.Serializer.serialize(
+      self, compilerVersion,
+      mockSerializedGraphVersion ?? Self.serializedGraphVersion)
 
     do {
       try fileSystem.writeFileContents(path,
@@ -711,6 +718,7 @@ extension ModuleDependencyGraph {
 
   fileprivate final class Serializer {
     let compilerVersion: String
+    let serializedGraphVersion: Version
     let stream = BitstreamWriter()
     private var abbreviations = [RecordID: Bitstream.AbbreviationID]()
     private var identifiersToWrite = [String]()
@@ -719,8 +727,10 @@ extension ModuleDependencyGraph {
     fileprivate private(set) var nodeIDs = [Node: Int]()
     private var lastNodeID: Int = 0
 
-    private init(compilerVersion: String) {
+    private init(compilerVersion: String,
+                 serializedGraphVersion: Version) {
       self.compilerVersion = compilerVersion
+      self.serializedGraphVersion = serializedGraphVersion
     }
 
     private func emitSignature() {
@@ -765,10 +775,8 @@ extension ModuleDependencyGraph {
     private func writeMetadata() {
       self.stream.writeRecord(self.abbreviations[.metadata]!, {
         $0.append(RecordID.metadata)
-        // Major version
-        $0.append(1 as UInt32)
-        // Minor version
-        $0.append(0 as UInt32)
+        $0.append(serializedGraphVersion.majorForWriting)
+        $0.append(serializedGraphVersion.minorForWriting)
       },
       blob: self.compilerVersion)
     }
@@ -903,9 +911,12 @@ extension ModuleDependencyGraph {
 
     public static func serialize(
       _ graph: ModuleDependencyGraph,
-      _ compilerVersion: String
+      _ compilerVersion: String,
+      _ serializedGraphVersion: Version
     ) -> ByteString {
-      let serializer = Serializer(compilerVersion: compilerVersion)
+      let serializer = Serializer(
+        compilerVersion: compilerVersion,
+        serializedGraphVersion: serializedGraphVersion)
       serializer.emitSignature()
       serializer.writeBlockInfoBlock()
 
@@ -1065,5 +1076,18 @@ extension Set where Element == ModuleDependencyGraph.Node {
 extension Set where Element == FingerprintedExternalDependency {
   fileprivate func matches(_ other: Self) -> Bool {
     self == other
+  }
+}
+
+fileprivate extension Version {
+  var majorForWriting: UInt32 {
+    let r = UInt32(Int64(major))
+    assert(Int(r) == Int(major))
+    return r
+  }
+  var minorForWriting: UInt32 {
+    let r = UInt32(Int64(minor))
+    assert(Int(r) == Int(minor))
+    return r
   }
 }

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -26,17 +26,20 @@ class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker
     let fs = InMemoryFileSystem()
     let graph = Self.mockGraphCreator.mockUpAGraph()
     let currentVersion = ModuleDependencyGraph.serializedGraphVersion
+    let alteredVersion = currentVersion.withAlteredMinor
     try graph.write(
       to: mockPath,
       on: fs,
       compilerVersion: "Swift 99",
-      mockSerializedGraphVersion: currentVersion.withAlteredMinor)
+      mockSerializedGraphVersion: alteredVersion)
     do {
       _ = try ModuleDependencyGraph.read(from: mockPath,
                                          info: .mock(fileSystem: fs))
       XCTFail("Should have thrown an exception")
     }
-    catch ModuleDependencyGraph.ReadError.mismatchedSerializedGraphVersion {
+    catch let ModuleDependencyGraph.ReadError.mismatchedSerializedGraphVersion(expected, read) {
+      XCTAssertEqual(expected, currentVersion)
+      XCTAssertEqual(read, alteredVersion)
     }
     catch {
       XCTFail("Threw an unexpected exception: \(error.localizedDescription)")

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -12,6 +12,7 @@
 
 @_spi(Testing) import SwiftDriver
 import TSCBasic
+import TSCUtility
 import Foundation
 import XCTest
 
@@ -47,6 +48,12 @@ extension ModuleDependencyGraph {
         XCTAssertTrue(nodeIDs.contains(use), "Node ID was not registered! \(use), \(String(describing: use.fingerprint))")
       }
     }
+  }
+}
+
+extension Version {
+  var withAlteredMinor: Self {
+    Self(major, minor + 1, patch)
   }
 }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -320,8 +320,6 @@ extension IncrementalCompilationTests {
                                 on: localFileSystem,
                                 compilerVersion: compilerVersion,
                                 mockSerializedGraphVersion: incrementedVersion)
-    // Reset mod time to priors modTime on newly-written priors
-    // in order to support a future priors mod-time check
 
     try checkReactionToObsoletePriors()
     try checkNullBuild(checkDiagnostics: true)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -1190,7 +1190,7 @@ extension DiagVerifiable {
     "Incremental compilation: Read dependency graph"
   }
   @DiagsBuilder var couldNotReadPriors: [Diagnostic.Message] {
-      .warning("Will not do cross-module incremental builds, wrong version of priors at '")
+      .warning("Will not do cross-module incremental builds, wrong version of priors; expected")
   }
   // MARK: - dependencies
   @DiagsBuilder func fingerprintChanged(_ aspect: DependencyKey.DeclAspect, _ input: String) -> [Diagnostic.Message] {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 import TSCBasic
+import TSCUtility
 
 @_spi(Testing) import SwiftDriver
 import SwiftOptions
@@ -297,6 +298,35 @@ extension IncrementalCompilationTests {
     try checkReactionToTouchingSymlinks(checkDiagnostics: true)
     try checkReactionToTouchingSymlinkTargets(checkDiagnostics: true)
   }
+
+  /// Ensure that the driver can detect and then recover from a priors version mismatch
+  func testPriorsVersionDetectionAndRecovery() throws {
+#if !os(Linux)
+    // create a baseline priors
+    try buildInitialState(checkDiagnostics: true)
+    let driver = try checkNullBuild(checkDiagnostics: true)
+
+    // Read the priors, change the minor version, and write it back out
+    let outputFileMap = try driver.moduleDependencyGraph().info.outputFileMap
+    let info = IncrementalCompilationState.IncrementalDependencyAndInputSetup
+      .mock(outputFileMap: outputFileMap)
+    let priorsWithOldVersion = try ModuleDependencyGraph.read(
+      from: .absolute(priorsPath),
+      info: info)
+    // let priorsModTime = try localFileSystem.getFileInfo(priorsPath).modTime
+    let compilerVersion = try XCTUnwrap(driver.buildRecordInfo).actualSwiftVersion
+    let incrementedVersion = ModuleDependencyGraph.serializedGraphVersion.withAlteredMinor
+    try priorsWithOldVersion?.write(to: .absolute(priorsPath),
+                                on: localFileSystem,
+                                compilerVersion: compilerVersion,
+                                mockSerializedGraphVersion: incrementedVersion)
+    // Reset mod time to priors modTime on newly-written priors
+    // in order to support a future priors mod-time check
+
+    try checkReactionToObsoletePriors()
+    try checkNullBuild(checkDiagnostics: true)
+#endif
+  }
 }
 
 // MARK: - Test adding an input
@@ -454,10 +484,11 @@ extension IncrementalCompilationTests {
   /// - Parameters:
   ///   - checkDiagnostics: If true verify the diagnostics
   ///   - extraArguments: Additional command-line arguments
+  @discardableResult
   private func checkNullBuild(
     checkDiagnostics: Bool = false,
     extraArguments: [String] = []
-  ) throws {
+  ) throws -> Driver {
     try doABuild(
       "as is",
       checkDiagnostics: checkDiagnostics,
@@ -829,6 +860,19 @@ extension IncrementalCompilationTests {
     return graph
   }
 
+  private func checkReactionToObsoletePriors() throws {
+    try doABuild(
+      "check reaction to obsolete priors",
+      checkDiagnostics: true,
+      extraArguments: [],
+      whenAutolinking: autolinkLifecycleExpectedDiags) {
+      couldNotReadPriors
+      createdGraphFromSwiftdeps
+      enablingCrossModule
+      skippingAll("main", "other")
+    }
+  }
+
   private func checkReactionToTouchingSymlinks(
     checkDiagnostics: Bool = false,
     extraArguments: [String] = []
@@ -1144,6 +1188,9 @@ extension DiagVerifiable {
   }
   @DiagsBuilder var readGraph: [Diagnostic.Message] {
     "Incremental compilation: Read dependency graph"
+  }
+  @DiagsBuilder var couldNotReadPriors: [Diagnostic.Message] {
+      .warning("Will not do cross-module incremental builds, wrong version of priors at '")
   }
   // MARK: - dependencies
   @DiagsBuilder func fingerprintChanged(_ aspect: DependencyKey.DeclAspect, _ input: String) -> [Diagnostic.Message] {


### PR DESCRIPTION
Test effect of a minor version number change on the priors, and also add the needed affordances.
Also increment the minor version to reflect the omission of the no-longer-needed serialized inputDependencySourceMap.

Required before landing https://github.com/apple/swift-driver/pull/728