### PR TITLE
Pass-down -prebuilt-module-cache-dir when targeting at macCatalyst

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -336,6 +336,18 @@ public final class DarwinToolchain: Toolchain {
       commandLine.append(.flag("-target-variant-sdk-version"))
       commandLine.append(.flag(sdkInfo.sdkVersion(for: targetVariantTriple).description))
     }
+    // We should be able to pass down prebuilt module dir for all other SDKs.
+    // For macCatalyst, doing so is specifically necessary because -target-sdk-version
+    // doesn't always match the macosx sdk version so the compiler may fail to find
+    // the prebuilt module in the versioned sub-dir.
+    if frontendTargetInfo.target.triple.isMacCatalyst {
+      commandLine.appendFlag(.prebuiltModuleCachePath)
+      commandLine.appendPath(try getToolPath(.swiftCompiler).parentDirectory/*bin*/
+        .parentDirectory/*usr*/
+        .appending(component: "lib").appending(component: "swift")
+        .appending(component: "macosx").appending(component: "prebuilt-modules")
+        .appending(component: sdkInfo.versionString))
+    }
   }
 }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4925,6 +4925,28 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testPrebuiltModuleCacheFlags() throws {
+    let packageRootPath = URL(fileURLWithPath: #file).pathComponents
+      .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
+    let testInputsPath = packageRootPath + "/TestInputs"
+    let mockSDKPath : String = testInputsPath + "/mock-sdk.sdk"
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-target", "x86_64-apple-ios13.0-macabi", "foo.swift", "-sdk", mockSDKPath])
+      let plannedJobs = try driver.planBuild()
+      let job = plannedJobs[0]
+      XCTAssertTrue(job.commandLine.contains(.flag("-prebuilt-module-cache-path")))
+      XCTAssertTrue(job.commandLine.contains { arg in
+        if case .path(let curPath) = arg {
+          if curPath.basename == "10.15" && curPath.parentDirectory.basename == "prebuilt-modules" {
+              return true
+          }
+        }
+        return false
+      })
+    }
+  }
+
   func testRelativeResourceDir() throws {
     do {
       var driver = try Driver(args: ["swiftc",


### PR DESCRIPTION
All prebuilt modules are emitted into SDK-versioned subdirs. When targeting at macCatalyst,
the value from -target-sdk-version doesn't match the actual SDK version because the SDK under
used is a macosx SDK. This patch computes the prebuilt module cache path and passes it down directly
to the compiler invocation.

rdar://82464316