### PR TITLE
Stop launching REPL when there aren't inputs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1471,13 +1471,7 @@ extension Driver {
       switch outputOption.option {
       case .emitImportedModules:
         return .singleCompile
-
-      case .repl:
-        if driverKind == .interactive, !parsedOptions.hasAnyInput {
-          diagnosticsEngine.emit(.warning_unnecessary_repl_mode(option: outputOption.option, kind: driverKind))
-        }
-        fallthrough
-      case .lldbRepl:
+      case .repl, .lldbRepl:
         return .repl
 
       case .deprecatedIntegratedRepl:
@@ -1553,10 +1547,6 @@ extension Driver {
 }
 
 extension Diagnostic.Message {
-  static func warning_unnecessary_repl_mode(option: Option, kind: DriverKind) -> Diagnostic.Message {
-    .warning("unnecessary option '\(option.spelling)'; this is the default for '\(kind.rawValue)' with no input files")
-  }
-
   static func warn_ignoring_batch_mode(_ option: Option) -> Diagnostic.Message {
     .warning("ignoring '-enable-batch-mode' because '\(option.spelling)' was also specified")
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -740,19 +740,7 @@ extension Driver {
       }
       return ([try generateDumpPCMJob(input: inputFiles.first!)], nil)
     case .intro:
-      // TODO: Remove this check once the REPL no longer launches
-      // by default.
-      if !inputFiles.isEmpty {
-        throw PlanningError.replReceivedInput
-      }
-      // end TODO.
-
-      var introJobs = try helpIntroJobs()
-
-      // TODO: Remove this to stop launching the REPL by default.
-      introJobs.append(try replJob())
-
-      return (introJobs, nil)
+      return (try helpIntroJobs(), nil)
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/SwiftHelpIntroJob.swift
+++ b/Sources/SwiftDriver/Jobs/SwiftHelpIntroJob.swift
@@ -16,15 +16,6 @@ extension Driver {
     return [
       Job(
         moduleName: moduleOutputInfo.name,
-        kind: .versionRequest,
-        tool: .absolute(try toolchain.getToolPath(.swiftCompiler)),
-        commandLine: [.flag("--version")],
-        inputs: [],
-        primaryInputs: [],
-        outputs: [],
-        requiresInPlaceExecution: false),
-      Job(
-        moduleName: moduleOutputInfo.name,
         kind: .help,
         tool: .absolute(try toolchain.getToolPath(.swiftHelp)),
         commandLine: [.flag("intro")],

--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -110,7 +110,7 @@ struct SwiftHelp: ParsableCommand {
     // `repl` not included in `Subcommand`, also print it here.
     do {
       let padding = String(repeating: " ", count: maxSubcommandNameLength - "repl".count)
-      print("  \(plainBold)swift repl\(plain)\(padding)    Experiment with Swift code interactively (default)")
+      print("  \(plainBold)swift repl\(plain)\(padding)    Experiment with Swift code interactively")
     }
 
     print("\n  Use \(plainBold)`swift --help`\(plain) for descriptions of available options and flags.")

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -517,12 +517,6 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(driver.moduleOutputInfo.name, "main")
     }
 
-    try assertDriverDiagnostics(args: "swift", "-repl") { driver, verifier in
-      verifier.expect(.warning("unnecessary option '-repl'; this is the default for 'swift' with no input files"))
-      XCTAssertNil(driver.moduleOutputInfo.output)
-      XCTAssertEqual(driver.moduleOutputInfo.name, "REPL")
-    }
-
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "bar.swift", "-emit-library", "-o", "libWibble.so") { driver in
       XCTAssertEqual(driver.moduleOutputInfo.name, "Wibble")
     }
@@ -2584,20 +2578,11 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift"], env: envWithFakeSwiftHelp)
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 3)
+      XCTAssertEqual(plannedJobs.count, 1)
 
-      let versionJob = plannedJobs[0]
-      XCTAssertTrue(versionJob.tool.name.contains("swift"))
-      XCTAssertTrue(versionJob.commandLine.contains(.flag("--version")))
-
-      let helpJob = plannedJobs[1]
+      let helpJob = plannedJobs[0]
       XCTAssertTrue(helpJob.tool.name.contains("swift-help"))
       XCTAssertTrue(helpJob.commandLine.contains(.flag("intro")))
-
-      let replJob = plannedJobs[2]
-      XCTAssertTrue(replJob.tool.name.contains("lldb"))
-      XCTAssertTrue(replJob.requiresInPlaceExecution)
-      XCTAssert(replJob.commandLine.contains(where: { isExpectedLLDBREPLFlag($0) }))
     }
 
     do {


### PR DESCRIPTION
Now that there is a more user-friendly help intro that shows by
default, stop launching the REPL when there are no input files.
Launch the REPL explicitly with the `repl` subcommand.