### PR TITLE
[Incremental] Fix clean build quadratic performance bug

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -348,7 +348,7 @@ extension DependencyKey.Designator: Comparable {}
 // MARK: - InvalidationReason
 extension ExternalDependency {
   /// When explaining incremental decisions, it helps to know why a particular external dependency
-  /// was investigated.
+  /// caused invalidation.
   public enum InvalidationReason: String, CustomStringConvertible {
     /// An `import` of this file was added to the source code.
     case added
@@ -356,7 +356,7 @@ extension ExternalDependency {
     /// The imported file has changed.
     case changed
 
-    /// Used when testing invalidation
+    /// Used when testing
     case testing
 
     public var description: String { rawValue }

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -131,13 +131,13 @@ extension IncrementalCompilationState.FirstWaveComputer {
       }
     }
 
-    let inputsHavingMalformedDependencySources =
-      sourceFiles.currentInOrder.filter { sourceFile in
-        !moduleDependencyGraph.containsNodes(forSourceFile: sourceFile)
-      }
+    let inputsMissingFromGraph = sourceFiles.currentInOrder.filter { sourceFile in
+      !moduleDependencyGraph.containsNodes(forSourceFile: sourceFile)
+    }
 
-    if let reporter = reporter {
-      for input in inputsHavingMalformedDependencySources {
+    if let reporter = reporter,
+       moduleDependencyGraph.phase == .buildingFromSwiftDeps {
+      for input in inputsMissingFromGraph {
         reporter.report("Has malformed dependency source; will queue", input)
       }
     }
@@ -156,7 +156,7 @@ extension IncrementalCompilationState.FirstWaveComputer {
     let definitelyRequiredInputs =
       Set(changedInputs.map({ $0.filePath }) +
             inputsInvalidatedByExternals +
-            inputsHavingMalformedDependencySources +
+            inputsMissingFromGraph +
             inputsMissingOutputs)
     if let reporter = reporter {
       for scheduledInput in sortByCommandLineOrder(definitelyRequiredInputs) {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -206,7 +206,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
       return readPriorGraphAndCollectInputsInvalidatedByChangedOrAddedExternals()
     }
     // Every external is added, but don't want to compile an unchanged input that has an import
-    // so just changed, not changedOrAdded
+    // so just changed, not changedOrAdded.
     return buildInitialGraphFromSwiftDepsAndCollectInputsInvalidatedByChangedExternals()
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -280,6 +280,6 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   private func bulidEmptyGraphAndCompileEverything()
   -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet) {
     let graph = ModuleDependencyGraph(self, .buildingAfterEachCompilation)
-    return (graph, TransitivelyInvalidatedInputSet(sourceFiles.currentInOrder))
+    return (graph, TransitivelyInvalidatedInputSet())
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -79,18 +79,7 @@ extension ModuleDependencyGraph {
         return true
       }
     }
-
-    var isWholeGraphPresent: Bool {
-      !isBuilding
-    }
-
-    var isBuilding: Bool {
-      switch self {
-      case .buildingWithoutAPrior, .buildingAfterEachCompilation: return true
-      case .updatingFromAPrior, .updatingAfterCompilation: return false
-      }
-    }
- }
+  }
 }
 
 // MARK: - Building from swiftdeps
@@ -350,10 +339,7 @@ extension ModuleDependencyGraph {
   func findNodesInvalidated(
     by integrand: ExternalIntegrand
   ) -> DirectlyInvalidatedNodeSet {
-    // If the whole graph isn't present yet, the driver must not integrate
-    // incrementally because it would have to integrate the same `swiftmodule`
-    // repeatedy for each new `swiftdeps` read.
-    self.info.isCrossModuleIncrementalBuildEnabled && self.phase.isWholeGraphPresent
+    self.info.isCrossModuleIncrementalBuildEnabled
     ?    incrementallyFindNodesInvalidated(by: integrand)
     : indiscriminatelyFindNodesInvalidated(by: integrand)
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -393,10 +393,11 @@ extension ModuleDependencyGraph {
   private func indiscriminatelyFindNodesInvalidated(
     by integrand: ExternalIntegrand
   ) -> DirectlyInvalidatedNodeSet {
-    if let reason = whyIndiscriminatelyFindNodesInvalidated(by: integrand) {
-      return collectUntracedNodes(thatUse: integrand.externalDependency, reason)
+    guard let reason = whyIndiscriminatelyFindNodesInvalidated(by: integrand)
+    else {
+      return DirectlyInvalidatedNodeSet()
     }
-    return DirectlyInvalidatedNodeSet()
+    return collectUntracedNodes(thatUse: integrand.externalDependency, reason)
   }
 
   /// Figure out the reason to integrate, (i.e. process) a dependency that will be read and integrated.
@@ -471,7 +472,7 @@ extension ModuleDependencyGraph {
   ///
   /// If not using incremental imports, a given build may have to invalidate nodes more than once for the same `swiftmodule`:
   /// For example, on a clean build, as each initial `swiftdeps` is integrated, if the file uses a changed `swiftmodule`,
-  /// iit must be scheduled for recompilation. Thus invalidation happens for every dependent input file.
+  /// it must be scheduled for recompilation. Thus invalidation happens for every dependent input file.
   fileprivate struct ExternalDependencyCurrencyCache {
     private let fileSystem: FileSystem
     private let buildStartTime: Date

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -459,13 +459,13 @@ extension ModuleDependencyGraph {
     else {
       return nil
     }
+    // When doing incremental imports, never read the same swiftmodule twice
+    self.currencyCache.beCurrent(fed.externalDependency)
     let invalidatedNodes = Integrator.integrate(
       from: unserializedDepGraph,
       dependencySource: source,
       into: self)
     info.reporter?.reportInvalidated(invalidatedNodes, by: fed.externalDependency, why)
-    // When doing incremental imports, never read the same swiftmodule twice
-    self.currencyCache.beCurrent(fed.externalDependency)
     return invalidatedNodes
   }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -326,8 +326,8 @@ extension ModuleDependencyGraph {
     init(_ fed: FingerprintedExternalDependency,
          in graph: ModuleDependencyGraph ) {
       self = graph.fingerprintedExternalDependencies.insert(fed).inserted
-      ? .old(fed)
-      : .new(fed)
+      ? .new(fed)
+      : .old(fed)
     }
 
     init(_ fed: FingerprintedExternalDependency,

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -81,7 +81,14 @@ extension ModuleDependencyGraph {
     }
 
     var isWholeGraphPresent: Bool {
-      self != .buildingWithoutAPrior
+      !isBuilding
+    }
+
+    var isBuilding: Bool {
+      switch self {
+      case .buildingWithoutAPrior, .buildingAfterEachCompilation: return true
+      case .updatingFromAPrior, .updatingAfterCompilation: return false
+      }
     }
  }
 }
@@ -425,16 +432,8 @@ extension ModuleDependencyGraph {
       return self.currencyCache.isCurrent(integrand.externalDependency.externalDependency)
       ? nil : .changed
     case .updatingAfterCompilation:
-      switch integrand {
-      case .new:
-        // An import was added, some other file that does not import this might (transitively) depend on it
-        // so do the invalidation.
-        return .added
-      case .old:
-        // Not new to the graph in general, and this file was already compiled,
-        // so no work needed.
-        return nil
-      }
+      // Since this file has been compiled anyway, no need
+      return nil
     case .buildingAfterEachCompilation:
       // No need to do any invalidation; every file will be compiled anyway
       return nil

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -424,7 +424,7 @@ extension ModuleDependencyGraph {
   /// Compute the reason for (non-incrementally) invalidating nodes
   ///
   /// Parameter integrand: The exernal dependency causing the invalidation
-  /// Returns: nil if no invalidation is needed, otherwise the reason.
+  /// - Returns: nil if no invalidation is needed, otherwise the reason.
   private func whyIndiscriminatelyFindNodesInvalidated(by integrand: ExternalIntegrand
   ) -> ExternalDependency.InvalidationReason? {
     switch self.phase {
@@ -443,7 +443,7 @@ extension ModuleDependencyGraph {
 
   /// Try to read and integrate an external dependency.
   ///
-  /// Return: nil if an error occurs, or the set of directly affected nodes.
+  /// - Returns: nil if an error occurs, or the set of directly affected nodes.
   private func integrateIncrementalImport(
     of fed: FingerprintedExternalDependency,
     _ why: ExternalDependency.InvalidationReason

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -113,7 +113,7 @@ extension ModuleDependencyGraph {
   func collectNodesInvalidatedByChangedOrAddedExternals() -> DirectlyInvalidatedNodeSet {
     fingerprintedExternalDependencies.reduce(into: DirectlyInvalidatedNodeSet()) {
       invalidatedNodes, fed in
-      invalidatedNodes.formUnion(self.incrementallyFindNodesInvalidated(
+      invalidatedNodes.formUnion(self.findNodesInvalidated(
         by: ExternalIntegrand(fed, shouldBeIn: self)))
     }
   }
@@ -355,7 +355,11 @@ extension ModuleDependencyGraph {
     // repeatedy for each new `swiftdeps` read so that external
     // fingerprint changes would invalidate matching nodes in the
     // yet-to-be-read swiftdeps.
-    self.info.isCrossModuleIncrementalBuildEnabled && self.phase.isWholeGraphPresent
+    //
+    // If the integrand has no fingerprint, it's academic, cannot integrate it incrementally.
+    self.info.isCrossModuleIncrementalBuildEnabled &&
+    self.phase.isWholeGraphPresent &&
+    integrand.externalDependency.fingerprint != nil
     ?    incrementallyFindNodesInvalidated(by: integrand)
     : indiscriminatelyFindNodesInvalidated(by: integrand)
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -55,6 +55,7 @@ extension DependencySource {
   ) -> SourceFileDependencyGraph? {
     guard let fileToRead = fileToRead(info: info) else {return nil}
     do {
+      info.reporter?.report("Reading deps from \(description)")
       return try SourceFileDependencyGraph.read(from: fileToRead, on: info.fileSystem)
     }
     catch {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -55,7 +55,7 @@ extension DependencySource {
   ) -> SourceFileDependencyGraph? {
     guard let fileToRead = fileToRead(info: info) else {return nil}
     do {
-      info.reporter?.report("Reading deps from \(description)")
+      info.reporter?.report("Reading dependencies from \(description)")
       return try SourceFileDependencyGraph.read(from: fileToRead, on: info.fileSystem)
     }
     catch {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -233,7 +233,8 @@ extension ModuleDependencyGraph.Integrator {
   private mutating func recordInvalidations(
     from externalDependency: FingerprintedExternalDependency
   ) {
-    let invalidated = destination.integrateExternal(.unknown(externalDependency))
+    let integrand = ModuleDependencyGraph.ExternalIntegrand(externalDependency, in: destination)
+    let invalidated = destination.findNodesInvalidated(by: integrand)
     recordUsesOfSomeExternal(invalidated)
   }
 }

--- a/Tests/IncrementalTestFramework/CompiledSourceCollector.swift
+++ b/Tests/IncrementalTestFramework/CompiledSourceCollector.swift
@@ -21,7 +21,6 @@ import TestUtilities
 /// - seealso: Test
 struct CompiledSourceCollector {
   private var collectedCompiledBasenames = [String]()
-  private var collectedReadDependenciesInOrder = [String]()
   private var collectedReadDependencies = Set<String>()
 
   private func getCompiledBasenames(from d: Diagnostic) -> [String] {
@@ -50,7 +49,6 @@ struct CompiledSourceCollector {
   }
 
   private mutating func appendReadDependency(_ dep: String) {
-    collectedReadDependenciesInOrder.append(dep)
     let wasNew = collectedReadDependencies.insert(dep).inserted
     guard wasNew || dep.hasSuffix(FileType.swift.rawValue)
     else {

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -174,7 +174,7 @@ struct MockModuleDependencyGraphCreator {
   }
 
   func mockUpAGraph() -> ModuleDependencyGraph {
-    ModuleDependencyGraph(info, .buildingWithoutAPrior)!
+    ModuleDependencyGraph(info, .buildingFromSwiftDeps)
   }
 }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -825,9 +825,9 @@ extension IncrementalCompilationTests {
           fingerprintChanged(.interface, "main")
           fingerprintChanged(.implementation, "main")
 
-          let affectedInputs = removeInputFromInvocation && !afterRestoringBadPriors
-          ? ["other"]
-          : [removedInput, "other"]
+          let affectedInputs = removeInputFromInvocation
+            ? ["other"]
+            : [removedInput, "other"]
           for input in affectedInputs {
             trace {
               TraceStep(.interface, source: "main")
@@ -836,10 +836,6 @@ extension IncrementalCompilationTests {
                         input == removedInput && afterRestoringBadPriors
                         ? nil : input)
             }
-          }
-          if removeInputFromInvocation && afterRestoringBadPriors {
-            failedToFindSource(removedInput)
-            failedToReadSomeSource(compiling: "main")
           }
           let affectedInputsInBuild = affectedInputs.filter(inputs.contains)
           queuingLater(affectedInputsInBuild)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -1188,7 +1188,7 @@ extension DiagVerifiable {
   // MARK: - dependencies
   @DiagsBuilder func reading(deps inputs: [String]) -> [Diagnostic.Message] {
     for input in inputs {
-      "Incremental compilation: Reading deps from \(input).swift"
+      "Incremental compilation: Reading dependencies from \(input).swift"
     }
   }
   @DiagsBuilder func reading(deps inputs: String...) -> [Diagnostic.Message] {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -525,6 +525,7 @@ extension IncrementalCompilationTests {
       skipping("main")
       readGraph
       findingBatchingCompiling("other")
+      reading(deps: "other")
       schedLinking
       skipped("main")
     }
@@ -551,6 +552,7 @@ extension IncrementalCompilationTests {
       readGraph
       schedulingChangedInitialQueuing("main", "other")
       findingBatchingCompiling("main", "other")
+      reading(deps: "main", "other")
       schedLinking
     }
   }
@@ -579,6 +581,7 @@ extension IncrementalCompilationTests {
       notSchedulingDependentsUnknownChanges("main")
       skipping("other")
       findingBatchingCompiling("main")
+      reading(deps: "main")
       fingerprintChanged(.interface, "main")
       fingerprintChanged(.implementation, "main")
       trace {
@@ -588,6 +591,7 @@ extension IncrementalCompilationTests {
       }
       queuingLaterSchedInvalBatchLink("other")
       findingBatchingCompiling("other")
+      reading(deps: "other")
       schedLinking
     }
   }
@@ -626,6 +630,7 @@ extension IncrementalCompilationTests {
       addingToBatchThenForming("main", "other")
       schedulingPostCompileJobs
       compiling("main", "other")
+      reading(deps: "main", "other")
       linking
     }
   }
@@ -902,6 +907,7 @@ extension IncrementalCompilationTests {
       readGraph
       schedulingChangedInitialQueuing("main", "other")
       findingBatchingCompiling("main", "other")
+      reading(deps: "main", "other")
       schedulingPostCompileJobs
       linking
     }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -955,14 +955,14 @@ extension ModuleDependencyGraph {
   -> [Int]
   {
     phase = .updatingAfterCompilation
-    let directlyIinvalidatedNodes = getInvalidatedNodesForSimulatedLoad(
+    let directlyInvalidatedNodes = getInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex,
       dependencyDescriptions,
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError)
 
-    return collectInputsUsingInvalidated(nodes: directlyIinvalidatedNodes)
+    return collectInputsUsingInvalidated(nodes: directlyInvalidatedNodes)
       .map { $0.mockID }
   }
 
@@ -1006,7 +1006,7 @@ extension ModuleDependencyGraph {
     on fingerprintedExternalDependency: FingerprintedExternalDependency
   ) -> [TypedVirtualPath] {
     var foundSources = [TypedVirtualPath]()
-    for dependent in collectUntracedNodes(from: fingerprintedExternalDependency, .testing) {
+    for dependent in collectUntracedNodes(thatUse: fingerprintedExternalDependency, .testing) {
       let dependencySource = dependent.dependencySource!
       foundSources.append(dependencySource.typedFile)
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive


### PR DESCRIPTION
The status quo reads every `swiftmodule` file for every input file. This PR fixes that. It is trickier than it seems because, when incremental imports are disabled, every time an initial `swiftdeps` file is processed, invalidation must happen for every (changed) `swiftmodule` referenced. So, this fix involves a larger reorganization that it would seem at first blush.

I've tried to include enough comments, etc., so that this code should be understandable.