### PR TITLE
Respect -use-ld= on Darwin

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -250,7 +250,11 @@ extension DarwinToolchain {
     commandLine.appendFlag("-o")
     commandLine.appendPath(outputFile)
 
-    return try getToolPath(linkerTool)
+    if let arg = parsedOptions.getLastArgument(.useLd) {
+      return AbsolutePath(arg.asSingle)
+    } else {
+      return try getToolPath(linkerTool)
+    }
   }
 
   private func addLinkInputs(shouldUseInputFileList: Bool,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1244,6 +1244,19 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(cmd.contains(.flag("-shared")))
     }
 
+    do {
+      // -use-ld
+      var driver = try Driver(args: commonArgs + ["-use-ld=/bin/my-ld"], env: env)
+      let plannedJobs = try driver.planBuild()
+
+      XCTAssertEqual(3, plannedJobs.count)
+      XCTAssertFalse(plannedJobs.contains { $0.kind == .autolinkExtract })
+
+      let linkJob = plannedJobs[2]
+      XCTAssertEqual(linkJob.kind, .link)
+      XCTAssertEqual(linkJob.tool.name, "/bin/my-ld")
+    }
+
     #if os(Linux)
     do {
       // Xlinker flags


### PR DESCRIPTION
Use the custom ld path rather than the system 'ld'.