### PR TITLE
Verify emitted modules interfaces of public frameworks by default

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -430,11 +430,15 @@ extension Driver {
 
   private mutating func addVerifyJobs(emitModuleJob: Job, addJob: (Job) -> Void )
   throws {
+    // Turn this flag on by default with the env var or for public frameworks.
+    let onByDefault = env["ENABLE_DEFAULT_INTERFACE_VERIFIER"] != nil ||
+        parsedOptions.getLastArgument(.libraryLevel)?.asSingle == "api"
+
     guard
        parsedOptions.hasArgument(.enableLibraryEvolution),
        parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
                              negative: .noVerifyEmittedModuleInterface,
-                             default: true),
+                             default: onByDefault),
 
       // Don't verify by default modules emitted from a merge-module job
       // as it's more likely to be invalid
@@ -444,12 +448,6 @@ extension Driver {
                               default: false)
     else { return }
 
-    // FIXME: remove this when we are confident to enable interface verification
-    // by default.
-    if env["ENABLE_DEFAULT_INTERFACE_VERIFIER"] == nil &&
-        !parsedOptions.hasArgument(.verifyEmittedModuleInterface) {
-      return
-    }
     func addVerifyJob(forPrivate: Bool) throws {
       let isNeeded =
         forPrivate

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4107,6 +4107,30 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(verifyJob.inputs[0] == emitInterfaceOutput[0])
       XCTAssertTrue(verifyJob.commandLine.contains(.path(emitInterfaceOutput[0].file)))
     }
+
+    // Enabled by default when the library-level is api.
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
+                                     "foo", "-emit-module-interface",
+                                     "-enable-library-evolution",
+                                     "-whole-module-optimization",
+                                     "-library-level", "api"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 2)
+      XCTAssertTrue(plannedJobs.contains() {$0.kind == .verifyModuleInterface})
+    }
+
+    // Not enabled by default when the library-level is spi.
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
+                                     "foo", "-emit-module-interface",
+                                     "-enable-library-evolution",
+                                     "-whole-module-optimization",
+                                     "-library-level", "spi"])
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+    }
   }
 
   func testPCHGeneration() throws {


### PR DESCRIPTION
Verify emitted module interfaces of public frameworks by default. These framework's interfaces are critical and must be valid.

We can verify the module interfaces of all frameworks later on.

rdar://82987741