### PR TITLE
[Incremental] Relax currency test to fix ci errors

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -186,10 +186,6 @@ extension IncrementalCompilationState {
         incrementalOptions: options, buildStartTime: buildStartTime,
         buildEndTime: buildEndTime)
     }
-
-    var buildTimeSpan: ClosedRange<Date> {
-      buildStartTime...buildEndTime
-    }
   }
 }
 
@@ -227,10 +223,10 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
         warning: "Will not do cross-module incremental builds, wrong version of priors; expected \(expected) but read \(read) at '\(dependencyGraphPath)'")
       graphIfPresent = nil
     }
-    catch let ModuleDependencyGraph.ReadError.timeTravellingPriors(priorsDate, timeSpan) {
+    catch let ModuleDependencyGraph.ReadError.timeTravellingPriors(priorsModTime: priorsModTime, buildRecordModTime: buildRecordModTime) {
       diagnosticEngine.emit(
-        warning: "Will not do cross-module incremental builds, priors saved at \(priorsDate), " +
-        "but the previous build happend from \(timeSpan.lowerBound) to \(timeSpan.upperBound), at '\(dependencyGraphPath)'")
+        warning: "Will not do cross-module incremental builds, priors saved at \(priorsModTime)), " +
+        "but the previous build started at \(buildRecordModTime), at '\(dependencyGraphPath)'")
       graphIfPresent = nil
     }
     catch {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -836,7 +836,6 @@ extension IncrementalCompilationTests {
       else {
         let firstWave = haveGraph ? changedInputs : inputs
         let omittedFromFirstWave = haveGraph ? unchangedInputs : []
-        let forcedInFirstWave = haveGraph ? [] : inputs
         schedulingChanged(changedInputs)
         maySkip(unchangedInputs)
         queuingInitial(firstWave)


### PR DESCRIPTION
Some lit tests are failing on CI, but they won't fail locally. Based on the output, I suspect the priors currency test is failing and it shouldn't. So let's try relaxing the test: using the build-record mod time instead of the build-start time, and don't do the build end time test, since the build record had better be from the previous run anyway.