### PR TITLE
Fix swiftpm warnings about CMakeLists.txt files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,12 +49,14 @@ let package = Package(
     .target(
       name: "SwiftDriver",
       dependencies: ["SwiftOptions", "SwiftToolsSupport-auto",
-                     "CSwiftScan", "Yams"]),
+                     "CSwiftScan", "Yams"],
+      exclude: ["CMakeLists.txt"]),
 
     /// The execution library.
     .target(
       name: "SwiftDriverExecution",
-      dependencies: ["SwiftDriver", "SwiftToolsSupport-auto"]),
+      dependencies: ["SwiftDriver", "SwiftToolsSupport-auto"],
+      exclude: ["CMakeLists.txt"]),
 
     /// Driver tests.
     .testTarget(
@@ -83,7 +85,8 @@ let package = Package(
     /// The options library.
     .target(
       name: "SwiftOptions",
-      dependencies: ["SwiftToolsSupport-auto"]),
+      dependencies: ["SwiftToolsSupport-auto"],
+      exclude: ["CMakeLists.txt"]),
     .testTarget(
       name: "SwiftOptionsTests",
       dependencies: ["SwiftOptions"]),
@@ -91,17 +94,20 @@ let package = Package(
     /// The primary driver executable.
     .target(
       name: "swift-driver",
-      dependencies: ["SwiftDriverExecution", "SwiftDriver"]),
+      dependencies: ["SwiftDriverExecution", "SwiftDriver"],
+      exclude: ["CMakeLists.txt"]),
 
     /// The help executable.
     .target(
       name: "swift-help",
-      dependencies: ["SwiftOptions", "ArgumentParser", "SwiftToolsSupport-auto"]),
+      dependencies: ["SwiftOptions", "ArgumentParser", "SwiftToolsSupport-auto"],
+      exclude: ["CMakeLists.txt"]),
 
     /// The help executable.
     .target(
       name: "swift-build-sdk-interfaces",
-      dependencies: ["SwiftDriver", "SwiftDriverExecution"]),
+      dependencies: ["SwiftDriver", "SwiftDriverExecution"],
+      exclude: ["CMakeLists.txt"]),
 
     /// The `makeOptions` utility (for importing option definitions).
     .target(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -54,7 +54,8 @@ let package = Package(
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         "CSwiftScan",
         .product(name: "Yams", package: "Yams"),
-      ]),
+      ],
+      exclude: ["CMakeLists.txt"]),
 
     /// The execution library.
     .target(
@@ -62,7 +63,8 @@ let package = Package(
       dependencies: [
         "SwiftDriver",
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
-      ]),
+      ],
+      exclude: ["CMakeLists.txt"]),
 
     /// Driver tests.
     .testTarget(
@@ -97,7 +99,8 @@ let package = Package(
       name: "SwiftOptions",
       dependencies: [
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ]),
+      ],
+      exclude: ["CMakeLists.txt"]),
     .testTarget(
       name: "SwiftOptionsTests",
       dependencies: ["SwiftOptions"]),
@@ -105,7 +108,8 @@ let package = Package(
     /// The primary driver executable.
     .executableTarget(
       name: "swift-driver",
-      dependencies: ["SwiftDriverExecution", "SwiftDriver"]),
+      dependencies: ["SwiftDriverExecution", "SwiftDriver"],
+      exclude: ["CMakeLists.txt"]),
 
     /// The help executable.
     .executableTarget(
@@ -114,12 +118,14 @@ let package = Package(
         "SwiftOptions",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ]),
+      ],
+      exclude: ["CMakeLists.txt"]),
 
     /// The help executable.
     .executableTarget(
       name: "swift-build-sdk-interfaces",
-      dependencies: ["SwiftDriver", "SwiftDriverExecution"]),
+      dependencies: ["SwiftDriver", "SwiftDriverExecution"],
+      exclude: ["CMakeLists.txt"]),
 
     /// The `makeOptions` utility (for importing option definitions).
     .executableTarget(


### PR DESCRIPTION
Exclude the CMakeLists.txt files explicitly so that swiftpm does not issue warnings about them.

I still see a warning about `Sources/SwiftDriver/SwiftDriver.docc`, but I wasn't sure if it's correct to exclude it or if that might interfere with using it from Xcode or not.