### PR TITLE
[Incremental] Make dot file writer a struct

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -12,7 +12,7 @@
 import TSCBasic
 
 // MARK: - Asking to write dot files / interface
-public class DependencyGraphDotFileWriter {
+public struct DependencyGraphDotFileWriter {
   /// Holds file-system and options
   private let info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
 
@@ -22,21 +22,21 @@ public class DependencyGraphDotFileWriter {
     self.info = info
   }
 
-  func write(_ sfdg: SourceFileDependencyGraph, for file: TypedVirtualPath) {
+  mutating func write(_ sfdg: SourceFileDependencyGraph, for file: TypedVirtualPath) {
     let basename = file.file.basename
     write(sfdg, basename: basename)
   }
   
-  func write(_ mdg: ModuleDependencyGraph) {
+  mutating func write(_ mdg: ModuleDependencyGraph) {
     write(mdg, basename: Self.moduleDependencyGraphBasename)
   }
 
-  public static let moduleDependencyGraphBasename = "moduleDependencyGraph"
+  @_spi(Testing) public static let moduleDependencyGraphBasename = "moduleDependencyGraph"
 }
 
 // MARK: Asking to write dot files / implementation
 fileprivate extension DependencyGraphDotFileWriter {
-  func write<Graph: ExportableGraph>(_ graph: Graph, basename: String) {
+  mutating func write<Graph: ExportableGraph>(_ graph: Graph, basename: String) {
     let path = dotFilePath(for: basename)
     try! info.fileSystem.writeFileContents(path) { stream in
       var s = DOTDependencyGraphSerializer<Graph>(
@@ -49,7 +49,7 @@ fileprivate extension DependencyGraphDotFileWriter {
     }
   }
 
-  func dotFilePath(for basename: String) -> VirtualPath {
+  mutating func dotFilePath(for basename: String) -> VirtualPath {
     let nextVersionNumber = versionNumber
     versionNumber += 1
     return info.buildRecordInfo.dotFileDirectory

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -51,6 +51,9 @@ fileprivate extension DependencyGraphDotFileWriter {
 
   mutating func dotFilePath(for basename: String) -> VirtualPath {
     let nextVersionNumber = versionNumber
+    // Update the version number so that successive saved dot files for the graph
+    // (for instance the ModuleDependencyGraph) can be examined in order to see
+    // how an import changed the graph.
     versionNumber += 1
     return info.buildRecordInfo.dotFileDirectory
       .appending(component: "\(basename).\(nextVersionNumber).dot")

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -30,7 +30,7 @@ import SwiftOptions
   @_spi(Testing) public let info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
 
   /// For debugging, something to write out files for visualizing graphs
-  let dotFileWriter: DependencyGraphDotFileWriter?
+  var dotFileWriter: DependencyGraphDotFileWriter?
 
   @_spi(Testing) public var phase: Phase
 


### PR DESCRIPTION
Since the dot file writer contains a sequence number, it gets mutated whenever a dot file is written.
Make this a struct to pass that info upwards in preparation for making thread-safety for the incremental state clearer.