### PR TITLE
[5.5] Get tests working again by passing in explicit -sdk argument

### DIFF
--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -41,6 +41,9 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
   }
 
   func testChangingOutputFileMap() throws {
+    guard let sdkArguments = try Driver.sdkArgumentsForTesting() else {
+      throw XCTSkip()
+    }
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let magic = path.appending(component: "magic.swift")
@@ -54,18 +57,19 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
           $0 + "-some_suffix"
         }
       }
-
+      
+      let driverArgs = [
+        "swiftc",
+        "-incremental",
+        "-emit-module",
+        "-output-file-map", ofm.pathString,
+        "-module-name", "MagicKit",
+        "-working-directory", path.pathString,
+        "-c",
+        magic.pathString,
+      ] + sdkArguments
       do {
-        var driver = try Driver(args: [
-          "swiftc",
-          "-incremental",
-          "-emit-module",
-          "-output-file-map", ofm.pathString,
-          "-module-name", "MagicKit",
-          "-working-directory", path.pathString,
-          "-c",
-          magic.pathString,
-        ])
+        var driver = try Driver(args: driverArgs)
         let jobs = try driver.planBuild()
         try driver.run(jobs: jobs)
       }
@@ -77,16 +81,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       }
 
       do {
-        var driver = try Driver(args: [
-          "swiftc",
-          "-incremental",
-          "-emit-module",
-          "-output-file-map", ofm.pathString,
-          "-module-name", "MagicKit",
-          "-working-directory", path.pathString,
-          "-c",
-          magic.pathString,
-        ])
+        var driver = try Driver(args: driverArgs)
         let jobs = try driver.planBuild()
         try driver.run(jobs: jobs)
       }
@@ -94,6 +89,9 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
   }
 
   func testEmbeddedModuleDependencies() throws {
+    guard let sdkArguments = try Driver.sdkArgumentsForTesting() else {
+      throw XCTSkip()
+    }
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       do {
@@ -116,7 +114,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
           "-working-directory", path.pathString,
           "-c",
           magic.pathString,
-        ])
+        ] + sdkArguments)
         let jobs = try driver.planBuild()
         try driver.run(jobs: jobs)
       }
@@ -142,7 +140,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
         "-working-directory", path.pathString,
         "-c",
         main.pathString,
-      ])
+      ] + sdkArguments)
 
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -267,6 +267,9 @@ final class NonincrementalCompilationTests: XCTestCase {
     expecting expectations: [Diagnostic.Message],
     alsoExpectingWhenAutolinking autolinkExpectations: [Diagnostic.Message] = []
   ) throws {
+    guard let sdkArguments = try Driver.sdkArgumentsForTesting() else {
+      throw XCTSkip("cannot get sdk arguments on this platform")
+    }
     try withTemporaryDirectory { path in
       let main = path.appending(component: "main.swift")
       try localFileSystem.writeFileContents(main) {
@@ -279,7 +282,7 @@ final class NonincrementalCompilationTests: XCTestCase {
       try assertDriverDiagnostics(args: [
         "swiftc", "-module-name", "theModule", "-working-directory", path.pathString,
         main.pathString, other.pathString
-      ] + otherArgs) {driver, verifier in
+      ] + otherArgs + sdkArguments) {driver, verifier in
         verifier.forbidUnexpected(.error, .warning, .note, .remark, .ignored)
 
         expectations.forEach {verifier.expect($0)}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/806
------------------------------------------------------------
Four tests started failing. They can be fixed by passing in an `-sdk` argument to the driver. I don't know how they worked before, but perhaps something changed in how the frontend finds the standard library, or how Xcode is set up.

This fix depends on the `xcrun` command, which, AFAIK, is only present on MacOS, so the tests in question must be skipped on other platforms.

rdar://82304093