### PR TITLE
begin to integrate SwiftSystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ find_package(dispatch QUIET)
 find_package(Foundation QUIET)
 find_package(Yams CONFIG REQUIRED)
 find_package(ArgumentParser CONFIG REQUIRED)
+find_package(SwiftSystem CONFIG REQUIRED)
 
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)


### PR DESCRIPTION
motivation: SwiftSystem provides infra that can replace some bespoke implementations in TSC and, improving the cross-platform support. as such we are adding it as a dependency to TSC

changes: add SwiftSystem to CMake setup so it can be included in CMake based builds