### PR TITLE
[5.5] PrebuiltModuleGen: only use -err in log file names that contain fatal errors

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -25,6 +25,16 @@ import SwiftOptions
   return false
 }
 
+fileprivate func getErrKind(_ content: String) -> String {
+  if content.contains("error: ") {
+    return "err"
+  } else if content.contains("warning: "){
+    return "warn"
+  } else {
+    return "note"
+  }
+}
+
 func isIosMac(_ path: VirtualPath) -> Bool {
   // Infer macabi interfaces by the file name.
   // FIXME: more robust way to do this.
@@ -47,7 +57,7 @@ fileprivate func logOutput(_ job: Job, _ result: ProcessResult, _ logPath: Absol
     try localFileSystem.createDirectory(logPath, recursive: true)
   }
   let interfaceBase = getLastInputPath(job).basename
-  let fileName = "\(job.moduleName)-\(interfaceBase)-\(stdout ? "out" : "err").txt"
+  let fileName = "\(job.moduleName)-\(interfaceBase)-\(stdout ? "out" : getErrKind(content)).txt"
   try localFileSystem.writeFileContents(logPath.appending(component: fileName)) {
     $0 <<< content
   }


### PR DESCRIPTION
Explanation: This PR is to facilitate screening module failure logs. Using `-err` in every module log could raise false alarms if the log only contains remarks/warnings.

Original PR: https://github.com/apple/swift-driver/pull/881

Risk: Very low

rdar:  rdar://84469667

Reviewed by: @artemcm 


