### PR TITLE
[SwiftDriver] Make sure the proper file type is used for the optimization record file in a supplementary output file map

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -291,6 +291,9 @@ public struct Driver {
   /// Path to the Swift private interface file.
   let swiftPrivateInterfacePath: VirtualPath.Handle?
 
+  /// File type for the optimization record.
+  let optimizationRecordFileType: FileType?
+
   /// Path to the optimization record.
   let optimizationRecordPath: VirtualPath.Handle?
 
@@ -726,6 +729,7 @@ public struct Driver {
         break
       }
     }
+    self.optimizationRecordFileType = optimizationRecordFileType
     self.optimizationRecordPath = try Self.computeSupplementaryOutputPath(
         &parsedOptions, type: optimizationRecordFileType,
         isOutputOptions: [.saveOptimizationRecord, .saveOptimizationRecordEQ],

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -366,7 +366,7 @@ extension Driver {
         flag: "-emit-reference-dependencies-path")
 
       addOutputOfType(
-        outputType: .yamlOptimizationRecord,
+        outputType: self.optimizationRecordFileType ?? .yamlOptimizationRecord,
         finalOutputPath: optimizationRecordPath,
         input: input,
         flag: "-save-optimization-record-path")


### PR DESCRIPTION
Previously it was always using `yaml` type even if the format requested was bitstream.