### PR TITLE
Update maccatalyst 13.0 target minimum to 13.1

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -228,10 +228,10 @@ extension Triple {
         return Version(14, 0, 0)
       }
 
-      // Mac Catalyst was introduced with an iOS deployment target of 13.0;
+      // Mac Catalyst was introduced with an iOS deployment target of 13.1;
       // the linker doesn't want to see a deployment target before that.
       if _iOSVersion.major < 13 {
-        return Version(13, 0, 0)
+        return Version(13, 1, 0)
       }
 
       return _iOSVersion

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1173,7 +1173,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // macOS catalyst target
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-ios13.0-macabi"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-ios13.1-macabi"], env: env)
       let plannedJobs = try driver.planBuild()
 
       XCTAssertEqual(3, plannedJobs.count)
@@ -1186,8 +1186,8 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dylib")))
       XCTAssertTrue(cmd.contains(.flag("-arch")))
       XCTAssertTrue(cmd.contains(.flag("x86_64")))
-      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "mac-catalyst", "13.0.0"]))
-      XCTAssertTrue(cmd.contains(.flag("13.0.0")))
+      XCTAssertTrue(cmd.contains(subsequence: ["-platform_version", "mac-catalyst", "13.1.0"]))
+      XCTAssertTrue(cmd.contains(.flag("13.1.0")))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
@@ -2639,57 +2639,57 @@ final class SwiftDriverTests: XCTestCase {
 
   func testTargetVariant() throws {
     do {
-      var driver = try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-ios13.0-macabi", "-target-variant", "x86_64-apple-macosx10.14", "foo.swift"])
+      var driver = try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-ios13.1-macabi", "-target-variant", "x86_64-apple-macosx10.14", "foo.swift"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
 
       XCTAssertEqual(plannedJobs[0].kind, .compile)
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target")))
-      XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-ios13.0-macabi")))
+      XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-ios13.1-macabi")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target-variant")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
     }
 
     do {
-      var driver = try Driver(args: ["swiftc", "-emit-library", "-target", "x86_64-apple-ios13.0-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-module-name", "foo", "foo.swift"])
+      var driver = try Driver(args: ["swiftc", "-emit-library", "-target", "x86_64-apple-ios13.1-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-module-name", "foo", "foo.swift"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 2)
 
       XCTAssertEqual(plannedJobs[0].kind, .compile)
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target")))
-      XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-ios13.0-macabi")))
+      XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-ios13.1-macabi")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target-variant")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
 
       XCTAssertEqual(plannedJobs[1].kind, .link)
       XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [
-        "-platform_version", "mac-catalyst", "13.0.0"]))
+        "-platform_version", "mac-catalyst", "13.1.0"]))
       XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [
         "-platform_version", "macos", "10.14.0"]))
     }
 
     // Test -target-variant is passed to generate pch job
     do {
-      var driver = try Driver(args: ["swiftc", "-target", "x86_64-apple-ios13.0-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-enable-bridging-pch", "-import-objc-header", "TestInputHeader.h", "foo.swift"])
+      var driver = try Driver(args: ["swiftc", "-target", "x86_64-apple-ios13.1-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-enable-bridging-pch", "-import-objc-header", "TestInputHeader.h", "foo.swift"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 3)
 
       XCTAssertEqual(plannedJobs[0].kind, .generatePCH)
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-emit-pch")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target")))
-      XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-ios13.0-macabi")))
+      XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-ios13.1-macabi")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target-variant")))
       XCTAssert(plannedJobs[0].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
 
       XCTAssertEqual(plannedJobs[1].kind, .compile)
       XCTAssert(plannedJobs[1].commandLine.contains(.flag("-target")))
-      XCTAssert(plannedJobs[1].commandLine.contains(.flag("x86_64-apple-ios13.0-macabi")))
+      XCTAssert(plannedJobs[1].commandLine.contains(.flag("x86_64-apple-ios13.1-macabi")))
       XCTAssert(plannedJobs[1].commandLine.contains(.flag("-target-variant")))
       XCTAssert(plannedJobs[1].commandLine.contains(.flag("x86_64-apple-macosx10.14")))
 
       XCTAssertEqual(plannedJobs[2].kind, .link)
       XCTAssertTrue(plannedJobs[2].commandLine.contains(subsequence: [
-        "-platform_version", "mac-catalyst", "13.0.0"]))
+        "-platform_version", "mac-catalyst", "13.1.0"]))
       XCTAssertTrue(plannedJobs[2].commandLine.contains(subsequence: [
         "-platform_version", "macos", "10.14.0"]))
     }
@@ -3084,7 +3084,7 @@ final class SwiftDriverTests: XCTestCase {
       do {
         var driver = try Driver(args: ["swiftc",
                                        "-target", "x86_64-apple-macosx10.14",
-                                       "-target-variant", "x86_64-apple-ios13.0-macabi",
+                                       "-target-variant", "x86_64-apple-ios13.1-macabi",
                                        "-sdk", sdk1.description,
                                        "foo.swift"])
         let frontendJobs = try driver.planBuild()
@@ -3103,7 +3103,7 @@ final class SwiftDriverTests: XCTestCase {
           .flag("10.15.0"),
           .flag("-platform_version"),
           .flag("mac-catalyst"),
-          .flag("13.0.0"),
+          .flag("13.1.0"),
           .flag("13.1.0"),
         ]))
       }
@@ -3111,7 +3111,7 @@ final class SwiftDriverTests: XCTestCase {
       do {
         var driver = try Driver(args: ["swiftc",
                                        "-target", "x86_64-apple-macosx10.14",
-                                       "-target-variant", "x86_64-apple-ios13.0-macabi",
+                                       "-target-variant", "x86_64-apple-ios13.1-macabi",
                                        "-sdk", sdk2.description,
                                        "foo.swift"])
         let frontendJobs = try driver.planBuild()
@@ -3130,7 +3130,7 @@ final class SwiftDriverTests: XCTestCase {
           .flag("10.15.4"),
           .flag("-platform_version"),
           .flag("mac-catalyst"),
-          .flag("13.0.0"),
+          .flag("13.1.0"),
           .flag("13.4.0"),
         ]))
       }
@@ -3138,7 +3138,7 @@ final class SwiftDriverTests: XCTestCase {
       do {
         var driver = try Driver(args: ["swiftc",
                                        "-target-variant", "x86_64-apple-macosx10.14",
-                                       "-target", "x86_64-apple-ios13.0-macabi",
+                                       "-target", "x86_64-apple-ios13.1-macabi",
                                        "-sdk", sdk2.description,
                                        "foo.swift"])
         let frontendJobs = try driver.planBuild()
@@ -3153,7 +3153,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
           .flag("-platform_version"),
           .flag("mac-catalyst"),
-          .flag("13.0.0"),
+          .flag("13.1.0"),
           .flag("13.4.0"),
           .flag("-platform_version"),
           .flag("macos"),
@@ -3261,7 +3261,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
         .flag("-platform_version"),
         .flag("mac-catalyst"),
-        .flag("13.0.0"),
+        .flag("13.1.0"),
       ]))
     }
 
@@ -3824,7 +3824,7 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
-      var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-apple-ios13.0-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-sdk", "bar", "-resource-dir", "baz"])
+      var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-apple-ios13.1-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-sdk", "bar", "-resource-dir", "baz"])
       let plannedJobs = try driver.planBuild()
       XCTAssertTrue(plannedJobs.count == 1)
       let job = plannedJobs[0]
@@ -5081,7 +5081,7 @@ final class SwiftDriverTests: XCTestCase {
     let mockSDKPath : String = testInputsPath + "/mock-sdk.sdk"
 
     do {
-      var driver = try Driver(args: ["swiftc", "-target", "x86_64-apple-ios13.0-macabi", "foo.swift", "-sdk", mockSDKPath])
+      var driver = try Driver(args: ["swiftc", "-target", "x86_64-apple-ios13.1-macabi", "foo.swift", "-sdk", mockSDKPath])
       let plannedJobs = try driver.planBuild()
       let job = plannedJobs[0]
       XCTAssertTrue(job.commandLine.contains(.flag("-prebuilt-module-cache-path")))


### PR DESCRIPTION
Clang enforces a minimum 13.1 deployment target. Update the current 13.0
minimum to 13.1 to reflect this.