### PR TITLE
Add support for -lto_library linker flag

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -338,7 +338,12 @@ extension DarwinToolchain {
     )
 
     if lto != nil {
-      try addLTOLibArgs(to: &commandLine)
+      if let arg = parsedOptions.getLastArgument(.ltoLibrary)?.asSingle {
+        commandLine.appendFlag("-lto_library")
+        commandLine.appendPath(try VirtualPath(path: arg))
+      } else {
+        try addLTOLibArgs(to: &commandLine)
+      }
     }
 
     let fSystemArgs = parsedOptions.arguments(for: .F, .Fsystem)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -387,6 +387,7 @@ extension Option {
   public static let location: Option = Option("-location", .separate, attributes: [.noDriver], metaVar: "<location>", helpText: "Filter nodes with the given location.")
   public static let location_: Option = Option("--location", .separate, alias: Option.location, attributes: [.noDriver], metaVar: "<location>", helpText: "Filter nodes with the given location.")
   public static let lto: Option = Option("-lto=", .joined, attributes: [.frontend, .noInteractive], helpText: "Specify the LTO type to either 'llvm-thin' or 'llvm-full'")
+  public static let ltoLibrary: Option = Option("-lto-library", .separate, attributes: [.frontend, .argumentIsPath, .noInteractive], metaVar: "<lto-library>", helpText: "Perform LTO with <lto-library>")
   public static let L: Option = Option("-L", .joinedOrSeparate, attributes: [.frontend, .doesNotAffectIncrementalBuild, .argumentIsPath], helpText: "Add directory to library link search path", group: .linkerOption)
   public static let l: Option = Option("-l", .joined, attributes: [.frontend, .doesNotAffectIncrementalBuild], helpText: "Specifies a library which should be linked against", group: .linkerOption)
   public static let mergeModules: Option = Option("-merge-modules", .flag, attributes: [.frontend, .noDriver], helpText: "Merge the input modules without otherwise processing them", group: .modes)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -386,8 +386,8 @@ extension Option {
   public static let localizationPath: Option = Option("-localization-path", .separate, attributes: [.frontend, .doesNotAffectIncrementalBuild, .argumentIsPath], metaVar: "<path>", helpText: "Path to localized diagnostic messages directory")
   public static let location: Option = Option("-location", .separate, attributes: [.noDriver], metaVar: "<location>", helpText: "Filter nodes with the given location.")
   public static let location_: Option = Option("--location", .separate, alias: Option.location, attributes: [.noDriver], metaVar: "<location>", helpText: "Filter nodes with the given location.")
+  public static let ltoLibrary: Option = Option("-lto-library", .separate, attributes: [.frontend, .argumentIsPath], metaVar: "<lto-library>", helpText: "Perform LTO with <lto-library>")
   public static let lto: Option = Option("-lto=", .joined, attributes: [.frontend, .noInteractive], helpText: "Specify the LTO type to either 'llvm-thin' or 'llvm-full'")
-  public static let ltoLibrary: Option = Option("-lto-library", .separate, attributes: [.frontend, .argumentIsPath, .noInteractive], metaVar: "<lto-library>", helpText: "Perform LTO with <lto-library>")
   public static let L: Option = Option("-L", .joinedOrSeparate, attributes: [.frontend, .doesNotAffectIncrementalBuild, .argumentIsPath], helpText: "Add directory to library link search path", group: .linkerOption)
   public static let l: Option = Option("-l", .joined, attributes: [.frontend, .doesNotAffectIncrementalBuild], helpText: "Specifies a library which should be linked against", group: .linkerOption)
   public static let mergeModules: Option = Option("-merge-modules", .flag, attributes: [.frontend, .noDriver], helpText: "Merge the input modules without otherwise processing them", group: .modes)
@@ -987,6 +987,7 @@ extension Option {
       Option.localizationPath,
       Option.location,
       Option.location_,
+      Option.ltoLibrary,
       Option.lto,
       Option.L,
       Option.l,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3786,12 +3786,32 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.map(\.kind), [.compile, .link])
       XCTAssertTrue(plannedJobs[1].commandLine.contains("-lto_library"))
     }
+    
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-lto=llvm-thin", "-lto-library", "/foo/libLTO.dylib", "-target", "x86_64-apple-macos11.0"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.map(\.kind), [.compile, .link])
+      XCTAssertFalse(plannedJobs[0].commandLine.contains(.path(try VirtualPath(path: "/foo/libLTO.dylib"))))
+      XCTAssertTrue(plannedJobs[1].commandLine.contains("-lto_library"))
+      XCTAssertTrue(plannedJobs[1].commandLine.contains(.path(try VirtualPath(path: "/foo/libLTO.dylib"))))
+    }
+    
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-lto=llvm-full", "-target", "x86_64-apple-macos11.0"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.map(\.kind), [.compile, .link])
       XCTAssertTrue(plannedJobs[1].commandLine.contains("-lto_library"))
     }
+    
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-lto=llvm-full", "-lto-library", "/foo/libLTO.dylib", "-target", "x86_64-apple-macos11.0"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.map(\.kind), [.compile, .link])
+      XCTAssertFalse(plannedJobs[0].commandLine.contains(.path(try VirtualPath(path: "/foo/libLTO.dylib"))))
+      XCTAssertTrue(plannedJobs[1].commandLine.contains("-lto_library"))
+      XCTAssertTrue(plannedJobs[1].commandLine.contains(.path(try VirtualPath(path: "/foo/libLTO.dylib"))))
+    }
+    
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-target", "x86_64-apple-macos11.0"])
       let plannedJobs = try driver.planBuild()


### PR DESCRIPTION
Allow users to specify a particular LTO library on Darwin.