### PR TITLE
Jobs: do not inject the swiftautolink file into archives

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -294,7 +294,8 @@ extension GenericUnixToolchain {
       commandLine.appendFlag("crs")
       commandLine.appendPath(outputFile)
 
-      commandLine.append(contentsOf: inputs.map { .path($0.file) })
+      commandLine.append(contentsOf: inputs.filter { $0.type == .object }
+                                           .map { .path($0.file) })
       return try getToolPath(.staticLinker(lto))
     }
 


### PR DESCRIPTION
It has been observed that a static library may sometimes contain the
autolink extracted rules.  This causes autolink-extract to not be able
to process the archive as a dependency, causing a build failure.