### PR TITLE
Android: make lld the default linker, since the Android NDK just removed all other linkers

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -14,7 +14,7 @@ import SwiftOptions
 
 extension GenericUnixToolchain {
   private func defaultLinker(for targetTriple: Triple) -> String? {
-    if targetTriple.os == .openbsd {
+    if targetTriple.os == .openbsd || targetTriple.environment == .android {
       return "lld"
     }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1585,6 +1585,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-lotherlib")))
     }
 
+    do {
+      // The Android NDK only uses the lld linker now
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "aarch64-unknown-linux-android24"], env: env)
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      let lastJob = plannedJobs.last!
+      XCTAssertTrue(lastJob.tool.name.contains("clang"))
+      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
+    }
   }
 
   func testWebAssemblyUnsupportedFeatures() throws {


### PR DESCRIPTION
This is just bringing over [the one C++ Driver change from a larger compiler pull](https://github.com/apple/swift/pull/39921/files#diff-55fd9483c4660c88c6c3e942cdc38a2cae2647839c581e322c7bf292775e5c43), so I don't have to [change the linker manually all the time](https://github.com/buttaface/swift-android-sdk/blob/main/swift-android-trunk.patch#L112).