### PR TITLE
[Explicit Module Builds] Add API to specify richer external target module details

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
       name: "SwiftDriver",
       dependencies: ["SwiftOptions", "SwiftToolsSupport-auto",
                      "CSwiftScan", "Yams"],
-      exclude: ["CMakeLists.txt"]),
+      exclude: ["CMakeLists.txt", SwiftDriver.docc]),
 
     /// The execution library.
     .target(

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -23,6 +23,7 @@ public struct Driver {
     case invalidArgumentValue(String, String)
     case relativeFrontendPath(String)
     case subcommandPassedToDriver
+    case externalTargetDetailsAPIError
     case integratedReplRemoved
     case cannotSpecify_OForMultipleOutputs
     case conflictingOptions(Option, Option)
@@ -59,6 +60,8 @@ public struct Driver {
         return "relative frontend path: \(path)"
       case .subcommandPassedToDriver:
         return "subcommand passed to driver"
+      case .externalTargetDetailsAPIError:
+        return "Cannot specify both: externalTargetModulePathMap and externalTargetModuleDetailsMap"
       case .integratedReplRemoved:
         return "Compiler-internal integrated REPL has been removed; use the LLDB-enhanced REPL instead."
       case .cannotSpecify_OForMultipleOutputs:
@@ -319,7 +322,7 @@ public struct Driver {
 
   /// A dictionary of external targets that are a part of the same build, mapping to filesystem paths
   /// of their module files
-  @_spi(Testing) public var externalTargetModulePathMap: ExternalTargetModulePathMap? = nil
+  @_spi(Testing) public var externalTargetModuleDetailsMap: ExternalTargetModuleDetailsMap? = nil
 
   /// A collection of all the flags the selected toolchain's `swift-frontend` supports
   public let supportedFrontendFlags: Set<String>
@@ -400,8 +403,11 @@ public struct Driver {
   ///   an executable or as a library.
   /// - Parameter compilerExecutableDir: Directory that contains the compiler executable to be used.
   ///   Used when in `integratedDriver` mode as a substitute for the driver knowing its executable path.
-  /// - Parameter externalTargetModulePathMap: A dictionary of external targets that are a part of
-  ///   the same build, mapping to filesystem paths of their module files.
+  /// - Parameter externalTargetModulePathMap: DEPRECATED: A dictionary of external targets
+  ///   that are a part of the same build, mapping to filesystem paths of their module files.
+  /// - Parameter externalTargetModuleDetailsMap: A dictionary of external targets that are a part of
+  ///   the same build, mapping to a details value which includes a filesystem path of their
+  ///   `.swiftmodule` and a flag indicating whether the external target is a framework.
   /// - Parameter interModuleDependencyOracle: An oracle for querying inter-module dependencies,
   ///   shared across different module builds by a build system.
   public init(
@@ -412,7 +418,9 @@ public struct Driver {
     executor: DriverExecutor,
     integratedDriver: Bool = true,
     compilerExecutableDir: AbsolutePath? = nil,
+    // Deprecated in favour of the below `externalTargetModuleDetailsMap`
     externalTargetModulePathMap: ExternalTargetModulePathMap? = nil,
+    externalTargetModuleDetailsMap: ExternalTargetModuleDetailsMap? = nil,
     interModuleDependencyOracle: InterModuleDependencyOracle? = nil
   ) throws {
     self.env = env
@@ -422,8 +430,15 @@ public struct Driver {
     self.diagnosticEngine = diagnosticsEngine
     self.executor = executor
 
+    if externalTargetModulePathMap != nil && externalTargetModuleDetailsMap != nil {
+      throw Error.externalTargetDetailsAPIError
+    }
     if let externalTargetPaths = externalTargetModulePathMap {
-      self.externalTargetModulePathMap = externalTargetPaths
+      self.externalTargetModuleDetailsMap = externalTargetPaths.mapValues {
+        ExternalTargetModuleDetails(path: $0, isFramework: false)
+      }
+    } else if let externalTargetDetails = externalTargetModuleDetailsMap {
+      self.externalTargetModuleDetailsMap = externalTargetDetails
     }
 
     if case .subcommand = try Self.invocationRunMode(forArgs: args).mode {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -15,9 +15,10 @@ import TSCBasic
   /// For targets that are built alongside the driver's current module, the scanning action will report them as
   /// textual targets to be built from source. Because we can rely on these targets to have been built prior
   /// to the driver's current target, we resolve such external targets as prebuilt binary modules, in the graph.
-  mutating func resolveExternalDependencies(for externalTargetModulePathMap: ExternalTargetModulePathMap)
+  mutating func resolveExternalDependencies(for externalTargetModuleDetailsMap: ExternalTargetModuleDetailsMap)
   throws {
-    for (externalModuleId, externalModulePath) in externalTargetModulePathMap {
+    for (externalModuleId, externalModuleDetails) in externalTargetModuleDetailsMap {
+      let externalModulePath = externalModuleDetails.path
       // Replace the occurence of a Swift module to-be-built from source-file
       // to an info that describes a pre-built binary module.
       let swiftModuleId: ModuleDependencyId = .swift(externalModuleId.moduleName)
@@ -32,12 +33,12 @@ import TSCBasic
       let newModuleId: ModuleDependencyId = .swiftPrebuiltExternal(externalModuleId.moduleName)
       let newExternalModuleDetails =
       try SwiftPrebuiltExternalModuleDetails(compiledModulePath:
-                                              TextualVirtualPath(path: VirtualPath.absolute(externalModulePath).intern()))
+                                              TextualVirtualPath(path: VirtualPath.absolute(externalModulePath).intern()),
+                                             isFramework: externalModuleDetails.isFramework)
       let newInfo = ModuleInfo(modulePath: TextualVirtualPath(path: VirtualPath.absolute(externalModulePath).intern()),
                                sourceFiles: [],
                                directDependencies: currentInfo.directDependencies,
                                details: .swiftPrebuiltExternal(newExternalModuleDetails))
-
       Self.replaceModule(originalId: swiftModuleId, replacementId: newModuleId,
                          replacementInfo: newInfo, in: &modules)
     }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -132,12 +132,17 @@ public struct SwiftPrebuiltExternalModuleDetails: Codable {
   /// The path to the .swiftSourceInfo file.
   public var moduleSourceInfoPath: TextualVirtualPath?
 
+  /// A flag to indicate whether or not this module is a framework.
+  public var isFramework: Bool
+
   public init(compiledModulePath: TextualVirtualPath,
               moduleDocPath: TextualVirtualPath? = nil,
-              moduleSourceInfoPath: TextualVirtualPath? = nil) throws {
+              moduleSourceInfoPath: TextualVirtualPath? = nil,
+              isFramework: Bool = false) throws {
     self.compiledModulePath = compiledModulePath
     self.moduleDocPath = moduleDocPath
     self.moduleSourceInfoPath = moduleSourceInfoPath
+    self.isFramework = isFramework
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -532,9 +532,9 @@ extension Driver {
   throws -> InterModuleDependencyGraph {
     var dependencyGraph = try performDependencyScan()
 
-    if let externalTargetPaths = externalTargetModulePathMap {
+    if let externalTargetDetails = externalTargetModuleDetailsMap {
       // Resolve external dependencies in the dependency graph, if any.
-      try dependencyGraph.resolveExternalDependencies(for: externalTargetPaths)
+      try dependencyGraph.resolveExternalDependencies(for: externalTargetDetails)
     }
 
     // Re-scan Clang modules at all the targets they will be built against.

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -396,6 +396,82 @@ enum ModuleDependenciesInputs {
     """
   }
 
+  static var simpleDependencyGraphInput: String {
+    """
+    {
+      "mainModuleName": "main",
+      "modules": [
+        {
+          "swift": "main"
+        },
+        {
+          "modulePath": "main.swiftmodule",
+          "sourceFiles": [
+            "/main/main.swift"
+          ],
+          "directDependencies": [
+            {
+              "swift": "B"
+            },
+          ],
+          "details": {
+            "swift": {
+              "isFramework": false,
+              "extraPcmArgs": [
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ]
+            }
+          }
+        },
+        {
+          "swift" : "B"
+        },
+        {
+          "modulePath" : "B.swiftmodule",
+          "sourceFiles": [
+          ],
+          "directDependencies" : [
+            {
+              "swift": "A"
+            },
+          ],
+          "details" : {
+            "swift" : {
+              "moduleInterfacePath": "B.swiftmodule/B.swiftinterface",
+              "isFramework": false,
+              "extraPcmArgs": [
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ],
+            }
+          }
+        },
+        {
+          "swift": "A"
+        },
+        {
+          "modulePath": "/tmp/A.swiftmodule",
+          "sourceFiles": [
+            "/A/A.swift"
+          ],
+          "directDependencies" : [
+          ],
+          "details": {
+            "swift": {
+              "isFramework": false,
+              "extraPcmArgs": [
+                "-Xcc",
+                "-fapinotes-swift-version=5"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """
+  }
+
   static var mergeGraphInput2: String {
     """
     {


### PR DESCRIPTION
Specifically, whether an external target moduel is a framework. This is required to pass this information down to the compiler in order to generate correct auto-linking directives.

Part of rdar://81177797