### PR TITLE
[Explicit Module Builds] Use new form of `-fmodule-file` to work around Clang issue with explicit builds and emit-PCH

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -288,7 +288,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         TypedVirtualPath(file: moduleArtifactInfo.moduleMapPath.path,
                          type: .clangModuleMap)
       commandLine.appendFlags("-Xcc", "-Xclang", "-Xcc",
-                              "-fmodule-file=\(clangModulePath.file.description)")
+                              "-fmodule-file=\(moduleArtifactInfo.moduleName)=\(clangModulePath.file.description)")
       commandLine.appendFlags("-Xcc", "-Xclang", "-Xcc",
                               "-fmodule-map-file=\(clangModuleMapPath.file.description)")
       inputs.append(clangModulePath)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -128,7 +128,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
         XCTAssertTrue(job.inputs.contains(clangDependencyModulePath))
         XCTAssertTrue(job.inputs.contains(clangDependencyModuleMapPath))
         XCTAssertTrue(job.commandLine.contains(
-                        .flag(String("-fmodule-file=\(clangDependencyModulePathString)"))))
+          .flag(String("-fmodule-file=\(dependencyId.moduleName)=\(clangDependencyModulePathString)"))))
         XCTAssertTrue(job.commandLine.contains(
                         .flag(String("-fmodule-map-file=\(clangDependencyDetails.moduleMapPath.path.description)"))))
       case .swiftPlaceholder(_):


### PR DESCRIPTION
This form causes Swift's underlying Clang invocation to take different code-paths when loading pre-built PCM dependencies, which is not affected on whether the compiler is in emit-pre-built-header mode.

Workaround for rdar://83309762