### PR TITLE
Stop passing `-no_objc_category_merging` to the linker on Darwin.

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -418,8 +418,6 @@ extension DarwinToolchain {
       sdkPath: targetInfo.sdkPath?.path
     )
 
-    commandLine.appendFlag("-no_objc_category_merging")
-
     // These custom arguments should be right before the object file at the
     // end.
     try commandLine.appendAllExcept(

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -183,7 +183,7 @@ final class JobExecutorTests: XCTestCase {
           "-lobjc", "-lSystem", "-arch", .flag(hostTriple.archName),
           "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
           "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),
-          "-rpath", "/usr/lib/swift", "-macosx_version_min", "10.14.0", "-no_objc_category_merging", "-o",
+          "-rpath", "/usr/lib/swift", "-macosx_version_min", "10.14.0", "-o",
           .path(.relative(RelativePath("main"))),
         ],
         inputs: [
@@ -254,7 +254,7 @@ final class JobExecutorTests: XCTestCase {
           "-lobjc", "-lSystem", "-arch", .flag(hostTriple.archName),
           "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
           "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),
-          "-rpath", "/usr/lib/swift", "-macosx_version_min", "10.14.0", "-no_objc_category_merging",
+          "-rpath", "/usr/lib/swift", "-macosx_version_min", "10.14.0",
           "-o", .path(.absolute(exec)),
         ],
         inputs: [


### PR DESCRIPTION
ObjC category merging is a really useful optimization, so we should stop doing that. This flag was added in the legacy driver as a workaround in 2014:
```
commit 9a1cf1af1691edc5da237b88be0b0fac548a5a09
Author: Greg Parker <gparker@apple.com>
Date:   Wed Feb 19 09:22:38 2014 +0000
```
And whatever issue it was working around should now be resolved.

Resolves rdar://84099601