### PR TITLE
Specify -clang-target only when explicit module is on

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -68,8 +68,10 @@ extension Driver {
 
     // Pass down -clang-target.
     // If not specified otherwise, we should use the same triple as -target
+    // TODO: enable -clang-target for implicit module build as well.
     if !parsedOptions.hasArgument(.disableClangTarget) &&
-        isFrontendArgSupported(.clangTarget) {
+        isFrontendArgSupported(.clangTarget) &&
+        parsedOptions.contains(.driverExplicitModuleBuild) {
       let clangTriple = parsedOptions.getLastArgument(.clangTarget)?.asSingle ?? targetTriple.triple
       commandLine.appendFlag(.clangTarget)
       commandLine.appendFlag(clangTriple)


### PR DESCRIPTION
We should turn clang target on for implicit module after we are confident that the feature works nicely in explicit module builds.