### PR TITLE
Reapply swift-api-digester integration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "main",
-          "revision": "eed1ae7c419a354ec606108fcbec27cf4c8853e7",
+          "revision": "0f88ee40f297004547581ddd90b27f3a7e60a11a",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": "main",
-          "revision": "435a2708a6e486d69ea7d7aaa3f4ad243bc3b408",
+          "revision": "21a79185b2ea8f89b9253ed8cdf2338bf564c499",
           "version": null
         }
       },

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(SwiftDriver
   "IncrementalCompilation/SourceFileDependencyGraph.swift"
   "IncrementalCompilation/TwoDMap.swift"
 
+  Jobs/APIDigesterJobs.swift
   Jobs/AutolinkExtractJob.swift
   Jobs/BackendJob.swift
   Jobs/CommandLineArguments.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -34,6 +34,8 @@ public struct Driver {
     case missingProfilingData(String)
     case conditionalCompilationFlagHasRedundantPrefix(String)
     case conditionalCompilationFlagIsNotValidIdentifier(String)
+    case baselineGenerationRequiresTopLevelModule(String)
+    case optionRequiresAnother(String, String)
     // Explicit Module Build Failures
     case malformedModuleDependency(String, String)
     case missingPCMArguments(String)
@@ -100,6 +102,10 @@ public struct Driver {
         return "unable to load output file map '\(path)': no such file or directory"
       case .missingExternalDependency(let moduleName):
         return "Missing External dependency info for module: \(moduleName)"
+      case .baselineGenerationRequiresTopLevelModule(let arg):
+        return "generating a baseline with '\(arg)' is only supported with '-emit-module' or '-emit-module-path'"
+      case .optionRequiresAnother(let first, let second):
+        return "'\(first)' cannot be specified if '\(second)' is not present"
       }
     }
   }
@@ -287,6 +293,12 @@ public struct Driver {
 
   /// Path to the Swift module source information file.
   let moduleSourceInfoPath: VirtualPath.Handle?
+
+  /// Path to the module's digester baseline file.
+  let digesterBaselinePath: VirtualPath.Handle?
+
+  /// The mode the API digester should run in.
+  let digesterMode: DigesterMode
 
   /// Force the driver to emit the module first and then run compile jobs. This could be used to unblock
   /// dependencies in parallel builds.
@@ -535,6 +547,16 @@ public struct Driver {
     self.numThreads = Self.determineNumThreads(&parsedOptions, compilerMode: compilerMode, diagnosticsEngine: diagnosticEngine)
     self.numParallelJobs = Self.determineNumParallelJobs(&parsedOptions, diagnosticsEngine: diagnosticEngine, env: env)
 
+    var mode = DigesterMode.api
+    if let modeArg = parsedOptions.getLastArgument(.digesterMode)?.asSingle {
+      if let digesterMode = DigesterMode(rawValue: modeArg) {
+        mode = digesterMode
+      } else {
+        diagnosticsEngine.emit(Error.invalidArgumentValue(Option.digesterMode.spelling, modeArg))
+      }
+    }
+    self.digesterMode = mode
+
     Self.validateWarningControlArgs(&parsedOptions, diagnosticEngine: diagnosticEngine)
     Self.validateProfilingArgs(&parsedOptions,
                                fileSystem: fileSystem,
@@ -587,7 +609,7 @@ public struct Driver {
       diagnosticEngine: diagnosticEngine,
       toolchain: toolchain,
       targetInfo: frontendTargetInfo)
-    
+
     Self.validateSanitizerAddressUseOdrIndicatorFlag(&parsedOptions, diagnosticEngine: diagnosticsEngine, addressSanitizerEnabled: enabledSanitizers.contains(.address))
     
     Self.validateSanitizerRecoverArgValues(&parsedOptions, diagnosticEngine: diagnosticsEngine, enabledSanitizers: enabledSanitizers)
@@ -663,6 +685,15 @@ public struct Driver {
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name,
         projectDirectory: projectDirectory)
+    self.digesterBaselinePath = try Self.computeDigesterBaselineOutputPath(
+      &parsedOptions,
+      moduleOutputPath: self.moduleOutputInfo.output?.outputPath,
+      mode: self.digesterMode,
+      compilerOutputType: compilerOutputType,
+      compilerMode: compilerMode,
+      outputFileMap: self.outputFileMap,
+      moduleName: moduleOutputInfo.name,
+      projectDirectory: projectDirectory)
     self.swiftInterfacePath = try Self.computeSupplementaryOutputPath(
         &parsedOptions, type: .swiftInterface, isOutputOptions: [.emitModuleInterface],
         outputPath: .emitModuleInterfacePath,
@@ -699,6 +730,12 @@ public struct Driver {
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
+
+    Self.validateDigesterArgs(&parsedOptions,
+                              moduleOutputInfo: moduleOutputInfo,
+                              digesterMode: self.digesterMode,
+                              swiftInterfacePath: self.swiftInterfacePath,
+                              diagnosticEngine: diagnosticsEngine)
 
     try verifyOutputOptions()
   }
@@ -2196,6 +2233,36 @@ extension Driver {
     }
   }
 
+  static func validateDigesterArgs(_ parsedOptions: inout ParsedOptions,
+                                   moduleOutputInfo: ModuleOutputInfo,
+                                   digesterMode: DigesterMode,
+                                   swiftInterfacePath: VirtualPath.Handle?,
+                                   diagnosticEngine: DiagnosticsEngine) {
+    if moduleOutputInfo.output?.isTopLevel != true {
+      for arg in parsedOptions.arguments(for: .emitDigesterBaseline, .emitDigesterBaselinePath, .compareToBaselinePath) {
+        diagnosticEngine.emit(Error.baselineGenerationRequiresTopLevelModule(arg.option.spelling))
+      }
+    }
+
+    if parsedOptions.hasArgument(.serializeBreakingChangesPath) && !parsedOptions.hasArgument(.compareToBaselinePath) {
+      diagnosticEngine.emit(Error.optionRequiresAnother(Option.serializeBreakingChangesPath.spelling,
+                                                        Option.compareToBaselinePath.spelling))
+    }
+    if parsedOptions.hasArgument(.digesterBreakageAllowlistPath) && !parsedOptions.hasArgument(.compareToBaselinePath) {
+      diagnosticEngine.emit(Error.optionRequiresAnother(Option.digesterBreakageAllowlistPath.spelling,
+                                                        Option.compareToBaselinePath.spelling))
+    }
+    if digesterMode == .abi && !parsedOptions.hasArgument(.enableLibraryEvolution) {
+      diagnosticEngine.emit(Error.optionRequiresAnother("\(Option.digesterMode.spelling) abi",
+                                                        Option.enableLibraryEvolution.spelling))
+    }
+    if digesterMode == .abi && swiftInterfacePath == nil {
+      diagnosticEngine.emit(Error.optionRequiresAnother("\(Option.digesterMode.spelling) abi",
+                                                        Option.emitModuleInterface.spelling))
+    }
+  }
+
+
   static func validateProfilingArgs(_ parsedOptions: inout ParsedOptions,
                                     fileSystem: FileSystem,
                                     workingDirectory: AbsolutePath?,
@@ -2649,6 +2716,31 @@ extension Driver {
                                                 moduleName: moduleName,
                                                 projectDirectory: projectDirectory)
   }
+
+  static func computeDigesterBaselineOutputPath(
+    _ parsedOptions: inout ParsedOptions,
+    moduleOutputPath: VirtualPath.Handle?,
+    mode: DigesterMode,
+    compilerOutputType: FileType?,
+    compilerMode: CompilerMode,
+    outputFileMap: OutputFileMap?,
+    moduleName: String,
+    projectDirectory: VirtualPath.Handle?
+  ) throws -> VirtualPath.Handle? {
+    // Only emit a baseline if at least of the arguments was provided.
+    guard parsedOptions.hasArgument(.emitDigesterBaseline, .emitDigesterBaselinePath) else { return nil }
+    return try computeModuleAuxiliaryOutputPath(&parsedOptions,
+                                                moduleOutputPath: moduleOutputPath,
+                                                type: mode.baselineFileType,
+                                                isOutput: .emitDigesterBaseline,
+                                                outputPath: .emitDigesterBaselinePath,
+                                                compilerOutputType: compilerOutputType,
+                                                compilerMode: compilerMode,
+                                                outputFileMap: outputFileMap,
+                                                moduleName: moduleName,
+                                                projectDirectory: projectDirectory)
+  }
+
 
 
   /// Determine the output path for a module auxiliary output.

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -54,6 +54,13 @@ public struct OutputFileMap: Hashable, Codable {
       }
       return VirtualPath.lookup(path).replacingExtension(with: outputType).intern()
 
+    case .jsonAPIBaseline, .jsonABIBaseline:
+      // Infer paths for these entities using .swiftsourceinfo path.
+      guard let path = entries[inputFile]?[.swiftSourceInfoFile] else {
+        return nil
+      }
+      return VirtualPath.lookup(path).replacingExtension(with: outputType).intern()
+
     case .object:
       // We may generate .o files from bitcode .bc files, but the output file map
       // uses .swift file as the key for .o file paths. So we need to dig further.

--- a/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
+++ b/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
@@ -1,0 +1,152 @@
+//===- APIDigesterJobs.swift - Baseline Generation and API/ABI Comparison -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCBasic
+
+enum DigesterMode: String {
+  case api, abi
+
+  var baselineFileType: FileType {
+    switch self {
+    case .api:
+      return .jsonAPIBaseline
+    case .abi:
+      return .jsonABIBaseline
+    }
+  }
+
+  var baselineGenerationJobKind: Job.Kind {
+    switch self {
+    case .api:
+      return .generateAPIBaseline
+    case .abi:
+      return .generateABIBaseline
+    }
+  }
+
+  var baselineComparisonJobKind: Job.Kind {
+    switch self {
+    case .api:
+      return .compareAPIBaseline
+    case .abi:
+      return .compareABIBaseline
+    }
+  }
+}
+
+extension Driver {
+  mutating func digesterBaselineGenerationJob(modulePath: VirtualPath.Handle, outputPath: VirtualPath.Handle, mode: DigesterMode) throws -> Job {
+    var commandLine = [Job.ArgTemplate]()
+    commandLine.appendFlag("-dump-sdk")
+
+    try addCommonDigesterOptions(&commandLine, modulePath: modulePath, mode: mode)
+
+    commandLine.appendFlag(.o)
+    commandLine.appendPath(VirtualPath.lookup(outputPath))
+
+    return Job(
+      moduleName: moduleOutputInfo.name,
+      kind: mode.baselineGenerationJobKind,
+      tool: .absolute(try toolchain.getToolPath(.swiftAPIDigester)),
+      commandLine: commandLine,
+      inputs: [.init(file: modulePath, type: .swiftModule)],
+      primaryInputs: [],
+      outputs: [.init(file: outputPath, type: mode.baselineFileType)],
+      supportsResponseFiles: true
+    )
+  }
+
+  mutating func digesterCompareToBaselineJob(modulePath: VirtualPath.Handle, baselinePath: VirtualPath.Handle, mode: DigesterMode) throws -> Job {
+    var commandLine = [Job.ArgTemplate]()
+    commandLine.appendFlag("-diagnose-sdk")
+    commandLine.appendFlag("-disable-fail-on-error")
+    commandLine.appendFlag("-baseline-path")
+    commandLine.appendPath(VirtualPath.lookup(baselinePath))
+
+    try addCommonDigesterOptions(&commandLine, modulePath: modulePath, mode: mode)
+
+    var serializedDiagnosticsPath: VirtualPath.Handle?
+    if let arg = parsedOptions.getLastArgument(.serializeBreakingChangesPath)?.asSingle {
+      let path = try VirtualPath.intern(path: arg)
+      commandLine.appendFlag("-serialize-diagnostics-path")
+      commandLine.appendPath(VirtualPath.lookup(path))
+      serializedDiagnosticsPath = path
+    }
+    if let arg = parsedOptions.getLastArgument(.digesterBreakageAllowlistPath)?.asSingle {
+      let path = try VirtualPath(path: arg)
+      commandLine.appendFlag("-breakage-allowlist-path")
+      commandLine.appendPath(path)
+    }
+
+    var inputs: [TypedVirtualPath] = [.init(file: modulePath, type: .swiftModule),
+                                      .init(file: baselinePath, type: mode.baselineFileType)]
+    // If a module interface was emitted, treat it as an input in ABI mode.
+    if let interfacePath = self.swiftInterfacePath, mode == .abi {
+      inputs.append(.init(file: interfacePath, type: .swiftInterface))
+    }
+
+    return Job(
+      moduleName: moduleOutputInfo.name,
+      kind: mode.baselineComparisonJobKind,
+      tool: .absolute(try toolchain.getToolPath(.swiftAPIDigester)),
+      commandLine: commandLine,
+      inputs: inputs,
+      primaryInputs: [],
+      outputs: [.init(file: serializedDiagnosticsPath ?? VirtualPath.Handle.standardOutput, type: .diagnostics)],
+      supportsResponseFiles: true
+    )
+  }
+
+  private mutating func addCommonDigesterOptions(_ commandLine: inout [Job.ArgTemplate],
+                                                 modulePath: VirtualPath.Handle,
+                                                 mode: DigesterMode) throws {
+    commandLine.appendFlag("-module")
+    commandLine.appendFlag(moduleOutputInfo.name)
+    if mode == .abi {
+      commandLine.appendFlag("-abi")
+      commandLine.appendFlag("-use-interface-for-module")
+      commandLine.appendFlag(moduleOutputInfo.name)
+    }
+
+    // Add a search path for the emitted module, and its module interface if there is one.
+    let searchPath = VirtualPath.lookup(modulePath).parentDirectory
+    commandLine.appendFlag(.I)
+    commandLine.appendPath(searchPath)
+    if let interfacePath = self.swiftInterfacePath  {
+      let interfaceSearchPath = VirtualPath.lookup(interfacePath).parentDirectory
+      if interfaceSearchPath != searchPath {
+        commandLine.appendFlag(.I)
+        commandLine.appendPath(interfaceSearchPath)
+      }
+    }
+
+    commandLine.appendFlag(.target)
+    commandLine.appendFlag(targetTriple.triple)
+
+    if let sdkPath = frontendTargetInfo.sdkPath?.path {
+      commandLine.appendFlag(.sdk)
+      commandLine.append(.path(VirtualPath.lookup(sdkPath)))
+    }
+
+    commandLine.appendFlag(.resourceDir)
+    commandLine.appendPath(VirtualPath.lookup(frontendTargetInfo.runtimeResourcePath.path))
+
+    try commandLine.appendAll(.I, from: &parsedOptions)
+    try commandLine.appendAll(.F, from: &parsedOptions)
+    for systemFramework in parsedOptions.arguments(for: .Fsystem) {
+      commandLine.appendFlag(.iframework)
+      commandLine.appendFlag(systemFramework.argument.asSingle)
+    }
+
+    try commandLine.appendLast(.swiftVersion, from: &parsedOptions)
+  }
+}

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -93,7 +93,7 @@ extension Driver {
          .privateSwiftInterface, .swiftSourceInfoFile, .diagnostics, .objcHeader, .swiftDeps,
          .remap, .tbd, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
          .pch, .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
-         .indexUnitOutputPath, .modDepCache, nil:
+         .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline, nil:
       return false
     }
   }
@@ -444,7 +444,7 @@ extension FileType {
          .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
          .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
          .privateSwiftInterface, .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts,
-         .indexUnitOutputPath, .modDepCache:
+         .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline:
       fatalError("Output type can never be a primary output")
     }
   }

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -37,6 +37,10 @@ public struct Job: Codable, Equatable, Hashable {
     case scanDependencies = "scan-dependencies"
     case verifyModuleInterface = "verify-emitted-module-interface"
     case help
+    case generateAPIBaseline = "generate-api-baseline"
+    case generateABIBaseline = "generate-abi-baseline"
+    case compareAPIBaseline = "compare-api-baseline"
+    case compareABIBaseline = "compare-abi-baseline"
   }
 
   public enum ArgTemplate: Equatable, Hashable {
@@ -220,6 +224,18 @@ extension Job : CustomStringConvertible {
 
     case .verifyModuleInterface:
       return "Verifying emitted module interface for module \(moduleName)"
+
+    case .generateAPIBaseline:
+      return "Generating API baseline file for module \(moduleName)"
+
+    case .generateABIBaseline:
+      return "Generating ABI baseline file for module \(moduleName)"
+
+    case .compareAPIBaseline:
+      return "Comparing API of \(moduleName) to baseline"
+
+    case .compareABIBaseline:
+      return "Comparing ABI of \(moduleName) to baseline"
     }
   }
 
@@ -242,7 +258,8 @@ extension Job.Kind {
         .versionRequest, .emitSupportedFeatures, .scanDependencies, .verifyModuleInterface:
         return true
 
-    case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo, .moduleWrap:
+    case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo, .moduleWrap,
+        .generateAPIBaseline, .generateABIBaseline, .compareAPIBaseline, .compareABIBaseline:
         return false
     }
   }
@@ -256,7 +273,9 @@ extension Job.Kind {
          .generatePCM, .dumpPCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
          .help, .link, .verifyDebugInfo, .scanDependencies,
-         .emitSupportedFeatures, .moduleWrap, .verifyModuleInterface:
+         .emitSupportedFeatures, .moduleWrap, .verifyModuleInterface,
+         .generateAPIBaseline, .generateABIBaseline, .compareAPIBaseline,
+         .compareABIBaseline:
       return false
     }
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -147,6 +147,7 @@ extension Driver {
       addJobBeforeCompiles: addJobBeforeCompiles,
       addCompileJobGroup: addCompileJobGroup,
       addJobAfterCompiles: addJobAfterCompiles)
+    try addAPIDigesterJobs(addJob: addJobAfterCompiles)
     try addLinkAndPostLinkJobs(linkerInputs: linkerInputs,
                                debugInfo: debugInfo,
                                addJob: addJobAfterCompiles)
@@ -459,6 +460,17 @@ extension Driver {
       assert(mergeModuleOutputs.count == 1,
              "Merge module job should only have one swiftmodule output")
       addLinkerInput(mergeModuleOutputs[0])
+    }
+  }
+
+  private mutating func addAPIDigesterJobs(addJob: (Job) -> Void) throws {
+    guard let moduleOutputPath = moduleOutputInfo.output?.outputPath else { return }
+    if let apiBaselinePath = self.digesterBaselinePath {
+      try addJob(digesterBaselineGenerationJob(modulePath: moduleOutputPath, outputPath: apiBaselinePath, mode: digesterMode))
+    }
+    if let baselineArg = parsedOptions.getLastArgument(.compareToBaselinePath)?.asSingle,
+       let baselinePath = try? VirtualPath.intern(path: baselineArg) {
+      addJob(try digesterCompareToBaselineJob(modulePath: moduleOutputPath, baselinePath: baselinePath, mode: digesterMode))
     }
   }
 

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -78,6 +78,8 @@ import SwiftOptions
       return try lookup(executable: "dwarfdump")
     case .swiftHelp:
       return try lookup(executable: "swift-help")
+    case .swiftAPIDigester:
+      return try lookup(executable: "swift-api-digester")
     }
   }
 

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -83,6 +83,8 @@ import TSCBasic
       return try lookup(executable: "dwarfdump")
     case .swiftHelp:
       return try lookup(executable: "swift-help")
+    case .swiftAPIDigester:
+      return try lookup(executable: "swift-api-digester")
     }
   }
 

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -23,6 +23,7 @@ public enum Tool: Hashable {
   case lldb
   case dwarfdump
   case swiftHelp
+  case swiftAPIDigester
 }
 
 /// Describes a toolchain, which includes information about compilers, linkers

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -107,6 +107,8 @@ import SwiftOptions
       return try lookup(executable: "dwarfdump")
     case .swiftHelp:
       return try lookup(executable: "swift-help")
+    case .swiftAPIDigester:
+      return try lookup(executable: "swift-api-digester")
     }
   }
 

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -136,6 +136,12 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
 
   /// Clang Module Map
   case clangModuleMap = "modulemap"
+
+  /// API baseline JSON
+  case jsonAPIBaseline = "api.json"
+
+  /// ABI baseline JSON
+  case jsonABIBaseline = "abi.json"
 }
 
 extension FileType: CustomStringConvertible {
@@ -207,6 +213,12 @@ extension FileType: CustomStringConvertible {
 
     case .diagnostics:
       return "diagnostics"
+
+    case .jsonAPIBaseline:
+      return "api-baseline-json"
+
+    case .jsonABIBaseline:
+      return "abi-baseline-json"
     }
   }
 }
@@ -224,7 +236,7 @@ extension FileType {
          .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
          .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile, .jsonDependencies,
          .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures, .jsonSwiftArtifacts,
-         .indexUnitOutputPath, .modDepCache:
+         .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline:
       return false
     }
   }
@@ -319,6 +331,10 @@ extension FileType {
       return "diagnostics"
     case .indexUnitOutputPath:
       return "index-unit-output-path"
+    case .jsonAPIBaseline:
+      return "api-baseline-json"
+    case .jsonABIBaseline:
+      return "abi-baseline-json"
     }
   }
 }
@@ -330,7 +346,7 @@ extension FileType {
          .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
          .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface,
          .jsonDependencies, .clangModuleMap, .jsonCompilerFeatures,
-         .jsonTargetInfo, .jsonSwiftArtifacts:
+         .jsonTargetInfo, .jsonSwiftArtifacts, .jsonAPIBaseline, .jsonABIBaseline:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -351,7 +367,8 @@ extension FileType {
          .swiftSourceInfoFile, .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap,
          .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord, .modDepCache,
          .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies, .clangModuleMap,
-         .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts, .indexUnitOutputPath:
+         .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts, .indexUnitOutputPath, .jsonAPIBaseline,
+         .jsonABIBaseline:
       return false
     }
   }

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -18,6 +18,14 @@ extension Option {
   public static let noEmitModuleSeparately: Option = Option("-no-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Force using merge-module as the incremental build mode")
   public static let useFrontendParseableOutput: Option = Option("-use-frontend-parseable-output", .flag, attributes: [.helpHidden], helpText: "Emit parseable-output from swift-frontend jobs instead of from the driver")
 
+  // API digester operations
+  public static let emitDigesterBaseline: Option = Option("-emit-digester-baseline", .flag, attributes: [.noInteractive, .supplementaryOutput], helpText: "Emit a baseline file for the module using the API digester")
+  public static let emitDigesterBaselinePath: Option = Option("-emit-digester-baseline-path", .separate, attributes: [.noInteractive, .supplementaryOutput, .argumentIsPath], metaVar: "<path>", helpText: "Emit a baseline file for the module to <path> using the API digester")
+  public static let compareToBaselinePath: Option = Option("-compare-to-baseline-path", .separate, attributes: [.noInteractive, .argumentIsPath], metaVar: "<path>", helpText: "Compare the built module to the baseline at <path> and diagnose breaking changes using the API digester")
+  public static let serializeBreakingChangesPath: Option = Option("-serialize-breaking-changes-path", .separate, attributes: [.noInteractive, .argumentIsPath], metaVar: "<path>", helpText: "Serialize breaking changes found by the API digester to <path>")
+  public static let digesterBreakageAllowlistPath: Option = Option("-digester-breakage-allowlist-path", .separate, attributes: [.noInteractive, .argumentIsPath], metaVar: "<path>", helpText: "The path to a list of permitted breaking changes the API digester should ignore")
+  public static let digesterMode: Option = Option("-digester-mode", .separate, attributes: [.noInteractive], metaVar: "<api|abi>", helpText: "Whether the API digester should run in API or ABI mode (defaults to API checking)")
+
   public static var extraOptions: [Option] {
     return [
       Option.driverPrintGraphviz,
@@ -26,7 +34,13 @@ extension Option {
       Option.driverWarnUnusedOptions,
       Option.emitModuleSeparately,
       Option.noEmitModuleSeparately,
-      Option.useFrontendParseableOutput
+      Option.useFrontendParseableOutput,
+      Option.emitDigesterBaseline,
+      Option.emitDigesterBaselinePath,
+      Option.compareToBaselinePath,
+      Option.serializeBreakingChangesPath,
+      Option.digesterBreakageAllowlistPath,
+      Option.digesterMode
     ]
   }
 }

--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -1,0 +1,392 @@
+//===----- APIDigesterTests.swift - API/ABI Digester Operation Tests ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import TSCBasic
+import TSCUtility
+@_spi(Testing) import SwiftDriver
+
+class APIDigesterTests: XCTestCase {
+  func testBaselineGenerationRequiresTopLevelModule() throws {
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-emit-digester-baseline"]) {
+      $1.expect(.error("generating a baseline with '-emit-digester-baseline' is only supported with '-emit-module' or '-emit-module-path"))
+    }
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-emit-digester-baseline-path", "/output/path.abi.json"]) {
+      $1.expect(.error("generating a baseline with '-emit-digester-baseline-path' is only supported with '-emit-module' or '-emit-module-path"))
+    }
+  }
+
+  func testDigesterModeValidation() throws {
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-emit-module", "-emit-digester-baseline", "-digester-mode", "notamode"]) {
+      $1.expect(.error("invalid value 'notamode' in '-digester-mode'"))
+    }
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-emit-digester-baseline", "-digester-mode", "api")
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-emit-module-interface",
+                                  "-enable-library-evolution", "-emit-digester-baseline", "-digester-mode", "abi")
+  }
+
+  func testABIDigesterRequirements() throws {
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-emit-module", "-emit-module-interface",
+                                       "-emit-digester-baseline", "-digester-mode", "abi"]) {
+      $1.expect(.error("'-digester-mode abi' cannot be specified if '-enable-library-evolution' is not present"))
+    }
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-emit-module",
+                                       "-enable-library-evolution", "-emit-digester-baseline", "-digester-mode", "abi"]) {
+      $1.expect(.error("'-digester-mode abi' cannot be specified if '-emit-module-interface' is not present"))
+    }
+  }
+
+  func testBaselineOutputPath() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-emit-digester-baseline"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateAPIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.api.json")))]))
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module","-emit-module-interface", "-enable-library-evolution", "-emit-digester-baseline", "-digester-mode", "abi"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.abi.json")))]))
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-emit-digester-baseline-path", "bar.api.json"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateAPIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("bar.api.json")))]))
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module","-emit-module-interface", "-enable-library-evolution", "-digester-mode", "abi", "-emit-digester-baseline-path", "bar.abi.json"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("bar.abi.json")))]))
+    }
+    do {
+      try withTemporaryDirectory { path in
+        let projectDirPath = path.appending(component: "Project")
+        try localFileSystem.createDirectory(projectDirPath)
+        var driver = try Driver(args: ["swiftc", "-emit-module",
+                                       path.appending(component: "foo.swift").pathString,
+                                       "-emit-digester-baseline",
+                                       "-o", path.appending(component: "foo.swiftmodule").pathString])
+        let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateAPIBaseline })
+        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(projectDirPath.appending(component: "foo.api.json")))]))
+      }
+    }
+    do {
+      try withTemporaryDirectory { path in
+        let projectDirPath = path.appending(component: "Project")
+        try localFileSystem.createDirectory(projectDirPath)
+        var driver = try Driver(args: ["swiftc", "-emit-module",
+                                       "-emit-module-interface", "-enable-library-evolution",
+                                       path.appending(component: "foo.swift").pathString,
+                                       "-emit-digester-baseline",
+                                       "-digester-mode", "abi",
+                                       "-o", path.appending(component: "foo.swiftmodule").pathString])
+        let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
+        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(projectDirPath.appending(component: "foo.abi.json")))]))
+      }
+    }
+    do {
+      try withTemporaryDirectory { path in
+        let ofmPath = path.appending(component: "ofm.json")
+        try localFileSystem.writeFileContents(ofmPath) {
+          $0 <<< """
+          {
+            "": {
+              "abi-baseline-json": "/path/to/baseline.abi.json"
+            }
+          }
+          """
+        }
+        var driver = try Driver(args: ["swiftc", "-wmo", "-emit-module",
+                                       "-emit-module-interface", "-enable-library-evolution",
+                                       path.appending(component: "foo.swift").pathString,
+                                       "-emit-digester-baseline",
+                                       "-digester-mode", "abi",
+                                       "-o", path.appending(component: "foo.swiftmodule").pathString,
+                                       "-output-file-map", ofmPath.pathString,
+                                      ])
+        let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
+        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/path/to/baseline.abi.json")))]))
+      }
+    }
+    do {
+      try withTemporaryDirectory { path in
+        let ofmPath = path.appending(component: "ofm.json")
+        try localFileSystem.writeFileContents(ofmPath) {
+          $0 <<< """
+          {
+            "": {
+              "swiftsourceinfo": "/path/to/sourceinfo"
+            }
+          }
+          """
+        }
+        var driver = try Driver(args: ["swiftc", "-wmo", "-emit-module",
+                                       "-emit-module-interface", "-enable-library-evolution",
+                                       path.appending(component: "foo.swift").pathString,
+                                       "-emit-digester-baseline",
+                                       "-digester-mode", "abi",
+                                       "-o", path.appending(component: "foo.swiftmodule").pathString,
+                                       "-output-file-map", ofmPath.pathString,
+                                      ])
+        let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
+        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/path/to/sourceinfo.abi.json")))]))
+      }
+    }
+  }
+
+  func testBaselineGenerationJobFlags() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-emit-digester-baseline",
+                                     "-sdk", "/path/to/sdk", "-I", "/some/path", "-F", "framework/path"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateAPIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains("-dump-sdk"))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.api.json")))]))
+
+      XCTAssertFalse(digesterJob.commandLine.contains("-abi"))
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-emit-module-interface",
+                                     "-enable-library-evolution", "-emit-digester-baseline",
+                                     "-digester-mode", "abi",
+                                     "-sdk", "/path/to/sdk", "-I", "/some/path", "-F", "framework/path"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains("-dump-sdk"))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.abi.json")))]))
+
+      XCTAssertTrue(digesterJob.commandLine.contains("-abi"))
+    }
+  }
+
+  func testBaselineGenerationEndToEnd() throws {
+    try withTemporaryDirectory { path in
+      try localFileSystem.changeCurrentWorkingDirectory(to: path)
+      let source = path.appending(component: "foo.swift")
+      try localFileSystem.writeFileContents(source) {
+        $0 <<< """
+        import C
+        import E
+        import G
+
+        public struct MyStruct {}
+        """
+      }
+
+      let packageRootPath = URL(fileURLWithPath: #file).pathComponents
+          .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
+      let testInputsPath = packageRootPath + "/TestInputs"
+      let cHeadersPath : String = testInputsPath + "/ExplicitModuleBuilds/CHeaders"
+      let swiftModuleInterfacesPath : String = testInputsPath + "/ExplicitModuleBuilds/Swift"
+      var driver = try Driver(args: ["swiftc",
+                                     "-I", cHeadersPath,
+                                     "-I", swiftModuleInterfacesPath,
+                                     "-working-directory", path.pathString,
+                                     source.pathString,
+                                     "-emit-module",
+                                     "-emit-digester-baseline",
+                                    ],
+                              env: ProcessEnv.vars)
+      let jobs = try driver.planBuild()
+      try driver.run(jobs: jobs)
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
+      let baseline = try localFileSystem.readFileContents(path.appending(component: "foo.api.json"))
+      try baseline.withData {
+        let json = try JSONSerialization.jsonObject(with: $0, options: []) as? [String: Any]
+        XCTAssertEqual((json?["children"] as? [Any])?.count, 1)
+      }
+    }
+  }
+
+  func testComparisonOptionValidation() throws {
+    try assertDriverDiagnostics(args: ["swiftc", "foo.swift",
+                                       "-serialize-breaking-changes-path", "/path",
+                                       "-digester-breakage-allowlist-path", "/path"]) {
+      $1.expect(.error("'-serialize-breaking-changes-path' cannot be specified if '-compare-to-baseline-path' is not present"))
+      $1.expect(.error("'-digester-breakage-allowlist-path' cannot be specified if '-compare-to-baseline-path' is not present"))
+    }
+  }
+
+  func testBaselineComparisonJobFlags() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-compare-to-baseline-path", "/baseline/path",
+                                     "-sdk", "/path/to/sdk", "-I", "/some/path", "-F", "framework/path",
+                                     "-digester-breakage-allowlist-path", "allowlist/path"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareAPIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(.init("/baseline/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
+                                                                   .path(.relative(.init("allowlist/path")))]))
+
+      XCTAssertFalse(digesterJob.commandLine.contains("-abi"))
+    }
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-compare-to-baseline-path", "/baseline/path",
+                                     "-emit-module-interface", "-enable-library-evolution",
+                                     "-digester-mode", "abi",
+                                     "-sdk", "/path/to/sdk", "-I", "/some/path", "-F", "framework/path",
+                                     "-serialize-breaking-changes-path", "breaking-changes.dia",
+                                     "-digester-breakage-allowlist-path", "allowlist/path"])
+      let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareABIBaseline })
+      XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(.init("/baseline/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-serialize-diagnostics-path",
+                                                                   .path(.relative(.init("breaking-changes.dia")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
+                                                                   .path(.relative(.init("allowlist/path")))]))
+
+      XCTAssertTrue(digesterJob.commandLine.contains("-abi"))
+    }
+  }
+
+  func testAPIComparisonEndToEnd() throws {
+    try withTemporaryDirectory { path in
+      try localFileSystem.changeCurrentWorkingDirectory(to: path)
+      let source = path.appending(component: "foo.swift")
+      try localFileSystem.writeFileContents(source) {
+        $0 <<< """
+        public struct MyStruct {
+          public var a: Int
+        }
+        """
+      }
+      var driver = try Driver(args: ["swiftc",
+                                     "-working-directory", path.pathString,
+                                     source.pathString,
+                                     "-emit-module",
+                                     "-emit-digester-baseline"
+                                    ],
+                              env: ProcessEnv.vars)
+      guard driver.supportedFrontendFlags.contains("disable-fail-on-error") else {
+        throw XCTSkip("Skipping: swift-api-digester does not support '-disable-fail-on-error'")
+      }
+      let jobs = try driver.planBuild()
+      try driver.run(jobs: jobs)
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
+
+      try localFileSystem.writeFileContents(source) {
+        $0 <<< """
+        public struct MyStruct {
+          public var a: Bool
+        }
+        """
+      }
+      var driver2 = try Driver(args: ["swiftc",
+                                      "-working-directory", path.pathString,
+                                      source.pathString,
+                                      "-emit-module",
+                                      "-compare-to-baseline-path",
+                                      path.appending(component: "foo.api.json").pathString,
+                                      "-serialize-breaking-changes-path",
+                                      path.appending(component: "changes.dia").pathString
+                                     ],
+                              env: ProcessEnv.vars)
+      let jobs2 = try driver2.planBuild()
+      try driver2.run(jobs: jobs2)
+      XCTAssertFalse(driver2.diagnosticEngine.hasErrors)
+      let contents = try localFileSystem.readFileContents(path.appending(component: "changes.dia"))
+      let diags = try SerializedDiagnostics(bytes: contents)
+      XCTAssertEqual(diags.diagnostics.map(\.text), [
+        "API breakage: var MyStruct.a has declared type change from Swift.Int to Swift.Bool",
+        "API breakage: accessor MyStruct.a.Get() has return type change from Swift.Int to Swift.Bool",
+        "API breakage: accessor MyStruct.a.Set() has parameter 0 type change from Swift.Int to Swift.Bool"
+      ])
+    }
+  }
+
+  func testABIComparisonEndToEnd() throws {
+    try withTemporaryDirectory { path in
+      try localFileSystem.changeCurrentWorkingDirectory(to: path)
+      let source = path.appending(component: "foo.swift")
+      let allowlist = path.appending(component: "allowlist.txt")
+      try localFileSystem.writeFileContents(source) {
+        $0 <<< """
+        @frozen public struct MyStruct {
+          var a: Int
+          var b: String
+          var c: Int
+        }
+        """
+      }
+      try localFileSystem.writeFileContents(allowlist) {
+        $0 <<< "ABI breakage: var MyStruct.c has declared type change from Swift.Int to Swift.String"
+      }
+      var driver = try Driver(args: ["swiftc",
+                                     "-working-directory", path.pathString,
+                                     source.pathString,
+                                     "-emit-module",
+                                     "-emit-module-interface",
+                                     "-enable-library-evolution",
+                                     "-emit-digester-baseline",
+                                     "-digester-mode", "abi"
+                                    ],
+                              env: ProcessEnv.vars)
+      guard driver.supportedFrontendFlags.contains("disable-fail-on-error") else {
+        throw XCTSkip("Skipping: swift-api-digester does not support '-disable-fail-on-error'")
+      }
+      let jobs = try driver.planBuild()
+      try driver.run(jobs: jobs)
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
+
+      try localFileSystem.writeFileContents(source) {
+        $0 <<< """
+        @frozen public struct MyStruct {
+          var b: String
+          var a: Int
+          var c: String
+        }
+        """
+      }
+      var driver2 = try Driver(args: ["swiftc",
+                                      "-working-directory", path.pathString,
+                                      source.pathString,
+                                      "-emit-module",
+                                      "-emit-module-interface",
+                                      "-enable-library-evolution",
+                                      "-compare-to-baseline-path",
+                                      path.appending(component: "foo.abi.json").pathString,
+                                      "-serialize-breaking-changes-path",
+                                      path.appending(component: "changes.dia").pathString,
+                                      "-digester-breakage-allowlist-path",
+                                      allowlist.pathString,
+                                      "-digester-mode", "abi"
+                                     ],
+                              env: ProcessEnv.vars)
+      let jobs2 = try driver2.planBuild()
+      try driver2.run(jobs: jobs2)
+      XCTAssertFalse(driver2.diagnosticEngine.hasErrors)
+      let contents = try localFileSystem.readFileContents(path.appending(component: "changes.dia"))
+      let diags = try SerializedDiagnostics(bytes: contents)
+      XCTAssertEqual(diags.diagnostics.map(\.text), [
+        "ABI breakage: var MyStruct.a in a non-resilient type changes position from 0 to 1",
+        "ABI breakage: var MyStruct.b in a non-resilient type changes position from 1 to 0"
+      ])
+    }
+  }
+}

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -25,7 +25,7 @@ def error(message):
 
 # Tools constructed as a part of the a development build toolchain
 driver_toolchain_tools = ['swift', 'swift-frontend', 'clang', 'swift-help',
-                          'swift-autolink-extract', 'lldb']
+                          'swift-autolink-extract', 'lldb', 'swift-api-digester']
 
 executables_to_install = ['swift-driver', 'swift-help', 'swift-build-sdk-interfaces']
 


### PR DESCRIPTION
This reapplies the patch that caused failure on the package bots, then updates build-script-helper to include swift-api-digester in the list of tools whose lookup is override by the --toolchain flag