### PR TITLE
Ensure that the separate emit-module job does not emit `.d.` outputs.

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -822,7 +822,8 @@ final class SwiftDriverTests: XCTestCase {
     let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
     XCTAssertEqual(plannedJobs.count, 3)
     XCTAssertTrue(plannedJobs[0].kind == .emitModule)
-    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-emit-dependencies-path")))
+    // TODO: This check is disabled as per rdar://85253406
+    // XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-emit-dependencies-path")))
     XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-serialize-diagnostics-path")))
   }
 


### PR DESCRIPTION
If we have both individual source files and the emit-module file emit .d files, we
are risking collisions in output filenames.

In cases where other compile jobs exist, they will produce dependency outputs already.
There are currently no cases where this is the only job because even an `-emit-module`
driver invocation currently still involves partial compilation jobs.
When partial compilation jobs are removed for the `compilerOutputType == .swiftModule`
case, this will need to be changed here.

Workaround for rdar://85253406