### PR TITLE
SwiftDriverTests: disable some tests

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -155,6 +155,7 @@ private func pcmArgsEncodedRelativeModulePath(for moduleName: String, with pcmAr
 /// Test that for the given JSON module dependency graph, valid jobs are generated
 final class ExplicitModuleBuildTests: XCTestCase {
   func testModuleDependencyBuildCommandGeneration() throws {
+    #if os(macOS)
     do {
       var driver = try Driver(args: ["swiftc", "-explicit-module-build",
                                      "-module-name", "testModuleDependencyBuildCommandGeneration",
@@ -208,6 +209,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         }
       }
     }
+    #endif
   }
 
   func testModuleDependencyBuildCommandGenerationWithExternalFramework() throws {
@@ -297,6 +299,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
   /// Test generation of explicit module build jobs for dependency modules when the driver
   /// is invoked with -explicit-module-build
   func testExplicitModuleBuildJobs() throws {
+    #if os(macOS)
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleBuildJobs.swift")
       try localFileSystem.writeFileContents(main) {
@@ -444,9 +447,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
         }
       }
     }
+    #endif
   }
 
   func testImmediateModeExplicitModuleBuild() throws {
+    #if os(macOS)
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleBuildJobs.swift")
       try localFileSystem.writeFileContents(main) {
@@ -570,6 +575,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         }
       }
     }
+    #endif
   }
 
   func testExplicitModuleBuildEndToEnd() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2673,6 +2673,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testClangTargetForExplicitModule() throws {
+    #if os(macOS)
     // Check -clang-target is on by defualt when explicit module is on.
     try withTemporaryDirectory { path in
       let main = path.appending(component: "Foo.swift")
@@ -2706,6 +2707,7 @@ final class SwiftDriverTests: XCTestCase {
         job.commandLine.contains(.flag("-clang-target"))
       })
     }
+    #endif
   }
 
   func testDisableClangTargetForImplicitModule() throws {


### PR DESCRIPTION
These tests explicitly hardcode the macOS triple into the test, making
them inherently non-portable.  Just disable the tests.