### PR TITLE
PrebuiltModuleGen: check if an interface is for macabi by reading interface contents

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -12,6 +12,19 @@
 import TSCBasic
 import SwiftOptions
 
+@_spi(Testing) public func isIosMacInterface(_ path: VirtualPath) throws -> Bool {
+  let data = try localFileSystem.readFileContents(path).cString
+  let myStrings = data.components(separatedBy: .newlines)
+  let prefix = "// swift-module-flags: "
+  if let argLine = myStrings.first(where: { $0.hasPrefix(prefix) }) {
+    let args = argLine.dropFirst(prefix.count).components(separatedBy: " ")
+    if let idx = args.firstIndex(of: "-target"), idx + 1 < args.count {
+      return args[idx + 1].contains("macabi")
+    }
+  }
+  return false
+}
+
 func isIosMac(_ path: VirtualPath) -> Bool {
   // Infer macabi interfaces by the file name.
   // FIXME: more robust way to do this.
@@ -432,7 +445,7 @@ extension Driver {
       commandLine.appendFlag(.parseStdlib)
     }
     // Add macabi-specific search path.
-    if isIosMac(inputPath.path.file) {
+    if try isIosMacInterface(inputPath.path.file) {
       commandLine.appendFlag(.Fsystem)
       commandLine.append(.path(iosMacFrameworksSearchPath))
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5030,6 +5030,17 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testIsIosMacInterface() throws {
+    try withTemporaryFile { file in
+      try localFileSystem.writeFileContents(file.path) { $0 <<< "// swift-module-flags: -target x86_64-apple-ios15.0-macabi" }
+      XCTAssertTrue(try isIosMacInterface(VirtualPath.absolute(file.path)))
+    }
+    try withTemporaryFile { file in
+      try localFileSystem.writeFileContents(file.path) { $0 <<< "// swift-module-flags: -target arm64e-apple-macos12.0" }
+      XCTAssertFalse(try isIosMacInterface(VirtualPath.absolute(file.path)))
+    }
+  }
+
   func testSupportedFeatureJson() throws {
     let driver = try Driver(args: ["swiftc", "-emit-module", "foo.swift"])
     XCTAssertFalse(driver.supportedFrontendFeatures.isEmpty)


### PR DESCRIPTION
Previously, we were using the file name to infer whether an interface is for macabi.
However, this seems to be inaccurate because some macabi interfaces don't have "-macabi" in
the file names. This patch teaches the driver to open interface files and check
module targets specifically.