### PR TITLE
[Incremental] Add SwiftSourceFile type

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(SwiftDriver
   "IncrementalCompilation/KeyAndFingerprintHolder.swift"
   "IncrementalCompilation/ModuleDependencyGraph.swift"
   "IncrementalCompilation/Multidictionary.swift"
+  "IncrementalCompilation/SwiftSourceFile.swift"
   "IncrementalCompilation/SourceFileDependencyGraph.swift"
   "IncrementalCompilation/TwoDMap.swift"
 

--- a/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DirectAndTransitiveCollections.swift
@@ -85,5 +85,7 @@ public typealias TransitivelyInvalidatedNodeArray = InvalidatedArray<Transitivel
 public typealias TransitivelyInvalidatedSourceSet = InvalidatedSet<Transitively, DependencySource>
 public typealias TransitivelyInvalidatedInputArray = InvalidatedArray<Transitively, TypedVirtualPath>
 public typealias TransitivelyInvalidatedInputSet = InvalidatedSet<Transitively, TypedVirtualPath>
+public typealias TransitivelyInvalidatedSwiftSourceFileArray = InvalidatedArray<Transitively, SwiftSourceFile>
+public typealias TransitivelyInvalidatedSwiftSourceFileSet = InvalidatedSet<Transitively, SwiftSourceFile>
 public typealias DirectlyInvalidatedNodeArray = InvalidatedArray<Directly, ModuleDependencyGraph.Node>
 public typealias DirectlyInvalidatedNodeSet = InvalidatedSet<Directly, ModuleDependencyGraph.Node>

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -166,8 +166,8 @@ extension IncrementalCompilationState {
         if let reporter = reporter {
           reporter.report(
             "Incremental compilation has been disabled, "
-              + "because the following inputs were used in the previous compilation but not in this one: "
-              + sourceFiles.disappeared.map { $0.basename }.joined(separator: ", "))
+            + "because the following inputs were used in the previous compilation but not in this one: "
+            + sourceFiles.disappeared.map { $0.typedFile.file.basename }.joined(separator: ", "))
         }
         return nil
       }
@@ -197,7 +197,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   /// For inputs with swiftDeps in OFM, but no readable file, puts input in graph map, but no nodes in graph:
   ///   caller must ensure scheduling of those
   private func computeGraphAndInputsInvalidatedByExternals()
-    -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet)?
+    -> (ModuleDependencyGraph, TransitivelyInvalidatedSwiftSourceFileSet)?
   {
     precondition(
       sourceFiles.disappeared.isEmpty,
@@ -211,7 +211,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   }
 
   private func readPriorGraphAndCollectInputsInvalidatedByChangedOrAddedExternals(
-  ) -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet)?
+  ) -> (ModuleDependencyGraph, TransitivelyInvalidatedSwiftSourceFileSet)?
   {
     let dependencyGraphPath = buildRecordInfo.dependencyGraphPath
     let graphIfPresent: ModuleDependencyGraph?
@@ -269,10 +269,10 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   /// For externalDependencies, puts then in graph.fingerprintedExternalDependencies, but otherwise
   /// does nothing special.
   private func buildInitialGraphFromSwiftDepsAndCollectInputsInvalidatedByChangedExternals()
-  -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet)?
+  -> (ModuleDependencyGraph, TransitivelyInvalidatedSwiftSourceFileSet)?
   {
     let graph = ModuleDependencyGraph(self, .buildingFromSwiftDeps)
-    var inputsInvalidatedByChangedExternals = TransitivelyInvalidatedInputSet()
+    var inputsInvalidatedByChangedExternals = TransitivelyInvalidatedSwiftSourceFileSet()
     for input in sourceFiles.currentInOrder {
        guard let invalidatedInputs =
               graph.collectInputsRequiringCompilationFromExternalsFoundByCompiling(input: input)
@@ -286,8 +286,8 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   }
 
   private func bulidEmptyGraphAndCompileEverything()
-  -> (ModuleDependencyGraph, TransitivelyInvalidatedInputSet) {
+  -> (ModuleDependencyGraph, TransitivelyInvalidatedSwiftSourceFileSet) {
     let graph = ModuleDependencyGraph(self, .buildingAfterEachCompilation)
-    return (graph, TransitivelyInvalidatedInputSet())
+    return (graph, TransitivelyInvalidatedSwiftSourceFileSet())
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -39,6 +39,10 @@ public struct DependencySource: Hashable, CustomStringConvertible {
     self.init(TypedVirtualPath(file: file, type: type))
   }
 
+  public init(_ swiftSourceFile: SwiftSourceFile) {
+    self.init(swiftSourceFile.typedFile)
+  }
+
   public var file: VirtualPath { typedFile.file }
 
   public var description: String {

--- a/Sources/SwiftDriver/IncrementalCompilation/SwiftSourceFile.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SwiftSourceFile.swift
@@ -1,0 +1,48 @@
+//===-------------------- SwiftSourceFile.swift - Incremental -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import TSCBasic
+
+/// Because the incremental compilation system treats files containing Swift source code specially,
+/// it is helpful to statically distinguish them wherever an input must be swift source code.
+public struct SwiftSourceFile: Hashable {
+  // must be .swift
+  public let fileHandle: VirtualPath.Handle
+
+  init(_ fileHandle: VirtualPath.Handle) {
+    self.fileHandle = fileHandle
+  }
+  public init(_ path: TypedVirtualPath) {
+    assert(path.type == .swift)
+    self.init(path.fileHandle)
+  }
+  public init?(ifSource path: TypedVirtualPath) {
+    guard path.type == .swift else { return nil }
+    self.init(path)
+  }
+
+  public init(_ path: VirtualPath) {
+    assert(path.name.hasSuffix(".\(FileType.swift.rawValue)"))
+    self.init(path.intern())
+  }
+
+  public var typedFile: TypedVirtualPath {
+    TypedVirtualPath(file: fileHandle, type: .swift)
+  }
+}
+
+public extension Sequence where Element == TypedVirtualPath {
+  var swiftSourceFiles: [SwiftSourceFile] {
+    compactMap(SwiftSourceFile.init(ifSource:))
+  }
+}

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -129,6 +129,8 @@ public struct Job: Codable, Equatable, Hashable {
     self.requiresInPlaceExecution = requiresInPlaceExecution
     self.supportsResponseFiles = supportsResponseFiles
   }
+
+  public var primarySwiftSourceFiles: [SwiftSourceFile] { primaryInputs.swiftSourceFiles }
 }
 
 extension Job {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -50,8 +50,13 @@ struct CompileJobGroup {
     backendJob.map {[compileJob, $0]} ?? [compileJob]
   }
 
+  /// Any type of file that is `partOfSwiftCompilation`
   var primaryInput: TypedVirtualPath {
     compileJob.primaryInputs[0]
+  }
+
+  var primarySwiftSourceInput: SwiftSourceFile? {
+    SwiftSourceFile(ifSource: primaryInput)
   }
 
   var outputs: [TypedVirtualPath] {

--- a/Tests/SwiftDriverTests/CleanBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/CleanBuildPerformanceTests.swift
@@ -61,7 +61,7 @@ class CleanBuildPerformanceTests: XCTestCase {
   /// Build the `OutputFileMap` and input vector for ``testCleanBuildSwiftDepsPerformance(_, atMost)``
   private func createOFMAndInputs(_ swiftDepsDirectory: String,
                                   atMost limit: Int
-  ) throws -> (OutputFileMap, [TypedVirtualPath]) {
+  ) throws -> (OutputFileMap, [SwiftSourceFile]) {
     let workingDirectory = localFileSystem.currentWorkingDirectory!
     let swiftDepsDirPath = try VirtualPath.init(path: swiftDepsDirectory).resolvedRelativePath(base: workingDirectory).absolutePath!
     let withoutExtensions: ArraySlice<Substring> = try! localFileSystem.getDirectoryContents(swiftDepsDirPath)
@@ -84,7 +84,7 @@ class CleanBuildPerformanceTests: XCTestCase {
         file: VirtualPath.absolute(swiftDepsDirPath.appending(component: name + "." + type.rawValue)).intern(),
         type: type)
     }
-    let inputs = withoutExtensions.map {mkPath($0, .swift)}
+    let inputs = withoutExtensions.map {mkPath($0, .swift)}.swiftSourceFiles
     let swiftDepsVPs = withoutExtensions.map {mkPath($0, .swiftDeps)}
     let entries = Dictionary(
       uniqueKeysWithValues:
@@ -95,7 +95,7 @@ class CleanBuildPerformanceTests: XCTestCase {
   }
 
   /// Read the `swiftdeps` files for each input into a `ModuleDependencyGraph`
-  private func readSwiftDeps(for inputs: [TypedVirtualPath], into g: ModuleDependencyGraph) {
+  private func readSwiftDeps(for inputs: [SwiftSourceFile], into g: ModuleDependencyGraph) {
     let result = inputs.reduce(into: Set()) { invalidatedInputs, primaryInput in
       // too verbose: print("processing", primaryInput)
       invalidatedInputs.formUnion(g.collectInputsRequiringCompilation(byCompiling: primaryInput)!)

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -79,9 +79,9 @@ extension DependencySource {
   }
 }
 
-extension TypedVirtualPath {
+extension SwiftSourceFile {
   var mockID: Int {
-    Int(file.basenameWithoutExt)!
+    Int(typedFile.file.basenameWithoutExt)!
   }
 }
 

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1004,16 +1004,16 @@ extension ModuleDependencyGraph {
   /// Can return duplicates
   func findUntracedInputsDependent(
     on fingerprintedExternalDependency: FingerprintedExternalDependency
-  ) -> [TypedVirtualPath] {
-    var foundSources = [TypedVirtualPath]()
+  ) -> [SwiftSourceFile] {
+    var foundSources = [SwiftSourceFile]()
     for dependent in collectUntracedNodes(thatUse: fingerprintedExternalDependency, .testing) {
       let dependencySource = dependent.dependencySource!
-      foundSources.append(dependencySource.typedFile)
+      foundSources.append(SwiftSourceFile(dependencySource.typedFile))
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive
       // Don't return job twice.
       let filesToRebuild =
         collectInputsUsing(dependencySource: dependencySource)
-        .filter({ marked in marked != dependencySource.typedFile })
+        .filter({ marked in marked != SwiftSourceFile(dependencySource.typedFile) })
       foundSources.append(contentsOf: filesToRebuild)
     }
     return foundSources


### PR DESCRIPTION
Add a distinguished wrapper type for `SwiftSourceFile` in order to clarify where the incremental code is dealing with any sort of input file, or exactly a Swift source file.

In service of rdar://79790907