### PR TITLE
Revert "Revert "[Dependency Scanning] Restore passing external target map as inputs to the scanning action.""

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -53,10 +53,36 @@ public extension Driver {
                                  moduleDependencyGraphUse: .dependencyScan)
     // FIXME: MSVC runtime flags
 
+    // Pass in external target dependencies to be treated as placeholder dependencies by the scanner
+    if let externalTargetPaths = externalTargetModuleDetailsMap?.mapValues({ $0.path }) {
+      let dependencyPlaceholderMapFile =
+      try serializeExternalDependencyArtifacts(externalTargetPaths: externalTargetPaths)
+      commandLine.appendFlag("-placeholder-dependency-module-map-file")
+      commandLine.appendPath(dependencyPlaceholderMapFile)
+    }
+
     // Pass on the input files
     commandLine.append(contentsOf: inputFiles.map { .path($0.file) })
     return (inputs, commandLine)
   }
+
+  /// Serialize a map of placeholder (external) dependencies for the dependency scanner.
+   private func serializeExternalDependencyArtifacts(externalTargetPaths: ExternalTargetModulePathMap)
+   throws -> VirtualPath {
+     var placeholderArtifacts: [SwiftModuleArtifactInfo] = []
+     // Explicit external targets
+     for (moduleId, binaryModulePath) in externalTargetPaths {
+       let modPath = TextualVirtualPath(path: VirtualPath.absolute(binaryModulePath).intern())
+       placeholderArtifacts.append(
+           SwiftModuleArtifactInfo(name: moduleId.moduleName,
+                                   modulePath: modPath))
+     }
+     let encoder = JSONEncoder()
+     encoder.outputFormatting = [.prettyPrinted]
+     let contents = try encoder.encode(placeholderArtifacts)
+     return VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("\(moduleOutputInfo.name)-external-modules.json"),
+                                                                   contents)
+   }
 
   /// Returns false if the lib is available and ready to use
   private func initSwiftScanLib() throws -> Bool {


### PR DESCRIPTION
This reverts commit 095cdac250314895c6b77146d78595c3fa2599b5, restoring the reverted functionality. 