### PR TITLE
[5.5] Disable output file map diagnostic for non-incremental mode

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -570,6 +570,7 @@ public struct Driver {
       fileSystem: fileSystem,
       moduleOutputInfo: moduleOutputInfo,
       outputFileMap: outputFileMap,
+      incremental: self.shouldAttemptIncrementalCompilation,
       parsedOptions: parsedOptions,
       recordedInputModificationDates: recordedInputModificationDates)
 

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -74,12 +74,14 @@ import SwiftOptions
     fileSystem: FileSystem,
     moduleOutputInfo: ModuleOutputInfo,
     outputFileMap: OutputFileMap?,
+    incremental: Bool,
     parsedOptions: ParsedOptions,
     recordedInputModificationDates: [TypedVirtualPath: Date]
   ) {
     // Cannot write a buildRecord without a path.
     guard let buildRecordPath = Self.computeBuildRecordPath(
             outputFileMap: outputFileMap,
+            incremental: incremental,
             compilerOutputType: compilerOutputType,
             workingDirectory: workingDirectory,
             diagnosticEngine: diagnosticEngine)
@@ -124,6 +126,7 @@ import SwiftOptions
   /// Determine the input and output path for the build record
   private static func computeBuildRecordPath(
     outputFileMap: OutputFileMap?,
+    incremental: Bool,
     compilerOutputType: FileType?,
     workingDirectory: AbsolutePath?,
     diagnosticEngine: DiagnosticsEngine
@@ -136,7 +139,9 @@ import SwiftOptions
     guard let partialBuildRecordPath =
             ofm.existingOutputForSingleInput(outputType: .swiftDeps)
     else {
-      diagnosticEngine.emit(.warning_incremental_requires_build_record_entry)
+      if incremental {
+        diagnosticEngine.emit(.warning_incremental_requires_build_record_entry)
+      }
       return nil
     }
     return workingDirectory

--- a/Tests/TestUtilities/OutputFileMapCreator.swift
+++ b/Tests/TestUtilities/OutputFileMapCreator.swift
@@ -18,23 +18,28 @@ public struct OutputFileMapCreator {
   private let module: String
   private let inputPaths: [AbsolutePath]
   private let derivedData: AbsolutePath
+  // The main entry isn't required for some WMO builds
+  private let excludeMainEntry: Bool
 
-  private init(module: String, inputPaths: [AbsolutePath], derivedData: AbsolutePath) {
+  private init(module: String, inputPaths: [AbsolutePath], derivedData: AbsolutePath, excludeMainEntry: Bool) {
     self.module = module
     self.inputPaths = inputPaths
     self.derivedData = derivedData
+    self.excludeMainEntry = excludeMainEntry
   }
 
   public static func write(module: String,
                            inputPaths: [AbsolutePath],
                            derivedData: AbsolutePath,
-                           to dst: AbsolutePath) {
-    let creator = Self(module: module, inputPaths: inputPaths, derivedData: derivedData)
+                           to dst: AbsolutePath,
+                           excludeMainEntry: Bool = false) {
+    let creator = Self(module: module, inputPaths: inputPaths, derivedData: derivedData, excludeMainEntry: excludeMainEntry)
     try! localFileSystem.writeIfChanged(path: dst, bytes: ByteString(creator.generateData()))
   }
 
   private func generateDict() -> [String: [String: String]] {
     let master = ["swift-dependencies": "\(derivedData.pathString)/\(module)-master.swiftdeps"]
+    let mainEntryDict = self.excludeMainEntry ? [:] : ["": master]
     func baseNameEntry(_ s: AbsolutePath) -> [String: String] {
       [
         "dependencies": ".d",
@@ -49,7 +54,7 @@ public struct OutputFileMapCreator {
     return Dictionary(uniqueKeysWithValues:
                         inputPaths.map { ("\($0)", baseNameEntry($0)) }
     )
-    .merging(["": master]) {_, _ in fatalError()}
+    .merging(mainEntryDict) {_, _ in fatalError()}
   }
 
   private func generateData() -> Data {


### PR DESCRIPTION
This re-implements this logic https://github.com/apple/swift/blob/3116eed2e465a2688f070b3b87adc106cbbaf09f/lib/Driver/Driver.cpp#L414-L417 to not warn when output file maps don't have a main entry when using WMO

This cherry picks https://github.com/apple/swift-driver/pull/707 with some significant compatibility changes to the tests