### PR TITLE
Revert "Replace lenient version parsing implementation with the one in TSC"

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,16 +6,16 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
+          "revision": "986d191f94cec88f6350056da59c2e59e83d1229",
+          "version": "0.4.3"
         }
       },
       {
-        "package": "llbuild",
+        "package": "swift-llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "main",
-          "revision": "08c0a758a697bad5d5849ad5d0b1eedb507b0596",
+          "revision": "0f88ee40f297004547581ddd90b27f3a7e60a11a",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": "main",
-          "revision": "3cabb66f57f157ed083c4c07ddfca28932437e6b",
+          "revision": "21a79185b2ea8f89b9253ed8cdf2338bf564c499",
           "version": null
         }
       },

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2155,7 +2155,7 @@ extension Driver {
       diagnosticsEngine.emit(.warning_no_sdksettings_json(sdkPath.pathString))
       return false
     }
-    guard let sdkVersion = try? Version(versionString: sdkInfo.versionString, usesLenientParsing: true) else {
+    guard let sdkVersion = Version(potentiallyIncompleteVersionString: sdkInfo.versionString) else {
       diagnosticsEngine.emit(.warning_fail_parse_sdk_ver(sdkInfo.versionString, sdkPath.pathString))
       return false
     }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -254,12 +254,12 @@ public final class DarwinToolchain: Toolchain {
         let mappingDict = try keyedContainer.decode([String: String].self, forKey: .macOSToCatalystMapping)
         self.macOSToCatalystMapping = [:]
         try mappingDict.forEach { key, value in
-          guard let newKey = try? Version(versionString: key, usesLenientParsing: true) else {
+          guard let newKey = Version(potentiallyIncompleteVersionString: key) else {
             throw DecodingError.dataCorruptedError(forKey: .macOSToCatalystMapping,
                                                    in: keyedContainer,
                                                    debugDescription: "Malformed version string")
           }
-          guard let newValue = try? Version(versionString: value, usesLenientParsing: true) else {
+          guard let newValue = Version(potentiallyIncompleteVersionString: value) else {
             throw DecodingError.dataCorruptedError(forKey: .macOSToCatalystMapping,
                                                    in: keyedContainer,
                                                    debugDescription: "Malformed version string")
@@ -277,7 +277,7 @@ public final class DarwinToolchain: Toolchain {
 
       self.versionString = try keyedContainer.decode(String.self, forKey: .version)
       self.canonicalName = try keyedContainer.decode(String.self, forKey: .canonicalName)
-      guard let version = try? Version(versionString: versionString, usesLenientParsing: true) else {
+      guard let version = Version(potentiallyIncompleteVersionString: versionString) else {
         throw DecodingError.dataCorruptedError(forKey: .version,
                                                in: keyedContainer,
                                                debugDescription: "Malformed version string")

--- a/Sources/SwiftDriver/Utilities/VersionExtensions.swift
+++ b/Sources/SwiftDriver/Utilities/VersionExtensions.swift
@@ -14,6 +14,45 @@ import TSCUtility
 
 // TODO: maybe move this to TSC.
 extension Version {
+  /// Create a version from a string, replacing unknown trailing components with '0'.
+  init?(potentiallyIncompleteVersionString string: String) {
+    // This is a copied version of TSC's version parsing, modified to fill
+    // in missing components if needed.
+    let prereleaseStartIndex = string.firstIndex(of: "-")
+    let metadataStartIndex = string.firstIndex(of: "+")
+
+    let requiredEndIndex = prereleaseStartIndex ?? metadataStartIndex ?? string.endIndex
+    let requiredCharacters = string.prefix(upTo: requiredEndIndex)
+    var requiredComponents = requiredCharacters
+      .split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false)
+      .map(String.init).compactMap({ Int($0) }).filter({ $0 >= 0 })
+
+    requiredComponents.append(contentsOf:
+                                Array(repeating: 0,
+                                      count: max(0, 3 - requiredComponents.count)))
+
+    let major = requiredComponents[0]
+    let minor = requiredComponents[1]
+    let patch = requiredComponents[2]
+
+    func identifiers(start: String.Index?, end: String.Index) -> [String] {
+      guard let start = start else { return [] }
+      let identifiers = string[string.index(after: start)..<end]
+      return identifiers.split(separator: ".").map(String.init)
+    }
+
+    let prereleaseIdentifiers = identifiers(
+      start: prereleaseStartIndex,
+      end: metadataStartIndex ?? string.endIndex)
+    let buildMetadataIdentifiers = identifiers(
+      start: metadataStartIndex,
+      end: string.endIndex)
+
+    self.init(major, minor, patch,
+              prereleaseIdentifiers: prereleaseIdentifiers,
+              buildMetadataIdentifiers: buildMetadataIdentifiers)
+  }
+
   /// Returns the version with out any build/release metadata numbers.
   var withoutBuildNumbers: Version {
     return Version(self.major, self.minor, self.patch)


### PR DESCRIPTION
Reverts apple/swift-driver#794

This is an attempt to unblock mysterious CI failures.