### PR TITLE
[5.5] PrebuiltModuleGen: check if an interface is for macabi by reading interface contents

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4742,6 +4742,17 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testIsIosMacInterface() throws {
+    try withTemporaryFile { file in
+      try localFileSystem.writeFileContents(file.path) { $0 <<< "// swift-module-flags: -target x86_64-apple-ios15.0-macabi" }
+      XCTAssertTrue(try isIosMacInterface(VirtualPath.absolute(file.path)))
+    }
+    try withTemporaryFile { file in
+      try localFileSystem.writeFileContents(file.path) { $0 <<< "// swift-module-flags: -target arm64e-apple-macos12.0" }
+      XCTAssertFalse(try isIosMacInterface(VirtualPath.absolute(file.path)))
+    }
+  }
+
   func testSupportedFeatureJson() throws {
     let driver = try Driver(args: ["swiftc", "-emit-module", "foo.swift"])
     XCTAssertFalse(driver.supportedFrontendFeatures.isEmpty)


### PR DESCRIPTION
Explanation: Previously, we were using the file name to infer whether an interface is for macabi.
However, this seems to be inaccurate because some macabi interfaces don't have "-macabi" in
the file names. This patch teaches the driver to open interface files and check
module target specifically.

Scope: Swift prebuilt module generation

Risk: Very low

Testing: regression test added

Reviewed by: @xymus 

Cherry-pick of: https://github.com/apple/swift-driver/pull/855