### PR TITLE
[5.5] Emit ABI descriptor while emitting the final module

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -333,6 +333,9 @@ public struct Driver {
   /// A global queue for emitting non-interrupted messages into stderr
   public static let stdErrQueue = DispatchQueue(label: "org.swift.driver.emit-to-stderr")
 
+  enum KnownCompilerFeature: String {
+    case emit_abi_descriptor = "emit-abi-descriptor"
+  }
 
   lazy var sdkPath: VirtualPath? = {
     guard let rawSdkPath = frontendTargetInfo.sdkPath?.path else {
@@ -362,6 +365,10 @@ public struct Driver {
         return false
       }
     }
+  }
+
+  func isFeatureSupported(_ feature: KnownCompilerFeature) -> Bool {
+    return supportedFrontendFeatures.contains(feature.rawValue)
   }
 
   /// Handler for emitting diagnostics to stderr.

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -327,6 +327,9 @@ public struct Driver {
   /// A collection of all the flags the selected toolchain's `swift-frontend` supports
   public let supportedFrontendFlags: Set<String>
 
+  /// A collection of all the features the selected toolchain's `swift-frontend` supports
+  public let supportedFrontendFeatures: Set<String>
+
   /// A global queue for emitting non-interrupted messages into stderr
   public static let stdErrQueue = DispatchQueue(label: "org.swift.driver.emit-to-stderr")
 
@@ -602,11 +605,12 @@ public struct Driver {
                                                                                outputFileMap: outputFileMap)
 
     self.supportedFrontendFlags =
-      try Self.computeSupportedCompilerFeatures(of: self.toolchain, hostTriple: self.hostTriple,
+      try Self.computeSupportedCompilerArgs(of: self.toolchain, hostTriple: self.hostTriple,
                                                 parsedOptions: &self.parsedOptions,
                                                 diagnosticsEngine: diagnosticEngine,
                                                 fileSystem: fileSystem, executor: executor,
                                                 env: env)
+    self.supportedFrontendFeatures = try Self.computeSupportedCompilerFeatures(of: self.toolchain, env: env)
 
     self.enabledSanitizers = try Self.parseSanitizerArgValues(
       &parsedOptions,

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -348,7 +348,7 @@ public extension Driver {
       .appending(component: "lib_InternalSwiftScan" + sharedLibExt)
   }
 
-  fileprivate static func getRootPath(of toolchain: Toolchain, env: [String: String])
+  static func getRootPath(of toolchain: Toolchain, env: [String: String])
   throws -> AbsolutePath {
     if let overrideString = env["SWIFT_DRIVER_SWIFT_SCAN_TOOLCHAIN_PATH"] {
       return try AbsolutePath(validating: overrideString)

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -78,9 +78,13 @@ extension Driver {
       commandLine.appendFlag(.parseAsLibrary)
     }
 
+    let outputPath = VirtualPath.lookup(moduleOutputPath)
     commandLine.appendFlag(.o)
-    commandLine.appendPath(VirtualPath.lookup(moduleOutputPath))
-
+    commandLine.appendPath(outputPath)
+    if isFeatureSupported(.emit_abi_descriptor) {
+      commandLine.appendFlag(.emitAbiDescriptorPath)
+      commandLine.appendPath(outputPath.replacingExtension(with: .jsonABIBaseline))
+    }
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .emitModule,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -72,9 +72,14 @@ extension Driver {
       try commandLine.appendLast(.disableIncrementalImports, from: &parsedOptions)
     }
 
+    let outputPath = VirtualPath.lookup(moduleOutputInfo.output!.outputPath)
     commandLine.appendFlag(.o)
-    commandLine.appendPath(VirtualPath.lookup(moduleOutputInfo.output!.outputPath))
+    commandLine.appendPath(outputPath)
 
+    if isFeatureSupported(.emit_abi_descriptor) {
+      commandLine.appendFlag(.emitAbiDescriptorPath)
+      commandLine.appendPath(outputPath.replacingExtension(with: .jsonABIBaseline))
+    }
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .mergeModule,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4728,6 +4728,12 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testSupportedFeatureJson() throws {
+    let driver = try Driver(args: ["swiftc", "-emit-module", "foo.swift"])
+    XCTAssertFalse(driver.supportedFrontendFeatures.isEmpty)
+    XCTAssertTrue(driver.supportedFrontendFeatures.contains("experimental-skip-all-function-bodies"))
+  }
+
   func testFilelist() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-emit-module", "./a.swift", "./b.swift", "./c.swift", "-module-name", "main", "-target", "x86_64-apple-macosx10.9", "-driver-filelist-threshold=0"])


### PR DESCRIPTION
Explanation: This change asks the compiler to emit ABI descriptors while generating module files if this feature (emitting ABI while emitting module) is supported by the compiler. To check whether the feature is supported by the compiler, this change also added support for the feature list file installed in the toolchain.
Risk: Low
Reviewed by: @artemcm 
Testing: Automated tests added


This is a cherry-pick of https://github.com/apple/swift-driver/pull/845