### PR TITLE
Driver: be more careful about extension handling

### DIFF
--- a/Sources/SwiftDriver/Driver/WindowsExtensions.swift
+++ b/Sources/SwiftDriver/Driver/WindowsExtensions.swift
@@ -14,7 +14,7 @@ import Foundation
 
 internal func executableName(_ name: String) -> String {
 #if os(Windows)
-  if name.suffix(from: name.index(name.endIndex, offsetBy: -4)) == ".exe" {
+  if name.count > 4, name.suffix(from: name.index(name.endIndex, offsetBy: -4)) == ".exe" {
     return name
   }
   return "\(name).exe"


### PR DESCRIPTION
We would previously try to strip the extension without care about the
length.  This can potentially cause an out-of-bounds access (which
fortunately an assert helped caught this!).  Add a guard to avoid an
invalid access.  This is important to enable a subsequent change that
makes finding tools more flexible for cross-platform testing.