### PR TITLE
Format SDK versions in -target-sdk-version as major.minor when patch number is zero

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -346,11 +346,11 @@ public final class DarwinToolchain: Toolchain {
           let sdkInfo = getTargetSDKInfo(sdkPath: sdkPath) else { return }
 
     commandLine.append(.flag("-target-sdk-version"))
-    commandLine.append(.flag(sdkInfo.sdkVersion(for: frontendTargetInfo.target.triple).description))
+    commandLine.append(.flag(sdkInfo.sdkVersion(for: frontendTargetInfo.target.triple).sdkVersionString))
 
     if let targetVariantTriple = frontendTargetInfo.targetVariant?.triple {
       commandLine.append(.flag("-target-variant-sdk-version"))
-      commandLine.append(.flag(sdkInfo.sdkVersion(for: targetVariantTriple).description))
+      commandLine.append(.flag(sdkInfo.sdkVersion(for: targetVariantTriple).sdkVersionString))
     }
 
     if driver.isFrontendArgSupported(.targetSdkName) &&
@@ -381,4 +381,13 @@ extension Diagnostic.Message {
         "pass '-no-link-objc-runtime' to silence this warning"
       )
     }
+}
+
+private extension Version {
+  var sdkVersionString: String {
+    if patch == 0 && prereleaseIdentifiers.isEmpty && buildMetadataIdentifiers.isEmpty {
+      return "\(major).\(minor)"
+    }
+    return self.description
+  }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3116,7 +3116,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertEqual(frontendJobs[0].kind, .compile)
         XCTAssertTrue(frontendJobs[0].commandLine.contains(subsequence: [
           .flag("-target-sdk-version"),
-          .flag("10.15.0")
+          .flag("10.15")
         ]))
         if driver.isFrontendArgSupported(.targetSdkName) {
           XCTAssertTrue(frontendJobs[0].commandLine.contains(subsequence: [
@@ -3143,9 +3143,9 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertEqual(frontendJobs[0].kind, .compile)
         XCTAssertTrue(frontendJobs[0].commandLine.contains(subsequence: [
           .flag("-target-sdk-version"),
-          .flag("10.15.0"),
+          .flag("10.15"),
           .flag("-target-variant-sdk-version"),
-          .flag("13.1.0"),
+          .flag("13.1"),
         ]))
         XCTAssertEqual(frontendJobs[1].kind, .link)
         XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
@@ -3172,7 +3172,7 @@ final class SwiftDriverTests: XCTestCase {
           .flag("-target-sdk-version"),
           .flag("10.15.4"),
           .flag("-target-variant-sdk-version"),
-          .flag("13.4.0")
+          .flag("13.4")
         ]))
         if driver.isFrontendArgSupported(.targetSdkName) {
           XCTAssertTrue(frontendJobs[0].commandLine.contains(subsequence: [
@@ -3203,7 +3203,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertEqual(frontendJobs[0].kind, .compile)
         XCTAssertTrue(frontendJobs[0].commandLine.contains(subsequence: [
           .flag("-target-sdk-version"),
-          .flag("13.4.0"),
+          .flag("13.4"),
           .flag("-target-variant-sdk-version"),
           .flag("10.15.4")
         ]))


### PR DESCRIPTION
The motivation is that I'm trying to fix a linker/LTO warning that shows up when LTO-ing together C and Swift code:

```
ld: warning: linking module flags 'SDK Version': IDs have conflicting values ('[2 x i32] [i32 11, i32 0]' from clang.o with '[3 x i32] [i32 11, i32 0, i32 0]' from ld-temp.o)
```

Apparently, Clang passes -target-sdk-version 11.0, and the *old* Swift driver does as well, but the new Swift driver uses 11.0.0. Let's fix that.