### PR TITLE
[5.5] ABIChecking: use the always-generated-abi-descriptor to diagnose ABI breakages

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -353,6 +353,17 @@ public struct Driver {
       .appending(component: "Frameworks")
   } ()
 
+  lazy var abiDescriptorPath: TypedVirtualPath? = {
+    guard isFeatureSupported(.emit_abi_descriptor) else {
+      return nil
+    }
+    guard let moduleOutput = moduleOutputInfo.output else {
+      return nil
+    }
+    return TypedVirtualPath(file: VirtualPath.lookup(moduleOutput.outputPath)
+      .replacingExtension(with: .jsonABIBaseline).intern(), type: .jsonABIBaseline)
+  }()
+
   public func isFrontendArgSupported(_ opt: Option) -> Bool {
     var current = opt.spelling
     while(true) {
@@ -690,6 +701,7 @@ public struct Driver {
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
+
     let projectDirectory = Self.computeProjectDirectoryPath(
       moduleOutputPath: self.moduleOutputInfo.output?.outputPath,
       fileSystem: self.fileSystem)
@@ -717,7 +729,6 @@ public struct Driver {
         compilerMode: compilerMode,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
-
     self.swiftPrivateInterfacePath = try Self.computeSupplementaryOutputPath(
         &parsedOptions, type: .privateSwiftInterface, isOutputOptions: [],
         outputPath: .emitPrivateModuleInterfacePath,

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -92,9 +92,9 @@ extension Driver {
     let outputPath = VirtualPath.lookup(moduleOutputPath)
     commandLine.appendFlag(.o)
     commandLine.appendPath(outputPath)
-    if isFeatureSupported(.emit_abi_descriptor) {
+    if let abiPath = abiDescriptorPath {
       commandLine.appendFlag(.emitAbiDescriptorPath)
-      commandLine.appendPath(outputPath.replacingExtension(with: .jsonABIBaseline))
+      commandLine.appendPath(abiPath.file)
     }
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -40,7 +40,7 @@ public struct Job: Codable, Equatable, Hashable {
     case generateAPIBaseline = "generate-api-baseline"
     case generateABIBaseline = "generate-abi-baseline"
     case compareAPIBaseline = "compare-api-baseline"
-    case compareABIBaseline = "compare-abi-baseline"
+    case compareABIBaseline = "Check ABI stability"
   }
 
   public enum ArgTemplate: Equatable, Hashable {

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -76,9 +76,9 @@ extension Driver {
     commandLine.appendFlag(.o)
     commandLine.appendPath(outputPath)
 
-    if isFeatureSupported(.emit_abi_descriptor) {
+    if let abiPath = abiDescriptorPath {
       commandLine.appendFlag(.emitAbiDescriptorPath)
-      commandLine.appendPath(outputPath.replacingExtension(with: .jsonABIBaseline))
+      commandLine.appendPath(abiPath.file)
     }
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -495,7 +495,7 @@ extension Driver {
     }
     if let baselineArg = parsedOptions.getLastArgument(.compareToBaselinePath)?.asSingle,
        let baselinePath = try? VirtualPath.intern(path: baselineArg) {
-      addJob(try digesterCompareToBaselineJob(modulePath: moduleOutputPath, baselinePath: baselinePath, mode: digesterMode))
+      addJob(try digesterDiagnosticsJob(modulePath: moduleOutputPath, baselinePath: baselinePath, mode: digesterMode))
     }
   }
 

--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -252,18 +252,11 @@ class APIDigesterTests: XCTestCase {
                                      "-digester-breakage-allowlist-path", "allowlist/path"])
       let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareABIBaseline })
       XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(.init("/baseline/path")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-serialize-diagnostics-path",
-                                                                   .path(.relative(.init("breaking-changes.dia")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-input-paths", .path(.absolute(.init("/baseline/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
                                                                    .path(.relative(.init("allowlist/path")))]))
-
       XCTAssertTrue(digesterJob.commandLine.contains("-abi"))
+      XCTAssertTrue(digesterJob.commandLine.contains("-serialize-diagnostics-path"))
     }
   }
 


### PR DESCRIPTION
• Explanation: Previously, in order to diagnose ABI breakages, the driver needs to first import the generated Swift interface, which requires us to set up search paths correctly. Since we now generate the ABI descriptor JSON file alongside the Swift module/interface, we should be able to use these JSON files directly without importing the generated Swift interface, bypassing the problem space of setting search paths properly for the ABI checker invocation as a result.

• Scope of Issue: Swift ABI checker

• Origination: Issue found when invoking ABI checker

• Risk: Very Low. Internal Tools only

• Cherry-pick of: https://github.com/apple/swift-driver/pull/885

• Resolves: rdar://84595482

• Reviewed By: Artem

• Automated Testing: Regression tests updated

