### PR TITLE
Jobs: permit bitcode items when building with LTO

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -297,8 +297,10 @@ extension GenericUnixToolchain {
       commandLine.appendFlag("crs")
       commandLine.appendPath(outputFile)
 
-      commandLine.append(contentsOf: inputs.filter { $0.type == .object }
-                                           .map { .path($0.file) })
+      commandLine.append(contentsOf: inputs.lazy.filter {
+                            lto == nil ? $0.type == .object
+                                       : $0.type == .object || $0.type == .llvmBitcode
+                         }.map { .path($0.file) })
       return try getToolPath(.staticLinker(lto))
     }
 


### PR DESCRIPTION
When building an archive, permit the LLVM bitcode content into the
archive as the LTO path will add those.  This should ensure that we can
continue to experiment with the LTO optimizations.