### PR TITLE
[5.5] Enable checking for -no-toolchain-stdlib-rpath and use it on this repo's binaries before installing

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -124,6 +124,10 @@ extension GenericUnixToolchain {
       let staticExecutable = parsedOptions.hasFlag(positive: .staticExecutable,
                                                    negative: .noStaticExecutable,
                                                   default: false)
+      let toolchainStdlibRpath = parsedOptions
+                                 .hasFlag(positive: .toolchainStdlibRpath,
+                                          negative: .noToolchainStdlibRpath,
+                                          default: true)
       let hasRuntimeArgs = !(staticStdlib || staticExecutable)
 
       let runtimePaths = try runtimeLibraryPaths(
@@ -133,7 +137,8 @@ extension GenericUnixToolchain {
         isShared: hasRuntimeArgs
       )
 
-      if hasRuntimeArgs && targetTriple.environment != .android {
+      if hasRuntimeArgs && targetTriple.environment != .android &&
+          toolchainStdlibRpath {
         // FIXME: We probably shouldn't be adding an rpath here unless we know
         //        ahead of time the standard library won't be copied.
         for path in runtimePaths {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1122,6 +1122,16 @@ final class SwiftDriverTests: XCTestCase {
     #endif
 
     do {
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-no-toolchain-stdlib-rpath",
+                                                  "-target", "aarch64-unknown-linux"], env: env)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 4)
+      let linkJob = plannedJobs[3]
+      let cmd = linkJob.commandLine
+      XCTAssertFalse(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("-rpath"), .flag("-Xlinker")]))
+    }
+
+    do {
       // Object file inputs
       var driver = try Driver(args: commonArgs + ["baz.o", "-emit-library", "-target", "x86_64-apple-macosx10.15"], env: env)
       let plannedJobs = try driver.planBuild()

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -109,6 +109,9 @@ def get_swiftpm_options(args):
         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/linux',
       ]
 
+  if args.action == 'install':
+    swiftpm_args += ['-Xswiftc', '-no-toolchain-stdlib-rpath']
+
   return swiftpm_args
 
 def install_binary(file, source_dir, install_dir, verbose):


### PR DESCRIPTION
Cherry-pick of #732 and #767

- Explanation: This [matches the upstream driver](https://github.com/apple/swift/blob/0149ccd0ca69a8e97a4d13d172c8ce67f5498a60/lib/Driver/UnixToolChains.cpp#L134) and removes the build toolchain's rpath for this shipping swift-driver executable itself on ELF platforms.
- Scope: Adds behavior to match upstream and remove an extraneous rpath from the swift-driver and other executables from this repo. 
- Risk: None
- Testing: Passes all tests, as indicated in the upstream pull, and should now pass more tests from the compiler test suite.
- Reviewer: @artemcm