### PR TITLE
build: remove bogus dependency on `swift-driver`

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -69,8 +69,7 @@ let package = Package(
     /// Driver tests.
     .testTarget(
       name: "SwiftDriverTests",
-      dependencies: ["SwiftDriver", "SwiftDriverExecution", "swift-driver",
-                     "TestUtilities"]),
+      dependencies: ["SwiftDriver", "SwiftDriverExecution", "TestUtilities"]),
 
     /// IncrementalImport tests
     .testTarget(


### PR DESCRIPTION
The `SwiftDriverTests` target should not depend on the `swift-driver`
target.  The latter is the executable binary.  This was noticed when
trying to port the swift-driver project to Windows.  The Windows linker
caught the fact that the `main` entry point was multiply defined, once
from the test binary, and once from the `swift-driver` executable.  Do
not add the `swift-driver` to the dependency set as that will cause a
link dependency, which results in the multiply defined symbols.