### PR TITLE
Alias the Local yams Package to Yams

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -158,7 +158,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
 } else {
     package.dependencies += [
         .package(path: "../swift-tools-support-core"),
-        .package(path: "../yams"),
+        .package(name: "Yams", path: "../yams"),
         .package(path: "../swift-argument-parser"),
     ]
 }


### PR DESCRIPTION
The inverse of #754 when building in Swift-CI because the local package
URL is lowercase...