### PR TITLE
TestUtilities: add path utilities

### DIFF
--- a/Tests/TestUtilities/PathExtensions.swift
+++ b/Tests/TestUtilities/PathExtensions.swift
@@ -1,0 +1,30 @@
+//===-------- DriverExtensions.swift - Driver Testing Extensions ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import TSCBasic
+
+extension String {
+  public func escaped() -> Self {
+#if os(Windows)
+    return self.replacingOccurrences(of: "\\", with: "\\\\")
+#else
+    return self
+#endif
+  }
+
+  public func nativePathString() -> Self {
+    return URL(fileURLWithPath: self).withUnsafeFileSystemRepresentation {
+      String(cString: $0!)
+    }
+  }
+}

--- a/Tests/TestUtilities/PathExtensions.swift
+++ b/Tests/TestUtilities/PathExtensions.swift
@@ -1,4 +1,4 @@
-//===-------- DriverExtensions.swift - Driver Testing Extensions ----------===//
+//===---------- PathExtensions.swift - Driver Testing Extensions ----------===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
The path handling in the tests needs to account for the fact that path
representation is currently hardcoded and the representation differs on
different platforms.  These are intended to help convert the
representation.