### PR TITLE
ABIChecking: use the always-generated-abi-descriptor to diagnose ABI breakages

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -356,6 +356,17 @@ public struct Driver {
       .appending(component: "Frameworks")
   } ()
 
+  lazy var abiDescriptorPath: TypedVirtualPath? = {
+    guard isFeatureSupported(.emit_abi_descriptor) else {
+      return nil
+    }
+    guard let moduleOutput = moduleOutputInfo.output else {
+      return nil
+    }
+    return TypedVirtualPath(file: VirtualPath.lookup(moduleOutput.outputPath)
+      .replacingExtension(with: .jsonABIBaseline).intern(), type: .jsonABIBaseline)
+  }()
+
   public func isFrontendArgSupported(_ opt: Option) -> Bool {
     var current = opt.spelling
     while(true) {
@@ -694,6 +705,7 @@ public struct Driver {
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
+
     let projectDirectory = Self.computeProjectDirectoryPath(
       moduleOutputPath: self.moduleOutputInfo.output?.outputPath,
       fileSystem: self.fileSystem)
@@ -721,7 +733,6 @@ public struct Driver {
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
-
     self.swiftPrivateInterfacePath = try Self.computeSupplementaryOutputPath(
         &parsedOptions, type: .privateSwiftInterface, isOutputOptions: [],
         outputPath: .emitPrivateModuleInterfacePath,

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -92,11 +92,10 @@ extension Driver {
     let outputPath = VirtualPath.lookup(moduleOutputPath)
     commandLine.appendFlag(.o)
     commandLine.appendPath(outputPath)
-    if isFeatureSupported(.emit_abi_descriptor) {
+    if let abiPath = abiDescriptorPath {
       commandLine.appendFlag(.emitAbiDescriptorPath)
-      let abiOutput = outputPath.replacingExtension(with: .jsonABIBaseline)
-      commandLine.appendPath(abiOutput)
-      outputs.append(TypedVirtualPath(file: abiOutput.intern(), type: .jsonABIBaseline))
+      commandLine.appendPath(abiPath.file)
+      outputs.append(abiPath)
     }
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -41,7 +41,7 @@ public struct Job: Codable, Equatable, Hashable {
     case generateAPIBaseline = "generate-api-baseline"
     case generateABIBaseline = "generate-abi-baseline"
     case compareAPIBaseline = "compare-api-baseline"
-    case compareABIBaseline = "compare-abi-baseline"
+    case compareABIBaseline = "Check ABI stability"
   }
 
   public enum ArgTemplate: Equatable, Hashable {

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -76,11 +76,10 @@ extension Driver {
     commandLine.appendFlag(.o)
     commandLine.appendPath(outputPath)
 
-    if isFeatureSupported(.emit_abi_descriptor) {
+    if let abiPath = abiDescriptorPath {
       commandLine.appendFlag(.emitAbiDescriptorPath)
-      let abiOutput = outputPath.replacingExtension(with: .jsonABIBaseline)
-      commandLine.appendPath(abiOutput)
-      outputs.append(TypedVirtualPath(file: abiOutput.intern(), type: .jsonABIBaseline))
+      commandLine.appendPath(abiPath.file)
+      outputs.append(abiPath)
     }
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -510,7 +510,7 @@ extension Driver {
     }
     if let baselineArg = parsedOptions.getLastArgument(.compareToBaselinePath)?.asSingle,
        let baselinePath = try? VirtualPath.intern(path: baselineArg) {
-      addJob(try digesterCompareToBaselineJob(modulePath: moduleOutputPath, baselinePath: baselinePath, mode: digesterMode))
+      addJob(try digesterDiagnosticsJob(modulePath: moduleOutputPath, baselinePath: baselinePath, mode: digesterMode))
     }
   }
 

--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -252,18 +252,11 @@ class APIDigesterTests: XCTestCase {
                                      "-digester-breakage-allowlist-path", "allowlist/path"])
       let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareABIBaseline })
       XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(.init("/baseline/path")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-serialize-diagnostics-path",
-                                                                   .path(.relative(.init("breaking-changes.dia")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-input-paths", .path(.absolute(.init("/baseline/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
                                                                    .path(.relative(.init("allowlist/path")))]))
-
       XCTAssertTrue(digesterJob.commandLine.contains("-abi"))
+      XCTAssertTrue(digesterJob.commandLine.contains("-serialize-diagnostics-path"))
     }
   }
 


### PR DESCRIPTION
rdar://84595482