### PR TITLE
[Dependency Scanning] Do not include PCH-handling command-line flags on the scanning jobs

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -49,7 +49,7 @@ public extension Driver {
     commandLine.appendFlag("-frontend")
     commandLine.appendFlag("-scan-dependencies")
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
-                                 bridgingHeaderHandling: .precompiled,
+                                 bridgingHeaderHandling: .ignored,
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
@@ -224,7 +224,7 @@ public extension Driver {
     commandLine.appendFlag("-scan-dependencies")
     commandLine.appendFlag("-import-prescan")
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
-                                 bridgingHeaderHandling: .precompiled,
+                                 bridgingHeaderHandling: .ignored,
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
@@ -255,7 +255,7 @@ public extension Driver {
     commandLine.appendFlag("-frontend")
     commandLine.appendFlag("-scan-dependencies")
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
-                                 bridgingHeaderHandling: .precompiled,
+                                 bridgingHeaderHandling: .ignored,
                                  moduleDependencyGraphUse: .dependencyScan)
 
     let batchScanInputFilePath = try serializeBatchScanningModuleArtifacts(moduleInfos: moduleInfos)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -758,6 +758,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath,
                                      "-I", swiftModuleInterfacesPath,
+                                     "-import-objc-header",
                                      "-experimental-explicit-module-build",
                                      "-working-directory", path.pathString,
                                      "-disable-clang-target",
@@ -771,6 +772,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
       if scannerCommand.first == "-frontend" {
         scannerCommand.removeFirst()
       }
+
+      // Ensure we do not propagate the ususal PCH-handling arguments to the scanner invocation
+      XCTAssertFalse(scannerCommand.contains("-pch-output-dir"))
 
       // Here purely to dump diagnostic output in a reasonable fashion when things go wrong.
       let lock = NSLock()


### PR DESCRIPTION
These jobs do not require handling of the module's PCH.
If we do emit these flags, the underlying Clang invocation will have expectations that may not be met (such as going looking for existing PCH files, etc.).