### PR TITLE
Introduce module aliasing to Driver

### DIFF
--- a/Sources/SwiftDriver/Driver/ModuleOutputInfo.swift
+++ b/Sources/SwiftDriver/Driver/ModuleOutputInfo.swift
@@ -48,4 +48,7 @@
 
   /// Whether `name` was picked by the driver instead of the user.
   public let nameIsFallback: Bool
+
+  /// Map of aliases and real names of modules referenced by source files in the current module
+  public let aliases: [String: String]?
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -204,6 +204,7 @@ extension Driver {
     try commandLine.appendAllArguments(.Xfrontend, from: &parsedOptions)
     try commandLine.appendAll(.coveragePrefixMap, from: &parsedOptions)
     try commandLine.appendLast(.warnConcurrency, from: &parsedOptions)
+    try commandLine.appendAll(.moduleAlias, from: &parsedOptions)
 
     // Expand the -experimental-hermetic-seal-at-link flag
     if parsedOptions.hasArgument(.experimentalHermeticSealAtLink) {

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -89,6 +89,22 @@ extension Diagnostic.Message {
     return .error("module name \"\(moduleName)\" is reserved for the standard library\(suffix)")
   }
 
+  static func error_bad_module_alias(_ arg: String,
+                                     moduleName: String,
+                                     formatted: Bool = true,
+                                     isDuplicate: Bool = false) -> Diagnostic.Message {
+    if !formatted {
+      return .error("invalid format \"\(arg)\"; use the format '-module-alias alias_name=underlying_name'")
+    }
+    if arg == moduleName {
+      return .error("module alias \"\(arg)\" should be different from the module name \"\(moduleName)\"")
+    }
+    if isDuplicate {
+      return .error("the name \"\(arg)\" is already used for a module alias or an underlying name")
+    }
+    return .error("bad module alias \"\(arg)\"")
+  }
+
   static var error_hermetic_seal_cannot_have_library_evolution: Diagnostic.Message {
     .error("Cannot use -experimental-hermetic-seal-at-link with -enable-library-evolution")
   }


### PR DESCRIPTION
Support -module-alias in driver 
Parse input and store aliases in ModuleOutputInfo
Validate input aliases and emit diagnostics 
Resolves rdar://85523248