### PR TITLE
[Incremental Builds] Skip `jobsBeforeCompiles` if no compilation jobs are to be run.

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -323,6 +323,14 @@ extension IncrementalCompilationTests {
     }
   }
 
+  func testNullBuildNoEmitModule() throws {
+    let extraArguments = ["-experimental-emit-module-separately", "-emit-module"]
+    try buildInitialState(extraArguments: extraArguments)
+    let driver = try checkNullBuild(extraArguments: extraArguments)
+    let mandatoryJobs = try XCTUnwrap(driver.incrementalCompilationState?.mandatoryJobsInOrder)
+    XCTAssertTrue(mandatoryJobs.isEmpty)
+  }
+
   func testSymlinkModification() throws {
     // Remap
     // main.swift -> links/main.swift


### PR DESCRIPTION
Otherwise, for example, when using the `emit-module-separately` mode, the `emit-module` job is *always* mandatory, even on a null build.

Resolves rdar://85554508