### PR TITLE
Tests: avoid some warnings on Windows (NFCI)

### DIFF
--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -176,8 +176,10 @@ class APIDigesterTests: XCTestCase {
   }
 
   func testBaselineGenerationEndToEnd() throws {
+#if true
     // rdar://82302797
     throw XCTSkip()
+#else
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let source = path.appending(component: "foo.swift")
@@ -214,6 +216,7 @@ class APIDigesterTests: XCTestCase {
         XCTAssertTrue((json?["children"] as? [Any])!.count >= 1)
       }
     }
+#endif
   }
 
   func testComparisonOptionValidation() throws {
@@ -261,8 +264,10 @@ class APIDigesterTests: XCTestCase {
   }
 
   func testAPIComparisonEndToEnd() throws {
+#if true
     // rdar://82302797
     throw XCTSkip()
+#else
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let source = path.appending(component: "foo.swift")
@@ -315,11 +320,14 @@ class APIDigesterTests: XCTestCase {
         "API breakage: accessor MyStruct.a.Set() has parameter 0 type change from Swift.Int to Swift.Bool"
       ])
     }
+#endif
   }
 
   func testABIComparisonEndToEnd() throws {
+#if true
     // rdar://82302797
     throw XCTSkip()
+#else
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let source = path.appending(component: "foo.swift")
@@ -386,5 +394,6 @@ class APIDigesterTests: XCTestCase {
       XCTAssertTrue(messages.contains("ABI breakage: var MyStruct.a in a non-resilient type changes position from 0 to 1"))
       XCTAssertTrue(messages.contains("ABI breakage: var MyStruct.b in a non-resilient type changes position from 1 to 0"))
     }
+#endif
   }
 }

--- a/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
@@ -34,10 +34,10 @@ class IncrementalBuildPerformanceTests: XCTestCase {
 
   func testPerformance(_ whatToMeasure: WhatToMeasure) throws {
 
-    #if !os(macOS)
+#if !os(macOS)
       // rdar://81411914
       throw XCTSkip()
-    #endif
+#else
 
     let packageRootPath = AbsolutePath(#file)
       .parentDirectory
@@ -52,6 +52,7 @@ class IncrementalBuildPerformanceTests: XCTestCase {
     #endif
 
     try test(swiftDepsDirectory: swiftDepsDirectoryPath.pathString, atMost: limit, whatToMeasure)
+#endif
   }
 
   /// Test the cost of reading `swiftdeps` files without doing a full build.

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -136,9 +136,9 @@ extension IncrementalCompilationTests {
   /// Much of the code below is taking from testLinking(), but uses the output file map code here.
   func testAutolinkOutputPath() {
 #if os(Windows)
-    XCTSkip("Driver.init fatalError")
+    // XCTSkip("Driver.init fatalError")
     return
-#endif
+#else
     var env = ProcessEnv.vars
     env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
@@ -158,6 +158,7 @@ extension IncrementalCompilationTests {
     let autoOut = autoOuts[0]
     let expected = AbsolutePath(derivedDataPath, "\(module).autolink")
     XCTAssertEqual(autoOut.file.absolutePath, expected)
+#endif
   }
 }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -134,10 +134,9 @@ extension IncrementalCompilationTests {
   /// Ensure that autolink output file goes with .o directory, to not prevent incremental omission of
   /// autolink job.
   /// Much of the code below is taking from testLinking(), but uses the output file map code here.
-  func testAutolinkOutputPath() {
+  func testAutolinkOutputPath() throws {
 #if os(Windows)
-    // XCTSkip("Driver.init fatalError")
-    return
+    throw XCTSkip("Driver.init fatalError")
 #else
     var env = ProcessEnv.vars
     env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -290,7 +290,7 @@ final class JobExecutorTests: XCTestCase {
   func testStubProcessProtocol() throws {
 #if os(Windows)
     throw XCTSkip("processId.getter returning `-1`")
-#endif
+#else
     let job = Job(
       moduleName: "main",
       kind: .compile,
@@ -311,6 +311,7 @@ final class JobExecutorTests: XCTestCase {
     try executor.execute(env: ProcessEnv.vars, fileSystem: localFileSystem)
 
     XCTAssertEqual(try delegate.finished[0].1.utf8Output(), "test")
+#endif
   }
 
   func testSwiftDriverExecOverride() throws {
@@ -347,7 +348,7 @@ final class JobExecutorTests: XCTestCase {
   func testInputModifiedDuringSingleJobBuild() throws {
 #if os(Windows)
     throw XCTSkip("Requires -sdk")
-#endif
+#else
     try withTemporaryDirectory { path in
       let main = path.appending(component: "main.swift")
       try localFileSystem.writeFileContents(main) {
@@ -369,6 +370,7 @@ final class JobExecutorTests: XCTestCase {
       }
 
     }
+#endif
   }
 
   func testShellEscapingArgsInJobDescription() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -262,7 +262,7 @@ final class SwiftDriverTests: XCTestCase {
   func testRecordedInputModificationDates() throws {
 #if os(Windows)
     throw XCTSkip("TSCUtility.RelativePath failure")
-#endif
+#else
     try withTemporaryDirectory { path in
       guard let cwd = localFileSystem
         .currentWorkingDirectory else { fatalError() }
@@ -282,6 +282,7 @@ final class SwiftDriverTests: XCTestCase {
         .init(file: VirtualPath.relative(utilRelative).intern(), type: .swift) : utilMDate,
       ])
     }
+#endif
   }
 
   func testPrimaryOutputKinds() throws {
@@ -958,7 +959,7 @@ final class SwiftDriverTests: XCTestCase {
   func testOutputFileMapRelativePathArg() throws {
 #if os(Windows)
     throw XCTSkip("TSCUtility.RelativePath failure")
-#endif
+#else
     try withTemporaryDirectory { path in
       guard let cwd = localFileSystem
         .currentWorkingDirectory else { fatalError() }
@@ -988,6 +989,7 @@ final class SwiftDriverTests: XCTestCase {
         "main.swift", "util.swift",
       ]))
     }
+#endif
   }
 
   func testResponseFileExpansion() throws {
@@ -1659,15 +1661,16 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   private func clangPathInActiveXcode() throws -> AbsolutePath? {
-    #if !os(macOS)
+#if !os(macOS)
     return nil
-    #endif
+#else
     let process = Process(arguments: ["xcrun", "-toolchain", "default", "-f", "clang"])
     try process.launch()
     let result = try process.waitUntilExit()
     guard result.exitStatus == .terminated(code: EXIT_SUCCESS) else { return nil }
     guard let path = String(bytes: try result.output.get(), encoding: .utf8) else { return nil }
     return path.isEmpty ? nil : AbsolutePath(path.spm_chomp())
+#endif
   }
 
   func testCompatibilityLibs() throws {


### PR DESCRIPTION
Process away the body of the tests on Windows to avoid the warning
during the build.  This is hopefully temporary as the tests should
not be skipped, but require further investigation and skipping the
tests enables running the test suite completely on Windows.