### PR TITLE
Tests: account for EOL marker differences

### DIFF
--- a/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
+++ b/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
@@ -174,12 +174,18 @@ fileprivate extension Array where Element == Change {
   }
 
   var expectedOutput: ExpectedProcessResult {
+#if os(Windows)
+      let eol = "\r\n"
+#else
+      let eol = "\n"
+#endif
+
     let specOrGen = Change.allCases .map {
       contains($0) ? "specific" : "general"
     }
     let output = zip(specOrGen, Change.allLociOfExposure)
       .map { "\($0.0) in \($0.1)"}
-      .joined(separator: "\n")
+      .joined(separator: eol)
     return ExpectedProcessResult(output: output)
   }
 


### PR DESCRIPTION
Windows uses a different EOL marker (CR+LF) compared to Unix (LF).  This
accounts for that in the output enabling the
HideAndShowFuncInStrucAndExtensionTest to now pass on Windows.