### PR TITLE
Move the check for the swiftmodule SDK behind an env var

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -353,7 +353,8 @@ public final class DarwinToolchain: Toolchain {
       commandLine.append(.flag(sdkInfo.sdkVersion(for: targetVariantTriple).description))
     }
 
-    if driver.isFrontendArgSupported(.targetSdkName) {
+    if driver.isFrontendArgSupported(.targetSdkName) &&
+       env["ENABLE_RESTRICT_SWIFTMODULE_SDK"] != nil {
       commandLine.append(.flag(Option.targetSdkName.spelling))
       commandLine.append(.flag(sdkInfo.canonicalName))
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3025,6 +3025,9 @@ final class SwiftDriverTests: XCTestCase {
 
   // Test cases ported from Driver/macabi-environment.swift
   func testDarwinSDKVersioning() throws {
+    var envVars = ProcessEnv.vars
+    envVars["ENABLE_RESTRICT_SWIFTMODULE_SDK"] = "YES"
+
     try withTemporaryDirectory { tmpDir in
       let sdk1 = tmpDir.appending(component: "MacOSX10.15.sdk")
       try localFileSystem.writeFileContents(sdk1.appending(component: "SDKSettings.json")) {
@@ -3084,7 +3087,7 @@ final class SwiftDriverTests: XCTestCase {
         var driver = try Driver(args: ["swiftc",
                                        "-target", "x86_64-apple-macosx10.14",
                                        "-sdk", sdk1.description,
-                                       "foo.swift"])
+                                       "foo.swift"], env: envVars)
         let frontendJobs = try driver.planBuild()
         XCTAssertEqual(frontendJobs[0].kind, .compile)
         XCTAssertTrue(frontendJobs[0].commandLine.contains(subsequence: [
@@ -3138,7 +3141,7 @@ final class SwiftDriverTests: XCTestCase {
                                        "-target", "x86_64-apple-macosx10.14",
                                        "-target-variant", "x86_64-apple-ios13.1-macabi",
                                        "-sdk", sdk2.description,
-                                       "foo.swift"])
+                                       "foo.swift"], env: envVars)
         let frontendJobs = try driver.planBuild()
         XCTAssertEqual(frontendJobs[0].kind, .compile)
         XCTAssertTrue(frontendJobs[0].commandLine.contains(subsequence: [


### PR DESCRIPTION
Set the env var `ENABLE_RESTRICT_SWIFTMODULE_SDK` to enable passing down the SDK name to the compiler for it to ensure that swiftmodule are only loaded with the SDK used to build them.