### PR TITLE
SR-14796: Don't lose '-sdk /' when dropping the trailing slash

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2100,7 +2100,7 @@ extension Driver {
     }
 
     // Delete trailing /.
-    sdkPath = sdkPath.map { $0.last == "/" ? String($0.dropLast()) : $0 }
+    sdkPath = sdkPath.map { $0.count > 1 && $0.last == "/" ? String($0.dropLast()) : $0 }
 
     // Validate the SDK if we found one.
     if let sdkPath = sdkPath {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3442,6 +3442,10 @@ final class SwiftDriverTests: XCTestCase {
   func testRegressions() throws {
     var driverWithEmptySDK = try Driver(args: ["swiftc", "-sdk", "", "file.swift"])
     _ = try driverWithEmptySDK.planBuild()
+
+    var driver = try Driver(args: ["swiftc", "foo.swift", "-sdk", "/"])
+    let plannedJobs = try driver.planBuild()
+    XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/")))]))
   }
 
   func testDumpASTOverride() throws {


### PR DESCRIPTION
This is a regression from [the C++ Driver](https://github.com/apple/swift/blob/35735e7d0c57b57953623eb069d3812cd95d25e6/lib/Driver/Driver.cpp#L1776), ~will add a test later today and this should be~ ready to go.