### PR TITLE
Enable checking for -no-toolchain-stdlib-rpath and use it on this repo's binaries before installing

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -128,6 +128,10 @@ extension GenericUnixToolchain {
       let staticExecutable = parsedOptions.hasFlag(positive: .staticExecutable,
                                                    negative: .noStaticExecutable,
                                                   default: false)
+      let toolchainStdlibRpath = parsedOptions
+                                 .hasFlag(positive: .toolchainStdlibRpath,
+                                          negative: .noToolchainStdlibRpath,
+                                          default: true)
       let hasRuntimeArgs = !(staticStdlib || staticExecutable)
 
       let runtimePaths = try runtimeLibraryPaths(
@@ -137,7 +141,8 @@ extension GenericUnixToolchain {
         isShared: hasRuntimeArgs
       )
 
-      if hasRuntimeArgs && targetTriple.environment != .android {
+      if hasRuntimeArgs && targetTriple.environment != .android &&
+          toolchainStdlibRpath {
         // FIXME: We probably shouldn't be adding an rpath here unless we know
         //        ahead of time the standard library won't be copied.
         for path in runtimePaths {

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -109,6 +109,9 @@ def get_swiftpm_options(args):
         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/linux',
       ]
 
+  if args.action == 'install':
+    swiftpm_args += ['-Xswiftc', '-no-toolchain-stdlib-rpath']
+
   return swiftpm_args
 
 def install_binary(file, source_dir, install_dir, verbose):


### PR DESCRIPTION
This [matches the upstream driver](https://github.com/apple/swift/blob/0149ccd0ca69a8e97a4d13d172c8ce67f5498a60/lib/Driver/UnixToolChains.cpp#L134) and removes the build toolchain's rpath for this shipping swift-driver executable itself on ELF platforms, as I've done before for SPM, apple/swift-package-manager#2703, and other repos:
```
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2021-06-12-a-centos8/usr/bin/swift-driver | ag runpath
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/swift-nightly-install/usr/lib/swift/linux:$ORIGIN:$ORIGIN/../lib/swift/linux]
```
I ran the following command twice to test this pull with a prebuilt trunk snapshot, because the swift-driver used the first time didn't have this Swift addition:
```
./swift/utils/build-script -R --no-assertions --skip-build-cmark --skip-build-llvm --skip-build-swift --swift-driver -T --skip-early-swift-driver --install-swift-driver --native-swift-tools-path=/home/butta/src/swift-DEVELOPMENT-SNAPSHOT-2021-06-12-a-centos8/usr/bin/
```
I also had to make this build-script change to run that with a prebuilt toolchain, will look into upstreaming it later:
```
diff --git a/utils/swift_build_support/swift_build_support/products/swiftdriver.py b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
index 3bd5755de35..f77396ab450 100644
--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -91,8 +91,7 @@ def run_build_script_helper(action, host_target, product, args):
         install_destdir = swiftpm.SwiftPM.get_install_destdir(args,
                                                               host_target,
                                                               product.build_dir)
-    toolchain_path = targets.toolchain_path(install_destdir,
-                                            args.install_prefix)
+    toolchain_path = product.install_toolchain_path(host_target)
 
     # Pass Dispatch directory down if we built it
     dispatch_build_dir = os.path.join(
```
I didn't bother adding a test since the validation suite [already](https://github.com/apple/swift/blob/main/test/Driver/linker.swift) has [them](https://github.com/apple/swift/blob/main/test/Driver/linker-rpath.swift), which are presumably failing now? This should get them to pass.