### PR TITLE
Add help intro

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(SwiftDriver
   Jobs/Planning.swift
   Jobs/PrintTargetInfoJob.swift
   Jobs/ReplJob.swift
+  Jobs/SwiftHelpIntroJob.swift
   Jobs/Toolchain+InterpreterSupport.swift
   Jobs/Toolchain+LinkerSupport.swift
   Jobs/VerifyDebugInfoJob.swift

--- a/Sources/SwiftDriver/Driver/CompilerMode.swift
+++ b/Sources/SwiftDriver/Driver/CompilerMode.swift
@@ -32,6 +32,9 @@
 
   /// Dump information about a precompiled Clang module
   case dumpPCM
+
+  /// Introduce the user to Swift concepts depending on context.
+  case intro
 }
 
 /// Information about batch mode, which is used to determine how to form
@@ -46,7 +49,7 @@ extension CompilerMode {
   /// Whether this compilation mode uses -primary-file to specify its inputs.
   public var usesPrimaryFileInputs: Bool {
     switch self {
-    case .immediate, .repl, .singleCompile, .compilePCM, .dumpPCM:
+    case .immediate, .repl, .singleCompile, .compilePCM, .dumpPCM, .intro:
       return false
 
     case .standardCompile, .batchCompile:
@@ -57,7 +60,7 @@ extension CompilerMode {
   /// Whether this compilation mode compiles the whole target in one job.
   public var isSingleCompilation: Bool {
     switch self {
-    case .immediate, .repl, .standardCompile, .batchCompile:
+    case .immediate, .repl, .standardCompile, .batchCompile, .intro:
       return false
 
     case .singleCompile, .compilePCM, .dumpPCM:
@@ -67,7 +70,7 @@ extension CompilerMode {
 
   public var isStandardCompilationForPlanning: Bool {
     switch self {
-      case .immediate, .repl, .compilePCM, .dumpPCM:
+    case .immediate, .repl, .compilePCM, .dumpPCM, .intro:
         return false
       case .batchCompile, .standardCompile, .singleCompile:
         return true
@@ -93,7 +96,7 @@ extension CompilerMode {
     switch self {
     case .batchCompile, .singleCompile, .standardCompile, .compilePCM, .dumpPCM:
       return true
-    case .immediate, .repl:
+    case .immediate, .repl, .intro:
       return false
     }
   }
@@ -116,6 +119,8 @@ extension CompilerMode: CustomStringConvertible {
         return "compile Clang module (.pcm)"
       case .dumpPCM:
         return "dump Clang module (.pcm)"
+      case .intro:
+        return "introduction to Swift and packages"
       }
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -101,7 +101,7 @@ fileprivate extension CompilerMode {
   var supportsIncrementalCompilation: Bool {
     switch self {
     case .standardCompile, .immediate, .repl, .batchCompile: return true
-    case .singleCompile, .compilePCM, .dumpPCM: return false
+    case .singleCompile, .compilePCM, .dumpPCM, .intro: return false
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -64,6 +64,8 @@ extension Driver {
         commandLine.appendFlag(.target)
         commandLine.appendFlag(targetTriple.triple)
       }
+    case .intro:
+      break
     }
 
     // Pass down -clang-target.
@@ -270,7 +272,7 @@ extension Driver {
     }
 
     // Repl Jobs shouldn't include -module-name.
-    if compilerMode != .repl {
+    if compilerMode != .repl && compilerMode != .intro {
       commandLine.appendFlags("-module-name", moduleOutputInfo.name)
     }
 

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -699,7 +699,7 @@ extension Driver {
     }
 
     // The REPL doesn't require input files, but all other modes do.
-    guard !inputFiles.isEmpty || compilerMode == .repl else {
+    guard !inputFiles.isEmpty || compilerMode == .repl || compilerMode == .intro else {
       if parsedOptions.hasArgument(.v) {
         // `swiftc -v` is allowed and prints version information.
         return ([], nil)
@@ -735,6 +735,20 @@ extension Driver {
         throw PlanningError.dumpPCMWrongInputFiles
       }
       return ([try generateDumpPCMJob(input: inputFiles.first!)], nil)
+    case .intro:
+      // TODO: Remove this check once the REPL no longer launches
+      // by default.
+      if !inputFiles.isEmpty {
+        throw PlanningError.replReceivedInput
+      }
+      // end TODO.
+
+      var introJobs = try helpIntroJobs()
+
+      // TODO: Remove this to stop launching the REPL by default.
+      introJobs.append(try replJob())
+
+      return (introJobs, nil)
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/SwiftHelpIntroJob.swift
+++ b/Sources/SwiftDriver/Jobs/SwiftHelpIntroJob.swift
@@ -1,0 +1,38 @@
+//===--------------- SwiftHelpIntroJob.swift - Swift REPL -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import SwiftOptions
+
+extension Driver {
+  mutating func helpIntroJobs() throws -> [Job] {
+    return [
+      Job(
+        moduleName: moduleOutputInfo.name,
+        kind: .versionRequest,
+        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
+        commandLine: [.flag("--version")],
+        inputs: [],
+        primaryInputs: [],
+        outputs: [],
+        requiresInPlaceExecution: false),
+      Job(
+        moduleName: moduleOutputInfo.name,
+        kind: .help,
+        tool: .absolute(try toolchain.getToolPath(.swiftHelp)),
+        commandLine: [.flag("intro")],
+        inputs: [],
+        primaryInputs: [],
+        outputs: [],
+        requiresInPlaceExecution: false
+      ),
+    ]
+  }
+}


### PR DESCRIPTION
> Note: This PR is for a pitch discussion and building a test toolchain. Please don't merge this – thanks!

Add an "intro" topic to swift-help, printing the version, welcome message, and
available subcommands.

When running `swift` by itself, show the intro before entering the REPL.

When running `swift-help` directly or via `swift --help`, show all of the
available flags as previously.

rdar://78280423

More context: https://forums.swift.org/t/command-line-ux-enhancements-for-swift/50670