### PR TITLE
Do not set `DYLD_LIBRARY_PATH` to point the installed toolchain/sdk on macOS.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "swift-llbuild",
+        "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "main",

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -38,17 +38,9 @@ extension DarwinToolchain {
     targetInfo: FrontendTargetInfo) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
-    let runtimePaths = try runtimeLibraryPaths(
-      for: targetInfo,
-      parsedOptions: &parsedOptions,
-      sdkPath: sdkPath,
-      isShared: true
-    ).map { $0.name }
-
     addPathEnvironmentVariableIfNeeded("DYLD_LIBRARY_PATH", to: &envVars,
                                        currentEnv: env, option: .L,
-                                       parsedOptions: &parsedOptions,
-                                       extraPaths: runtimePaths)
+                                       parsedOptions: &parsedOptions)
 
     addPathEnvironmentVariableIfNeeded("DYLD_FRAMEWORK_PATH", to: &envVars,
                                        currentEnv: env, option: .F,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2338,7 +2338,12 @@ final class SwiftDriverTests: XCTestCase {
       }
 
       XCTAssertFalse(job.commandLine.contains(.flag("--")))
+      // On darwin, swift ships in the OS. Immediate mode should use that runtime.
+      #if os(macOS)
+      XCTAssertFalse(job.extraEnvironment.keys.contains("\(driver.targetTriple.isDarwin ? "DYLD" : "LD")_LIBRARY_PATH"))
+      #else
       XCTAssertTrue(job.extraEnvironment.keys.contains("\(driver.targetTriple.isDarwin ? "DYLD" : "LD")_LIBRARY_PATH"))
+      #endif
     }
 
     do {


### PR DESCRIPTION
This has not been a good idea since Swift started shipping in the OS. 
The OS runtime is the one we would like Swift scripts to use. Using the installed toolchain can potentially cause sync issues.

Continue setting this variable in other UNIX toolchains, because there is no runtime shipped in the OS there. 

Resolves rdar://78951185