### PR TITLE
Disable `testCleanBuildSwiftDepsPerformance` on non-macOS hosts to investigate failure.

### DIFF
--- a/Tests/SwiftDriverTests/CleanBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/CleanBuildPerformanceTests.swift
@@ -20,6 +20,11 @@ class CleanBuildPerformanceTests: XCTestCase {
   /// `cd` to the package directory, then:
   /// `rm TestInputs/SampleSwiftDeps/*; rm -rf .build; swift build; find .build -name \*.swiftdeps -a -exec cp \{\} TestInputs/SampleSwiftDeps \;`
   func testCleanBuildSwiftDepsPerformance() throws {
+    #if !os(macOS)
+      // rdar://81411914
+      throw XCTSkip()
+    #endif
+
     let packageRootPath = AbsolutePath(#file)
       .parentDirectory
       .parentDirectory


### PR DESCRIPTION
This test is failing on Linux, e.g.:
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04-long-test/8571/

rdar://81411914