### PR TITLE
[5.5][Dependency Scanning] Do not support generating command-line response-files for dependency scanning jobs.

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -23,7 +23,7 @@ public extension Driver {
   /// Precompute the dependencies for a given Swift compilation, producing a
   /// dependency graph including all Swift and C module files and
   /// source files.
-  mutating private func dependencyScanningJob() throws -> Job {
+  mutating func dependencyScanningJob() throws -> Job {
     let (inputs, commandLine) = try dependencyScannerInvocationCommand()
 
     // Construct the scanning job.
@@ -35,7 +35,7 @@ public extension Driver {
                inputs: inputs,
                primaryInputs: [],
                outputs: [TypedVirtualPath(file: .standardOutput, type: .jsonDependencies)],
-               supportsResponseFiles: true)
+               supportsResponseFiles: false)
   }
 
   /// Generate a full command-line invocation to be used for the dependency scanning action
@@ -262,7 +262,7 @@ public extension Driver {
                inputs: inputs,
                primaryInputs: [],
                outputs: [TypedVirtualPath(file: .standardOutput, type: .jsonDependencies)],
-               supportsResponseFiles: true)
+               supportsResponseFiles: false)
   }
 
   /// Precompute the dependencies for a given collection of modules using swift frontend's batch scanning mode
@@ -311,7 +311,7 @@ public extension Driver {
                inputs: inputs,
                primaryInputs: [],
                outputs: outputs,
-               supportsResponseFiles: true)
+               supportsResponseFiles: false)
   }
 
   /// Serialize a collection of modules into an input format expected by the batch module dependency scanner.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -696,6 +696,31 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
   }
 
+
+  /// Test that the scanner invocation does not rely in response files
+  func testDependencyScanningNoResponse() throws {
+    try withTemporaryDirectory { path in
+      let main = path.appending(component: "testDependencyScanning.swift")
+      // With a number of inputs this large, a response file should be generated
+      // unless explicitly not supported, as should be the case for scan-deps.
+      let lotsOfInputs = (0...700).map{"test\($0).swift"}
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+      var driver = try Driver(args: ["swiftc",
+                                     "-experimental-explicit-module-build",
+                                     "-working-directory", path.pathString,
+                                     main.pathString] + lotsOfInputs + sdkArgumentsForTesting,
+                              env: ProcessEnv.vars)
+      let scannerJob = try driver.dependencyScanningJob()
+
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
+      let (args, _) = try resolver.resolveArgumentList(for: scannerJob,
+                                                       forceResponseFiles: false,
+                                                       quotePaths: true)
+      XCTAssertTrue(args.count > 1)
+      XCTAssertFalse(args[0].hasSuffix(".resp"))
+    }
+  }
+
   /// Test the libSwiftScan dependency scanning.
   func testDependencyScanning() throws {
     let (stdLibPath, shimsPath, toolchain, hostTriple) = try getDriverArtifactsForScanning()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/811
------------------------------------------------------------------------

**Explanation:** The dependency scanner library does not currently support accepting its arguments via response files. Therefore, we should prevent the driver from ever generating response-file-based scanner invocation commands.

**Scope of Issue:** Building a module with a very large number of source-files in Explicit Module Build mode will fail if the scanner invocation command switches over to response-files. 

**Origination:** Issue new to explicit module builds. 

**Risk:** Very Low