### PR TITLE
Improve Deserialization Performance

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -308,16 +308,12 @@ public struct DependencyKey: CustomStringConvertible {
   /*@_spi(Testing)*/ public let aspect: DeclAspect
   /*@_spi(Testing)*/ public let designator: Designator
 
-  private let cachedHash: Int
-
-
   /*@_spi(Testing)*/ public init(
     aspect: DeclAspect,
     designator: Designator)
   {
     self.aspect = aspect
     self.designator = designator
-    self.cachedHash = Self.computeHash(aspect, designator)
   }
 
   /*@_spi(Testing)*/ public var correspondingImplementation: Self? {
@@ -338,35 +334,16 @@ public struct DependencyKey: CustomStringConvertible {
   }
 }
 
-extension DependencyKey: Equatable, Hashable {
-
-  private static func computeHash(_ aspect: DeclAspect, _ designator: Designator) -> Int {
-    var h = Hasher()
-    h.combine(aspect)
-    h.combine(designator)
-    return h.finalize()
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(cachedHash)
-  }
-
-  public static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs.aspect == rhs.aspect && lhs.designator == rhs.designator
-  }
-}
-
-// MARK: - Comparing
-/// Needed to sort nodes to make tracing deterministic to test against emitted diagnostics
-extension DependencyKey: Comparable {
+extension DependencyKey: Equatable, Hashable, Comparable {
   public static func < (lhs: Self, rhs: Self) -> Bool {
-    lhs.aspect != rhs.aspect ? lhs.aspect < rhs.aspect :
-      lhs.designator < rhs.designator
+    guard lhs.aspect == rhs.aspect else {
+      return lhs.aspect < rhs.aspect
+    }
+    return lhs.designator < rhs.designator
   }
 }
 
-extension DependencyKey.Designator: Comparable {
-}
+extension DependencyKey.Designator: Comparable {}
 
 // MARK: - InvalidationReason
 extension ExternalDependency {

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -213,8 +213,8 @@ extension SourceFileDependencyGraph {
                             defsIDependUpon: defsNodeDependUpon,
                             isProvides: isProvides)
         self.key = nil
-        defsNodeDependUpon = []
-        nodes.append(node)
+        self.defsNodeDependUpon.removeAll(keepingCapacity: true)
+        self.nodes.append(node)
       }
       mutating func visit(record: BitcodeElement.Record) throws {
         guard let kind = RecordKind(rawValue: record.id) else { throw ReadError.unknownRecord }
@@ -249,7 +249,7 @@ extension SourceFileDependencyGraph {
           self.key = DependencyKey(aspect: declAspect, designator: designator)
           self.fingerprint = nil
           self.nodeSequenceNumber = nextSequenceNumber
-          self.defsNodeDependUpon = []
+          self.defsNodeDependUpon.removeAll(keepingCapacity: true)
 
           nextSequenceNumber += 1
         case .fingerprintNode:

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -225,13 +225,12 @@ extension SourceFileDependencyGraph {
             throw ReadError.unexpectedMetadataRecord
           }
           guard record.fields.count == 2,
-                case .blob(let compilerVersionBlob) = record.payload,
-                let compilerVersionString = String(data: compilerVersionBlob, encoding: .utf8)
+                case .blob(let compilerVersionBlob) = record.payload
           else { throw ReadError.malformedMetadataRecord }
 
           self.majorVersion = record.fields[0]
           self.minorVersion = record.fields[1]
-          self.compilerVersionString = compilerVersionString
+          self.compilerVersionString = String(decoding: compilerVersionBlob, as: UTF8.self)
         case .sourceFileDepGraphNode:
           try finalizeNode()
           let kindCode = record.fields[0]
@@ -255,22 +254,22 @@ extension SourceFileDependencyGraph {
         case .fingerprintNode:
           guard key != nil,
                 record.fields.count == 0,
-                case .blob(let fingerprintBlob) = record.payload,
-                let fingerprint = String(data: fingerprintBlob, encoding: .utf8) else {
+                case .blob(let fingerprintBlob) = record.payload
+          else {
             throw ReadError.malformedFingerprintRecord
           }
-          self.fingerprint = fingerprint
+          self.fingerprint = String(decoding: fingerprintBlob, as: UTF8.self)
         case .dependsOnDefinitionNode:
           guard key != nil,
                 record.fields.count == 1 else { throw ReadError.malformedDependsOnDefinitionRecord }
           self.defsNodeDependUpon.append(Int(record.fields[0]))
         case .identifierNode:
           guard record.fields.count == 0,
-                case .blob(let identifierBlob) = record.payload,
-                let identifier = String(data: identifierBlob, encoding: .utf8) else {
+                case .blob(let identifierBlob) = record.payload
+          else {
             throw ReadError.malformedIdentifierRecord
           }
-          identifiers.append(identifier)
+          identifiers.append(String(decoding: identifierBlob, as: UTF8.self))
         }
       }
     }


### PR DESCRIPTION
Consume the new non-owning bitstream deserialization in apple/swift-tools-support-core#236 to provide a 3-5x boost to deserialization performance for source and module dependency graph files. Also, undo a cached hash optimization that was only really necessary because of the quadratic COW issue resolved in #654. Otherwise, the hash was being eagerly computed during deserialization which forced an extra half-second of wall time.