### PR TITLE
update symbol graph emission flags

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -354,6 +354,8 @@ extension Driver {
       try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
       try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
     }
+    try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
+    try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
 
     addJobOutputs(outputs)
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -84,6 +84,8 @@ extension Driver {
 
     try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
     try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
+    try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
+    try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
     try commandLine.appendLast(.checkApiAvailabilityOnly, from: &parsedOptions)
 
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -61,6 +61,8 @@ extension Driver {
 
     try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
     try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
+    try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
+    try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
 
     // Propagate the disable flag for cross-module incremental builds
     // if necessary. Note because we're interested in *disabling* this feature,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -554,6 +554,7 @@ extension Option {
   public static let swiftOnly_: Option = Option("--swift-only", .flag, alias: Option.swiftOnly, attributes: [.noDriver], helpText: "Only include APIs defined from Swift source")
   public static let swiftVersion: Option = Option("-swift-version", .separate, attributes: [.frontend, .moduleInterface], metaVar: "<vers>", helpText: "Interpret input according to a specific Swift language version number")
   public static let switchCheckingInvocationThresholdEQ: Option = Option("-switch-checking-invocation-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver])
+  public static let symbolGraphMinimumAccessLevel: Option = Option("-symbol-graph-minimum-access-level", .separate, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], metaVar: "<level>", helpText: "Include symbols with this access level or more when emitting a symbol graph")
   public static let S: Option = Option("-S", .flag, alias: Option.emitAssembly, attributes: [.frontend, .noInteractive], group: .modes)
   public static let tabWidth: Option = Option("-tab-width", .separate, attributes: [.noInteractive, .noBatch, .indent], metaVar: "<n>", helpText: "Width of tab character.", group: .codeFormatting)
   public static let targetCpu: Option = Option("-target-cpu", .separate, attributes: [.frontend, .moduleInterface], helpText: "Generate code for a particular CPU variant")
@@ -1179,6 +1180,7 @@ extension Option {
       Option.swiftOnly_,
       Option.swiftVersion,
       Option.switchCheckingInvocationThresholdEQ,
+      Option.symbolGraphMinimumAccessLevel,
       Option.S,
       Option.tabWidth,
       Option.targetCpu,


### PR DESCRIPTION
As part of https://github.com/apple/swift/pull/39865, this updates swift-driver to include the new `-symbol-graph-minimum-access-level` flag.

I also updated the job CLI flag code to bring it up to speed with the symbol-graph flags that are added during the old driver's job planning process.