### PR TITLE
Toolchains: adjust environment variable generation on Windows

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -138,10 +138,10 @@ extension Toolchain {
   /// - Returns: String in the form of: `SWIFT_DRIVER_TOOLNAME_EXEC`
   private func envVarName(for toolName: String) -> String {
     let lookupName = toolName
+#if os(Windows)
+      .replacingOccurrences(of: ".exe", with: "")
+#endif
       .replacingOccurrences(of: "-", with: "_")
-      // FIXME(compnerd) we should extract the extension for generating the
-      // toolname rather than assuming that we can convert the tool name blindly
-      .replacingOccurrences(of: ".", with: "_")
       .uppercased()
     return "SWIFT_DRIVER_\(lookupName)_EXEC"
   }


### PR DESCRIPTION
Avoid injecting a `_EXE` into environment variables for tool
replacements on Windows.  This allows us to use the same variable across
all the platforms.