### PR TITLE
[5.5][NFC] Fix executable tests by passing in the SDK path explicitly.

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -557,6 +557,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         $0 <<< "import G;"
       }
 
+      let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting() ?? []
       let packageRootPath = URL(fileURLWithPath: #file).pathComponents
           .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
       let testInputsPath = packageRootPath + "/TestInputs"
@@ -567,7 +568,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", swiftModuleInterfacesPath,
                                      "-experimental-explicit-module-build",
                                      "-working-directory", path.pathString,
-                                     main.pathString],
+                                     main.pathString] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -474,9 +474,10 @@ final class JobExecutorTests: XCTestCase {
                                                fileSystem: localFileSystem,
                                                env: ProcessEnv.vars)
         let outputPath = path.appending(component: "finalOutput")
+        let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting() ?? []
         var driver = try Driver(args: ["swiftc", main.pathString,
                                        "-driver-filelist-threshold", "0",
-                                       "-o", outputPath.pathString],
+                                       "-o", outputPath.pathString] + sdkArgumentsForTesting,
                                 env: ProcessEnv.vars,
                                 diagnosticsEngine: diags,
                                 fileSystem: localFileSystem,
@@ -511,10 +512,11 @@ final class JobExecutorTests: XCTestCase {
                                                fileSystem: localFileSystem,
                                                env: ProcessEnv.vars)
         let outputPath = path.appending(component: "finalOutput")
+        let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting() ?? []
         var driver = try Driver(args: ["swiftc", main.pathString,
                                        "-save-temps",
                                        "-driver-filelist-threshold", "0",
-                                       "-o", outputPath.pathString],
+                                       "-o", outputPath.pathString] + sdkArgumentsForTesting,
                                 env: ProcessEnv.vars,
                                 diagnosticsEngine: diags,
                                 fileSystem: localFileSystem,
@@ -549,10 +551,11 @@ final class JobExecutorTests: XCTestCase {
                                                fileSystem: localFileSystem,
                                                env: ProcessEnv.vars)
         let outputPath = path.appending(component: "finalOutput")
+        let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting() ?? []
         var driver = try Driver(args: ["swiftc", main.pathString,
                                        "-driver-filelist-threshold", "0",
                                        "-Xfrontend", "-debug-crash-immediately",
-                                       "-o", outputPath.pathString],
+                                       "-o", outputPath.pathString] + sdkArgumentsForTesting,
                                 env: ProcessEnv.vars,
                                 diagnosticsEngine: diags,
                                 fileSystem: localFileSystem,

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -354,9 +354,10 @@ final class ParsableMessageTests: XCTestCase {
             $0 <<< "print(\"hello, world!\")"
           }
           let diags = DiagnosticsEngine()
+          let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting() ?? []
           var driver = try Driver(args: ["swiftc", main.pathString,
                                          "-use-frontend-parseable-output",
-                                         "-o", output.pathString],
+                                         "-o", output.pathString] + sdkArgumentsForTesting,
                                   env: ProcessEnv.vars,
                                   diagnosticsEngine: diags,
                                   fileSystem: localFileSystem)


### PR DESCRIPTION
As-is, these tests are sensitive to the environment and are currently failing with:
```
ld: library not found for -lobjc
```
Passing in the sdk path explicitly should make them pass and be more resilient.

Resolves rdar://79934188