### PR TITLE
SwiftDriverTests: adjust for Windows

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -606,6 +606,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let swiftModuleInterfacesPath: String =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
                         .appending(component: "Swift")
+                        .pathString
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString().escaped(),

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -601,7 +601,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let cHeadersPath: String =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
-                        .appending(compnent: "CHeaders")
+                        .appending(component: "CHeaders")
                         .pathString
       let swiftModuleInterfacesPath: String =
           testInputsPath.appending(component: "ExplicitModuleBuilds")


### PR DESCRIPTION
This adjusts the tests for Windows.  With this set of changes, the
ExplicitModuleBuildTests all pass on Windows (except those which use a
macOS target triple).