### PR TITLE
Improve diagnostics to explain why an identifier isn't a valid

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2137,10 +2137,19 @@ extension Driver {
         moduleName = "__bad__"
       }
     }
-
-    if !moduleName.sd_isSwiftIdentifier {
-      fallbackOrDiagnose(.error_bad_module_name(moduleName: moduleName, explicitModuleName: parsedOptions.contains(.moduleName)))
-    } else if moduleName == "Swift" && !parsedOptions.contains(.parseStdlib) {
+		
+    do {
+      try moduleName.sd_validateSwiftIdentifier()
+    }
+    catch let validationFailure as InvalidSwiftIdentifierError {
+      fallbackOrDiagnose(.error_bad_module_name(
+        moduleName: moduleName,
+        explicitModuleName: parsedOptions.contains(.moduleName),
+        validationFailureReason: validationFailure.reason
+      ))
+    }
+	  
+    if moduleName == "Swift" && !parsedOptions.contains(.parseStdlib) {
       fallbackOrDiagnose(.error_stdlib_module_name(moduleName: moduleName, explicitModuleName: parsedOptions.contains(.moduleName)))
     }
 

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -63,16 +63,17 @@ extension Diagnostic.Message {
 
   static func error_bad_module_name(
     moduleName: String,
-    explicitModuleName: Bool
+    explicitModuleName: Bool,
+		validationFailureReason reason: String
   ) -> Diagnostic.Message {
     let suffix: String
     if explicitModuleName {
       suffix = ""
     } else {
-      suffix = "; use -module-name flag to specify an alternate name"
+      suffix = " Use -module-name flag to specify an alternate name"
     }
 
-    return .error("module name \"\(moduleName)\" is not a valid identifier\(suffix)")
+    return .error("module name \"\(moduleName)\" is not a valid Swift identifier, because \(reason).\(suffix)")
   }
 
   static func error_stdlib_module_name(

--- a/Sources/SwiftDriver/Utilities/StringAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/StringAdditions.swift
@@ -9,17 +9,24 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+public struct InvalidSwiftIdentifierError: Error {
+  let reason: String
+}
+
 extension String {
   /// Whether this string is a Swift identifier.
   public var sd_isSwiftIdentifier: Bool {
-    guard let start = unicodeScalars.first else {
-      return false
-    }
-
-    let continuation = unicodeScalars.dropFirst()
-
-    return start.isValidSwiftIdentifierStart &&
-           continuation.allSatisfy { $0.isValidSwiftIdentifierContinuation }
+		do {
+			try sd_validateSwiftIdentifier()
+			return true
+		} catch {
+			return false
+		}
+  }
+	
+  public func sd_validateSwiftIdentifier() throws {
+    // TODO: implement me
   }
 }
 


### PR DESCRIPTION
This is a WIP, just changed the test cases to gauge the interest.

This spawned from my confusion in https://forums.swift.org/t/is-this-a-swiftc-bug-error-module-name-foo-is-not-a-valid-identifier/53119/5

I think we should offer more detail as to what exactly makes an identifier invalid.

Thoughts?