### PR TITLE
Add a reverse index to Multidictionary

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -141,11 +141,6 @@
     if self.reverseIndex[v] != nil {
       return false
     }
-    for vals in self.forwardDictionary.values {
-      if vals.contains(v) {
-        return false
-      }
-    }
-    return true
+    return !self.forwardDictionary.values.contains(where: { $0.contains(v) })
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -89,7 +89,7 @@
   ///                this dictionary.
   /// - Returns: The set of keys associated with the given value.
   public func keysContainingValue(_ v: Value) -> Set<Key> {
-    return self.reverseIndex[v, default: []]
+    return self.reverseIndex[v] ?? []
   }
 
   /// Inserts the given value in the set of values associated with the given key.

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -20,6 +20,8 @@
   public typealias Element = (Key, Set<Value>)
   public typealias Index = Dictionary<Key, Set<Value>>.Index
 
+  public init() {}
+
   /// The number of key-value pairs in this multi-dictionary.
   public var count: Int {
     self.dictionary.count
@@ -123,9 +125,22 @@
   ///
   /// - Parameter v: The value to remove.
   public mutating func removeOccurrences(of v: Value) {
-    for k in self.reverseIndex[v, default: []] {
+    for k in self.reverseIndex.removeValue(forKey: v) ?? [] {
       self.dictionary[k]!.remove(v)
     }
-    self.reverseIndex.removeValue(forKey: v)
+    assert(expensivelyCheckThatValueIsRemoved(v))
+  }
+
+  /// For assertions. Returns true `v` is removed from all `dictionary` values.
+  private func expensivelyCheckThatValueIsRemoved(_ v: Value) -> Bool {
+    if self.reverseIndex[v] != nil {
+      return false
+    }
+    for vals in self.dictionary.values {
+      if vals.contains(v) {
+        return false
+      }
+    }
+    return true
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -136,7 +136,7 @@
     assert(expensivelyCheckThatValueIsRemoved(v))
   }
 
-  /// For assertions. Returns true `v` is removed from all `dictionary` values.
+  /// For assertions. Returns true `v` is removed from all `forwardDictionary` values.
   private func expensivelyCheckThatValueIsRemoved(_ v: Value) -> Bool {
     if self.reverseIndex[v] != nil {
       return false

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -101,8 +101,10 @@
   ///            other values for the given key. Else, returns `false.
   @discardableResult
   public mutating func insertValue(_ v: Value, forKey key: Key) -> Bool {
-    self.reverseIndex[v, default: []].insert(key)
-    return self.dictionary[key, default: []].insert(v).inserted
+    let inserted1 = self.reverseIndex[v, default: []].insert(key).inserted
+    let inserted2 = self.dictionary[key, default: []].insert(v).inserted
+    assert(inserted1 == inserted2)
+    return inserted1
   }
 
   /// Removes the given value from the set of values associated with the given key.
@@ -113,8 +115,11 @@
   /// - Returns: The removed element, if any.
   @discardableResult
   public mutating func removeValue(_ v: Value, forKey key: Key) -> Value? {
-    self.reverseIndex[v]?.remove(key)
-    return self.dictionary[key, default: []].remove(v)
+    let removedKey = self.reverseIndex[v]?.remove(key)
+    let removedVal = self.dictionary[key, default: []].remove(v)
+    assert((removedKey == nil && removedVal == nil) ||
+           (removedKey != nil && removedVal != nil))
+    return removedVal
   }
 
   /// Removes all occurrences of the given value from all entries in this

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -116,7 +116,7 @@
   @discardableResult
   public mutating func removeValue(_ v: Value, forKey key: Key) -> Value? {
     let removedKey = self.reverseIndex[v]?.remove(key)
-    let removedVal = self.dictionary[key, default: []].remove(v)
+    let removedVal = self.dictionary[key]?.remove(v)
     assert((removedKey == nil && removedVal == nil) ||
            (removedKey != nil && removedVal != nil))
     return removedVal

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -12,7 +12,7 @@
 
 /// A collection that associates keys with one or more values.
 @_spi(Testing) public struct Multidictionary<Key: Hashable, Value: Hashable>: Collection, Equatable {
-  private var dictionary: Dictionary<Key, Set<Value>> = [:]
+  private var forwardDictionary: Dictionary<Key, Set<Value>> = [:]
 
   /// Reverse index used to make value removal more efficient.
   private var reverseIndex: Dictionary<Value, Set<Key>> = [:]
@@ -24,18 +24,18 @@
 
   /// The number of key-value pairs in this multi-dictionary.
   public var count: Int {
-    self.dictionary.count
+    self.forwardDictionary.count
   }
 
   /// The position of the first element in a nonempty multi-dictionary.
   public var startIndex: Index {
-    self.dictionary.startIndex
+    self.forwardDictionary.startIndex
   }
 
   /// The collection’s “past the end” position—that is, the position one greater
   /// than the last valid subscript argument.
   public var endIndex: Index {
-    self.dictionary.endIndex
+    self.forwardDictionary.endIndex
   }
 
   /// Returns the index for the given key.
@@ -44,7 +44,7 @@
   /// - Returns: The index for key and its associated value if key is in the
   ///            multi-dictionary; otherwise, nil.
   public func index(forKey key: Key) -> Dictionary<Key, Set<Value>>.Index? {
-    self.dictionary.index(forKey: key)
+    self.forwardDictionary.index(forKey: key)
   }
 
   /// Computes the position immediately after the given index.
@@ -52,26 +52,26 @@
   /// - Parameter i: A valid index of the collection. i must be less than endIndex.
   /// - Returns: The position immediately after the given index.
   @_spi(Testing) public func index(after i: Dictionary<Key, Set<Value>>.Index) -> Dictionary<Key, Set<Value>>.Index {
-    self.dictionary.index(after: i)
+    self.forwardDictionary.index(after: i)
   }
 
   @_spi(Testing) public subscript(position: Dictionary<Key, Set<Value>>.Index) -> (Key, Set<Value>) {
-    self.dictionary[position]
+    self.forwardDictionary[position]
   }
 
   /// A collection containing just the keys of this multi-dictionary.
   public var keys: Dictionary<Key, Set<Value>>.Keys {
-    return self.dictionary.keys
+    return self.forwardDictionary.keys
   }
 
   /// A collection containing just the values of this multi-dictionary.
   public var values: Dictionary<Key, Set<Value>>.Values {
-    return self.dictionary.values
+    return self.forwardDictionary.values
   }
 
   /// Accesses the values associated with the given key for reading and writing.
   public subscript(key: Key) -> Set<Value>? {
-    self.dictionary[key]
+    self.forwardDictionary[key]
   }
 
   /// Accesses the values associated with the given key for reading and writing.
@@ -80,7 +80,7 @@
   /// provided default value as if the key and default value existed in
   /// this multi-dictionary.
   public subscript(key: Key, default defaultValues: @autoclosure () -> Set<Value>) -> Set<Value> {
-    self.dictionary[key, default: defaultValues()]
+    self.forwardDictionary[key, default: defaultValues()]
   }
 
   /// Returns a set of keys that the given value is associated with.
@@ -102,7 +102,7 @@
   @discardableResult
   public mutating func insertValue(_ v: Value, forKey key: Key) -> Bool {
     let inserted1 = self.reverseIndex[v, default: []].insert(key).inserted
-    let inserted2 = self.dictionary[key, default: []].insert(v).inserted
+    let inserted2 = self.forwardDictionary[key, default: []].insert(v).inserted
     assert(inserted1 == inserted2)
     return inserted1
   }
@@ -116,7 +116,7 @@
   @discardableResult
   public mutating func removeValue(_ v: Value, forKey key: Key) -> Value? {
     let removedKey = self.reverseIndex[v]?.remove(key)
-    let removedVal = self.dictionary[key]?.remove(v)
+    let removedVal = self.forwardDictionary[key]?.remove(v)
     assert((removedKey == nil && removedVal == nil) ||
            (removedKey != nil && removedVal != nil))
     return removedVal
@@ -131,7 +131,7 @@
   /// - Parameter v: The value to remove.
   public mutating func removeOccurrences(of v: Value) {
     for k in self.reverseIndex.removeValue(forKey: v) ?? [] {
-      self.dictionary[k]!.remove(v)
+      self.forwardDictionary[k]!.remove(v)
     }
     assert(expensivelyCheckThatValueIsRemoved(v))
   }
@@ -141,7 +141,7 @@
     if self.reverseIndex[v] != nil {
       return false
     }
-    for vals in self.dictionary.values {
+    for vals in self.forwardDictionary.values {
       if vals.contains(v) {
         return false
       }

--- a/Tests/SwiftDriverTests/MultidictionaryTests.swift
+++ b/Tests/SwiftDriverTests/MultidictionaryTests.swift
@@ -55,6 +55,83 @@ class MultidictionaryTests: XCTestCase {
     XCTAssertEqual(dict.keysContainingValue(4), ["c"])
   }
 
+  func testInsertion_existingPair() {
+    var dict = multidictionaryWith([
+      "a": [1],
+      "b": [1, 2],
+      "c": [1, 2, 3, 4],
+    ])
+
+    // Inserting an existing k:v pair a second time should do nothing.
+    XCTAssertFalse(dict.insertValue(1, forKey: "a"))
+
+    XCTAssertEqual(dict.count, 3)
+    XCTAssertEqual(dict["a"], [1])
+    XCTAssertEqual(dict["b"], [1, 2])
+    XCTAssertEqual(dict["c"], [1, 2, 3, 4])
+    XCTAssertEqual(dict.keysContainingValue(1), ["a", "b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(3), ["c"])
+    XCTAssertEqual(dict.keysContainingValue(4), ["c"])
+  }
+
+  func testRemoveValue() throws {
+    var dict = multidictionaryWith([
+      "a": [1],
+      "b": [1, 2],
+      "c": [1, 2, 3, 4],
+    ])
+
+    XCTAssertNotNil(dict.removeValue(2, forKey: "c"))
+
+    XCTAssertEqual(dict.count, 3)
+    XCTAssertEqual(dict["a"], [1])
+    XCTAssertEqual(dict["b"], [1, 2])
+    XCTAssertEqual(dict["c"], [1, 3, 4])
+    XCTAssertEqual(dict.keysContainingValue(1), ["a", "b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b"])
+    XCTAssertEqual(dict.keysContainingValue(3), ["c"])
+    XCTAssertEqual(dict.keysContainingValue(4), ["c"])
+  }
+
+  func testRemoveValue_nonExistentValue() throws {
+    var dict = multidictionaryWith([
+      "a": [1],
+      "b": [1, 2],
+      "c": [1, 2, 3, 4],
+    ])
+
+    XCTAssertNil(dict.removeValue(5, forKey: "c"))
+
+    XCTAssertEqual(dict.count, 3)
+    XCTAssertEqual(dict["a"], [1])
+    XCTAssertEqual(dict["b"], [1, 2])
+    XCTAssertEqual(dict["c"], [1, 2, 3, 4])
+    XCTAssertEqual(dict.keysContainingValue(1), ["a", "b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(3), ["c"])
+    XCTAssertEqual(dict.keysContainingValue(4), ["c"])
+  }
+
+  func testRemoveValue_nonExistentKey() throws {
+    var dict = multidictionaryWith([
+      "a": [1],
+      "b": [1, 2],
+      "c": [1, 2, 3, 4],
+    ])
+
+    XCTAssertNil(dict.removeValue(1, forKey: "d"))
+
+    XCTAssertEqual(dict.count, 3)
+    XCTAssertEqual(dict["a"], [1])
+    XCTAssertEqual(dict["b"], [1, 2])
+    XCTAssertEqual(dict["c"], [1, 2, 3, 4])
+    XCTAssertEqual(dict.keysContainingValue(1), ["a", "b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(3), ["c"])
+    XCTAssertEqual(dict.keysContainingValue(4), ["c"])
+  }
+
   func testRemoveOccurencesOf() throws {
     var dict = multidictionaryWith([
       "a": [1],
@@ -74,21 +151,21 @@ class MultidictionaryTests: XCTestCase {
     XCTAssertEqual(dict.keysContainingValue(4), ["c"])
   }
 
-  func testRemoveValue() throws {
+  func testRemoveOccurencesOf_nonExistentValue() throws {
     var dict = multidictionaryWith([
       "a": [1],
       "b": [1, 2],
       "c": [1, 2, 3, 4],
     ])
 
-    dict.removeValue(2, forKey: "c")
+    dict.removeOccurrences(of: 5)
 
     XCTAssertEqual(dict.count, 3)
     XCTAssertEqual(dict["a"], [1])
     XCTAssertEqual(dict["b"], [1, 2])
-    XCTAssertEqual(dict["c"], [1, 3, 4])
+    XCTAssertEqual(dict["c"], [1, 2, 3, 4])
     XCTAssertEqual(dict.keysContainingValue(1), ["a", "b", "c"])
-    XCTAssertEqual(dict.keysContainingValue(2), ["b"])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b", "c"])
     XCTAssertEqual(dict.keysContainingValue(3), ["c"])
     XCTAssertEqual(dict.keysContainingValue(4), ["c"])
   }

--- a/Tests/SwiftDriverTests/MultidictionaryTests.swift
+++ b/Tests/SwiftDriverTests/MultidictionaryTests.swift
@@ -1,0 +1,95 @@
+//===------------ MultidictionaryTests.swift - Swift Testing ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@_spi(Testing) import SwiftDriver
+
+class MultidictionaryTests: XCTestCase {
+
+  private func multidictionaryWith<K: Hashable, V: Hashable>(_ keysAndValues: Dictionary<K, [V]>) -> Multidictionary<K, V>{
+    var dict = Multidictionary<K, V>()
+    for (k, vals) in keysAndValues {
+      for v in vals {
+        dict.insertValue(v, forKey: k)
+      }
+    }
+    return dict
+  }
+
+  func testInit() throws {
+    let dict = Multidictionary<String, Int>()
+
+    XCTAssertEqual(dict.count, 0)
+    XCTAssertEqual(dict.keys.count, 0)
+    XCTAssertEqual(dict.values.count, 0)
+    XCTAssertEqual(dict.startIndex, dict.endIndex)
+  }
+
+  func testInsertion() throws {
+    var dict = Multidictionary<String, Int>()
+
+    dict.insertValue(1, forKey: "a")
+    dict.insertValue(1, forKey: "b")
+    dict.insertValue(2, forKey: "b")
+    dict.insertValue(1, forKey: "c")
+    dict.insertValue(2, forKey: "c")
+    dict.insertValue(3, forKey: "c")
+    dict.insertValue(4, forKey: "c")
+
+    XCTAssertEqual(dict.count, 3)
+    XCTAssertEqual(dict["a"], [1])
+    XCTAssertEqual(dict["b"], [1, 2])
+    XCTAssertEqual(dict["c"], [1, 2, 3, 4])
+    XCTAssertEqual(dict.keysContainingValue(1), ["a", "b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(3), ["c"])
+    XCTAssertEqual(dict.keysContainingValue(4), ["c"])
+  }
+
+  func testRemoveOccurencesOf() throws {
+    var dict = multidictionaryWith([
+      "a": [1],
+      "b": [1, 2],
+      "c": [1, 2, 3, 4],
+    ])
+
+    dict.removeOccurrences(of: 1)
+
+    XCTAssertEqual(dict.count, 3)
+    XCTAssertEqual(dict["a"], [])
+    XCTAssertEqual(dict["b"], [2])
+    XCTAssertEqual(dict["c"], [2, 3, 4])
+    XCTAssertEqual(dict.keysContainingValue(1), [])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(3), ["c"])
+    XCTAssertEqual(dict.keysContainingValue(4), ["c"])
+  }
+
+  func testRemoveValue() throws {
+    var dict = multidictionaryWith([
+      "a": [1],
+      "b": [1, 2],
+      "c": [1, 2, 3, 4],
+    ])
+
+    dict.removeValue(2, forKey: "c")
+
+    XCTAssertEqual(dict.count, 3)
+    XCTAssertEqual(dict["a"], [1])
+    XCTAssertEqual(dict["b"], [1, 2])
+    XCTAssertEqual(dict["c"], [1, 3, 4])
+    XCTAssertEqual(dict.keysContainingValue(1), ["a", "b", "c"])
+    XCTAssertEqual(dict.keysContainingValue(2), ["b"])
+    XCTAssertEqual(dict.keysContainingValue(3), ["c"])
+    XCTAssertEqual(dict.keysContainingValue(4), ["c"])
+  }
+}


### PR DESCRIPTION
Add a reverse index to Multidictionary to make value removal more efficient in large dictionaries.

In a module with several tens of thousands of definitions in the dependency graph, disappearing nodes from the graph becomes very expensive as removeOccurences(of:) is an O(number_of_keys) operation. This change makes removeOccurrences(of:) O(number_of_keys_containing_the_value), which can be tens of thousands of times faster.

The cost of this change is that insertValue(:forKey:) and removeValue(:forKey:) are approximately twice as expensive, and the dictionary will use about twice as much memory. For small graphs, this difference should be trivial. For my several-tens-of-thousands-of-definitions graph, it takes about four seconds to load rather than two. The driver doesn't seem to use significantly more memory overall. Without this change removeOccurences(of:) is so exceedingly expensive (about 0.5 seconds per call) that the increase in load time is well worth it.

This change could be further optimized so that the `reverseIndex` is only built the first time removeOccurences(of:) is called. Then there would be no negative performance impact at all for many builds. However, the negative impact seems to be quite small, so I am not sure the extra complexity of such an optimization is worthwhile.