### PR TITLE
Tests: drop `testAutolinkOutputPath`

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -135,6 +135,10 @@ extension IncrementalCompilationTests {
   /// autolink job.
   /// Much of the code below is taking from testLinking(), but uses the output file map code here.
   func testAutolinkOutputPath() {
+#if !os(Linux)
+    XCTSkip("Driver.init invokes the frontend, which requires the stdlib and driver to match")
+    return
+#endif
     var env = ProcessEnv.vars
     env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"


### PR DESCRIPTION
This somehow uses the wrong Toolchain.  Using `GenericUnixToolchain` on
Windows or Darwin is not guaranteed to work.  This is required to enable
the test suite on Windows.