### PR TITLE
[Explicit Module Builds] When resolving explicit dependency paths to the module cache, only skip main module if it is a Swift module.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -623,7 +623,8 @@ extension Driver {
   throws {
     for (moduleId, moduleInfo) in dependencyGraph.modules {
       // Output path on the main module is determined by the invocation arguments.
-      guard moduleId.moduleName != dependencyGraph.mainModuleName else {
+      if case .swift(let name) = moduleId,
+         name == dependencyGraph.mainModuleName {
         continue
       }
       let modulePath = VirtualPath.lookup(moduleInfo.modulePath.path)


### PR DESCRIPTION
We may very well have a dependency with the same name as the main module being built that is a Clang module, and we must ensure that we resolve that dependency's PCM to the module cache also.