### PR TITLE
[5.5][Test Change] Use `Driver` to generate scanner invocation in dependency scanning test

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -40,7 +40,7 @@ public extension Driver {
 
   /// Generate a full command-line invocation to be used for the dependency scanning action
   /// on the target module.
-  mutating private func dependencyScannerInvocationCommand()
+  @_spi(Testing) public mutating func dependencyScannerInvocationCommand()
   throws -> ([TypedVirtualPath],[Job.ArgTemplate]) {
     // Aggregate the fast dependency scanner arguments
     var inputs: [TypedVirtualPath] = []


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/814
----------------------------------------------------------------------------------
This is more robust than just relying on a hand-written command, and unblocks this test passing on Apple Silicon.