### PR TITLE
gitattributes: add attributes for test inputs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.swiftinterface text eol=lf


### PR DESCRIPTION
Ensure that the swift interface files are always checked out with unix
line-endings irrespective of the configuration.