### PR TITLE
Do not emit a dependency-scanner fallback warning when in integrated-driver mode

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -105,7 +105,11 @@ public extension Driver {
         .verifyOrCreateScannerInstance(fileSystem: fileSystem,
                                        swiftScanLibPath: scanLibPath) == false {
       fallbackToFrontend = true
-      diagnosticEngine.emit(.warn_scanner_frontend_fallback())
+      // This warning is mostly useful for debugging the driver, so let's hide it
+      // when libSwiftDriver is used, instead of a swift-driver executable.
+      if !integratedDriver {
+        diagnosticEngine.emit(.warn_scanner_frontend_fallback())
+      }
     }
     return fallbackToFrontend
   }


### PR DESCRIPTION
This warning is mostly useful for debugging the driver, so let's hide it when `libSwiftDriver` is used, instead of a `swift-driver `executable.
There are also valid scenarios where the scanning action can succeed just-as-well using the fallback path where this warning is extraneous and may confuse users because it is not actionable.