### PR TITLE
[Dependency Scanning] Restore passing external target map as inputs to the scanning action.

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -52,10 +52,36 @@ public extension Driver {
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
+    // Pass in external target dependencies to be treated as placeholder dependencies by the scanner
+    if let externalTargetPaths = externalTargetModulePathMap {
+      let dependencyPlaceholderMapFile =
+      try serializeExternalDependencyArtifacts(externalTargetPaths: externalTargetPaths)
+      commandLine.appendFlag("-placeholder-dependency-module-map-file")
+      commandLine.appendPath(dependencyPlaceholderMapFile)
+    }
+
     // Pass on the input files
     commandLine.append(contentsOf: inputFiles.map { .path($0.file) })
     return (inputs, commandLine)
   }
+
+  /// Serialize a map of placeholder (external) dependencies for the dependency scanner.
+   private func serializeExternalDependencyArtifacts(externalTargetPaths: ExternalTargetModulePathMap)
+   throws -> VirtualPath {
+     var placeholderArtifacts: [SwiftModuleArtifactInfo] = []
+     // Explicit external targets
+     for (moduleId, binaryModulePath) in externalTargetPaths {
+       let modPath = TextualVirtualPath(path: VirtualPath.absolute(binaryModulePath).intern())
+       placeholderArtifacts.append(
+           SwiftModuleArtifactInfo(name: moduleId.moduleName,
+                                   modulePath: modPath))
+     }
+     let encoder = JSONEncoder()
+     encoder.outputFormatting = [.prettyPrinted]
+     let contents = try encoder.encode(placeholderArtifacts)
+     return VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("\(moduleOutputInfo.name)-external-modules.json"),
+                                                                   contents)
+   }
 
   /// Returns false if the lib is available and ready to use
   private func initSwiftScanLib() throws -> Bool {


### PR DESCRIPTION
I got overzealous when deleting code in https://github.com/apple/swift-driver/pull/749 and removed one piece of functionality that we still rely on.
Although the external target map is no longer necessary when scanning dependencies using libSwiftScan, we still use it for resolution of `canImport` statements during the scan.
We need to figure out a better way to deal with `canImport` statements in the scanner, but in the meantime this will restore functionality.