### PR TITLE
[5.5][Dependency Scanning] Do not include PCH-handling command-line flags on the scanning jobs

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -48,7 +48,7 @@ public extension Driver {
     commandLine.appendFlag("-frontend")
     commandLine.appendFlag("-scan-dependencies")
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
-                                 bridgingHeaderHandling: .precompiled,
+                                 bridgingHeaderHandling: .ignored,
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
@@ -246,7 +246,7 @@ public extension Driver {
     commandLine.appendFlag("-scan-dependencies")
     commandLine.appendFlag("-import-prescan")
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
-                                 bridgingHeaderHandling: .precompiled,
+                                 bridgingHeaderHandling: .ignored,
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
@@ -277,7 +277,7 @@ public extension Driver {
     commandLine.appendFlag("-frontend")
     commandLine.appendFlag("-scan-dependencies")
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs,
-                                 bridgingHeaderHandling: .precompiled,
+                                 bridgingHeaderHandling: .ignored,
                                  moduleDependencyGraphUse: .dependencyScan)
 
     let batchScanInputFilePath = try serializeBatchScanningModuleArtifacts(moduleInfos: moduleInfos)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -755,6 +755,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath,
                                      "-I", swiftModuleInterfacesPath,
+                                     "-import-objc-header",
                                      "-experimental-explicit-module-build",
                                      "-working-directory", path.pathString,
                                      "-disable-clang-target",
@@ -768,6 +769,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
       if scannerCommand.first == "-frontend" {
         scannerCommand.removeFirst()
       }
+
+      // Ensure we do not propagate the ususal PCH-handling arguments to the scanner invocation
+      XCTAssertFalse(scannerCommand.contains("-pch-output-dir"))
 
       // Here purely to dump diagnostic output in a reasonable fashion when things go wrong.
       let lock = NSLock()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/841
------------------------------------------------------------------
Explanation: These jobs do not require handling of the module's PCH. If we do emit these flags, the underlying Clang invocation will have expectations that may not be met (such as going looking for existing PCH files, etc.), leading to errors/crashes.
Risk: Low
Reviewed by: @nkcsgexi
Testing: Automated tests modified to capture the new behavior restriction
