### PR TITLE
Pass-down -downgrade-typecheck-interface-error to interface verification job

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -452,6 +452,8 @@ extension Driver {
                               default: false)
     else { return }
 
+    let optIn = env["ENABLE_DEFAULT_INTERFACE_VERIFIER"] != nil ||
+      parsedOptions.hasArgument(.verifyEmittedModuleInterface)
     func addVerifyJob(forPrivate: Bool) throws {
       let isNeeded =
         forPrivate
@@ -464,11 +466,11 @@ extension Driver {
       let mergeInterfaceOutputs = emitModuleJob.outputs.filter { $0.type == outputType }
       assert(mergeInterfaceOutputs.count == 1,
              "Merge module job should only have one swiftinterface output")
-      let job = try verifyModuleInterfaceJob(interfaceInput: mergeInterfaceOutputs[0])
+      let job = try verifyModuleInterfaceJob(interfaceInput: mergeInterfaceOutputs[0], optIn: optIn)
       addJob(job)
     }
     try addVerifyJob(forPrivate: false)
-    try addVerifyJob(forPrivate: true )
+    try addVerifyJob(forPrivate: true)
   }
 
   private mutating func addAutolinkExtractJob(

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Driver {
-  mutating func verifyModuleInterfaceJob(interfaceInput: TypedVirtualPath) throws -> Job {
+  mutating func verifyModuleInterfaceJob(interfaceInput: TypedVirtualPath, optIn: Bool) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     var inputs: [TypedVirtualPath] = [interfaceInput]
     commandLine.appendFlags("-frontend", "-typecheck-module-from-interface")
@@ -26,6 +26,10 @@ extension Driver {
       outputs.append(TypedVirtualPath(file: outputPath, type: .diagnostics))
     }
 
+    // TODO: remove this because we'd like module interface errors to fail the build.
+    if !optIn && isFrontendArgSupported(.downgradeTypecheckInterfaceError) {
+      commandLine.appendFlag(.downgradeTypecheckInterfaceError)
+    }
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .verifyModuleInterface,


### PR DESCRIPTION
The interface verification phase should downgrade errors to warnings as an
intermediate step to stage it in. This won't fail the build if interface errors
occur but it should help users verify project-side fixes.