### PR TITLE
[5.5][Dependency Scanning] Adapt to changes in dependency scanner to capture initial PCM arguments

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -134,6 +134,8 @@ typedef struct {
   (*swiftscan_clang_detail_get_context_hash)(swiftscan_module_details_t);
   swiftscan_string_set_t *
   (*swiftscan_clang_detail_get_command_line)(swiftscan_module_details_t);
+  swiftscan_string_set_t *
+  (*swiftscan_clang_detail_get_captured_pcm_args)(swiftscan_module_details_t);
 
   //=== Batch Scan Input Functions ------------------------------------------===//
   swiftscan_batch_scan_input_t *

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
@@ -55,6 +55,11 @@ internal extension Driver {
         return moduleInfos
       }.reduce([], +)
 
+    guard !batchScanInputList.isEmpty else {
+      // If no new re-scans are needed, we are done here.
+      return
+    }
+
     // Batch scan all clang modules for each discovered new, unique set of PCMArgs, per module
     let moduleVersionedGraphMap: [ModuleDependencyId: [InterModuleDependencyGraph]] =
       try performBatchDependencyScan(moduleInfos: batchScanInputList)
@@ -143,7 +148,7 @@ private extension InterModuleDependencyGraph {
           // captured in the described dependencies of this module. Only re-scan at PCMArgs not
           // already captured.
           let alreadyCapturedPCMArgs =
-            clangModuleDetails.dependenciesCapturedPCMArgs ?? Set<[String]>()
+            clangModuleDetails.capturedPCMArgs ?? Set<[String]>()
           let newPCMArgSet = pathPCMArtSet.filter { !alreadyCapturedPCMArgs.contains($0) }
           // Add current path's PCMArgs to the SetMap and stop traversal
           if pcmArgSetMap[moduleId] != nil {
@@ -184,10 +189,10 @@ private extension InterModuleDependencyGraph {
         throw Driver.Error.malformedModuleDependency(moduleId.moduleName,
                                                      "no Clang `details` object")
       }
-      if clangModuleDetails.dependenciesCapturedPCMArgs == nil {
-        clangModuleDetails.dependenciesCapturedPCMArgs = Set<[String]>()
+      if clangModuleDetails.capturedPCMArgs == nil {
+        clangModuleDetails.capturedPCMArgs = Set<[String]>()
       }
-      newPCMArgs.forEach { clangModuleDetails.dependenciesCapturedPCMArgs!.insert($0) }
+      newPCMArgs.forEach { clangModuleDetails.capturedPCMArgs!.insert($0) }
       modules[moduleId]!.details = .clang(clangModuleDetails)
     }
   }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -184,7 +184,7 @@ extension InterModuleDependencyGraph {
 
     // As far as their dependencies go, these module infos are identical
     if firstInfo.directDependencies == secondInfo.directDependencies,
-       firstDetails.dependenciesCapturedPCMArgs == secondDetails.dependenciesCapturedPCMArgs,
+       firstDetails.capturedPCMArgs == secondDetails.capturedPCMArgs,
        firstInfo.sourceFiles == secondInfo.sourceFiles {
       return firstInfo
     }
@@ -198,15 +198,15 @@ extension InterModuleDependencyGraph {
     let secondModuleDependencies = secondInfo.directDependencies ?? []
     let combinedDependencies = Array(Set(firstModuleDependencies + secondModuleDependencies))
 
-    let firstModuleCapturedPCMArgs = firstDetails.dependenciesCapturedPCMArgs ?? Set<[String]>()
-    let secondModuleCapturedPCMArgs = secondDetails.dependenciesCapturedPCMArgs ?? Set<[String]>()
+    let firstModuleCapturedPCMArgs = firstDetails.capturedPCMArgs ?? Set<[String]>()
+    let secondModuleCapturedPCMArgs = secondDetails.capturedPCMArgs ?? Set<[String]>()
     let combinedCapturedPCMArgs = firstModuleCapturedPCMArgs.union(secondModuleCapturedPCMArgs)
 
     let combinedModuleDetails =
       ClangModuleDetails(moduleMapPath: firstDetails.moduleMapPath,
-                         dependenciesCapturedPCMArgs: combinedCapturedPCMArgs,
                          contextHash: firstDetails.contextHash,
-                         commandLine: firstDetails.commandLine)
+                         commandLine: firstDetails.commandLine,
+                         capturedPCMArgs: combinedCapturedPCMArgs)
 
     return ModuleInfo(modulePath: firstInfo.modulePath,
                       sourceFiles: combinedSourceFiles,

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -151,24 +151,24 @@ public struct ClangModuleDetails: Codable {
   /// The path to the module map used to build this module.
   public var moduleMapPath: TextualVirtualPath
 
-  /// Set of PCM Arguments of depending modules which
-  /// are covered by the directDependencies info of this module
-  public var dependenciesCapturedPCMArgs: Set<[String]>?
-
   /// clang-generated context hash
   public var contextHash: String
 
   /// Options to the compile command
   public var commandLine: [String] = []
 
+  /// Set of PCM Arguments of depending modules which
+  /// are covered by the directDependencies info of this module
+  public var capturedPCMArgs: Set<[String]>?
+
   public init(moduleMapPath: TextualVirtualPath,
-              dependenciesCapturedPCMArgs: Set<[String]>?,
               contextHash: String,
-              commandLine: [String]) {
+              commandLine: [String],
+              capturedPCMArgs: Set<[String]>?) {
     self.moduleMapPath = moduleMapPath
-    self.dependenciesCapturedPCMArgs = dependenciesCapturedPCMArgs
     self.contextHash = contextHash
     self.commandLine = commandLine
+    self.capturedPCMArgs = capturedPCMArgs
   }
 }
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -87,7 +87,7 @@ public class InterModuleDependencyOracle {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to serialize scanner cache with no scanner instance.")
     }
-    if swiftScan.canLoadStoreScannerCache() {
+    if swiftScan.canLoadStoreScannerCache {
       swiftScan.serializeScannerCache(to: path)
     }
   }
@@ -96,7 +96,7 @@ public class InterModuleDependencyOracle {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to load scanner cache with no scanner instance.")
     }
-    if swiftScan.canLoadStoreScannerCache() {
+    if swiftScan.canLoadStoreScannerCache {
       return swiftScan.loadScannerCache(from: path)
     }
     return false
@@ -106,7 +106,7 @@ public class InterModuleDependencyOracle {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to reset scanner cache with no scanner instance.")
     }
-    if swiftScan.canLoadStoreScannerCache() {
+    if swiftScan.canLoadStoreScannerCache {
       swiftScan.resetScannerCache()
     }
   }

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -230,10 +230,20 @@ private extension SwiftScan {
                                using: api.swiftscan_clang_detail_get_command_line,
                                fieldName: "clang_detail.commandLine")
 
+    let capturedPCMArgs : Set<[String]>?
+    if clangDetailsHaveCapturedPCMArgs {
+      let capturedArgs = try getStringArrayDetail(from: moduleDetailsRef,
+                                                  using: api.swiftscan_clang_detail_get_captured_pcm_args,
+                                                  fieldName: "clang_detail.capturedPCMArgs")
+      capturedPCMArgs = [capturedArgs]
+    } else {
+      capturedPCMArgs = nil
+    }
+
     return ClangModuleDetails(moduleMapPath: moduleMapPath,
-                              dependenciesCapturedPCMArgs: nil,
                               contextHash: contextHash,
-                              commandLine: commandLine)
+                              commandLine: commandLine,
+                              capturedPCMArgs: capturedPCMArgs)
   }
 }
 

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -208,10 +208,14 @@ internal final class SwiftScan {
     return resultGraphMap
   }
 
-  @_spi(Testing) public func canLoadStoreScannerCache() -> Bool {
-    return api.swiftscan_scanner_cache_load != nil &&
-           api.swiftscan_scanner_cache_serialize != nil &&
-           api.swiftscan_scanner_cache_reset != nil
+  @_spi(Testing) public var canLoadStoreScannerCache : Bool {
+    api.swiftscan_scanner_cache_load != nil &&
+    api.swiftscan_scanner_cache_serialize != nil &&
+    api.swiftscan_scanner_cache_reset != nil
+  }
+
+  @_spi(Testing) public var clangDetailsHaveCapturedPCMArgs : Bool {
+    api.swiftscan_clang_detail_get_captured_pcm_args != nil
   }
 
   func serializeScannerCache(to path: AbsolutePath) {
@@ -288,6 +292,10 @@ private extension swiftscan_functions_t {
       try loadOptional("swiftscan_scanner_cache_load")
     self.swiftscan_scanner_cache_reset =
       try loadOptional("swiftscan_scanner_cache_reset")
+
+    // Clang dependency captured PCM args
+    self.swiftscan_clang_detail_get_captured_pcm_args =
+      try loadOptional("swiftscan_clang_detail_get_captured_pcm_args")
 
     // MARK: Required Methods
     func loadRequired<T>(_ symbol: String) throws -> T {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/848
-----------------------------------------------
- Explanation: The graph coming out of the scanner will already contain an initial set of captured PCM arguments as defined by the initial scanner invocation. This will allow us to skip the batch re-scan at argument sets that are redundant because they were already captured via the initial scan.
- Risk: Low
