### PR TITLE
Unblock package bots by making tests more resilient to environment changes.

### DIFF
--- a/TestInputs/ExplicitModuleBuilds/Swift/Swift.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/Swift.swiftinterface
@@ -1,4 +1,0 @@
-// swift-interface-format-version: 1.0
-// swift-compiler-version: Swift version 5.4-dev (LLVM bd2476a8056e227, Swift 68ac381af6ca0e3)
-// swift-module-flags: -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-library-evolution -module-link-name swiftCore -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -enable-experimental-concise-pound-file -module-name Swift
-import SwiftShims

--- a/TestInputs/ExplicitModuleBuilds/Swift/SwiftOnoneSupport.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/SwiftOnoneSupport.swiftinterface
@@ -1,4 +1,0 @@
-// swift-interface-format-version: 1.0
-// swift-compiler-version: Swift version 5.4-dev (LLVM bd2476a8056e227, Swift 68ac381af6ca0e3)
-// swift-module-flags: -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-library-evolution -module-link-name swiftSwiftOnoneSupport -parse-stdlib -swift-version 5 -O -enforce-exclusivity=unchecked -module-name SwiftOnoneSupport
-import Swift

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -327,12 +327,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let testInputsPath = packageRootPath + "/TestInputs"
       let cHeadersPath : String = testInputsPath + "/ExplicitModuleBuilds/CHeaders"
       let swiftModuleInterfacesPath : String = testInputsPath + "/ExplicitModuleBuilds/Swift"
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
                                      "-target", "x86_64-apple-macosx11.0",
                                      "-I", cHeadersPath,
                                      "-I", swiftModuleInterfacesPath,
                                      "-experimental-explicit-module-build",
-                                     main.pathString])
+                                     main.pathString] + sdkArgumentsForTesting)
 
       let jobs = try driver.planBuild()
       // Figure out which Triples to use.
@@ -346,8 +347,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let pcmArgsCurrent = mainModuleSwiftDetails.extraPcmArgs
       var pcmArgs9 = ["-Xcc","-target","-Xcc","x86_64-apple-macosx10.9"]
+      var pcmArgs15 = ["-Xcc","-target","-Xcc","x86_64-apple-macosx10.15"]
       if driver.targetTriple.isDarwin {
         pcmArgs9.append(contentsOf: ["-Xcc", "-fapinotes-swift-version=5"])
+        pcmArgs15.append(contentsOf: ["-Xcc", "-fapinotes-swift-version=5"])
       }
       let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath.Handle in
         try! driver.explicitDependencyBuildPlanner!.targetEncodedClangModuleFilePath(for: moduleInfo,
@@ -436,6 +439,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
               try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs9, moduleId: .clang("SwiftShims"),
                                               dependencyOracle: dependencyOracle,
                                               pcmFileEncoder: pcmFileEncoder)
+            case .relative(pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgs15,
+                                                            pcmModuleNameEncoder: pcmModuleNameEncoder)):
+              try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs15, moduleId: .clang("SwiftShims"),
+                                              dependencyOracle: dependencyOracle,
+                                              pcmFileEncoder: pcmFileEncoder)
             case .relative(pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgsCurrent,
                                                             pcmModuleNameEncoder: pcmModuleNameEncoder)):
               try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgsCurrent, moduleId: .clang("SwiftShims"),
@@ -473,12 +481,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let testInputsPath = packageRootPath + "/TestInputs"
       let cHeadersPath : String = testInputsPath + "/ExplicitModuleBuilds/CHeaders"
       let swiftModuleInterfacesPath : String = testInputsPath + "/ExplicitModuleBuilds/Swift"
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swift",
                                      "-target", "x86_64-apple-macosx11.0",
                                      "-I", cHeadersPath,
                                      "-I", swiftModuleInterfacesPath,
                                      "-experimental-explicit-module-build",
-                                     main.pathString])
+                                     main.pathString] + sdkArgumentsForTesting)
 
       let jobs = try driver.planBuild()
 
@@ -501,8 +510,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let pcmArgsCurrent = mainModuleSwiftDetails.extraPcmArgs
       var pcmArgs9 = ["-Xcc","-target","-Xcc","x86_64-apple-macosx10.9"]
+      var pcmArgs15 = ["-Xcc","-target","-Xcc","x86_64-apple-macosx10.15"]
       if driver.targetTriple.isDarwin {
         pcmArgs9.append(contentsOf: ["-Xcc", "-fapinotes-swift-version=5"])
+        pcmArgs15.append(contentsOf: ["-Xcc", "-fapinotes-swift-version=5"])
       }
       let pcmFileEncoder = { (moduleInfo: ModuleInfo, hashParts: [String]) -> VirtualPath.Handle in
         try! driver.explicitDependencyBuildPlanner!.targetEncodedClangModuleFilePath(for: moduleInfo,
@@ -558,6 +569,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
             case .relative(pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgs9,
                                                             pcmModuleNameEncoder: pcmModuleNameEncoder)):
               try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs9, moduleId: .clang("SwiftShims"),
+                                              dependencyOracle: dependencyOracle,
+                                              pcmFileEncoder: pcmFileEncoder)
+            case .relative(pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgs15,
+                                                            pcmModuleNameEncoder: pcmModuleNameEncoder)):
+              try checkExplicitModuleBuildJob(job: job, pcmArgs: pcmArgs15, moduleId: .clang("SwiftShims"),
                                               dependencyOracle: dependencyOracle,
                                               pcmFileEncoder: pcmFileEncoder)
             case .relative(pcmArgsEncodedRelativeModulePath(for: "SwiftShims", with: pcmArgsCurrent,
@@ -693,13 +709,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let testInputsPath = packageRootPath + "/TestInputs"
       let cHeadersPath : String = testInputsPath + "/ExplicitModuleBuilds/CHeaders"
       let swiftModuleInterfacesPath : String = testInputsPath + "/ExplicitModuleBuilds/Swift"
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let scannerCommand = ["-scan-dependencies",
                             "-import-prescan",
                             "-I", cHeadersPath,
                             "-I", swiftModuleInterfacesPath,
                             "-I", stdLibPath.description,
                             "-I", shimsPath.description,
-                            main.pathString]
+                            main.pathString] + sdkArgumentsForTesting
 
       let imports =
         try! dependencyOracle.getImports(workingDirectory: path,
@@ -741,12 +758,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let testInputsPath = packageRootPath + "/TestInputs"
       let cHeadersPath : String = testInputsPath + "/ExplicitModuleBuilds/CHeaders"
       let swiftModuleInterfacesPath : String = testInputsPath + "/ExplicitModuleBuilds/Swift"
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let scannerCommand = ["-scan-dependencies",
                             "-I", cHeadersPath,
                             "-I", swiftModuleInterfacesPath,
                             "-I", stdLibPath.description,
                             "-I", shimsPath.description,
-                            main.pathString]
+                            main.pathString] + sdkArgumentsForTesting
 
       // Here purely to dump diagnostic output in a reasonable fashion when things go wrong.
       let lock = NSLock()
@@ -810,12 +828,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let testInputsPath = packageRootPath + "/TestInputs"
       let cHeadersPath : String = testInputsPath + "/ExplicitModuleBuilds/CHeaders"
       let swiftModuleInterfacesPath : String = testInputsPath + "/ExplicitModuleBuilds/Swift"
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let scannerCommand = ["-scan-dependencies",
+                            "-disable-implicit-concurrency-module-import",
                             "-I", cHeadersPath,
                             "-I", swiftModuleInterfacesPath,
                             "-I", stdLibPath.description,
                             "-I", shimsPath.description,
-                            main.pathString]
+                            main.pathString] + sdkArgumentsForTesting
 
       let scanLibPath = try Driver.getScanLibPath(of: toolchain,
                                                   hostTriple: hostTriple,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2468,6 +2468,9 @@ final class SwiftDriverTests: XCTestCase {
   func testClangTarget() throws {
     var driver = try Driver(args: ["swiftc", "-target",
                                    "x86_64-apple-macosx10.14", "foo.swift", "bar.swift"])
+    guard driver.isFrontendArgSupported(.clangTarget) else {
+      throw XCTSkip("Skipping: compiler does not support '-clang-target'")
+    }
     let plannedJobs = try driver.planBuild()
     XCTAssertEqual(plannedJobs.count, 3)
     XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target")))
@@ -3808,6 +3811,9 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
                                      "foo", "-user-module-version", "12.21"])
+      guard driver.isFrontendArgSupported(.userModuleVersion) else {
+        throw XCTSkip("Skipping: compiler does not support '-user-module-version'")
+      }
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 2)
       let compileJob = plannedJobs[0]


### PR DESCRIPTION
- Pass down SDK paths to explicit module tests
- Remove "fake" stdlib files, making sure dependency scanning tests rely on the real ones
- Gate a couple of tests on frontend flag availability

Package bots are currently failing on a few SwiftDriver tests:
https://ci.swift.org/job/oss-swift-package-macos/5970/console