### PR TITLE
[5.5] PrebuiltModuleGen: cherry-pick recent changes

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -267,6 +267,8 @@ extension Driver {
       commandLine.append(.path(try VirtualPath(path: mcp)))
     }
     commandLine.appendFlag(.serializeParseableModuleInterfaceDependencyHashes)
+    commandLine.appendFlag(.badFileDescriptorRetryCount)
+    commandLine.appendFlag("30")
     return Job(
       moduleName: moduleName,
       kind: .compile,

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -261,6 +261,11 @@ extension Driver {
       commandLine.appendFlag(.Fsystem)
       commandLine.append(.path(iosMacFrameworksSearchPath))
     }
+    // Use the specified module cache dir
+    if let mcp = parsedOptions.getLastArgument(.moduleCachePath)?.asSingle {
+      commandLine.appendFlag(.moduleCachePath)
+      commandLine.append(.path(try VirtualPath(path: mcp)))
+    }
     commandLine.appendFlag(.serializeParseableModuleInterfaceDependencyHashes)
     return Job(
       moduleName: moduleName,

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -53,8 +53,8 @@ let verbose = CommandLine.arguments.contains("-v")
 let skipExecution = CommandLine.arguments.contains("-n")
 
 do {
-  let sdkPath = try getArgumentAsPath("-sdk", "SDKROOT")
-  guard let sdkPath = sdkPath else {
+  let sdkPathArg = try getArgumentAsPath("-sdk", "SDKROOT")
+  guard let sdkPath = sdkPathArg else {
     diagnosticsEngine.emit(.error("need to set SDKROOT"))
     exit(1)
   }

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -137,7 +137,7 @@ do {
     if skipExecution {
       exit(0)
     }
-    let delegate = PrebuitModuleGenerationDelegate(jobs, diagnosticsEngine, verbose)
+    let delegate = PrebuitModuleGenerationDelegate(jobs, diagnosticsEngine, verbose, logPath: try getArgumentAsPath("-log-path"))
     do {
       try executor.execute(workload: DriverExecutorWorkload.init(jobs, nil, continueBuildingAfterErrors: true),
                            delegate: delegate, numParallelJobs: 128)

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -32,6 +32,13 @@ func getArgument(_ flag: String) -> String? {
   return nil
 }
 
+func getArgumentAsPath(_ flag: String) throws -> AbsolutePath? {
+  if let raw = getArgument(flag) {
+    return try VirtualPath(path: raw).absolutePath
+  }
+  return nil
+}
+
 guard let rawOutputDir = getArgument("-o") else {
   diagnosticsEngine.emit(.error("need to specify -o"))
   exit(1)
@@ -119,7 +126,8 @@ do {
                             diagnosticsEngine: diagnosticsEngine,
                             executor: executor,
                             compilerExecutableDir: swiftcPath.parentDirectory)
-    let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: inputMap, into: outputDir, exhaustive: !coreMode)
+    let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: inputMap,
+      into: outputDir, exhaustive: !coreMode, dotGraphPath: getArgumentAsPath("-dot-graph-path"))
     if verbose {
       Driver.stdErrQueue.sync {
         stderrStream <<< "job count: \(jobs.count + danglingJobs.count)\n"

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -62,7 +62,7 @@ do {
     outputDir = outputDir.appending(RelativePath(collector.versionString))
   }
   if !localFileSystem.exists(outputDir) {
-    try localFileSystem.createDirectory(outputDir)
+    try localFileSystem.createDirectory(outputDir, recursive: true)
   }
   let swiftcPathRaw = ProcessEnv.vars["SWIFT_EXEC"]
   var swiftcPath: AbsolutePath

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -874,8 +874,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
         $0 <<< "import H\n"
         $0 <<< "import Swift\n"
       }
+      let moduleCachePath = "/tmp/module-cache"
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
+                                     "-module-cache-path", moduleCachePath
                                     ])
 
       let (jobs, danglingJobs) = try driver.generatePrebuitModuleGenerationJobs(with: interfaceMap,
@@ -890,6 +892,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertTrue(jobs.allSatisfy {$0.outputs.count == 1})
       XCTAssertTrue(jobs.allSatisfy {$0.kind == .compile})
       XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-compile-module-from-interface"))})
+      XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-module-cache-path"))})
+      XCTAssertTrue(try jobs.allSatisfy {$0.commandLine.contains(.path(try VirtualPath(path: moduleCachePath)))})
       let HJobs = jobs.filter { $0.moduleName == "H"}
       XCTAssertTrue(HJobs.count == 2)
       XCTAssertTrue(getInputModules(HJobs[0]) == ["A", "E", "F", "G", "Swift"])

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -893,6 +893,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertTrue(jobs.allSatisfy {$0.kind == .compile})
       XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-compile-module-from-interface"))})
       XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-module-cache-path"))})
+      XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-bad-file-descriptor-retry-count"))})
       XCTAssertTrue(try jobs.allSatisfy {$0.commandLine.contains(.path(try VirtualPath(path: moduleCachePath)))})
       let HJobs = jobs.filter { $0.moduleName == "H"}
       XCTAssertTrue(HJobs.count == 2)


### PR DESCRIPTION
These cherry-picks from `main` complete the `swift-build-sdk-interfaces` tool to be functionally equivalent to the legacy implementation of `swift_build_sdk_interfaces.py`, so we could replace the legacy mechanism with the new one for better efficiency.

related to: rdar://81848232