### PR TITLE
SwiftDriver: initial (incomplete) windows port

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -86,12 +86,14 @@ add_library(SwiftDriver
   Jobs/VerifyDebugInfoJob.swift
   Jobs/VerifyModuleInterfaceJob.swift
   Jobs/WebAssemblyToolchain+LinkerSupport.swift
+  Jobs/WindowsToolchain+LinkerSupport.swift
   Jobs/PrebuiltModulesJob.swift
 
   Toolchains/DarwinToolchain.swift
   Toolchains/GenericUnixToolchain.swift
   Toolchains/Toolchain.swift
   Toolchains/WebAssemblyToolchain.swift
+  Toolchains/WindowsToolchain.swift
 
   Utilities/DOTJobGraphSerializer.swift
   Utilities/DateAdditions.swift

--- a/Sources/SwiftDriver/Driver/WindowsExtensions.swift
+++ b/Sources/SwiftDriver/Driver/WindowsExtensions.swift
@@ -1,0 +1,24 @@
+//===------------- WindowsExtensions.swift - Windows Extensions -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+internal func executableName(_ name: String) -> String {
+#if os(Windows)
+  if name.suffix(from: name.index(name.endIndex, offsetBy: -4)) == ".exe" {
+    return name
+  }
+  return "\(name).exe"
+#else
+  return name
+#endif
+}

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -314,6 +314,14 @@ public extension Driver {
 @_spi(Testing) public extension Driver {
   static func getScanLibPath(of toolchain: Toolchain, hostTriple: Triple,
                              env: [String: String]) throws -> AbsolutePath {
+    if hostTriple.isWindows {
+      // no matter if we are in a build tree or an installed tree, the layout is
+      // always: `bin/_InternalSwiftScan.dll`
+      return try getRootPath(of: toolchain, env: env)
+                    .appending(component: "bin")
+                    .appending(component: "_InternalSwiftScan.dll")
+    }
+
     let sharedLibExt: String
     if hostTriple.isMacOSX {
       sharedLibExt = ".dylib"

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -73,3 +73,16 @@ extension GenericUnixToolchain {
     return envVars
   }
 }
+
+extension WindowsToolchain {
+  public func platformSpecificInterpreterEnvironmentVariables(
+    env: [String : String],
+    parsedOptions: inout ParsedOptions,
+    sdkPath: VirtualPath.Handle?,
+    targetInfo: FrontendTargetInfo) throws -> [String: String] {
+
+    // TODO(compnerd): setting up `Path` is meaningless currently as the lldb
+    // support required for the interpreter mode fails to load the dependencies.
+    return [:]
+  }
+}

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -1,0 +1,130 @@
+//===--------------- WindowsToolchain+LinkerSupport.swift -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCBasic
+import SwiftOptions
+
+extension WindowsToolchain {
+  public func addPlatformSpecificLinkerArgs(to commandLine: inout [Job.ArgTemplate],
+                                            parsedOptions: inout ParsedOptions,
+                                            linkerOutputType: LinkOutputType,
+                                            inputs: [TypedVirtualPath],
+                                            outputFile: VirtualPath,
+                                            shouldUseInputFileList: Bool,
+                                            lto: LTOKind?,
+                                            sanitizers: Set<Sanitizer>,
+                                            targetInfo: FrontendTargetInfo)
+      throws -> AbsolutePath {
+    let targetTriple = targetInfo.target.triple
+
+    if !targetTriple.triple.isEmpty {
+      commandLine.appendFlag("-target")
+      commandLine.appendFlag(targetTriple.triple)
+    }
+
+    switch linkerOutputType {
+    case .staticLibrary:
+      break
+    case .dynamicLibrary:
+      commandLine.appendFlag("-shared")
+    case .executable:
+      break
+    }
+
+    // Select the linker to use.
+    if let arg = parsedOptions.getLastArgument(.useLd) {
+      commandLine.appendFlag("-fuse-ld=\(arg.asSingle)")
+    } else if lto != nil {
+      commandLine.appendFlag("-fuse-ld=lld")
+    }
+
+    switch lto {
+    case .some(.llvmThin):
+      commandLine.appendFlag("-flto=thin")
+    case .some(.llvmFull):
+      commandLine.appendFlag("-flto=full")
+    case .none:
+      break
+    }
+
+    // FIXME(compnerd): render `-Xlinker /DEBUG` or `-Xlinker /DEBUG:DWARF` with
+    // DWARF + lld
+
+    // Rely on `-libc` to correctly identify the MSVC Runtime Library.  We use
+    // `-nostartfiles` as that limits the difference to just the
+    // `-defaultlib:libcmt` which is passed unconditionally with the `clang`
+    // driver rather than the `clang-cl` driver.
+    commandLine.appendFlag("-nostartfiles")
+
+    // TODO(compnerd) investigate the proper way to port this logic over from
+    // the C++ driver.
+
+    // Since Windows has separate libraries per architecture, link against the
+    // architecture specific version of the static library.
+    commandLine.appendFlag(.L)
+    commandLine.appendPath(VirtualPath.lookup(targetInfo.runtimeLibraryImportPaths.last!.path))
+
+    // FIXME(compnerd) figure out how to ensure that the SDK relative path is
+    // the last one
+    commandLine.appendPath(VirtualPath.lookup(targetInfo.runtimeLibraryImportPaths.last!.path)
+                              .appending(component: "swiftrt.obj"))
+
+    commandLine.append(contentsOf: inputs.compactMap { (input: TypedVirtualPath) -> Job.ArgTemplate? in
+      switch input.type {
+      case .object, .llvmBitcode:
+        return .path(input.file)
+      default:
+        return nil
+      }
+    })
+
+    for framework in parsedOptions.arguments(for: .F, .Fsystem) {
+      commandLine.appendFlag(framework.option == .Fsystem ? "-iframework" : "-F")
+      try commandLine.appendPath(VirtualPath(path: framework.argument.asSingle))
+    }
+
+    if let sdkPath = targetInfo.sdkPath?.path {
+      commandLine.appendFlag("-I")
+      commandLine.appendPath(VirtualPath.lookup(sdkPath))
+    }
+
+    if let stdlib = parsedOptions.getLastArgument(.experimentalCxxStdlib) {
+      commandLine.appendFlag("-stdlib=\(stdlib.asSingle)")
+    }
+
+    // FIXME(compnerd) render asan/ubsan runtime link for executables
+
+    if parsedOptions.contains(.profileGenerate) {
+      commandLine.appendFlag("-Xlinker")
+      // FIXME(compnerd) wrap llvm::getInstrProfRuntimeHookVarName()
+      commandLine.appendFlag("-include:__llvm_profile_runtime")
+      commandLine.appendFlag("-lclang_rt.profile")
+    }
+
+    for option in parsedOptions.arguments(for: .Xlinker) {
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag(option.argument.asSingle)
+    }
+    // TODO(compnerd) is there a separate equivalent to OPT_linker_option_group?
+    try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+
+    if parsedOptions.contains(.v) {
+      commandLine.appendFlag("-v")
+    }
+
+    commandLine.appendFlag("-o")
+    commandLine.appendPath(outputFile)
+
+    // TODO(compnerd) handle static libraries
+    return try getToolPath(.clang)
+  }
+}

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -1,0 +1,144 @@
+//===----------- WindowsToolchain.swift - Swift Windows Toolchain ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TSCBasic
+import SwiftOptions
+
+extension WindowsToolchain {
+  public enum ToolchainValidationError: Error, DiagnosticData {
+    case unsupportedSanitizer(Sanitizer)
+  }
+}
+
+extension WindowsToolchain.ToolchainValidationError {
+  public var description: String {
+    switch self {
+    case .unsupportedSanitizer(let sanitizer):
+      return "unsupported sanitizer: \(sanitizer)"
+    }
+  }
+}
+
+@_spi(Testing) public final class WindowsToolchain: Toolchain {
+  public let env: [String:String]
+  public let executor: DriverExecutor
+  public let fileSystem: FileSystem
+  public let compilerExecutableDir: AbsolutePath?
+  public let toolDirectory: AbsolutePath?
+
+  public var dummyForTestingObjectFormat: Triple.ObjectFormat {
+    .coff
+  }
+
+  private var toolPaths: [Tool:AbsolutePath] = [:]
+
+  public init(env: [String:String], executor: DriverExecutor,
+              fileSystem: FileSystem = localFileSystem,
+              compilerExecutableDir: AbsolutePath? = nil,
+              toolDirectory: AbsolutePath? = nil) {
+    self.env = env
+    self.executor = executor
+    self.fileSystem = fileSystem
+    self.compilerExecutableDir = compilerExecutableDir
+    self.toolDirectory = toolDirectory
+  }
+
+  public func getToolPath(_ tool: Tool) throws -> AbsolutePath {
+    guard let toolPath = toolPaths[tool] else {
+      let toolPath = try lookupToolPath(tool)
+      toolPaths.updateValue(toolPath, forKey: tool)
+      return toolPath
+    }
+    return toolPath
+  }
+
+  private func lookupToolPath(_ tool: Tool) throws -> AbsolutePath {
+    switch tool {
+    case .swiftAPIDigester:
+      return try lookup(executable: "swift-api-digester.exe")
+    case .swiftCompiler:
+      return try lookup(executable: "swift-frontend.exe")
+    case .staticLinker:
+      return try lookup(executable: "llvm-ar.exe")
+    case .dynamicLinker:
+      return try lookup(executable: "clang.exe")
+    case .clang:
+      return try lookup(executable: "clang.exe")
+    case .swiftAutolinkExtract:
+      return try lookup(executable: "swift-autolink-extract.exe")
+    case .lldb:
+      return try lookup(executable: "lldb.exe")
+    case .dsymutil:
+      return try lookup(executable: "llvm-dsymutil.exe")
+    case .dwarfdump:
+      return try lookup(executable: "llvm-dwarfdump.exe")
+    case .swiftHelp:
+      return try lookup(executable: "swift-help.exe")
+    }
+  }
+
+  public func overrideToolPath(_ tool: Tool, path: AbsolutePath) {
+    toolPaths.updateValue(path, forKey: tool)
+  }
+
+  public func clearKnownToolPath(_ tool: Tool) {
+    toolPaths.removeValue(forKey: tool)
+  }
+
+  public func sdkStdlib(sdk: AbsolutePath) -> AbsolutePath {
+    sdk.appending(RelativePath("usr/lib/swift"))
+  }
+
+  public func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String {
+    switch type {
+    case .executable: return "\(moduleName).exe"
+    case .dynamicLibrary: return "\(moduleName).dll"
+    case .staticLibrary: return "lib\(moduleName).lib"
+    }
+  }
+
+  public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {
+    // The SDKROOT environment always takes precedent.  If SDKROOT is undefined,
+    // but we have DEVELOPER_DIR defined and a valid triple, compose the SDK
+    // root relative to the DEVELOPER_DIR.  The SDKs are always laid out as
+    // `[DeveloperDir]\Platforms\[OS].platform\Developer\SDKs\[OS].sdk`,
+    // allowing us to locate it relative to the DEVELOPER_DIR environment
+    // variable.
+
+    // TODO(compnerd): replicate the SPM processing of the SDKInfo.plist
+    if let SDKROOT = env["SDKROOT"] {
+      return AbsolutePath(SDKROOT)
+    } else if let DEVELOPER_DIR = env["DEVELOPER_DIR"], let os = target?.os?.rawValue {
+      // FIXME(compnerd) we should capitalise the OS name, e.g. windows ->
+      // Windows; we get away with this for now as Windows has a
+      // case-insensitive file system.
+      return AbsolutePath("\(DEVELOPER_DIR)\\Platforms\\\(os).platform\\Developer\\SDKs\\\(os).sdk")
+    }
+    return nil
+  }
+
+  public var shouldStoreInvocationInDebugInfo: Bool {
+    !env["RC_DEBUG_OPTIONS", default: ""].isEmpty
+  }
+
+  public func runtimeLibraryName(for sanitizer: Sanitizer, targetTriple: Triple,
+                                 isShared: Bool) throws -> String {
+    // TODO(compnerd) handle shared linking
+    return "clang_rt.\(sanitizer.libraryName).lib"
+  }
+
+  public func validateArgs(_ parsedOptions: inout ParsedOptions,
+                           targetTriple: Triple, targetVariantTriple: Triple?,
+                           diagnosticEngine: DiagnosticsEngine) throws {
+    // TODO(compnerd) validate any options we can
+  }
+}

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -340,7 +340,12 @@ extension VirtualPath {
       return try self.queue.sync(flags: .barrier) {
         guard let idx = self.uniquer[key] else {
           let path: VirtualPath
-          if let absolute = try? AbsolutePath(validating: key) {
+          // The path representation does not properly handle paths on all
+          // platforms.  On Windows, we often see an empty key which we would
+          // like to treat as being the relative path to cwd.
+          if key.isEmpty {
+            path = .relative(try RelativePath(validating: "."))
+          } else if let absolute = try? AbsolutePath(validating: key) {
             path = .absolute(absolute)
           } else {
             let relative = try RelativePath(validating: key)


### PR DESCRIPTION
This is sufficient to build on Windows, and the resulting driver is able
to somewhat function.  The tests are still not usable due to assumptions
about path which do not hold and the insufficiency of the path
representation in tools-support-core.  This is likely best approached by
replacing the use of `Path` from t-s-c with the representation in
system.  However, this allows some attempt to validate the swift-driver
which is increasingly becoming required for s-p-m, and thus unblocks
further work.