### PR TITLE
[Draft] Clean build: Only integrate module dependencies once

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "llbuild",
+        "package": "swift-llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "main",


### PR DESCRIPTION
Not sure if this change is safe, or if it needs to go further to impact incremental builds as well.

Currently this is shaving close to 2.5 minutes off of a clean build for a project with >150 modules and ~350 swift files in the main target.

Issue before was this was reading and integrating the module dependency information (M) for each input swift file (N), so (N*M), now it's only happening M times.

It needs more testing, but there is probably an incremental build situation where dependency information is being read and integrated N * M times where M is modules that have changed since last build.