### PR TITLE
Respect the single-input output-file-map entries when `emit-module` is the sole job.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2745,6 +2745,16 @@ extension Driver {
       return singleOutputPath
     }
 
+    // The driver lacks a compilerMode for *only* emitting a Swift module, but if the
+    // primary output type is a .swiftmodule and we are using the emit-module-separately
+    // flow, then also consider single output paths specified in the output file-map.
+    if compilerOutputType == .swiftModule &&
+        Driver.shouldEmitModuleSeparately(parsedOptions: &parsedOptions),
+       let singleOutputPath = outputFileMap?.existingOutputForSingleInput(
+           outputType: type) {
+      return singleOutputPath
+    }
+
     // If there is an output argument, derive the name from there.
     if let outputPathArg = parsedOptions.getLastArgument(.o) {
       let path = try VirtualPath(path: outputPathArg.asSingle)

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -9,6 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+import SwiftOptions
 extension Driver {
   /// Add options that are common to command lines that emit modules, e.g.,
   /// options for the paths of various module files.
@@ -117,13 +119,17 @@ extension Driver {
     }
   }
 
-  /// Returns true if the -emit-module-separately is active.
-  mutating func shouldEmitModuleSeparately() -> Bool {
+  static func shouldEmitModuleSeparately(parsedOptions: inout ParsedOptions) -> Bool {
     return parsedOptions.hasFlag(positive: .emitModuleSeparately,
                                  negative: .noEmitModuleSeparately,
                                  default: true)
-           && !parsedOptions.hasFlag(positive: .wholeModuleOptimization,
-                                     negative: .noWholeModuleOptimization,
-                                     default: false)
+             && !parsedOptions.hasFlag(positive: .wholeModuleOptimization,
+                                       negative: .noWholeModuleOptimization,
+                                       default: false)
+  }
+
+  /// Returns true if the -emit-module-separately is active.
+  mutating func shouldEmitModuleSeparately() -> Bool {
+    return Self.shouldEmitModuleSeparately(parsedOptions: &self.parsedOptions)
   }
 }


### PR DESCRIPTION
When the driver is invoked with the primary output of a swift module and we are in the `emit-module-separtely` mode, there will only be a single `emit-module` job, for which we need to respect module-wide supplementary output paths specified in the output file map.

Resolves rdar://84262412