### PR TITLE
[NFC] Box up consumed options.

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
@@ -25,7 +25,7 @@ internal extension Driver {
   // the dependency scanner. We must ensure to re-scan Clang modules at all targets at which
   // they will be compiled and record a super-set of the module's dependencies at all targets.
   /// For each clang module, compute its dependencies at all targets at which it will be compiled.
-  mutating func resolveVersionedClangDependencies(dependencyGraph: inout InterModuleDependencyGraph)
+  func resolveVersionedClangDependencies(dependencyGraph: inout InterModuleDependencyGraph)
   throws {
     // Traverse the dependency graph, collecting extraPCMArgs along each path
     // to all Clang modules, and compute a set of distinct PCMArgs across all paths to a

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -23,7 +23,7 @@ public extension Driver {
   /// Precompute the dependencies for a given Swift compilation, producing a
   /// dependency graph including all Swift and C module files and
   /// source files.
-  mutating private func dependencyScanningJob() throws -> Job {
+  private func dependencyScanningJob() throws -> Job {
     let (inputs, commandLine) = try dependencyScannerInvocationCommand()
 
     // Construct the scanning job.
@@ -40,7 +40,7 @@ public extension Driver {
 
   /// Generate a full command-line invocation to be used for the dependency scanning action
   /// on the target module.
-  mutating private func dependencyScannerInvocationCommand()
+  private func dependencyScannerInvocationCommand()
   throws -> ([TypedVirtualPath],[Job.ArgTemplate]) {
     // Aggregate the fast dependency scanner arguments
     var inputs: [TypedVirtualPath] = []
@@ -90,7 +90,7 @@ public extension Driver {
     }
   }
 
-  mutating func performImportPrescan() throws -> InterModuleDependencyImports {
+  func performImportPrescan() throws -> InterModuleDependencyImports {
     let preScanJob = try importPreScanningJob()
     let forceResponseFiles = parsedOptions.hasArgument(.driverForceResponseFiles)
     let imports: InterModuleDependencyImports
@@ -118,7 +118,7 @@ public extension Driver {
     return imports
   }
 
-  mutating internal func performDependencyScan() throws -> InterModuleDependencyGraph {
+  internal func performDependencyScan() throws -> InterModuleDependencyGraph {
     let scannerJob = try dependencyScanningJob()
     let forceResponseFiles = parsedOptions.hasArgument(.driverForceResponseFiles)
     let dependencyGraph: InterModuleDependencyGraph
@@ -145,7 +145,7 @@ public extension Driver {
     return dependencyGraph
   }
 
-  mutating internal func performBatchDependencyScan(moduleInfos: [BatchScanModuleInfo])
+  internal func performBatchDependencyScan(moduleInfos: [BatchScanModuleInfo])
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     let batchScanningJob = try batchDependencyScanningJob(for: moduleInfos)
     let forceResponseFiles = parsedOptions.hasArgument(.driverForceResponseFiles)
@@ -215,7 +215,7 @@ public extension Driver {
   }
 
   /// Precompute the set of module names as imported by the current module
-  mutating private func importPreScanningJob() throws -> Job {
+  private func importPreScanningJob() throws -> Job {
     // Aggregate the fast dependency scanner arguments
     var inputs: [TypedVirtualPath] = []
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
@@ -243,7 +243,7 @@ public extension Driver {
   }
 
   /// Precompute the dependencies for a given collection of modules using swift frontend's batch scanning mode
-  mutating private func batchDependencyScanningJob(for moduleInfos: [BatchScanModuleInfo]) throws -> Job {
+  private func batchDependencyScanningJob(for moduleInfos: [BatchScanModuleInfo]) throws -> Job {
     var inputs: [TypedVirtualPath] = []
 
     // Aggregate the fast dependency scanner arguments

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -50,9 +50,9 @@ extension IncrementalCompilationState {
       self.reporter = reporter
     }
 
-    public func compute(batchJobFormer: inout Driver) throws -> FirstWave {
+    public func compute(batchJobFormer: Driver) throws -> FirstWave {
       let (skippedCompileGroups, mandatoryJobsInOrder) =
-        try computeInputsAndGroups(batchJobFormer: &batchJobFormer)
+        try computeInputsAndGroups(batchJobFormer: batchJobFormer)
       return FirstWave(
         skippedCompileGroups: skippedCompileGroups,
         mandatoryJobsInOrder: mandatoryJobsInOrder)
@@ -64,7 +64,7 @@ extension IncrementalCompilationState {
 extension IncrementalCompilationState.FirstWaveComputer {
   /// At this stage the graph will have all external dependencies found in the swiftDeps or in the priors
   /// listed in fingerprintExternalDependencies.
-  private func computeInputsAndGroups(batchJobFormer: inout Driver)
+  private func computeInputsAndGroups(batchJobFormer: Driver)
   throws -> (skippedCompileGroups: [TypedVirtualPath: CompileJobGroup],
              mandatoryJobsInOrder: [Job])
   {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -61,7 +61,7 @@ public final class IncrementalCompilationState {
   ///
   /// After initialization, mutating accesses to the driver must be protected by
   /// the confinement queue.
-  private var driver: Driver
+  private let driver: Driver
 
   /// Keyed by primary input. As required compilations are discovered after the first wave, these shrink.
   ///
@@ -72,7 +72,7 @@ public final class IncrementalCompilationState {
   // MARK: - Creating IncrementalCompilationState
   /// Return nil if not compiling incrementally
   internal init(
-    driver: inout Driver,
+    driver: Driver,
     jobsInPhases: JobsInPhases,
     initialState: InitialStateForPlanning
   ) throws {
@@ -92,7 +92,7 @@ public final class IncrementalCompilationState {
 
     let firstWave =
       try FirstWaveComputer(initialState: initialState, jobsInPhases: jobsInPhases,
-                            driver: driver, reporter: reporter).compute(batchJobFormer: &driver)
+                            driver: driver, reporter: reporter).compute(batchJobFormer: driver)
 
     self.skippedCompileGroups = firstWave.skippedCompileGroups
     self.mandatoryJobsInOrder = firstWave.mandatoryJobsInOrder
@@ -153,7 +153,7 @@ extension IncrementalCompilationState {
 extension Driver {
   /// Check various arguments to rule out incremental compilation if need be.
   static func shouldAttemptIncrementalCompilation(
-    _ parsedOptions: inout ParsedOptions,
+    _ parsedOptions: ParsedOptions,
     diagnosticEngine: DiagnosticsEngine,
     compilerMode: CompilerMode
   ) -> Bool {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -15,12 +15,12 @@ import TSCBasic
 
 // Initial incremental state computation
 extension IncrementalCompilationState {
-  static func computeIncrementalStateForPlanning(driver: inout Driver)
+  static func computeIncrementalStateForPlanning(driver: Driver)
     throws -> IncrementalCompilationState.InitialStateForPlanning?
   {
     guard driver.shouldAttemptIncrementalCompilation else { return nil }
 
-    let options = computeIncrementalOptions(driver: &driver)
+    let options = computeIncrementalOptions(driver: driver)
 
     guard let outputFileMap = driver.outputFileMap else {
       driver.diagnosticEngine.emit(.warning_incremental_requires_output_file_map)
@@ -67,7 +67,7 @@ extension IncrementalCompilationState {
   }
 
   // Extract options relevant to incremental builds
-  static func computeIncrementalOptions(driver: inout Driver) -> IncrementalCompilationState.Options {
+  static func computeIncrementalOptions(driver: Driver) -> IncrementalCompilationState.Options {
     var options: IncrementalCompilationState.Options = []
     if driver.parsedOptions.contains(.driverAlwaysRebuildDependents) {
       options.formUnion(.alwaysRebuildDependents)

--- a/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
+++ b/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
@@ -44,7 +44,7 @@ enum DigesterMode: String {
 }
 
 extension Driver {
-  mutating func digesterBaselineGenerationJob(modulePath: VirtualPath.Handle, outputPath: VirtualPath.Handle, mode: DigesterMode) throws -> Job {
+  func digesterBaselineGenerationJob(modulePath: VirtualPath.Handle, outputPath: VirtualPath.Handle, mode: DigesterMode) throws -> Job {
     var commandLine = [Job.ArgTemplate]()
     commandLine.appendFlag("-dump-sdk")
 
@@ -65,7 +65,7 @@ extension Driver {
     )
   }
 
-  mutating func digesterCompareToBaselineJob(modulePath: VirtualPath.Handle, baselinePath: VirtualPath.Handle, mode: DigesterMode) throws -> Job {
+  func digesterCompareToBaselineJob(modulePath: VirtualPath.Handle, baselinePath: VirtualPath.Handle, mode: DigesterMode) throws -> Job {
     var commandLine = [Job.ArgTemplate]()
     commandLine.appendFlag("-diagnose-sdk")
     commandLine.appendFlag("-disable-fail-on-error")
@@ -106,9 +106,9 @@ extension Driver {
     )
   }
 
-  private mutating func addCommonDigesterOptions(_ commandLine: inout [Job.ArgTemplate],
-                                                 modulePath: VirtualPath.Handle,
-                                                 mode: DigesterMode) throws {
+  private func addCommonDigesterOptions(_ commandLine: inout [Job.ArgTemplate],
+                                        modulePath: VirtualPath.Handle,
+                                        mode: DigesterMode) throws {
     commandLine.appendFlag("-module")
     commandLine.appendFlag(moduleOutputInfo.name)
     if mode == .abi {
@@ -140,13 +140,13 @@ extension Driver {
     commandLine.appendFlag(.resourceDir)
     commandLine.appendPath(VirtualPath.lookup(frontendTargetInfo.runtimeResourcePath.path))
 
-    try commandLine.appendAll(.I, from: &parsedOptions)
-    try commandLine.appendAll(.F, from: &parsedOptions)
+    try commandLine.appendAll(.I, from: parsedOptions)
+    try commandLine.appendAll(.F, from: parsedOptions)
     for systemFramework in parsedOptions.arguments(for: .Fsystem) {
       commandLine.appendFlag(.iframework)
       commandLine.appendFlag(systemFramework.argument.asSingle)
     }
 
-    try commandLine.appendLast(.swiftVersion, from: &parsedOptions)
+    try commandLine.appendLast(.swiftVersion, from: parsedOptions)
   }
 }

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -20,7 +20,7 @@ extension Driver {
     [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil
   }
 
-  mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {
+  func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {
     guard let firstInput = inputs.first, isAutolinkExtractJobNeeded else {
       return nil
     }

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -14,9 +14,9 @@ import Foundation
 
 extension Driver {
   /// Form a backend job.
-  mutating func backendJob(input: TypedVirtualPath,
-                           baseInput: TypedVirtualPath?,
-                           addJobOutputs: ([TypedVirtualPath]) -> Void)
+  func backendJob(input: TypedVirtualPath,
+                  baseInput: TypedVirtualPath?,
+                  addJobOutputs: ([TypedVirtualPath]) -> Void)
   throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs = [TypedVirtualPath]()
@@ -43,13 +43,13 @@ extension Driver {
     }
 
     // Handle the CPU and its preferences.
-    try commandLine.appendLast(.targetCpu, from: &parsedOptions)
+    try commandLine.appendLast(.targetCpu, from: parsedOptions)
 
     // Enable optimizations, but disable all LLVM-IR-level transformations.
-    try commandLine.appendLast(in: .O, from: &parsedOptions)
+    try commandLine.appendLast(in: .O, from: parsedOptions)
     commandLine.appendFlag(.disableLlvmOptzns)
 
-    try commandLine.appendLast(.parseStdlib, from: &parsedOptions)
+    try commandLine.appendLast(.parseStdlib, from: parsedOptions)
 
     commandLine.appendFlag(.moduleName)
     commandLine.appendFlag(moduleOutputInfo.name)

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -110,7 +110,7 @@ extension Array where Element == Job.ArgTemplate {
 
   /// Append the last parsed option that matches one of the given options
   /// to this command line.
-  mutating func appendLast(_ options: Option..., from parsedOptions: inout ParsedOptions) throws {
+  mutating func appendLast(_ options: Option..., from parsedOptions: ParsedOptions) throws {
     guard let parsedOption = parsedOptions.last(for: options) else {
       return
     }
@@ -119,7 +119,7 @@ extension Array where Element == Job.ArgTemplate {
   }
 
   /// Append the last parsed option from the given group to this command line.
-  mutating func appendLast(in group: Option.Group, from parsedOptions: inout ParsedOptions) throws {
+  mutating func appendLast(in group: Option.Group, from parsedOptions: ParsedOptions) throws {
     guard let parsedOption = parsedOptions.getLast(in: group) else {
       return
     }
@@ -135,7 +135,7 @@ extension Array where Element == Job.ArgTemplate {
 
   /// Append all parsed options that match one of the given options
   /// to this command line.
-  mutating func appendAll(_ options: Option..., from parsedOptions: inout ParsedOptions) throws {
+  mutating func appendAll(_ options: Option..., from parsedOptions: ParsedOptions) throws {
     for matching in parsedOptions.arguments(for: options) {
       try append(matching)
     }
@@ -143,7 +143,7 @@ extension Array where Element == Job.ArgTemplate {
 
   /// Append just the arguments from all parsed options that match one of the given options
   /// to this command line.
-  mutating func appendAllArguments(_ options: Option..., from parsedOptions: inout ParsedOptions) throws {
+  mutating func appendAllArguments(_ options: Option..., from parsedOptions: ParsedOptions) throws {
     for matching in parsedOptions.arguments(for: options) {
       try self.appendSingleArgument(option: matching.option, argument: matching.argument.asSingle)
     }
@@ -152,7 +152,7 @@ extension Array where Element == Job.ArgTemplate {
   /// Append the last of the given flags that appears in the parsed options,
   /// or the flag that corresponds to the default value if neither
   /// appears.
-  mutating func appendFlag(true trueFlag: Option, false falseFlag: Option, default defaultValue: Bool, from parsedOptions: inout ParsedOptions) {
+  mutating func appendFlag(true trueFlag: Option, false falseFlag: Option, default defaultValue: Bool, from parsedOptions: ParsedOptions) {
     let isTrue = parsedOptions.hasFlag(
       positive: trueFlag,
       negative: falseFlag,

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -14,7 +14,7 @@ import SwiftOptions
 
 extension Driver {
   /// Add the appropriate compile mode option to the command line for a compile job.
-  mutating func addCompileModeOption(outputType: FileType?, commandLine: inout [Job.ArgTemplate]) {
+  func addCompileModeOption(outputType: FileType?, commandLine: inout [Job.ArgTemplate]) {
     if let compileOption = outputType?.frontendCompileOption {
       commandLine.appendFlag(compileOption)
     } else {
@@ -26,7 +26,7 @@ extension Driver {
     }
   }
 
-  mutating func computeIndexUnitOutput(for input: TypedVirtualPath, outputType: FileType, topLevel: Bool) -> TypedVirtualPath? {
+  func computeIndexUnitOutput(for input: TypedVirtualPath, outputType: FileType, topLevel: Bool) -> TypedVirtualPath? {
     if let path = outputFileMap?.existingOutput(inputFile: input.fileHandle, outputType: .indexUnitOutputPath) {
       return TypedVirtualPath(file: path, type: outputType)
     }
@@ -39,8 +39,8 @@ extension Driver {
     return nil
   }
 
-  mutating func computePrimaryOutput(for input: TypedVirtualPath, outputType: FileType,
-                                        isTopLevel: Bool) -> TypedVirtualPath {
+  func computePrimaryOutput(for input: TypedVirtualPath, outputType: FileType,
+                            isTopLevel: Bool) -> TypedVirtualPath {
     if let path = outputFileMap?.existingOutput(inputFile: input.fileHandle, outputType: outputType) {
       return TypedVirtualPath(file: path, type: outputType)
     }
@@ -101,12 +101,12 @@ extension Driver {
   /// Add the compiler inputs for a frontend compilation job, and return the
   /// corresponding primary set of outputs and, if not identical, the output
   /// paths to record in the index data (empty otherwise).
-  mutating func addCompileInputs(primaryInputs: [TypedVirtualPath],
-                                 indexFilePath: TypedVirtualPath?,
-                                 inputs: inout [TypedVirtualPath],
-                                 inputOutputMap: inout [TypedVirtualPath: [TypedVirtualPath]],
-                                 outputType: FileType?,
-                                 commandLine: inout [Job.ArgTemplate])
+  func addCompileInputs(primaryInputs: [TypedVirtualPath],
+                        indexFilePath: TypedVirtualPath?,
+                        inputs: inout [TypedVirtualPath],
+                        inputOutputMap: inout [TypedVirtualPath: [TypedVirtualPath]],
+                        outputType: FileType?,
+                        commandLine: inout [Job.ArgTemplate])
   -> ([TypedVirtualPath], [TypedVirtualPath]) {
     let useInputFileList: Bool
     if let allSourcesFileList = allSourcesFileList {
@@ -218,7 +218,7 @@ extension Driver {
   }
 
   /// Form a compile job, which executes the Swift frontend to produce various outputs.
-  mutating func compileJob(primaryInputs: [TypedVirtualPath],
+  func compileJob(primaryInputs: [TypedVirtualPath],
                            outputType: FileType?,
                            addJobOutputs: ([TypedVirtualPath]) -> Void,
                            emitModuleTrace: Bool)
@@ -255,8 +255,8 @@ extension Driver {
     // -save-optimization-record and -save-optimization-record= have different meanings.
     // In this case, we specifically want to pass the EQ variant to the frontend
     // to control the output type of optimization remarks (YAML or bitstream).
-    try commandLine.appendLast(.saveOptimizationRecordEQ, from: &parsedOptions)
-    try commandLine.appendLast(.saveOptimizationRecordPasses, from: &parsedOptions)
+    try commandLine.appendLast(.saveOptimizationRecordEQ, from: parsedOptions)
+    try commandLine.appendLast(.saveOptimizationRecordPasses, from: parsedOptions)
 
     let inputsGeneratingCodeCount = primaryInputs.isEmpty
       ? inputs.count
@@ -271,9 +271,9 @@ extension Driver {
       indexFilePath: indexFilePath)
 
     // Forward migrator flags.
-    try commandLine.appendLast(.apiDiffDataFile, from: &parsedOptions)
-    try commandLine.appendLast(.apiDiffDataDir, from: &parsedOptions)
-    try commandLine.appendLast(.dumpUsr, from: &parsedOptions)
+    try commandLine.appendLast(.apiDiffDataFile, from: parsedOptions)
+    try commandLine.appendLast(.apiDiffDataDir, from: parsedOptions)
+    try commandLine.appendLast(.dumpUsr, from: parsedOptions)
 
     if parsedOptions.hasArgument(.parseStdlib) {
       commandLine.appendFlag(.disableObjcAttrRequiresFoundationModule)
@@ -286,9 +286,9 @@ extension Driver {
       commandLine.appendFlag(.parseAsLibrary)
     }
 
-    try commandLine.appendLast(.parseSil, from: &parsedOptions)
+    try commandLine.appendLast(.parseSil, from: parsedOptions)
 
-    try commandLine.appendLast(.migrateKeepObjcVisibility, from: &parsedOptions)
+    try commandLine.appendLast(.migrateKeepObjcVisibility, from: parsedOptions)
 
     if numThreads > 0 {
       commandLine.appendFlags("-num-threads", numThreads.description)
@@ -322,7 +322,7 @@ extension Driver {
       }
     }
 
-    try commandLine.appendLast(.embedBitcodeMarker, from: &parsedOptions)
+    try commandLine.appendLast(.embedBitcodeMarker, from: parsedOptions)
 
     // For `-index-file` mode add `-disable-typo-correction`, since the errors
     // will be ignored and it can be expensive to do typo-correction.
@@ -331,7 +331,7 @@ extension Driver {
     }
 
     if parsedOptions.contains(.indexStorePath) {
-      try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
+      try commandLine.appendLast(.indexStorePath, from: parsedOptions)
       if !parsedOptions.contains(.indexIgnoreSystemModules) {
         commandLine.appendFlag(.indexSystemModules)
       }
@@ -342,15 +342,15 @@ extension Driver {
       commandLine.appendFlag(.debugInfoStoreInvocation)
     }
 
-    try commandLine.appendLast(.trackSystemDependencies, from: &parsedOptions)
-    try commandLine.appendLast(.CrossModuleOptimization, from: &parsedOptions)
-    try commandLine.appendLast(.disableAutolinkingRuntimeCompatibility, from: &parsedOptions)
-    try commandLine.appendLast(.runtimeCompatibilityVersion, from: &parsedOptions)
-    try commandLine.appendLast(.disableAutolinkingRuntimeCompatibilityDynamicReplacements, from: &parsedOptions)
+    try commandLine.appendLast(.trackSystemDependencies, from: parsedOptions)
+    try commandLine.appendLast(.CrossModuleOptimization, from: parsedOptions)
+    try commandLine.appendLast(.disableAutolinkingRuntimeCompatibility, from: parsedOptions)
+    try commandLine.appendLast(.runtimeCompatibilityVersion, from: parsedOptions)
+    try commandLine.appendLast(.disableAutolinkingRuntimeCompatibilityDynamicReplacements, from: parsedOptions)
 
     if compilerMode.isSingleCompilation {
-      try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
-      try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
+      try commandLine.appendLast(.emitSymbolGraph, from: parsedOptions)
+      try commandLine.appendLast(.emitSymbolGraphDir, from: parsedOptions)
     }
 
     addJobOutputs(outputs)

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -55,7 +55,7 @@ extension DarwinToolchain {
 
   func addLinkRuntimeLibraryRPath(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     targetInfo: FrontendTargetInfo,
     darwinLibName: String
   ) throws {
@@ -76,14 +76,14 @@ extension DarwinToolchain {
 
     let clangPath = try clangLibraryPath(
       for: targetInfo,
-      parsedOptions: &parsedOptions)
+      parsedOptions: parsedOptions)
     commandLine.appendFlag("-rpath")
     commandLine.appendPath(clangPath)
   }
 
   func addLinkSanitizerLibArgsForDarwin(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     targetInfo: FrontendTargetInfo,
     sanitizer: Sanitizer,
     isShared: Bool
@@ -103,13 +103,13 @@ extension DarwinToolchain {
       named: sanitizerName,
       to: &commandLine,
       for: targetInfo,
-      parsedOptions: &parsedOptions
+      parsedOptions: parsedOptions
     )
 
     if isShared {
       try addLinkRuntimeLibraryRPath(
         to: &commandLine,
-        parsedOptions: &parsedOptions,
+        parsedOptions: parsedOptions,
         targetInfo: targetInfo,
         darwinLibName: sanitizerName
       )
@@ -118,12 +118,12 @@ extension DarwinToolchain {
 
   private func addProfileGenerationArgs(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     targetInfo: FrontendTargetInfo
   ) throws {
     guard parsedOptions.hasArgument(.profileGenerate) else { return }
     let clangPath = try clangLibraryPath(for: targetInfo,
-                                         parsedOptions: &parsedOptions)
+                                         parsedOptions: parsedOptions)
 
     for runtime in targetInfo.target.triple.darwinPlatform!.profileLibraryNameSuffixes {
       let clangRTPath = clangPath
@@ -167,7 +167,7 @@ extension DarwinToolchain {
 
   private func addArgsToLinkARCLite(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     targetTriple: Triple
   ) throws {
     guard parsedOptions.hasFlag(
@@ -197,7 +197,7 @@ extension DarwinToolchain {
   /// options for a Darwin platform.
   public func addPlatformSpecificLinkerArgs(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     linkerOutputType: LinkOutputType,
     inputs: [TypedVirtualPath],
     outputFile: VirtualPath,
@@ -218,7 +218,7 @@ extension DarwinToolchain {
                     inputs: inputs,
                     linkerOutputType: linkerOutputType)
       try addDynamicLinkerFlags(targetInfo: targetInfo,
-                                parsedOptions: &parsedOptions,
+                                parsedOptions: parsedOptions,
                                 commandLine: &commandLine,
                                 sanitizers: sanitizers,
                                 linkerOutputType: linkerOutputType,
@@ -231,7 +231,7 @@ extension DarwinToolchain {
                     inputs: inputs,
                     linkerOutputType: linkerOutputType)
       try addDynamicLinkerFlags(targetInfo: targetInfo,
-                                parsedOptions: &parsedOptions,
+                                parsedOptions: parsedOptions,
                                 commandLine: &commandLine,
                                 sanitizers: sanitizers,
                                 linkerOutputType: linkerOutputType,
@@ -305,7 +305,7 @@ extension DarwinToolchain {
   }
 
   private func addDynamicLinkerFlags(targetInfo: FrontendTargetInfo,
-                                     parsedOptions: inout ParsedOptions,
+                                     parsedOptions: ParsedOptions,
                                      commandLine: inout [Job.ArgTemplate],
                                      sanitizers: Set<Sanitizer>,
                                      linkerOutputType: LinkOutputType,
@@ -325,7 +325,7 @@ extension DarwinToolchain {
     let compilerRTPath =
       try clangLibraryPath(
         for: targetInfo,
-        parsedOptions: &parsedOptions)
+        parsedOptions: parsedOptions)
       .appending(component: "libclang_rt.\(darwinPlatformSuffix).a")
     if try fileSystem.exists(compilerRTPath) {
       commandLine.append(.path(compilerRTPath))
@@ -333,7 +333,7 @@ extension DarwinToolchain {
 
     try addArgsToLinkARCLite(
       to: &commandLine,
-      parsedOptions: &parsedOptions,
+      parsedOptions: parsedOptions,
       targetTriple: targetTriple
     )
 
@@ -365,7 +365,7 @@ extension DarwinToolchain {
       }
       try addLinkSanitizerLibArgsForDarwin(
         to: &commandLine,
-        parsedOptions: &parsedOptions,
+        parsedOptions: parsedOptions,
         targetInfo: targetInfo,
         sanitizer: sanitizer,
         isShared: sanitizer != .fuzzer
@@ -398,7 +398,7 @@ extension DarwinToolchain {
 
     try addArgsToLinkStdlib(
       to: &commandLine,
-      parsedOptions: &parsedOptions,
+      parsedOptions: parsedOptions,
       targetInfo: targetInfo,
       linkerOutputType: linkerOutputType,
       fileSystem: fileSystem
@@ -406,7 +406,7 @@ extension DarwinToolchain {
 
     try addProfileGenerationArgs(
       to: &commandLine,
-      parsedOptions: &parsedOptions,
+      parsedOptions: parsedOptions,
       targetInfo: targetInfo
     )
 
@@ -425,7 +425,7 @@ extension DarwinToolchain {
     try commandLine.append(
       contentsOf: parsedOptions.arguments(in: .linkerOption)
     )
-    try commandLine.appendAllArguments(.Xlinker, from: &parsedOptions)
+    try commandLine.appendAllArguments(.Xlinker, from: parsedOptions)
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -12,7 +12,7 @@
 extension Driver {
   /// Add options that are common to command lines that emit modules, e.g.,
   /// options for the paths of various module files.
-  mutating func addCommonModuleOptions(
+  func addCommonModuleOptions(
       commandLine: inout [Job.ArgTemplate],
       outputs: inout [TypedVirtualPath],
       isMergeModule: Bool
@@ -49,7 +49,7 @@ extension Driver {
   }
 
   /// Form a job that emits a single module
-  @_spi(Testing) public mutating func emitModuleJob() throws -> Job {
+  @_spi(Testing) public func emitModuleJob() throws -> Job {
     let moduleOutputPath = moduleOutputInfo.output!.outputPath
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []
@@ -94,7 +94,7 @@ extension Driver {
 
   /// Returns true if the emit module job should be created.
   var shouldCreateEmitModuleJob: Bool {
-    mutating get {
+    get {
       return moduleOutputInfo.output != nil
         && (forceEmitModuleBeforeCompile
             || shouldEmitModuleSeparately())
@@ -102,7 +102,7 @@ extension Driver {
   }
 
   /// Returns true if the -emit-module-separately is active.
-  mutating func shouldEmitModuleSeparately() -> Bool {
+  func shouldEmitModuleSeparately() -> Bool {
     return parsedOptions.hasFlag(positive: .emitModuleSeparately,
                                  negative: .noEmitModuleSeparately,
                                  default: false)

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -53,7 +53,7 @@ extension Toolchain {
 
 extension Driver {
   static func computeSupportedCompilerFeatures(of toolchain: Toolchain, hostTriple: Triple,
-                                               parsedOptions: inout ParsedOptions,
+                                               parsedOptions: ParsedOptions,
                                                diagnosticsEngine: DiagnosticsEngine,
                                                fileSystem: FileSystem,
                                                executor: DriverExecutor, env: [String: String])
@@ -72,7 +72,7 @@ extension Driver {
 //    }
 
     // Invoke `swift-frontend -emit-supported-features`
-    let frontendOverride = try FrontendOverride(&parsedOptions, diagnosticsEngine)
+    let frontendOverride = try FrontendOverride(parsedOptions, diagnosticsEngine)
     frontendOverride.setUpForTargetInfo(toolchain)
     defer { frontendOverride.setUpForCompilation(toolchain) }
     let frontendFeaturesJob =

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -46,7 +46,7 @@ extension Driver {
     case computed
   }
   /// Add frontend options that are common to different frontend invocations.
-  mutating func addCommonFrontendOptions(
+  func addCommonFrontendOptions(
     commandLine: inout [Job.ArgTemplate],
     inputs: inout [TypedVirtualPath],
     bridgingHeaderHandling: BridgingHeaderHandling = .precompiled,
@@ -122,85 +122,85 @@ extension Driver {
     }
 
     // Handle the CPU and its preferences.
-    try commandLine.appendLast(.targetCpu, from: &parsedOptions)
+    try commandLine.appendLast(.targetCpu, from: parsedOptions)
 
     if let sdkPath = frontendTargetInfo.sdkPath?.path {
       commandLine.appendFlag(.sdk)
       commandLine.append(.path(VirtualPath.lookup(sdkPath)))
     }
 
-    try commandLine.appendAll(.I, from: &parsedOptions)
-    try commandLine.appendAll(.F, .Fsystem, from: &parsedOptions)
-    try commandLine.appendAll(.vfsoverlay, from: &parsedOptions)
+    try commandLine.appendAll(.I, from: parsedOptions)
+    try commandLine.appendAll(.F, .Fsystem, from: parsedOptions)
+    try commandLine.appendAll(.vfsoverlay, from: parsedOptions)
 
-    try commandLine.appendLast(.AssertConfig, from: &parsedOptions)
-    try commandLine.appendLast(.autolinkForceLoad, from: &parsedOptions)
+    try commandLine.appendLast(.AssertConfig, from: parsedOptions)
+    try commandLine.appendLast(.autolinkForceLoad, from: parsedOptions)
 
     if let colorOption = parsedOptions.last(for: .colorDiagnostics, .noColorDiagnostics) {
       commandLine.appendFlag(colorOption.option)
     } else if shouldColorDiagnostics() {
       commandLine.appendFlag(.colorDiagnostics)
     }
-    try commandLine.appendLast(.fixitAll, from: &parsedOptions)
-    try commandLine.appendLast(.warnSwift3ObjcInferenceMinimal, .warnSwift3ObjcInferenceComplete, from: &parsedOptions)
-    try commandLine.appendLast(.warnImplicitOverrides, from: &parsedOptions)
-    try commandLine.appendLast(.typoCorrectionLimit, from: &parsedOptions)
-    try commandLine.appendLast(.enableAppExtension, from: &parsedOptions)
-    try commandLine.appendLast(.enableLibraryEvolution, from: &parsedOptions)
-    try commandLine.appendLast(.enableTesting, from: &parsedOptions)
-    try commandLine.appendLast(.enablePrivateImports, from: &parsedOptions)
-    try commandLine.appendLast(.enableCxxInterop, from: &parsedOptions)
-    try commandLine.appendLast(in: .g, from: &parsedOptions)
-    try commandLine.appendLast(.debugInfoFormat, from: &parsedOptions)
-    try commandLine.appendLast(.importUnderlyingModule, from: &parsedOptions)
-    try commandLine.appendLast(.moduleCachePath, from: &parsedOptions)
-    try commandLine.appendLast(.moduleLinkName, from: &parsedOptions)
-    try commandLine.appendLast(.nostdimport, from: &parsedOptions)
-    try commandLine.appendLast(.parseStdlib, from: &parsedOptions)
-    try commandLine.appendLast(.solverMemoryThreshold, from: &parsedOptions)
-    try commandLine.appendLast(.valueRecursionThreshold, from: &parsedOptions)
-    try commandLine.appendLast(.warnSwift3ObjcInference, from: &parsedOptions)
-    try commandLine.appendLast(.RpassEQ, from: &parsedOptions)
-    try commandLine.appendLast(.RpassMissedEQ, from: &parsedOptions)
-    try commandLine.appendLast(.suppressWarnings, from: &parsedOptions)
-    try commandLine.appendLast(.profileGenerate, from: &parsedOptions)
-    try commandLine.appendLast(.profileUse, from: &parsedOptions)
-    try commandLine.appendLast(.profileCoverageMapping, from: &parsedOptions)
-    try commandLine.appendLast(.warningsAsErrors, .noWarningsAsErrors, from: &parsedOptions)
-    try commandLine.appendLast(.sanitizeEQ, from: &parsedOptions)
-    try commandLine.appendLast(.sanitizeRecoverEQ, from: &parsedOptions)
-    try commandLine.appendLast(.sanitizeAddressUseOdrIndicator, from: &parsedOptions)
-    try commandLine.appendLast(.sanitizeCoverageEQ, from: &parsedOptions)
-    try commandLine.appendLast(.static, from: &parsedOptions)
-    try commandLine.appendLast(.swiftVersion, from: &parsedOptions)
-    try commandLine.appendLast(.enforceExclusivityEQ, from: &parsedOptions)
-    try commandLine.appendLast(.statsOutputDir, from: &parsedOptions)
-    try commandLine.appendLast(.traceStatsEvents, from: &parsedOptions)
-    try commandLine.appendLast(.profileStatsEvents, from: &parsedOptions)
-    try commandLine.appendLast(.profileStatsEntities, from: &parsedOptions)
-    try commandLine.appendLast(.solverShrinkUnsolvedThreshold, from: &parsedOptions)
-    try commandLine.appendLast(in: .O, from: &parsedOptions)
-    try commandLine.appendLast(.RemoveRuntimeAsserts, from: &parsedOptions)
-    try commandLine.appendLast(.AssumeSingleThreaded, from: &parsedOptions)
-    try commandLine.appendLast(.packageDescriptionVersion, from: &parsedOptions)
-    try commandLine.appendLast(.serializeDiagnosticsPath, from: &parsedOptions)
-    try commandLine.appendLast(.debugDiagnosticNames, from: &parsedOptions)
-    try commandLine.appendLast(.scanDependencies, from: &parsedOptions)
-    try commandLine.appendLast(.enableExperimentalConcisePoundFile, from: &parsedOptions)
-    try commandLine.appendLast(.printEducationalNotes, from: &parsedOptions)
-    try commandLine.appendLast(.diagnosticStyle, from: &parsedOptions)
-    try commandLine.appendLast(.locale, from: &parsedOptions)
-    try commandLine.appendLast(.localizationPath, from: &parsedOptions)
-    try commandLine.appendLast(.requireExplicitAvailability, from: &parsedOptions)
-    try commandLine.appendLast(.requireExplicitAvailabilityTarget, from: &parsedOptions)
-    try commandLine.appendLast(.lto, from: &parsedOptions)
-    try commandLine.appendLast(.accessNotesPath, from: &parsedOptions)
-    try commandLine.appendLast(.enableActorDataRaceChecks, .disableActorDataRaceChecks, from: &parsedOptions)
-    try commandLine.appendAll(.D, from: &parsedOptions)
-    try commandLine.appendAll(.debugPrefixMap, from: &parsedOptions)
-    try commandLine.appendAllArguments(.Xfrontend, from: &parsedOptions)
-    try commandLine.appendAll(.coveragePrefixMap, from: &parsedOptions)
-    try commandLine.appendLast(.warnConcurrency, from: &parsedOptions)
+    try commandLine.appendLast(.fixitAll, from: parsedOptions)
+    try commandLine.appendLast(.warnSwift3ObjcInferenceMinimal, .warnSwift3ObjcInferenceComplete, from: parsedOptions)
+    try commandLine.appendLast(.warnImplicitOverrides, from: parsedOptions)
+    try commandLine.appendLast(.typoCorrectionLimit, from: parsedOptions)
+    try commandLine.appendLast(.enableAppExtension, from: parsedOptions)
+    try commandLine.appendLast(.enableLibraryEvolution, from: parsedOptions)
+    try commandLine.appendLast(.enableTesting, from: parsedOptions)
+    try commandLine.appendLast(.enablePrivateImports, from: parsedOptions)
+    try commandLine.appendLast(.enableCxxInterop, from: parsedOptions)
+    try commandLine.appendLast(in: .g, from: parsedOptions)
+    try commandLine.appendLast(.debugInfoFormat, from: parsedOptions)
+    try commandLine.appendLast(.importUnderlyingModule, from: parsedOptions)
+    try commandLine.appendLast(.moduleCachePath, from: parsedOptions)
+    try commandLine.appendLast(.moduleLinkName, from: parsedOptions)
+    try commandLine.appendLast(.nostdimport, from: parsedOptions)
+    try commandLine.appendLast(.parseStdlib, from: parsedOptions)
+    try commandLine.appendLast(.solverMemoryThreshold, from: parsedOptions)
+    try commandLine.appendLast(.valueRecursionThreshold, from: parsedOptions)
+    try commandLine.appendLast(.warnSwift3ObjcInference, from: parsedOptions)
+    try commandLine.appendLast(.RpassEQ, from: parsedOptions)
+    try commandLine.appendLast(.RpassMissedEQ, from: parsedOptions)
+    try commandLine.appendLast(.suppressWarnings, from: parsedOptions)
+    try commandLine.appendLast(.profileGenerate, from: parsedOptions)
+    try commandLine.appendLast(.profileUse, from: parsedOptions)
+    try commandLine.appendLast(.profileCoverageMapping, from: parsedOptions)
+    try commandLine.appendLast(.warningsAsErrors, .noWarningsAsErrors, from: parsedOptions)
+    try commandLine.appendLast(.sanitizeEQ, from: parsedOptions)
+    try commandLine.appendLast(.sanitizeRecoverEQ, from: parsedOptions)
+    try commandLine.appendLast(.sanitizeAddressUseOdrIndicator, from: parsedOptions)
+    try commandLine.appendLast(.sanitizeCoverageEQ, from: parsedOptions)
+    try commandLine.appendLast(.static, from: parsedOptions)
+    try commandLine.appendLast(.swiftVersion, from: parsedOptions)
+    try commandLine.appendLast(.enforceExclusivityEQ, from: parsedOptions)
+    try commandLine.appendLast(.statsOutputDir, from: parsedOptions)
+    try commandLine.appendLast(.traceStatsEvents, from: parsedOptions)
+    try commandLine.appendLast(.profileStatsEvents, from: parsedOptions)
+    try commandLine.appendLast(.profileStatsEntities, from: parsedOptions)
+    try commandLine.appendLast(.solverShrinkUnsolvedThreshold, from: parsedOptions)
+    try commandLine.appendLast(in: .O, from: parsedOptions)
+    try commandLine.appendLast(.RemoveRuntimeAsserts, from: parsedOptions)
+    try commandLine.appendLast(.AssumeSingleThreaded, from: parsedOptions)
+    try commandLine.appendLast(.packageDescriptionVersion, from: parsedOptions)
+    try commandLine.appendLast(.serializeDiagnosticsPath, from: parsedOptions)
+    try commandLine.appendLast(.debugDiagnosticNames, from: parsedOptions)
+    try commandLine.appendLast(.scanDependencies, from: parsedOptions)
+    try commandLine.appendLast(.enableExperimentalConcisePoundFile, from: parsedOptions)
+    try commandLine.appendLast(.printEducationalNotes, from: parsedOptions)
+    try commandLine.appendLast(.diagnosticStyle, from: parsedOptions)
+    try commandLine.appendLast(.locale, from: parsedOptions)
+    try commandLine.appendLast(.localizationPath, from: parsedOptions)
+    try commandLine.appendLast(.requireExplicitAvailability, from: parsedOptions)
+    try commandLine.appendLast(.requireExplicitAvailabilityTarget, from: parsedOptions)
+    try commandLine.appendLast(.lto, from: parsedOptions)
+    try commandLine.appendLast(.accessNotesPath, from: parsedOptions)
+    try commandLine.appendLast(.enableActorDataRaceChecks, .disableActorDataRaceChecks, from: parsedOptions)
+    try commandLine.appendAll(.D, from: parsedOptions)
+    try commandLine.appendAll(.debugPrefixMap, from: parsedOptions)
+    try commandLine.appendAllArguments(.Xfrontend, from: parsedOptions)
+    try commandLine.appendAll(.coveragePrefixMap, from: parsedOptions)
+    try commandLine.appendLast(.warnConcurrency, from: parsedOptions)
 
     // Pass down -user-module-version if we are working with a compiler that
     // supports it.
@@ -246,8 +246,8 @@ extension Driver {
     }
 
     // Pass through any subsystem flags.
-    try commandLine.appendAll(.Xllvm, from: &parsedOptions)
-    try commandLine.appendAll(.Xcc, from: &parsedOptions)
+    try commandLine.appendAll(.Xllvm, from: parsedOptions)
+    try commandLine.appendAll(.Xcc, from: parsedOptions)
 
     if let importedObjCHeader = importedObjCHeader,
         bridgingHeaderHandling != .ignored {
@@ -256,7 +256,7 @@ extension Driver {
           let pch = bridgingPrecompiledHeader {
         if parsedOptions.contains(.pchOutputDir) {
           commandLine.appendPath(VirtualPath.lookup(importedObjCHeader))
-          try commandLine.appendLast(.pchOutputDir, from: &parsedOptions)
+          try commandLine.appendLast(.pchOutputDir, from: parsedOptions)
           if !compilerMode.isSingleCompilation {
             commandLine.appendFlag(.pchDisableValidation)
           }
@@ -283,12 +283,12 @@ extension Driver {
                                                            frontendTargetInfo: frontendTargetInfo)
   }
 
-  mutating func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate],
-                                                        primaryInputs: [TypedVirtualPath],
-                                                        inputsGeneratingCodeCount: Int,
-                                                        inputOutputMap: inout [TypedVirtualPath: [TypedVirtualPath]],
-                                                        includeModuleTracePath: Bool,
-                                                        indexFilePath: TypedVirtualPath?) throws -> [TypedVirtualPath] {
+  func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate],
+                                               primaryInputs: [TypedVirtualPath],
+                                               inputsGeneratingCodeCount: Int,
+                                               inputOutputMap: inout [TypedVirtualPath: [TypedVirtualPath]],
+                                               includeModuleTracePath: Bool,
+                                               indexFilePath: TypedVirtualPath?) throws -> [TypedVirtualPath] {
     var flaggedInputOutputPairs: [(flag: String, input: TypedVirtualPath?, output: TypedVirtualPath)] = []
 
     /// Add output of a particular type, if needed.

--- a/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GenerateDSYMJob.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Driver {
-  mutating func generateDSYMJob(inputs: [TypedVirtualPath]) throws -> Job {
+  func generateDSYMJob(inputs: [TypedVirtualPath]) throws -> Job {
     assert(inputs.count == 1)
     let input = inputs[0]
 

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -14,7 +14,7 @@ import TSCBasic
 import TSCUtility
 
 extension Driver {
-  mutating func generatePCHJob(input: TypedVirtualPath, output: TypedVirtualPath) throws -> Job {
+  func generatePCHJob(input: TypedVirtualPath, output: TypedVirtualPath) throws -> Job {
     var inputs = [TypedVirtualPath]()
     var outputs = [TypedVirtualPath]()
 
@@ -25,7 +25,7 @@ extension Driver {
     try addCommonFrontendOptions(
       commandLine: &commandLine, inputs: &inputs, bridgingHeaderHandling: .parsed)
 
-    try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
+    try commandLine.appendLast(.indexStorePath, from: parsedOptions)
 
     // TODO: Should this just be pch output with extension changed?
     if parsedOptions.hasArgument(.serializeDiagnostics), let outputDirectory = parsedOptions.getLastArgument(.pchOutputDir)?.asSingle {
@@ -50,12 +50,12 @@ extension Driver {
     inputs.append(input)
     commandLine.appendPath(input.file)
 
-    try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
+    try commandLine.appendLast(.indexStorePath, from: parsedOptions)
 
     commandLine.appendFlag(.emitPch)
 
     if parsedOptions.hasArgument(.pchOutputDir) {
-      try commandLine.appendLast(.pchOutputDir, from: &parsedOptions)
+      try commandLine.appendLast(.pchOutputDir, from: parsedOptions)
     } else {
       commandLine.appendFlag(.o)
       commandLine.appendPath(output.file)

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -18,7 +18,7 @@ extension Driver {
   /// (https://clang.llvm.org/docs/Modules.html#module-map-language) and the
   /// output is a compiled module that also includes the additional information
   /// needed by Swift's Clang importer, e.g., the Swift name lookup tables.
-  mutating func generateEmitPCMJob(input: TypedVirtualPath) throws -> Job {
+  func generateEmitPCMJob(input: TypedVirtualPath) throws -> Job {
     var inputs = [TypedVirtualPath]()
     var outputs = [TypedVirtualPath]()
 
@@ -50,7 +50,7 @@ extension Driver {
     try addCommonFrontendOptions(
       commandLine: &commandLine, inputs: &inputs, bridgingHeaderHandling: .ignored)
 
-    try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
+    try commandLine.appendLast(.indexStorePath, from: parsedOptions)
 
     return Job(
       moduleName: moduleOutputInfo.name,
@@ -67,7 +67,7 @@ extension Driver {
   /// Create a job that dumps information about a Clang module
   ///
   /// The input is a Clang Pre-compiled module file (.pcm).
-  mutating func generateDumpPCMJob(input: TypedVirtualPath) throws -> Job {
+  func generateDumpPCMJob(input: TypedVirtualPath) throws -> Job {
     var inputs = [TypedVirtualPath]()
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
 

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -49,7 +49,7 @@ extension GenericUnixToolchain {
 
   public func addPlatformSpecificLinkerArgs(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     linkerOutputType: LinkOutputType,
     inputs: [TypedVirtualPath],
     outputFile: VirtualPath,
@@ -136,7 +136,7 @@ extension GenericUnixToolchain {
 
       let runtimePaths = try runtimeLibraryPaths(
         for: targetInfo,
-        parsedOptions: &parsedOptions,
+        parsedOptions: parsedOptions,
         sdkPath: targetInfo.sdkPath?.path,
         isShared: hasRuntimeArgs
       )
@@ -270,7 +270,7 @@ extension GenericUnixToolchain {
       }
 
       // Run clang++ in verbose mode if "-v" is set
-      try commandLine.appendLast(.v, from: &parsedOptions)
+      try commandLine.appendLast(.v, from: parsedOptions)
 
       // These custom arguments should be right before the object file at the
       // end.
@@ -283,7 +283,7 @@ extension GenericUnixToolchain {
         commandLine.appendFlag(.Xlinker)
         commandLine.appendFlag(linkerOpt.argument.asSingle)
       }
-      try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+      try commandLine.appendAllArguments(.XclangLinker, from: parsedOptions)
 
       // This should be the last option, for convenience in checking output.
       commandLine.appendFlag(.o)

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Driver {
-  mutating func interpretJob(inputs allInputs: [TypedVirtualPath]) throws -> Job {
+  func interpretJob(inputs allInputs: [TypedVirtualPath]) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []
 
@@ -30,14 +30,14 @@ extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
-    try commandLine.appendLast(.parseSil, from: &parsedOptions)
-    try commandLine.appendAll(.l, .framework, from: &parsedOptions)
+    try commandLine.appendLast(.parseSil, from: parsedOptions)
+    try commandLine.appendAll(.l, .framework, from: parsedOptions)
 
     // The immediate arguments must be last.
-    try commandLine.appendLast(.DASHDASH, from: &parsedOptions)
+    try commandLine.appendLast(.DASHDASH, from: parsedOptions)
 
     let extraEnvironment = try toolchain.platformSpecificInterpreterEnvironmentVariables(
-      env: self.env, parsedOptions: &parsedOptions,
+      env: self.env, parsedOptions: parsedOptions,
       sdkPath: frontendTargetInfo.sdkPath?.path, targetInfo: self.frontendTargetInfo)
 
     return Job(

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -40,7 +40,7 @@ extension Driver {
   }
 
   /// Link the given inputs.
-  mutating func linkJob(inputs: [TypedVirtualPath]) throws -> Job {
+  func linkJob(inputs: [TypedVirtualPath]) throws -> Job {
     var commandLine: [Job.ArgTemplate] = []
 
     // Compute the final output file
@@ -54,7 +54,7 @@ extension Driver {
     // Defer to the toolchain for platform-specific linking
     let toolPath = try toolchain.addPlatformSpecificLinkerArgs(
       to: &commandLine,
-      parsedOptions: &parsedOptions,
+      parsedOptions: parsedOptions,
       linkerOutputType: linkerOutputType!,
       inputs: inputs,
       outputFile: outputFile,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -13,7 +13,7 @@
 import TSCBasic
 
 extension Driver {
-  mutating func mergeModuleJob(inputs providedInputs: [TypedVirtualPath],
+  func mergeModuleJob(inputs providedInputs: [TypedVirtualPath],
                                inputsFromOutputs: [TypedVirtualPath]) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []
@@ -59,8 +59,8 @@ extension Driver {
 
     addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: true)
 
-    try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
-    try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
+    try commandLine.appendLast(.emitSymbolGraph, from: parsedOptions)
+    try commandLine.appendLast(.emitSymbolGraphDir, from: parsedOptions)
 
     // Propagate the disable flag for cross-module incremental builds
     // if necessary. Note because we're interested in *disabling* this feature,
@@ -69,7 +69,7 @@ extension Driver {
     if parsedOptions.hasFlag(positive: .disableIncrementalImports,
                              negative: .enableIncrementalImports,
                              default: false) {
-      try commandLine.appendLast(.disableIncrementalImports, from: &parsedOptions)
+      try commandLine.appendLast(.disableIncrementalImports, from: parsedOptions)
     }
 
     commandLine.appendFlag(.o)

--- a/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
+++ b/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Driver {
-  mutating func moduleWrapJob(moduleInput: TypedVirtualPath) throws -> Job {
+  func moduleWrapJob(moduleInput: TypedVirtualPath) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
 
     commandLine.appendFlags("-modulewrap")

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -89,7 +89,7 @@ extension Driver {
     // the planning process. This state contains the module dependency graph and
     // cross-module dependency information.
     let initialIncrementalState =
-      try IncrementalCompilationState.computeIncrementalStateForPlanning(driver: &self)
+      try IncrementalCompilationState.computeIncrementalStateForPlanning(driver: self)
 
     // Compute the set of all jobs required to build this module
     let jobsInPhases = try computeJobsForPhasedStandardBuild()
@@ -99,7 +99,7 @@ extension Driver {
     // If no initial state was computed, we will not be performing an incremental build
     if let initialState = initialIncrementalState {
       incrementalCompilationState =
-        try IncrementalCompilationState(driver: &self, jobsInPhases: jobsInPhases,
+        try IncrementalCompilationState(driver: self, jobsInPhases: jobsInPhases,
                                         initialState: initialState)
     } else {
       incrementalCompilationState = nil
@@ -165,7 +165,7 @@ extension Driver {
   }
 
 
-  private mutating func addPrecompileBridgingHeaderJob(addJob: (Job) -> Void) throws {
+  private func addPrecompileBridgingHeaderJob(addJob: (Job) -> Void) throws {
     guard
       let importedObjCHeader = importedObjCHeader,
       let bridgingPrecompiledHeader = bridgingPrecompiledHeader
@@ -251,7 +251,7 @@ extension Driver {
 
   /// When in single compile, add one compile job and possiblity multiple backend jobs.
   /// Return the compile job if one was created.
-  private mutating func addSingleCompileJobs(
+  private func addSingleCompileJobs(
     addJob: (Job) -> Void,
     addJobOutputs: ([TypedVirtualPath]) -> Void,
     emitModuleTrace: Bool
@@ -356,7 +356,7 @@ extension Driver {
     }
   }
 
-  private mutating func createAndAddCompileJobGroup(
+  private func createAndAddCompileJobGroup(
     primaryInput: TypedVirtualPath,
     emitModuleTrace: Bool,
     canSkipIfOnlyModule: Bool,
@@ -470,7 +470,7 @@ extension Driver {
     }
   }
 
-  private mutating func addAPIDigesterJobs(addJob: (Job) -> Void) throws {
+  private func addAPIDigesterJobs(addJob: (Job) -> Void) throws {
     guard let moduleOutputPath = moduleOutputInfo.output?.outputPath else { return }
     if let apiBaselinePath = self.digesterBaselinePath {
       try addJob(digesterBaselineGenerationJob(modulePath: moduleOutputPath, outputPath: apiBaselinePath, mode: digesterMode))
@@ -528,7 +528,7 @@ extension Driver {
     return try explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
   }
 
-  @_spi(Testing) public mutating func gatherModuleDependencies()
+  @_spi(Testing) public func gatherModuleDependencies()
   throws -> InterModuleDependencyGraph {
     var dependencyGraph = try performDependencyScan()
 
@@ -548,7 +548,7 @@ extension Driver {
 
   /// Update the given inter-module dependency graph to set module paths to be within the module cache,
   /// if one is present, and for Swift modules to use the context hash in the file name.
-  private mutating func resolveDependencyModulePaths(dependencyGraph: inout InterModuleDependencyGraph)
+  private func resolveDependencyModulePaths(dependencyGraph: inout InterModuleDependencyGraph)
   throws {
     // If a module cache path is specified, update all module dependencies
     // to be output into it.
@@ -563,7 +563,7 @@ extension Driver {
   }
 
   /// For Swift module dependencies, set the output path to include the module's context hash
-  private mutating func resolveSwiftDependencyModuleFileNames(dependencyGraph: inout InterModuleDependencyGraph)
+  private func resolveSwiftDependencyModuleFileNames(dependencyGraph: inout InterModuleDependencyGraph)
   throws {
     for (moduleId, moduleInfo) in dependencyGraph.modules {
       // Output path on the main module is determined by the invocation arguments.
@@ -583,8 +583,8 @@ extension Driver {
   }
 
   /// Resolve all paths to dependency binary module files to be relative to the module cache path.
-  private mutating func resolveDependencyModulePathsRelativeToModuleCache(dependencyGraph: inout InterModuleDependencyGraph,
-                                                                          moduleCachePath: String)
+  private func resolveDependencyModulePathsRelativeToModuleCache(dependencyGraph: inout InterModuleDependencyGraph,
+                                                                 moduleCachePath: String)
   throws {
     for (moduleId, moduleInfo) in dependencyGraph.modules {
       // Output path on the main module is determined by the invocation arguments.
@@ -613,7 +613,7 @@ extension Driver {
 extension Driver {
   /// Create a job if needed for simple requests that can be immediately
   /// forwarded to the frontend.
-  public mutating func immediateForwardingJob() throws -> Job? {
+  public func immediateForwardingJob() throws -> Job? {
     if parsedOptions.hasArgument(.printTargetInfo) {
       let sdkPath = try parsedOptions.getLastArgument(.sdk).map { try VirtualPath(path: $0.asSingle) }
       let resourceDirPath = try parsedOptions.getLastArgument(.resourceDir).map { try VirtualPath(path: $0.asSingle) }
@@ -727,7 +727,7 @@ extension Driver {
   ///
   /// So, in order to avoid making jobs and rebatching, the code would have to just get outputs for each
   /// compilation. But `compileJob` intermixes the output computation with other stuff.
-  mutating func formBatchedJobs(_ jobs: [Job], showJobLifecycle: Bool) throws -> [Job] {
+  func formBatchedJobs(_ jobs: [Job], showJobLifecycle: Bool) throws -> [Job] {
     guard compilerMode.isBatchCompile else {
       // Don't even go through the logic so as to not print out confusing
       // "batched foobar" messages.

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -11,15 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 extension Driver {
-  mutating func replJob() throws -> Job {
+  func replJob() throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = []
 
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
-    try commandLine.appendLast(.importObjcHeader, from: &parsedOptions)
-    try commandLine.appendAll(.l, .framework, .L, from: &parsedOptions)
+    try commandLine.appendLast(.importObjcHeader, from: parsedOptions)
+    try commandLine.appendAll(.l, .framework, .L, from: parsedOptions)
 
     // Squash important frontend options into a single argument for LLDB.
     let lldbCommandLine: [Job.ArgTemplate] = [.squashedArgumentList(option: "--repl=", args: commandLine)]

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -19,7 +19,7 @@ extension Toolchain {
     to env: inout [String : String],
     currentEnv: [String: String],
     option: Option,
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     extraPaths: [String] = []
     ) {
     let argPaths = parsedOptions.arguments(for: option)
@@ -33,18 +33,18 @@ extension Toolchain {
 extension DarwinToolchain {
   public func platformSpecificInterpreterEnvironmentVariables(
     env: [String : String],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     sdkPath: VirtualPath.Handle?,
     targetInfo: FrontendTargetInfo) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
     addPathEnvironmentVariableIfNeeded("DYLD_LIBRARY_PATH", to: &envVars,
                                        currentEnv: env, option: .L,
-                                       parsedOptions: &parsedOptions)
+                                       parsedOptions: parsedOptions)
 
     addPathEnvironmentVariableIfNeeded("DYLD_FRAMEWORK_PATH", to: &envVars,
                                        currentEnv: env, option: .F,
-                                       parsedOptions: &parsedOptions)
+                                       parsedOptions: parsedOptions)
 
     return envVars
   }
@@ -53,21 +53,21 @@ extension DarwinToolchain {
 extension GenericUnixToolchain {
   public func platformSpecificInterpreterEnvironmentVariables(
     env: [String : String],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     sdkPath: VirtualPath.Handle?,
     targetInfo: FrontendTargetInfo) throws -> [String: String] {
     var envVars: [String: String] = [:]
 
     let runtimePaths = try runtimeLibraryPaths(
       for: targetInfo,
-      parsedOptions: &parsedOptions,
+      parsedOptions: parsedOptions,
       sdkPath: sdkPath,
       isShared: true
     ).map { $0.name }
 
     addPathEnvironmentVariableIfNeeded("LD_LIBRARY_PATH", to: &envVars,
                                        currentEnv: env, option: .L,
-                                       parsedOptions: &parsedOptions,
+                                       parsedOptions: parsedOptions,
                                        extraPaths: runtimePaths)
 
     return envVars

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -22,7 +22,7 @@ extension Toolchain {
 
   func clangLibraryPath(
     for targetInfo: FrontendTargetInfo,
-    parsedOptions: inout ParsedOptions
+    parsedOptions: ParsedOptions
   ) throws -> VirtualPath {
     return VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
       .appending(components: "clang", "lib",
@@ -31,7 +31,7 @@ extension Toolchain {
 
   func runtimeLibraryPaths(
     for targetInfo: FrontendTargetInfo,
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     sdkPath: VirtualPath.Handle?,
     isShared: Bool
   ) throws -> [VirtualPath] {
@@ -60,11 +60,11 @@ extension Toolchain {
     named name: String,
     to commandLine: inout [Job.ArgTemplate],
     for targetInfo: FrontendTargetInfo,
-    parsedOptions: inout ParsedOptions
+    parsedOptions: ParsedOptions
   ) throws {
     let path = try clangLibraryPath(
       for: targetInfo,
-      parsedOptions: &parsedOptions)
+      parsedOptions: parsedOptions)
       .appending(component: name)
     commandLine.appendPath(path)
   }
@@ -72,7 +72,7 @@ extension Toolchain {
   func runtimeLibraryExists(
     for sanitizer: Sanitizer,
     targetInfo: FrontendTargetInfo,
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     isShared: Bool
   ) throws -> Bool {
     let runtimeName = try runtimeLibraryName(
@@ -82,7 +82,7 @@ extension Toolchain {
     )
     let path = try clangLibraryPath(
       for: targetInfo,
-      parsedOptions: &parsedOptions
+      parsedOptions: parsedOptions
     ).appending(component: runtimeName)
     return try fileSystem.exists(path)
   }
@@ -93,7 +93,7 @@ extension Toolchain {
 extension DarwinToolchain {
   func addArgsToLinkStdlib(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     targetInfo: FrontendTargetInfo,
     linkerOutputType: LinkOutputType,
     fileSystem: FileSystem
@@ -131,7 +131,7 @@ extension DarwinToolchain {
     // relative to the compiler.
     let runtimePaths = try runtimeLibraryPaths(
       for: targetInfo,
-      parsedOptions: &parsedOptions,
+      parsedOptions: parsedOptions,
       sdkPath: targetInfo.sdkPath?.path,
       isShared: true
     )
@@ -141,7 +141,7 @@ extension DarwinToolchain {
     }
 
     let rpaths = StdlibRpathRule(
-      parsedOptions: &parsedOptions,
+      parsedOptions: parsedOptions,
       targetInfo: targetInfo
     )
     for path in rpaths.paths(runtimeLibraryPaths: runtimePaths) {
@@ -165,7 +165,7 @@ extension DarwinToolchain {
     case none
 
     /// Determines the appropriate rule for the given set of options.
-    init(parsedOptions: inout ParsedOptions, targetInfo: FrontendTargetInfo) {
+    init(parsedOptions: ParsedOptions, targetInfo: FrontendTargetInfo) {
       if parsedOptions.hasFlag(
         positive: .toolchainStdlibRpath,
         negative: .noToolchainStdlibRpath,

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Driver {
-  mutating func verifyModuleInterfaceJob(interfaceInput: TypedVirtualPath) throws -> Job {
+  func verifyModuleInterfaceJob(interfaceInput: TypedVirtualPath) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = [interfaceInput]
     commandLine.appendFlags("-frontend", "-typecheck-module-from-interface")

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -15,7 +15,7 @@ import SwiftOptions
 extension WebAssemblyToolchain {
   public func addPlatformSpecificLinkerArgs(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     linkerOutputType: LinkOutputType,
     inputs: [TypedVirtualPath],
     outputFile: VirtualPath,
@@ -73,7 +73,7 @@ extension WebAssemblyToolchain {
 
       let runtimePaths = try runtimeLibraryPaths(
         for: targetInfo,
-        parsedOptions: &parsedOptions,
+        parsedOptions: parsedOptions,
         sdkPath: targetInfo.sdkPath?.path,
         isShared: false
       )
@@ -135,15 +135,15 @@ extension WebAssemblyToolchain {
       }
 
       // Run clang++ in verbose mode if "-v" is set
-      try commandLine.appendLast(.v, from: &parsedOptions)
+      try commandLine.appendLast(.v, from: parsedOptions)
 
       // These custom arguments should be right before the object file at the
       // end.
       try commandLine.append(
         contentsOf: parsedOptions.arguments(in: .linkerOption)
       )
-      try commandLine.appendAllArguments(.Xlinker, from: &parsedOptions)
-      try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+      try commandLine.appendAllArguments(.Xlinker, from: parsedOptions)
+      try commandLine.appendAllArguments(.XclangLinker, from: parsedOptions)
 
         // This should be the last option, for convenience in checking output.
       commandLine.appendFlag(.o)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -163,7 +163,7 @@ public final class DarwinToolchain: Toolchain {
     }
   }
 
-  public func validateArgs(_ parsedOptions: inout ParsedOptions,
+  public func validateArgs(_ parsedOptions: ParsedOptions,
                            targetTriple: Triple,
                            targetVariantTriple: Triple?,
                            diagnosticsEngine: DiagnosticsEngine) throws {
@@ -171,12 +171,12 @@ public final class DarwinToolchain: Toolchain {
     // Guard for the sake of tests runnin on all platforms
     #if os(macOS)
     // Validating arclite library path when link-objc-runtime.
-    validateLinkObjcRuntimeARCLiteLib(&parsedOptions,
+    validateLinkObjcRuntimeARCLiteLib(parsedOptions,
                                       targetTriple: targetTriple,
                                       diagnosticsEngine: diagnosticsEngine)
     #endif
     // Validating apple platforms deployment targets.
-    try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple)
+    try validateDeploymentTarget(parsedOptions, targetTriple: targetTriple)
     if let targetVariantTriple = targetVariantTriple,
        !targetTriple.isValidForZipperingWithTriple(targetVariantTriple) {
       throw ToolchainValidationError.unsupportedTargetVariant(variant: targetVariantTriple)
@@ -197,7 +197,7 @@ public final class DarwinToolchain: Toolchain {
     }
   }
 
-  func validateDeploymentTarget(_ parsedOptions: inout ParsedOptions,
+  func validateDeploymentTarget(_ parsedOptions: ParsedOptions,
                                 targetTriple: Triple) throws {
     // Check minimum supported OS versions.
     if targetTriple.isMacOSX,
@@ -222,7 +222,7 @@ public final class DarwinToolchain: Toolchain {
     }
   }
     
-  func validateLinkObjcRuntimeARCLiteLib(_ parsedOptions: inout ParsedOptions,
+  func validateLinkObjcRuntimeARCLiteLib(_ parsedOptions: ParsedOptions,
                                            targetTriple: Triple,
                                            diagnosticsEngine: DiagnosticsEngine) {
     if parsedOptions.hasFlag(positive: .linkObjcRuntime, negative: .noLinkObjcRuntime, default: targetTriple.supports(.compatibleObjCRuntime)) {

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -63,14 +63,14 @@ public protocol Toolchain {
   func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String
 
   /// Perform platform-specific argument validation.
-  func validateArgs(_ parsedOptions: inout ParsedOptions,
+  func validateArgs(_ parsedOptions: ParsedOptions,
                     targetTriple: Triple,
                     targetVariantTriple: Triple?, diagnosticsEngine: DiagnosticsEngine) throws
 
   /// Adds platform-specific linker flags to the provided command line
   func addPlatformSpecificLinkerArgs(
     to commandLine: inout [Job.ArgTemplate],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     linkerOutputType: LinkOutputType,
     inputs: [TypedVirtualPath],
     outputFile: VirtualPath,
@@ -88,7 +88,7 @@ public protocol Toolchain {
 
   func platformSpecificInterpreterEnvironmentVariables(
     env: [String: String],
-    parsedOptions: inout ParsedOptions,
+    parsedOptions: ParsedOptions,
     sdkPath: VirtualPath.Handle?,
     targetInfo: FrontendTargetInfo) throws -> [String: String]
 
@@ -188,7 +188,7 @@ extension Toolchain {
     return AbsolutePath(path)
   }
 
-  public func validateArgs(_ parsedOptions: inout ParsedOptions,
+  public func validateArgs(_ parsedOptions: ParsedOptions,
                            targetTriple: Triple,
                            targetVariantTriple: Triple?, diagnosticsEngine: DiagnosticsEngine) {}
 

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -135,7 +135,7 @@ public final class WebAssemblyToolchain: Toolchain {
   }
 
   public func platformSpecificInterpreterEnvironmentVariables(env: [String : String],
-                                                              parsedOptions: inout ParsedOptions,
+                                                              parsedOptions: ParsedOptions,
                                                               sdkPath: VirtualPath.Handle?,
                                                               targetInfo: FrontendTargetInfo) throws -> [String : String] {
     throw Error.interactiveModeUnsupportedForTarget(targetInfo.target.triple.triple)


### PR DESCRIPTION
Treat a method on the `Driver` whose only state change is the consumption of options as not changing the `Driver`. This change should facilitate an incremental build optimization to come.