### PR TITLE
Building object files using -c with -lto should respect the output file path (-o) if present

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -85,7 +85,7 @@ extension Driver {
       } else {
         // When -lto is set, .bc will be used for linking. Otherwise, .bc is
         // top-level output (-emit-bc)
-        return lto == nil
+        return lto == nil || linkerOutputType == nil
       }
     case .swiftModule:
       return compilerMode.isSingleCompilation && moduleOutputInfo.output?.isTopLevel ?? false

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -313,6 +313,28 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(driver6.compilerOutputType, .llvmBitcode)
   }
 
+  func testLtoOutputPath() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-lto=llvm-full", "-c", "-target", "x86_64-apple-macosx10.9"])
+      XCTAssertEqual(driver.compilerOutputType, .llvmBitcode)
+      XCTAssertEqual(driver.linkerOutputType, nil)
+      let jobs = try driver.planBuild()
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].outputs.count, 1)
+      XCTAssertEqual(jobs[0].outputs[0].file.basename, "foo.bc")
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-lto=llvm-full", "-c", "-target", "x86_64-apple-macosx10.9", "-o", "foo.o"])
+      XCTAssertEqual(driver.compilerOutputType, .llvmBitcode)
+      XCTAssertEqual(driver.linkerOutputType, nil)
+      let jobs = try driver.planBuild()
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].outputs.count, 1)
+      XCTAssertEqual(jobs[0].outputs[0].file.basename, "foo.o")
+    }
+  }
+
   func testPrimaryOutputKindsDiagnostics() throws {
       try assertDriverDiagnostics(args: "swift", "-i") {
         $1.expect(.error("the flag '-i' is no longer required and has been removed; use 'swift input-filename'"))


### PR DESCRIPTION
Currently, when combining -c + -lto + -o, the driver will produce a ".bc" file on disk, even if the -o argument said ".o". This PR fixes that and matches the behavior of the C++ driver in the swift repo.