### PR TITLE
Fix `guard let sdkPath = sdkPath` pattern for compatiblity with older compilers

### DIFF
--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -53,8 +53,8 @@ let verbose = CommandLine.arguments.contains("-v")
 let skipExecution = CommandLine.arguments.contains("-n")
 
 do {
-  let sdkPath = try getArgumentAsPath("-sdk", "SDKROOT")
-  guard let sdkPath = sdkPath else {
+  let sdkPathArg = try getArgumentAsPath("-sdk", "SDKROOT")
+  guard let sdkPath = sdkPathArg else {
     diagnosticsEngine.emit(.error("need to set SDKROOT"))
     exit(1)
   }


### PR DESCRIPTION
Introduced in https://github.com/apple/swift-driver/pull/796, this passed CI because swift-driver CI uses a recent compiler.
This broke SwiftPM CI because it uses a 5.3 compiler which contains a bug which makes such patterns fail to build.