### PR TITLE
swift-driver package fails to compile due to missing quotes around string

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
       name: "SwiftDriver",
       dependencies: ["SwiftOptions", "SwiftToolsSupport-auto",
                      "CSwiftScan", "Yams"],
-      exclude: ["CMakeLists.txt", SwiftDriver.docc]),
+      exclude: ["CMakeLists.txt", "SwiftDriver.docc"]),
 
     /// The execution library.
     .target(


### PR DESCRIPTION
Fix build breakage introduced in #779 

rdar://81367644