### PR TITLE
Propagate `-warn-concurrency` to frontend invocations.

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -200,6 +200,7 @@ extension Driver {
     try commandLine.appendAll(.debugPrefixMap, from: &parsedOptions)
     try commandLine.appendAllArguments(.Xfrontend, from: &parsedOptions)
     try commandLine.appendAll(.coveragePrefixMap, from: &parsedOptions)
+    try commandLine.appendLast(.warnConcurrency, from: &parsedOptions)
 
     // Pass down -user-module-version if we are working with a compiler that
     // supports it.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4792,6 +4792,15 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testWarnConcurrency() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-warn-concurrency", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertTrue(job.commandLine.contains(.flag("-warn-concurrency")))
+    }
+  }
+
   func testRelativeResourceDir() throws {
     do {
       var driver = try Driver(args: ["swiftc",


### PR DESCRIPTION
Matching behavior of this flag in the legacy driver.

Resolves rdar://80925867