### PR TITLE
Support response files with relative paths.

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -924,6 +924,55 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testResponseFileExpansionRelativePathsInCWD() throws {
+    try withTemporaryDirectory { path in
+      guard let preserveCwd = localFileSystem
+        .currentWorkingDirectory else { fatalError() }
+      try! localFileSystem.changeCurrentWorkingDirectory(to: path)
+      defer { try! localFileSystem.changeCurrentWorkingDirectory(to: preserveCwd) }
+
+      let diags = DiagnosticsEngine()
+      let fooPath = path.appending(component: "foo.rsp")
+      let barPath = path.appending(component: "bar.rsp")
+      try localFileSystem.writeFileContents(fooPath) {
+        $0 <<< "hello\nbye\nbye\\ to\\ you\n@bar.rsp"
+      }
+      try localFileSystem.writeFileContents(barPath) {
+        $0 <<< "from\nbar\n@foo.rsp"
+      }
+      let args = try Driver.expandResponseFiles(["swift", "compiler", "-Xlinker", "@loader_path", "@foo.rsp", "something"], fileSystem: localFileSystem, diagnosticsEngine: diags)
+      XCTAssertEqual(args, ["swift", "compiler", "-Xlinker", "@loader_path", "hello", "bye", "bye to you", "from", "bar", "something"])
+      XCTAssertEqual(diags.diagnostics.count, 1)
+      XCTAssert(diags.diagnostics.first!.description.contains("is recursively expanded"))
+    }
+  }
+
+  /// Tests that relative paths in response files are resolved based on the CWD, not the response file's location.
+  func testResponseFileExpansionRelativePathsNotInCWD() throws {
+    try withTemporaryDirectory { path in
+      guard let preserveCwd = localFileSystem
+        .currentWorkingDirectory else { fatalError() }
+      try! localFileSystem.changeCurrentWorkingDirectory(to: path)
+      defer { try! localFileSystem.changeCurrentWorkingDirectory(to: preserveCwd) }
+
+      try localFileSystem.createDirectory(path.appending(component: "subdir"))
+
+      let diags = DiagnosticsEngine()
+      let fooPath = path.appending(components: "subdir", "foo.rsp")
+      let barPath = path.appending(components: "subdir", "bar.rsp")
+      try localFileSystem.writeFileContents(fooPath) {
+        $0 <<< "hello\nbye\nbye\\ to\\ you\n@subdir/bar.rsp"
+      }
+      try localFileSystem.writeFileContents(barPath) {
+        $0 <<< "from\nbar\n@subdir/foo.rsp"
+      }
+      let args = try Driver.expandResponseFiles(["swift", "compiler", "-Xlinker", "@loader_path", "@subdir/foo.rsp", "something"], fileSystem: localFileSystem, diagnosticsEngine: diags)
+      XCTAssertEqual(args, ["swift", "compiler", "-Xlinker", "@loader_path", "hello", "bye", "bye to you", "from", "bar", "something"])
+      XCTAssertEqual(diags.diagnostics.count, 1)
+      XCTAssert(diags.diagnostics.first!.description.contains("is recursively expanded"))
+    }
+  }
+
   /// Tests how response files tokens such as spaces, comments, escaping characters and quotes, get parsed and expanded.
   func testResponseFileTokenization() throws {
     try withTemporaryDirectory { path  in


### PR DESCRIPTION
This makes swift-driver's behavior consistent with the old driver, which supports relative paths (both on the command line and in other response files). The LLVM response file parsing behavior used by the legacy driver is such that

-   Response file equivalence to prevent recursion is based on the file's device/inode pair, not its path.

-   Relative paths are resolved based on the current working directory of the process, even when the relative path is in another response file. (LLVM's parser has an option to make relative paths resolve based on the containing response file's path, but this is not enabled by the legacy driver.)

-   After resolving, the path is tested to ensure that it resolves to an actual file; this ensures that special linker paths like `@loader_path` fall back to regular arguments instead of throwing an error and exiting by attempting to read them.