### PR TITLE
Bump required CMake version to 3.19.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-cmake_minimum_required(VERSION 3.15.1)
+cmake_minimum_required(VERSION 3.19.6)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 

--- a/Sources/swift-driver/CMakeLists.txt
+++ b/Sources/swift-driver/CMakeLists.txt
@@ -11,20 +11,3 @@ add_executable(swift-driver
 target_link_libraries(swift-driver PUBLIC
   SwiftDriver
   SwiftDriverExecution)
-
-# This is a fairly egregious workaround for the fact that in versions < 3.17,
-# executables do not get `-rpath` linker arguments for their linked library
-# dependencies (direct and transitive)
-if(CMAKE_VERSION VERSION_LESS 3.17)
-  get_target_property(TSC_UTIL_LIB TSCUtility LOCATION)
-  get_filename_component(TSC_LIB_DIR ${TSC_UTIL_LIB} DIRECTORY)
-
-  get_target_property(LLBUILD_LIB llbuildSwift LOCATION)
-  get_filename_component(LLBUILD_LIB_DIR ${LLBUILD_LIB} DIRECTORY)
-
-  get_target_property(ARGPARSE_LIB ArgumentParser LOCATION)
-  get_filename_component(ARGPARSE_LIB_DIR ${ARGPARSE_LIB} DIRECTORY)
-
-  set_property(TARGET swift-driver PROPERTY BUILD_RPATH
-    ${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${TSC_LIB_DIR};${LLBUILD_LIB_DIR};${ARGPARSE_LIB_DIR})
-endif()

--- a/Sources/swift-help/CMakeLists.txt
+++ b/Sources/swift-help/CMakeLists.txt
@@ -12,17 +12,3 @@ target_link_libraries(swift-help PUBLIC
   SwiftOptions
   ArgumentParser
   TSCBasic)
-
-# This is a fairly egregious workaround for the fact that in versions < 3.17,
-# executables do not get `-rpath` linker arguments for their linked library
-# dependencies (direct and transitive)
-if(CMAKE_VERSION VERSION_LESS 3.17)
-  get_target_property(TSC_UTIL_LIB TSCUtility LOCATION)
-  get_filename_component(TSC_LIB_DIR ${TSC_UTIL_LIB} DIRECTORY)
-
-  get_target_property(ARGPARSE_LIB ArgumentParser LOCATION)
-  get_filename_component(ARGPARSE_LIB_DIR ${ARGPARSE_LIB} DIRECTORY)
-
-  set_property(TARGET swift-help PROPERTY BUILD_RPATH
-    ${CMAKE_LIBRARY_OUTPUT_DIRECTORY};${TSC_LIB_DIR};${ARGPARSE_LIB_DIR})
-endif()


### PR DESCRIPTION
Matching the Swift compiler's required CMake version: https://github.com/apple/swift/pull/36094
Also removes CMake < 3.17 workaround.