### PR TITLE
Clean Up Native ARC Feature Flag

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -173,7 +173,7 @@ extension DarwinToolchain {
     guard parsedOptions.hasFlag(
       positive: .linkObjcRuntime,
       negative: .noLinkObjcRuntime,
-      default: !targetTriple.supports(.compatibleObjCRuntime)
+      default: !targetTriple.supports(.nativeARC)
     ) else {
       return
     }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -168,7 +168,7 @@ public final class DarwinToolchain: Toolchain {
                            targetVariantTriple: Triple?,
                            diagnosticsEngine: DiagnosticsEngine) throws {
     // On non-darwin hosts, libArcLite won't be found and a warning will be emitted
-    // Guard for the sake of tests runnin on all platforms
+    // Guard for the sake of tests running on all platforms
     #if os(macOS)
     // Validating arclite library path when link-objc-runtime.
     validateLinkObjcRuntimeARCLiteLib(&parsedOptions,
@@ -225,11 +225,16 @@ public final class DarwinToolchain: Toolchain {
   func validateLinkObjcRuntimeARCLiteLib(_ parsedOptions: inout ParsedOptions,
                                            targetTriple: Triple,
                                            diagnosticsEngine: DiagnosticsEngine) {
-    if parsedOptions.hasFlag(positive: .linkObjcRuntime, negative: .noLinkObjcRuntime, default: targetTriple.supports(.compatibleObjCRuntime)) {
-        guard let _ = try? findARCLiteLibPath() else {
-            diagnosticsEngine.emit(.warn_arclite_not_found_when_link_objc_runtime)
-            return
-        }
+    guard parsedOptions.hasFlag(positive: .linkObjcRuntime,
+                                negative: .noLinkObjcRuntime,
+                                default: !targetTriple.supports(.nativeARC))
+    else {
+      return
+    }
+
+    guard let _ = try? findARCLiteLibPath() else {
+        diagnosticsEngine.emit(.warn_arclite_not_found_when_link_objc_runtime)
+        return
     }
   }
 

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -394,7 +394,14 @@ extension Triple {
 
 extension Triple.FeatureAvailability {
   /// Linking `libarclite` is unnecessary for triples supporting this feature.
-  static let compatibleObjCRuntime = Self(
+  ///
+  /// This impacts the `-link-objc-runtime` flag in Swift, which is akin to the
+  /// `-fobjc-link-runtime` build setting in clang. When set, these flags
+  /// automatically link libobjc, and any compatibility libraries that don't
+  /// ship with the OS. The versions here are the first OSes that support
+  /// ARC natively in their respective copies of the Objective-C runtime,
+  /// and therefore do not require additional support libraries.
+  static let nativeARC = Self(
     macOS: .available(since: Triple.Version(10, 11, 0)),
     iOS: .available(since: Triple.Version(9, 0, 0)),
     watchOS: .availableInAllVersions


### PR DESCRIPTION
Since this feature flag reflects the inverse of the check in the legacy driver,
clarify what the new meaning is and clean up its usages.