### PR TITLE
SwiftDriver: pass along link library requests on Windows

### DIFF
--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -124,9 +124,7 @@ extension WindowsToolchain {
     commandLine.appendFlag("-o")
     commandLine.appendPath(outputFile)
 
-    parsedOptions.arguments(for: .l).forEach {
-      commandLine.appendFlag("\($0.option.spelling)\($0.argument.asSingle)")
-    }
+    addLinkedLibArgs(to: &commandLine, parsedOptions: &parsedOptions)
 
     // TODO(compnerd) handle static libraries
     return try getToolPath(.clang)

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -124,6 +124,10 @@ extension WindowsToolchain {
     commandLine.appendFlag("-o")
     commandLine.appendPath(outputFile)
 
+    parsedOptions.arguments(for: .l).forEach {
+      commandLine.appendFlag("\($0.option.spelling)\($0.argument.asSingle)")
+    }
+
     // TODO(compnerd) handle static libraries
     return try getToolPath(.clang)
   }


### PR DESCRIPTION
This adds handling for passing along link library requests from the
driver to the linker driver.  This was detected by running the test
suite on Windows.  We now pass the
SwiftDriverTests.SwiftDriverTests/testLinking test on Windows.