### PR TITLE
[Explicit Module Builds] Use Clang dependencies' `contextHash` as partof its filename-encoded hash

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -224,7 +224,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         let targetEncodedModulePath =
           try targetEncodedClangModuleFilePath(for: moduleInfo,
                                                hashParts: getPCMHashParts(pcmArgs: pcmArgs,
-                                                                          moduleMapPath: moduleMapPath.description))
+                                                                          contextHash: moduleDetails.contextHash))
         outputs.append(TypedVirtualPath(file: targetEncodedModulePath, type: .pcm))
         commandLine.appendFlags("-emit-pcm", "-module-name", moduleId.moduleName,
                                 "-o", targetEncodedModulePath.description)
@@ -328,7 +328,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
           let clangModulePath =
             try targetEncodedClangModuleFilePath(for: dependencyInfo,
                                                  hashParts: getPCMHashParts(pcmArgs: pcmArgs,
-                                                                            moduleMapPath: moduleMapPath.description))
+                                                                            contextHash: dependencyClangModuleDetails.contextHash))
           // Accumulate the requried information about this dependency
           clangDependencyArtifacts.append(
             ClangModuleArtifactInfo(name: dependencyId.moduleName,
@@ -393,9 +393,9 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     return VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("\(moduleId.moduleName)-dependencies.json"), contents)
   }
 
-  private func getPCMHashParts(pcmArgs: [String], moduleMapPath: String) -> [String] {
+  private func getPCMHashParts(pcmArgs: [String], contextHash: String) -> [String] {
     var results: [String] = []
-    results.append(moduleMapPath)
+    results.append(contextHash)
     results.append(contentsOf: pcmArgs)
     if integratedDriver {
       return results

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -270,8 +270,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let moduleDetails = try? dependencyGraph.clangModuleDetails(of: .clang(moduleName))
       let lookupHashParts: [String]
       if let details = moduleDetails {
-        let moduleMapPath = details.moduleMapPath.path.description
-        lookupHashParts = [moduleMapPath] + hashParts
+        let contextHash = details.contextHash
+        lookupHashParts = [contextHash] + hashParts
       } else {
         // No such module found, no modulemap
         lookupHashParts = hashParts


### PR DESCRIPTION
It is a more-robust way of ensuring different instances of the same module will never end up overlapping.

Ever since we removed the `-target` argument from `PCMArgs`, previous method of using `PCMArgs` and `.modulemap` path could not, for example, distinguish building the same Clang module, from the same `.modulemap`, with different `-target` triples.