### PR TITLE
Get tests working again by passing in explicit `-sdk` argument

### DIFF
--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -266,6 +266,9 @@ final class NonincrementalCompilationTests: XCTestCase {
     expecting expectations: [Diagnostic.Message],
     alsoExpectingWhenAutolinking autolinkExpectations: [Diagnostic.Message] = []
   ) throws {
+    guard let sdkArguments = try Driver.sdkArgumentsForTesting() else {
+      throw XCTSkip("cannot get sdk arguments on this platform")
+    }
     try withTemporaryDirectory { path in
       let main = path.appending(component: "main.swift")
       try localFileSystem.writeFileContents(main) {
@@ -278,7 +281,7 @@ final class NonincrementalCompilationTests: XCTestCase {
       try assertDriverDiagnostics(args: [
         "swiftc", "-module-name", "theModule", "-working-directory", path.pathString,
         main.pathString, other.pathString
-      ] + otherArgs) {driver, verifier in
+      ] + otherArgs + sdkArguments) {driver, verifier in
         verifier.forbidUnexpected(.error, .warning, .note, .remark, .ignored)
 
         expectations.forEach {verifier.expect($0)}
@@ -293,8 +296,6 @@ final class NonincrementalCompilationTests: XCTestCase {
   }
 
   func testShowJobLifecycleAndIncremental() throws {
-    // rdar://82304093
-    throw XCTSkip()
     // Legacy MacOS driver output:
     //    Adding standard job to task queue: {compile: main.o <= main.swift}
     //    Added to TaskQueue: {compile: main.o <= main.swift}
@@ -321,8 +322,6 @@ final class NonincrementalCompilationTests: XCTestCase {
 
   }
   func testNoIncremental() throws {
-    // rdar://82304093
-    throw XCTSkip()
     try runDriver( with: [
       "-c",
       "-incremental",


### PR DESCRIPTION
Four tests started failing. They can be fixed by passing in an `-sdk` argument to the driver. I don't know how they worked before, but perhaps something changed in how the frontend finds the standard library, or how Xcode is set up.

This fix depends on the `xcrun` command, which, AFAIK, is only present on MacOS, so the tests in question must be skipped on other platforms.

rdar://82304093