### PR TITLE
[Gardening] Remove and Reformat Foundation Imports

### DIFF
--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import TSCBasic
 import Foundation
 

--- a/Sources/SwiftDriver/Execution/ProcessProtocol.swift
+++ b/Sources/SwiftDriver/Execution/ProcessProtocol.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import TSCBasic
 import Foundation
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import TSCBasic
 
 /// A map from a module identifier to a set of module dependency graphs

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
+
 /// A map from a module identifier to its info
 public typealias ModuleInfoMap = [ModuleDependencyId: ModuleInfo]
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-import Foundation
+import Dispatch
 
 // An inter-module dependency oracle, responsible for responding to queries about
 // dependencies of a given module, caching already-discovered dependencies along the way.

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import Foundation
 import TSCBasic
 import SwiftOptions

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 
 /// Describes a given Swift module's pre-built module artifacts:
 /// - Swift Module (name)

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 import TSCBasic
 
 /// A filename from another module

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -1,4 +1,3 @@
-import Foundation
 //===--------------- FirstWaveComputer.swift - Incremental --------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -10,6 +9,8 @@ import Foundation
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import Foundation
 import TSCBasic
 
 extension IncrementalCompilationState {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
@@ -9,9 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import Dispatch
 import TSCBasic
 import TSCUtility
-import Foundation
 import SwiftOptions
 
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -9,9 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import Dispatch
 import TSCBasic
 import TSCUtility
-import Foundation
 import SwiftOptions
 
 /// An instance of `IncrementalCompilationState` encapsulates the data necessary

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -1,5 +1,3 @@
-import Foundation
-import SwiftOptions
 //===----- IncrementalDependencyAndInputSetup.swift - Incremental --------===//
 //
 // This source file is part of the Swift.org open source project
@@ -11,7 +9,10 @@ import SwiftOptions
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import TSCBasic
+import Foundation
+import SwiftOptions
 
 // Initial incremental state computation
 extension IncrementalCompilationState {

--- a/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import Foundation
 import TSCBasic
 

--- a/Sources/SwiftDriver/IncrementalCompilation/KeyAndFingerprintHolder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/KeyAndFingerprintHolder.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 
 
 /// Encapsulates the invariant required for anything with a DependencyKey and an fingerprint

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import Foundation
 import TSCBasic
 import TSCUtility

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 import TSCBasic
 
 // MARK: - DependencySource

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-import Foundation
 
 extension ModuleDependencyGraph {
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 import TSCBasic
 
 // MARK: - ModuleDependencyGraph.Node

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 import TSCBasic
 
 extension ModuleDependencyGraph {

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 import TSCBasic
 import TSCUtility
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SwiftSourceFile.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SwiftSourceFile.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import TSCBasic
 
 /// Because the incremental compilation system treats files containing Swift source code specially,

--- a/Sources/SwiftDriver/Jobs/BackendJob.swift
+++ b/Sources/SwiftDriver/Jobs/BackendJob.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 
 extension Driver {
   /// Form a backend job.

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import TSCBasic
 import Foundation
 

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import Foundation
 import TSCBasic
 import SwiftOptions

--- a/Sources/SwiftDriver/Utilities/DateAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/DateAdditions.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import Foundation
 
 public extension Date {

--- a/Sources/SwiftDriver/Utilities/FileList.swift
+++ b/Sources/SwiftDriver/Utilities/FileList.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 
 public enum FileList: Hashable {
   /// File of file paths

--- a/Tests/IncrementalTestFramework/Module.swift
+++ b/Tests/IncrementalTestFramework/Module.swift
@@ -14,7 +14,6 @@ import TSCBasic
 @_spi(Testing) import SwiftDriver
 import SwiftOptions
 import TestUtilities
-import Foundation
 import XCTest
 
 /// Represents a module to be compiled.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 @_spi(Testing) import SwiftDriver
 import SwiftDriverExecution
 import TSCBasic

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -13,7 +13,6 @@
 @_spi(Testing) import SwiftDriver
 import TSCBasic
 import TSCUtility
-import Foundation
 import XCTest
 
 // MARK: - utilities for unit testing

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 
 enum ModuleDependenciesInputs {
   static var fastDependencyScannerOutput: String {

--- a/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/IncrementalCompilationInputs.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 
 enum Inputs {
   static var buildRecord: String {

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import XCTest
-import Foundation
 import TSCBasic
 import TSCUtility
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import Foundation
 @_spi(Testing) import SwiftDriver
 import SwiftDriverExecution
 import SwiftOptions

--- a/Tests/TestUtilities/OutputFileMapCreator.swift
+++ b/Tests/TestUtilities/OutputFileMapCreator.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-
 import Foundation
 
 public struct OutputFileMapCreator {


### PR DESCRIPTION
Foundation is imported by default in the template Swift files Xcode generates, but it's strictly not necessary in most cases.