### PR TITLE
[5.5] Add `.silent` mode to the ToolExecutionDelegate to be used in integrated driver mode

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "llbuild",
+        "package": "swift-llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "release/5.5",

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1074,11 +1074,14 @@ extension Driver {
   mutating func createToolExecutionDelegate() -> ToolExecutionDelegate {
     var mode: ToolExecutionDelegate.Mode = .regular
 
-    // FIXME: Old driver does _something_ if both are passed. Not sure if we want to support that.
+    // FIXME: Old driver does _something_ if both -parseable-output and -v are passed.
+    // Not sure if we want to support that.
     if parsedOptions.contains(.parseableOutput) {
       mode = .parsableOutput
     } else if parsedOptions.contains(.v) {
       mode = .verbose
+    } else if integratedDriver {
+      mode = .silent
     }
 
     return ToolExecutionDelegate(

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -37,6 +37,7 @@ import Glibc
     case verbose
     case parsableOutput
     case regular
+    case silent
   }
 
   public let mode: Mode
@@ -70,7 +71,7 @@ import Glibc
       diagnosticEngine.emit(.remark_job_lifecycle("Starting", job))
     }
     switch mode {
-    case .regular:
+    case .regular, .silent:
       break
     case .verbose:
       stdoutStream <<< arguments.map { $0.spm_shellEscaped() }.joined(separator: " ") <<< "\n"
@@ -100,6 +101,9 @@ import Glibc
     #endif
 
     switch mode {
+    case .silent:
+      break
+
     case .regular, .verbose:
       let output = (try? result.utf8Output() + result.utf8stderrOutput()) ?? ""
       if !output.isEmpty {
@@ -139,7 +143,7 @@ import Glibc
       diagnosticEngine.emit(.remark_job_lifecycle("Skipped", job))
     }
     switch mode {
-    case .regular, .verbose:
+    case .regular, .verbose, .silent:
       break
     case .parsableOutput:
       let skippedMessage = SkippedMessage(inputs: job.displayInputs.map{ $0.file.name })

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -21,7 +21,8 @@ extension Driver {
     args: [String],
     env: [String: String] = ProcessEnv.vars,
     diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
-    fileSystem: FileSystem = localFileSystem
+    fileSystem: FileSystem = localFileSystem,
+    integratedDriver: Bool = true
   ) throws {
     let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
                                        processSet: ProcessSet(),
@@ -31,7 +32,8 @@ extension Driver {
                   env: env,
                   diagnosticsEngine: diagnosticsEngine,
                   fileSystem: fileSystem,
-                  executor: executor)
+                  executor: executor,
+                  integratedDriver: integratedDriver)
   }
 
   /// For tests that need to set the sdk path.


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/752
-----------------------------------------------
When the integrated driver is being used, the individual job output should be tracked by the library client, instead of the driver outputting it into stderr.

Resolves rdar://80520371