### PR TITLE
Disable `testDependencyScanning` on Apple Silicon

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -730,6 +730,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
   /// Test the libSwiftScan dependency scanning.
   func testDependencyScanning() throws {
+    #if os(macOS) && arch(arm64)
+      // Temporarily disabled on Apple Silicon
+      throw XCTSkip()
+    #endif
     let (stdLibPath, shimsPath, toolchain, hostTriple) = try getDriverArtifactsForScanning()
 
     // The dependency oracle wraps an instance of libSwiftScan and ensures thread safety across


### PR DESCRIPTION
It is currently failing on Apple Silicon CI:
https://ci.swift.org/job/oss-swift-incremental-RA-macos-apple-silicon/1010/console