### PR TITLE
Tests: prefer `XCAssertEqual` over `XCAssertTrue(... = ...)`

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3206,7 +3206,7 @@ final class SwiftDriverTests: XCTestCase {
                                      "foo.swift"])
       let frontendJobs = try driver.planBuild()
       XCTAssertTrue(frontendJobs.count == 2)
-      XCTAssertTrue(frontendJobs[1].tool.absolutePath!.pathString == ld.pathString)
+      XCTAssertEqual(frontendJobs[1].tool.absolutePath!.pathString, ld.pathString)
     }
   }
 


### PR DESCRIPTION
This makes it easier to diagnose issues as we can immediately tell what
the two values are.