### PR TITLE
[5.5] Propagate `-warn-concurrency` to frontend invocations.

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -199,6 +199,7 @@ extension Driver {
     try commandLine.appendAll(.debugPrefixMap, from: &parsedOptions)
     try commandLine.appendAllArguments(.Xfrontend, from: &parsedOptions)
     try commandLine.appendAll(.coveragePrefixMap, from: &parsedOptions)
+    try commandLine.appendLast(.warnConcurrency, from: &parsedOptions)
 
     if let workingDirectory = workingDirectory {
       // Add -Xcc -working-directory before any other -Xcc options to ensure it is

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4661,6 +4661,15 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testWarnConcurrency() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-warn-concurrency", "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertTrue(job.commandLine.contains(.flag("-warn-concurrency")))
+    }
+  }
+
   func testRelativeResourceDir() throws {
     do {
       var driver = try Driver(args: ["swiftc",


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/770
------------------------------------
Resolves rdar://80925867