### PR TITLE
[5.5] Note file type for -emit-irgen.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1531,7 +1531,7 @@ extension Driver {
       case .emitSibgen:
         compilerOutputType = .raw_sib
 
-      case .emitIr:
+      case .emitIrgen, .emitIr:
         compilerOutputType = .llvmIR
 
       case .emitBc:


### PR DESCRIPTION
Forgot to cherry-pick this earlier when I landed it in https://github.com/apple/swift-driver/pull/676. Without this, trying to pass `-emit-irgen` to the new driver will crash (can be worked around by `-disallow-use-new-driver`).

(cherry picked from commit 9a85a8268c731bdd549b0237388b42e9a512efc9)

Fixes rdar://81971182.