### PR TITLE
[DNM] phoney-baloney change

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -32,6 +32,8 @@ import SwiftOptions
 /// The public API surface of this class is thread safe, but not re-entrant.
 /// FIXME: This should be an actor.
 public final class IncrementalCompilationState {
+  
+  public let getCIToTest = 17
 
   /// The oracle for deciding what depends on what. Applies to this whole module.
   @_spi(Testing) public let moduleDependencyGraph: ModuleDependencyGraph


### PR DESCRIPTION
Can't figure out why https://github.com/apple/swift-driver/pull/816 should affect `testABIComparisonEndToEnd` and it won't reproduce. So try essentially `main` as a control.