### PR TITLE
Tests: properly emit the output file map

### DIFF
--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -25,16 +25,16 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
     """
     {
       "": {
-        "swift-dependencies": "\(workingDirectory.appending(component: "module.swiftdeps"))"
+        "swift-dependencies": "\(workingDirectory.appending(component: "module.swiftdeps").pathString.nativePathString().escaped())"
       }
     """.appending(files.map { file in
       """
       ,
-      "\(file)": {
-        "dependencies": "\(transform(file.basenameWithoutExt) + ".d")",
-        "object": "\(transform(file.pathString) + ".o")",
-        "swiftmodule": "\(transform(file.basenameWithoutExt) + "~partial.swiftmodule")",
-        "swift-dependencies": "\(transform(file.basenameWithoutExt) + ".swiftdeps")"
+      "\(file.pathString.nativePathString().escaped())": {
+        "dependencies": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + ".d")",
+        "object": "\(transform(file.pathString.nativePathString().escaped()) + ".o")",
+        "swiftmodule": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + "~partial.swiftmodule")",
+        "swift-dependencies": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + ".swiftdeps")"
         }
       """
     }.joined(separator: "\n").appending("\n}"))


### PR DESCRIPTION
This adjusts the output file map emission to ensure that the path is
properly escaped.  This was causing problems on Windows, where the path
separator (`\`) was not escaped and would therefore generate invalid
JSON.  This allows the CrossModuleIncrementalBuildTests to now pass on
Windows.