### PR TITLE
Fix build break with an ambiguous contextual base on older compilers

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -137,12 +137,11 @@ extension Toolchain {
 
   /// - Returns: String in the form of: `SWIFT_DRIVER_TOOLNAME_EXEC`
   private func envVarName(for toolName: String) -> String {
-    let lookupName = toolName
+    var lookupName = toolName
 #if os(Windows)
-      .replacingOccurrences(of: ".exe", with: "")
+    lookupName = lookupName.replacingOccurrences(of: ".exe", with: "")
 #endif
-      .replacingOccurrences(of: "-", with: "_")
-      .uppercased()
+    lookupName = lookupName.replacingOccurrences(of: "-", with: "_").uppercased()
     return "SWIFT_DRIVER_\(lookupName)_EXEC"
   }
 


### PR DESCRIPTION
Slightly older compilers may error out here with:
```
error: cannot infer contextual base in reference to member 'replacingOccurrences'
           .replacingOccurrences(of: "-", with: "_")
           ~^~~~~~~~~~~~~~~~~~~~
```

Resolves rdar://86127658