### PR TITLE
Module aliasing: use real module names to resolve graph during dependency scan

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -313,7 +313,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
           let isFramework: Bool
           swiftModulePath = .init(file: dependencyInfo.modulePath.path,
                                   type: .swiftModule)
-          isFramework = try dependencyGraph.swiftModuleDetails(of: dependencyId).isFramework
+          isFramework = try dependencyGraph.swiftModuleDetails(of: dependencyId).isFramework ?? false
           // Accumulate the required information about this dependency
           // TODO: add .swiftdoc and .swiftsourceinfo for this module.
           swiftDependencyArtifacts.append(
@@ -336,7 +336,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         case .swiftPrebuiltExternal:
           let prebuiltModuleDetails = try dependencyGraph.swiftPrebuiltDetails(of: dependencyId)
           let compiledModulePath = prebuiltModuleDetails.compiledModulePath
-          let isFramework = prebuiltModuleDetails.isFramework
+          let isFramework = prebuiltModuleDetails.isFramework ?? false
           let swiftModulePath: TypedVirtualPath =
             .init(file: compiledModulePath.path, type: .swiftModule)
           // Accumulate the requried information about this dependency

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -108,7 +108,7 @@ public struct SwiftModuleDetails: Codable {
   public var extraPcmArgs: [String]
 
   /// A flag to indicate whether or not this module is a framework.
-  public var isFramework: Bool
+  public var isFramework: Bool?
 }
 
 /// Details specific to Swift placeholder dependencies.
@@ -133,7 +133,7 @@ public struct SwiftPrebuiltExternalModuleDetails: Codable {
   public var moduleSourceInfoPath: TextualVirtualPath?
 
   /// A flag to indicate whether or not this module is a framework.
-  public var isFramework: Bool
+  public var isFramework: Bool?
 
   public init(compiledModulePath: TextualVirtualPath,
               moduleDocPath: TextualVirtualPath? = nil,
@@ -274,4 +274,23 @@ public struct InterModuleDependencyGraph: Codable {
 
 public struct InterModuleDependencyImports: Codable {
   public var imports: [String]
+  
+  public init(imports: [String], moduleAliases: [String: String]? = nil) {
+    var realImports = [String]()
+    if let aliases = moduleAliases {
+      for elem in imports {
+        if let realName = aliases[elem] {
+          realImports.append(realName)
+        } else {
+          realImports.append(elem)
+        }
+      }
+    }
+
+    if !realImports.isEmpty {
+      self.imports = realImports
+    } else {
+      self.imports = imports
+    }
+  }
 }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -43,25 +43,27 @@ public class InterModuleDependencyOracle {
   }
 
   @_spi(Testing) public func getBatchDependencies(workingDirectory: AbsolutePath,
-                                                  commandLine: [String],
                                                   moduleAliases: [String: String]? = nil,
+                                                  commandLine: [String],
                                                   batchInfos: [BatchScanModuleInfo])
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     precondition(hasScannerInstance)
     return try queue.sync {
       return try swiftScanLibInstance!.batchScanDependencies(workingDirectory: workingDirectory,
-                                                            invocationCommand: commandLine,
                                                              moduleAliases: moduleAliases,
+                                                            invocationCommand: commandLine,
                                                             batchInfos: batchInfos)
     }
   }
 
   @_spi(Testing) public func getImports(workingDirectory: AbsolutePath,
+                                        moduleAliases: [String: String]? = nil,
                                              commandLine: [String])
   throws -> InterModuleDependencyImports {
     precondition(hasScannerInstance)
     return try queue.sync {
       return try swiftScanLibInstance!.preScanImports(workingDirectory: workingDirectory,
+                                                      moduleAliases: moduleAliases,
                                                       invocationCommand: commandLine)
     }
   }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -31,23 +31,27 @@ public class InterModuleDependencyOracle {
   public init() {}
 
   @_spi(Testing) public func getDependencies(workingDirectory: AbsolutePath,
+                                             moduleAliases: [String: String]? = nil,
                                              commandLine: [String])
   throws -> InterModuleDependencyGraph {
     precondition(hasScannerInstance)
     return try queue.sync {
       return try swiftScanLibInstance!.scanDependencies(workingDirectory: workingDirectory,
+                                                        moduleAliases: moduleAliases,
                                                        invocationCommand: commandLine)
     }
   }
 
   @_spi(Testing) public func getBatchDependencies(workingDirectory: AbsolutePath,
                                                   commandLine: [String],
+                                                  moduleAliases: [String: String]? = nil,
                                                   batchInfos: [BatchScanModuleInfo])
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     precondition(hasScannerInstance)
     return try queue.sync {
       return try swiftScanLibInstance!.batchScanDependencies(workingDirectory: workingDirectory,
                                                             invocationCommand: commandLine,
+                                                             moduleAliases: moduleAliases,
                                                             batchInfos: batchInfos)
     }
   }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -159,6 +159,7 @@ public extension Driver {
       sanitizeCommandForLibScanInvocation(&command)
       dependencyGraph =
         try interModuleDependencyOracle.getDependencies(workingDirectory: cwd,
+                                                        moduleAliases: moduleOutputInfo.aliases,
                                                         commandLine: command)
     } else {
       // Fallback to legacy invocation of the dependency scanner with
@@ -188,6 +189,7 @@ public extension Driver {
       moduleVersionedGraphMap =
         try interModuleDependencyOracle.getBatchDependencies(workingDirectory: cwd,
                                                              commandLine: command,
+                                                             moduleAliases: moduleOutputInfo.aliases,
                                                              batchInfos: moduleInfos)
     } else {
       // Fallback to legacy invocation of the dependency scanner with

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -131,6 +131,7 @@ public extension Driver {
       sanitizeCommandForLibScanInvocation(&command)
       imports =
         try interModuleDependencyOracle.getImports(workingDirectory: cwd,
+                                                   moduleAliases: moduleOutputInfo.aliases,
                                                    commandLine: command)
 
     } else {
@@ -188,8 +189,8 @@ public extension Driver {
       sanitizeCommandForLibScanInvocation(&command)
       moduleVersionedGraphMap =
         try interModuleDependencyOracle.getBatchDependencies(workingDirectory: cwd,
-                                                             commandLine: command,
                                                              moduleAliases: moduleOutputInfo.aliases,
+                                                             commandLine: command,
                                                              batchInfos: moduleInfos)
     } else {
       // Fallback to legacy invocation of the dependency scanner with

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -15,7 +15,8 @@
 internal extension SwiftScan {
   /// From a reference to a binary-format dependency graph returned by libSwiftScan,
   /// construct an instance of an `InterModuleDependencyGraph`.
-  func constructGraph(from scannerGraphRef: swiftscan_dependency_graph_t) throws
+  func constructGraph(from scannerGraphRef: swiftscan_dependency_graph_t,
+                      moduleAliases: [String: String]?) throws
   -> InterModuleDependencyGraph {
     let mainModuleNameRef =
       api.swiftscan_dependency_graph_get_main_module_name(scannerGraphRef)
@@ -35,7 +36,7 @@ internal extension SwiftScan {
       guard let moduleRef = moduleRefOrNull else {
         throw DependencyScanningError.missingField("dependency_set_t.modules[_]")
       }
-      let (moduleId, moduleInfo) = try constructModuleInfo(from: moduleRef)
+      let (moduleId, moduleInfo) = try constructModuleInfo(from: moduleRef, moduleAliases: moduleAliases)
       resultGraph.modules[moduleId] = moduleInfo
     }
 
@@ -56,6 +57,7 @@ internal extension SwiftScan {
   /// corresponding to the specified batch scan input (`BatchScanModuleInfo`), construct instances of
   /// `InterModuleDependencyGraph` for each result.
   func constructBatchResultGraphs(for batchInfos: [BatchScanModuleInfo],
+                                  moduleAliases: [String: String]?,
                                   from batchResultRef: swiftscan_batch_scan_result_t) throws
   -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     var resultMap: [ModuleDependencyId: [InterModuleDependencyGraph]] = [:]
@@ -66,7 +68,7 @@ internal extension SwiftScan {
       guard let resultGraphRef = resultGraphRefOrNull else {
         throw DependencyScanningError.dependencyScanFailed
       }
-      let decodedGraph = try constructGraph(from: resultGraphRef)
+      let decodedGraph = try constructGraph(from: resultGraphRef, moduleAliases: moduleAliases)
 
       let moduleId: ModuleDependencyId
       switch batchInfos[index] {
@@ -89,12 +91,13 @@ internal extension SwiftScan {
 private extension SwiftScan {
   /// From a reference to a binary-format module dependency module info returned by libSwiftScan,
   /// construct an instance of an `ModuleInfo` as used by the driver
-  func constructModuleInfo(from moduleInfoRef: swiftscan_dependency_info_t)
+  func constructModuleInfo(from moduleInfoRef: swiftscan_dependency_info_t,
+                           moduleAliases: [String: String]?)
   throws -> (ModuleDependencyId, ModuleInfo) {
     // Decode the module name and module kind
     let encodedModuleName =
       try toSwiftString(api.swiftscan_module_info_get_module_name(moduleInfoRef))
-    let moduleId = try decodeModuleNameAndKind(from: encodedModuleName)
+    let moduleId = try decodeModuleNameAndKind(from: encodedModuleName, moduleAliases: moduleAliases)
 
     // Decode module path and source file locations
     let modulePathStr = try toSwiftString(api.swiftscan_module_info_get_module_path(moduleInfoRef))
@@ -111,7 +114,7 @@ private extension SwiftScan {
     if let encodedDirectDepsRef = api.swiftscan_module_info_get_direct_dependencies(moduleInfoRef) {
       let encodedDirectDependencies = try toSwiftStringArray(encodedDirectDepsRef.pointee)
       directDependencies =
-        try encodedDirectDependencies.map { try decodeModuleNameAndKind(from: $0) }
+      try encodedDirectDependencies.map { try decodeModuleNameAndKind(from: $0, moduleAliases: moduleAliases) }
     } else {
       directDependencies = nil
     }
@@ -373,12 +376,17 @@ private extension SwiftScan {
   /// "swiftBinary"
   /// "swiftPlaceholder"
   /// "clang""
-  func decodeModuleNameAndKind(from encodedName: String) throws -> ModuleDependencyId {
+  func decodeModuleNameAndKind(from encodedName: String,
+                               moduleAliases: [String: String]?) throws -> ModuleDependencyId {
     switch encodedName {
       case _ where encodedName.starts(with: "swiftTextual:"):
         return .swift(String(encodedName.suffix(encodedName.count - "swiftTextual:".count)))
       case _ where encodedName.starts(with: "swiftBinary:"):
-        return .swiftPrebuiltExternal(String(encodedName.suffix(encodedName.count - "swiftBinary:".count)))
+        var namePart = String(encodedName.suffix(encodedName.count - "swiftBinary:".count))
+        if let moduleAliases = moduleAliases, let realName = moduleAliases[namePart] {
+          namePart = realName
+        }
+        return .swiftPrebuiltExternal(namePart)
       case _ where encodedName.starts(with: "swiftPlaceholder:"):
         return .swiftPlaceholder(String(encodedName.suffix(encodedName.count - "swiftPlaceholder:".count)))
       case _ where encodedName.starts(with: "clang:"):

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -93,6 +93,7 @@ internal final class SwiftScan {
   }
 
   func preScanImports(workingDirectory: AbsolutePath,
+                      moduleAliases: [String: String]?,
                       invocationCommand: [String]) throws -> InterModuleDependencyImports {
     // Create and configure the scanner invocation
     let invocation = api.swiftscan_scan_invocation_create()
@@ -112,7 +113,7 @@ internal final class SwiftScan {
       throw DependencyScanningError.dependencyScanFailed
     }
 
-    let importSet = try constructImportSet(from: importSetRef)
+    let importSet = try constructImportSet(from: importSetRef, with: moduleAliases)
     // Free the memory allocated for the in-memory representation of the import set
     // returned by the scanner, now that we have translated it.
     api.swiftscan_import_set_dispose(importSetRef)
@@ -149,8 +150,8 @@ internal final class SwiftScan {
   }
 
   func batchScanDependencies(workingDirectory: AbsolutePath,
-                             invocationCommand: [String],
                              moduleAliases: [String: String]?,
+                             invocationCommand: [String],
                              batchInfos: [BatchScanModuleInfo])
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     // Create and configure the scanner invocation

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -120,6 +120,7 @@ internal final class SwiftScan {
   }
 
   func scanDependencies(workingDirectory: AbsolutePath,
+                        moduleAliases: [String: String]?,
                         invocationCommand: [String]) throws -> InterModuleDependencyGraph {
     // Create and configure the scanner invocation
     let invocation = api.swiftscan_scan_invocation_create()
@@ -139,7 +140,7 @@ internal final class SwiftScan {
       throw DependencyScanningError.dependencyScanFailed
     }
 
-    let dependencyGraph = try constructGraph(from: graphRef)
+    let dependencyGraph = try constructGraph(from: graphRef, moduleAliases: moduleAliases)
     // Free the memory allocated for the in-memory representation of the dependency
     // graph returned by the scanner, now that we have translated it into an
     // `InterModuleDependencyGraph`.
@@ -149,6 +150,7 @@ internal final class SwiftScan {
 
   func batchScanDependencies(workingDirectory: AbsolutePath,
                              invocationCommand: [String],
+                             moduleAliases: [String: String]?,
                              batchInfos: [BatchScanModuleInfo])
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     // Create and configure the scanner invocation
@@ -201,6 +203,7 @@ internal final class SwiftScan {
     // Translate `swiftscan_batch_scan_result_t`
     // into `[ModuleDependencyId: [InterModuleDependencyGraph]]`
     let resultGraphMap = try constructBatchResultGraphs(for: batchInfos,
+                                                        moduleAliases:  moduleAliases,
                                                         from: batchResultRef.pointee)
     // Free the memory allocated for the in-memory representation of the batch scan
     // result, now that we have translated it.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -985,7 +985,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             main.pathString.escaped()] + sdkArgumentsForTesting
 
       let imports =
-        try dependencyOracle.getImports(workingDirectory: path,
+        try! dependencyOracle.getImports(workingDirectory: path,
                                          commandLine: scannerCommand)
       let expectedImports = ["C", "E", "G", "Swift", "SwiftOnoneSupport"]
       // Dependnig on how recent the platform we are running on, the Concurrency module may or may not be present.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -630,8 +630,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver2 = try Driver(args: ["swiftc",
                                       "-I",
                                       path.pathString.nativePathString().escaped(),
-                                      "-j",
-                                      "1",
                                       "-explicit-module-build",
                                       "-module-name",
                                       "Foo",

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -592,6 +592,200 @@ final class ExplicitModuleBuildTests: XCTestCase {
     #endif
   }
 
+  
+  func testModuleAliasingPrebuiltWithScanDeps() throws {
+    try withTemporaryDirectory { path in
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+
+      let srcBar = path.appending(component: "bar.swift")
+      let moduleBarPath = path.appending(component: "Bar.swiftmodule").pathString.nativePathString().escaped()
+      try localFileSystem.writeFileContents(srcBar) {
+        $0 <<< "public class KlassBar {}"
+      }
+      
+      // Create Bar.swiftmodule
+      var driver = try Driver(args: ["swiftc",
+                                      "-explicit-module-build",
+                                      srcBar.pathString.nativePathString().escaped(),
+                                      "-module-name",
+                                      "Bar",
+                                      "-emit-module",
+                                      "-emit-module-path",
+                                      moduleBarPath] + sdkArgumentsForTesting,
+                               env: ProcessEnv.vars)
+      let jobs = try driver.planBuild()
+      try driver.run(jobs: jobs)
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
+      XCTAssertTrue(FileManager.default.fileExists(atPath: moduleBarPath))
+      
+      // Foo imports Car which is mapped to the real module Bar via
+      // `-module-alias Car=Bar`; it allows Car (alias) to be referenced
+      // in source files, while its contents are compiled as Bar (real
+      // name on disk).
+      let srcFoo = path.appending(component: "Foo.swift")
+      try localFileSystem.writeFileContents(srcFoo) {
+        $0 <<< "import Car\n"
+        $0 <<< "func run() -> Car.KlassBar? { return nil }"
+      }
+      
+      // Module alias with the fallback scanner (frontend scanner)
+      var driverA = try Driver(args: ["swiftc",
+                                      "-nonlib-dependency-scanner",
+                                      "-explicit-module-build",
+                                      srcFoo.pathString.nativePathString().escaped(),
+                                      "-module-alias", "Car=Bar",
+                                      "-I",
+                                      path.pathString.nativePathString().escaped(),
+                                     ])
+      
+      // Resulting graph should contain the real module name Bar
+      let dependencyGraphA = try driverA.gatherModuleDependencies()
+      XCTAssertTrue(dependencyGraphA.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "Bar"
+      })
+      XCTAssertFalse(dependencyGraphA.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "Car"
+      })
+
+      let plannedJobsA = try driverA.planBuild()
+      XCTAssertTrue(plannedJobsA.contains { job in
+        job.commandLine.contains(.flag("-module-alias")) &&
+        job.commandLine.contains(.flag("Car=Bar"))
+      })
+
+      // Module alias with the default scanner (driver scanner)
+      var driverB = try Driver(args: ["swiftc",
+                                      "-explicit-module-build",
+                                      srcFoo.pathString.nativePathString().escaped(),
+                                      "-module-alias", "Car=Bar",
+                                      "-I",
+                                      path.pathString.nativePathString().escaped(),
+                                     ])
+      
+      // Resulting graph should contain the real module name Bar
+      let dependencyGraphB = try driverB.gatherModuleDependencies()
+      XCTAssertTrue(dependencyGraphB.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "Bar"
+      })
+      XCTAssertFalse(dependencyGraphB.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "Car"
+      })
+
+      let plannedJobsB = try driverB.planBuild()
+      XCTAssertTrue(plannedJobsB.contains { job in
+        job.commandLine.contains(.flag("-module-alias")) &&
+        job.commandLine.contains(.flag("Car=Bar"))
+      })
+    }
+  }
+  
+  func testModuleAliasingInterfaceWithScanDeps() throws {
+    try withTemporaryDirectory { path in
+      let swiftModuleInterfacesPath: String =
+          testInputsPath.appending(component: "ExplicitModuleBuilds")
+                        .appending(component: "Swift")
+                        .pathString
+
+      // Foo imports Car which is mapped to the real module Bar via
+      // `-module-alias Car=Bar`; it allows Car (alias) to be referenced
+      // in source files, while its contents are compiled as Bar (real
+      // name on disk).
+      let srcFoo = path.appending(component: "Foo.swift")
+      try localFileSystem.writeFileContents(srcFoo) {
+        $0 <<< "import Car\n"
+      }
+      
+      // Module alias with the fallback scanner (frontend scanner)
+      var driverA = try Driver(args: ["swiftc",
+                                      "-nonlib-dependency-scanner",
+                                      "-explicit-module-build",
+                                      srcFoo.pathString.nativePathString().escaped(),
+                                      "-module-alias", "Car=F",
+                                      "-I",
+                                      swiftModuleInterfacesPath.nativePathString().escaped(),
+                                     ])
+      
+      // Resulting graph should contain the real module name Bar
+      let dependencyGraphA = try driverA.gatherModuleDependencies()
+      XCTAssertTrue(dependencyGraphA.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "F"
+      })
+      XCTAssertFalse(dependencyGraphA.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "Car"
+      })
+
+      let plannedJobsA = try driverA.planBuild()
+      XCTAssertTrue(plannedJobsA.contains { job in
+        job.commandLine.contains(.flag("-module-alias")) &&
+        job.commandLine.contains(.flag("Car=F"))
+      })
+
+      // Module alias with the default scanner (driver scanner)
+      var driverB = try Driver(args: ["swiftc",
+                                      "-explicit-module-build",
+                                      srcFoo.pathString.nativePathString().escaped(),
+                                      "-module-alias", "Car=F",
+                                      "-I",
+                                      swiftModuleInterfacesPath.nativePathString().escaped(),
+                                     ])
+      
+      // Resulting graph should contain the real module name Bar
+      let dependencyGraphB = try driverB.gatherModuleDependencies()
+      XCTAssertTrue(dependencyGraphB.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "F"
+      })
+      XCTAssertFalse(dependencyGraphB.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
+        key.moduleName == "Car"
+      })
+
+      let plannedJobsB = try driverB.planBuild()
+      XCTAssertTrue(plannedJobsB.contains { job in
+        job.commandLine.contains(.flag("-module-alias")) &&
+        job.commandLine.contains(.flag("Car=F"))
+      })
+    }
+  }
+  
+  func testModuleAliasingWithImportPrescan() throws {
+    let (_, _, toolchain, hostTriple) = try getDriverArtifactsForScanning()
+
+    // The dependency oracle wraps an instance of libSwiftScan and ensures thread safety across
+    // queries.
+    let dependencyOracle = InterModuleDependencyOracle()
+    let scanLibPath = try Driver.getScanLibPath(of: toolchain,
+                                                hostTriple: hostTriple,
+                                                env: ProcessEnv.vars)
+    guard try dependencyOracle
+            .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
+                                           swiftScanLibPath: scanLibPath) else {
+      XCTFail("Dependency scanner library not found")
+      return
+    }
+
+    try withTemporaryDirectory { path in
+      let main = path.appending(component: "foo.swift")
+      try localFileSystem.writeFileContents(main) {
+        $0 <<< "import Car;"
+        $0 <<< "import Jet;"
+      }
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+      let scannerCommand = ["-scan-dependencies",
+                            "-import-prescan",
+                            "-module-alias",
+                            "Car=Bar",
+                            main.pathString.escaped()] + sdkArgumentsForTesting
+
+      let deps =
+        try! dependencyOracle.getImports(workingDirectory: path,
+                                         moduleAliases: ["Car": "Bar"],
+                                         commandLine: scannerCommand)
+      
+      XCTAssertTrue(deps.imports.contains("Bar"))
+      XCTAssertFalse(deps.imports.contains("Car"))
+      XCTAssertTrue(deps.imports.contains("Jet"))
+    }
+  }
+  
   func testModuleAliasingWithExplicitBuild() throws {
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
@@ -791,7 +985,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             main.pathString.escaped()] + sdkArgumentsForTesting
 
       let imports =
-        try! dependencyOracle.getImports(workingDirectory: path,
+        try dependencyOracle.getImports(workingDirectory: path,
                                          commandLine: scannerCommand)
       let expectedImports = ["C", "E", "G", "Swift", "SwiftOnoneSupport"]
       // Dependnig on how recent the platform we are running on, the Concurrency module may or may not be present.


### PR DESCRIPTION
Use real module names during dependency scan / construct deps graph and imports
Add tests using driver dependency scanner and fallback frontend scanner
Make isFramework optional in SwiftModuleDetails and SwiftPrebuiltExternalModuleDetails (else throws JSON Decoding error)

Resolves rdar://85525296