### PR TITLE
Add `-print-target-info` libSwiftScan entry-points

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -193,6 +193,10 @@ typedef struct {
   void
   (*swiftscan_scan_invocation_dispose)(swiftscan_scan_invocation_t);
 
+  //=== Target Info Functions-------- ---------------------------------------===//
+  swiftscan_string_ref_t
+  (*swiftscan_compiler_target_info_query)(swiftscan_scan_invocation_t);
+
   //=== Functionality Query Functions ---------------------------------------===//
   swiftscan_string_set_t *
   (*swiftscan_compiler_supported_arguments_query)(void);

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4649,7 +4649,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testPrintTargetInfo() throws {
     do {
-      var driver = try Driver(args: ["swift", "-print-target-info", "-target", "arm64-apple-ios12.0", "-sdk", "bar", "-resource-dir", "baz"])
+      var driver = try Driver(args: ["swift", "-print-target-info", "-sdk", "bar", "-resource-dir", "baz"])
       let plannedJobs = try driver.planBuild()
       XCTAssertTrue(plannedJobs.count == 1)
       let job = plannedJobs[0]
@@ -4658,6 +4658,22 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(job.commandLine.contains(.flag("-target")))
       XCTAssertTrue(job.commandLine.contains(.flag("-sdk")))
       XCTAssertTrue(job.commandLine.contains(.flag("-resource-dir")))
+    }
+
+    do {
+      let targetInfoArgs = ["-print-target-info", "-sdk", "bar", "-resource-dir", "baz"]
+      let driver = try Driver(args: ["swift"] + targetInfoArgs)
+
+      let env = ProcessEnv.vars
+      let swiftScanLibPath = try Driver.getScanLibPath(of: driver.toolchain,
+                                                       hostTriple: driver.hostTriple,
+                                                       env: env)
+      if localFileSystem.exists(swiftScanLibPath) {
+        let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
+        if libSwiftScanInstance.canQueryTargetInfo() {
+          let _ = try libSwiftScanInstance.queryTargetInfo(invocationCommand: targetInfoArgs)
+        }
+      }
     }
 
     do {


### PR DESCRIPTION
This change adds the relevant API entry-points to `SwiftScan`.
It does not yet transition the driver's current use-sites where we shell out a `swift-frontend` process, but should make it easy to do so.

The library itself is gaining these entry-points here:
https://github.com/apple/swift/pull/40160