### PR TITLE
Android: switch the archiver for static libraries over to llvm-ar

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -301,7 +301,12 @@ extension GenericUnixToolchain {
                             lto == nil ? $0.type == .object
                                        : $0.type == .object || $0.type == .llvmBitcode
                          }.map { .path($0.file) })
-      return try getToolPath(.staticLinker(lto))
+      if targetTriple.environment == .android {
+        // Always use the LTO archiver llvm-ar for Android
+        return try getToolPath(.staticLinker(.llvmFull))
+      } else {
+        return try getToolPath(.staticLinker(lto))
+      }
     }
 
   }


### PR DESCRIPTION
I just added this to a larger pull, apple/swift#39921, that updates the compiler repo to use Android NDK 23, which got rid of binutils, so updating the archiver here too. Not too important when cross-compiling, as you can still use the system `ar` just fine, but when natively compiling in the Termux app on Android, `llvm-ar` is now the default archiver there.

I also had to [patch llbuild to get SPM to use `llvm-ar`](https://github.com/termux/termux-packages/commit/a21ea2ad06d702b8ae59e9e9530cd5cf1857609c#diff-efe86a3fbe5cd2f773ba4c774b09efbbf5a2c6099fe15a6ab44212ac55f7d5b4R9), otherwise it just uses the first `ar` it finds in the system `PATH`. @neonichu, this means SPM doesn't use the `--toolchain` or `-Xswiftc -tools-directory` paths passed in for static library products that call the archiver, seemingly breaking that contract. Obviously not too important, as any archiver will do, but when the name changes like it does natively on Android, I had to patch llbuild too.