### PR TITLE
[5.5][Explicit Module Builds] Always set explicit dependency modules to output to the specified module cache path

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -569,7 +569,8 @@ extension Driver {
   throws {
     for (moduleId, moduleInfo) in dependencyGraph.modules {
       // Output path on the main module is determined by the invocation arguments.
-      guard moduleId.moduleName != dependencyGraph.mainModuleName else {
+      if case .swift(let name) = moduleId,
+         name == dependencyGraph.mainModuleName {
         continue
       }
       let modulePath = VirtualPath.lookup(moduleInfo.modulePath.path)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/807
--------------------------------------------------
**Explanation**: The existing check to see if the path produced by the dependency scanner is already-qualified is unnecessary and can lead to us missing some edge cases. If a dependency path is left un-adjusted to be in the module cache, driver clients (including its own llbuild executors) may be left with an ambiguous path. 

**Scope of Issue**: Explicit module builds of targets that have dependency modules whose output module path base name does not necessarily equal module name or is otherwise already qualified to a relative path of some kind.

**Origination**: Issue new to explicit module builds

**Risk**: Very low