### PR TITLE
Revert `Package.resolved` back to stable release format.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,41 +1,43 @@
 {
-  "pins" : [
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "83b23d940471b313427da226196661856f6ba3e0",
-        "version" : "0.4.4"
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "83b23d940471b313427da226196661856f6ba3e0",
+          "version": "0.4.4"
+        }
+      },
+      {
+        "package": "llbuild",
+        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "state": {
+          "branch": "main",
+          "revision": "c7fe760c4d8bd2909a05e1fef9638f6374f86b05",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
+        "state": {
+          "branch": "main",
+          "revision": "f9bbd6b80d67408021576adf6247e17c2e957d92",
+          "version": null
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
-    },
-    {
-      "identity" : "swift-llbuild",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-llbuild.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "08c0a758a697bad5d5849ad5d0b1eedb507b0596"
-      }
-    },
-    {
-      "identity" : "swift-tools-support-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-tools-support-core.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "3cabb66f57f157ed083c4c07ddfca28932437e6b"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-        "version" : "4.0.6"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }


### PR DESCRIPTION
https://github.com/apple/swift-driver/commit/c94045879f487c3a3d21d54181d64a898e2cfb4e included an update to `Package.resolved` using recent ToT SPM format, which we should not use because of risk of breaking external clients here.