### PR TITLE
Fix small API break in the incremental build state

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -139,6 +139,18 @@ extension IncrementalCompilationState {
       try $0.collectBatchedJobsDiscoveredToBeNeededAfterFinishing(job: finishedJob)
     }
   }
+
+  public func collectJobsDiscoveredToBeNeededAfterFinishing(
+    job finishedJob: Job, result: ProcessResult
+  ) throws -> [Job]? {
+    try collectJobsDiscoveredToBeNeededAfterFinishing(job: finishedJob)
+  }
+
+  public var skippedJobs: [Job] {
+    blockingConcurrentMutation {
+      $0.skippedJobs
+    }
+  }
 }
 
 // MARK: - Scheduling post-compile jobs


### PR DESCRIPTION
https://github.com/apple/swift-driver/pull/816 moved some things around in the incremental compilation state that may be relied on by clients as public API.
This PR restores the removed API surface. Sorry I missed these during review.