### PR TITLE
Don't unnecessarily constrain ifdefs to macOS

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -972,7 +972,7 @@ extension Driver {
   ///
   /// - Parameter content: response file's content to be tokenized.
   private static func tokenizeResponseFile(_ content: String) -> [String] {
-    #if !os(macOS) && !os(Linux) && !os(Android) && !os(OpenBSD)
+    #if !canImport(Darwin) && !os(Linux) && !os(Android) && !os(OpenBSD)
       #warning("Response file tokenization unimplemented for platform; behavior may be incorrect")
     #endif
     return content.split { $0 == "\n" || $0 == "\r\n" }
@@ -2621,7 +2621,7 @@ extension Triple {
 
 /// Toolchain computation.
 extension Driver {
-  #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  #if canImport(Darwin)
   static let defaultToolchainType: Toolchain.Type = DarwinToolchain.self
   #elseif os(Windows)
   static let defaultToolchainType: Toolchain.Type = WindowsToolchain.self

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -442,8 +442,8 @@ extension ExplicitDependencyBuildPlanner {
       return previouslyHashsedName
     }
     let hashedArguments: String
-    #if os(macOS)
-    if #available(macOS 10.15, iOS 13, *) {
+    #if canImport(Darwin)
+    if #available(macOS 10.15, *) {
       hashedArguments = CryptoKitSHA256().hash(hashInput).hexadecimalRepresentation
     } else {
       hashedArguments = SHA256().hash(hashInput).hexadecimalRepresentation

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -112,8 +112,8 @@ import SwiftOptions
       .map { $0.option.spelling }
       .sorted()
       .joined()
-    #if os(macOS)
-    if #available(macOS 10.15, iOS 13, *) {
+    #if canImport(Darwin)
+    if #available(macOS 10.15, *) {
       return CryptoKitSHA256().hash(hashInput).hexadecimalRepresentation
     } else {
       return SHA256().hash(hashInput).hexadecimalRepresentation

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -169,7 +169,7 @@ public final class DarwinToolchain: Toolchain {
                            diagnosticsEngine: DiagnosticsEngine) throws {
     // On non-darwin hosts, libArcLite won't be found and a warning will be emitted
     // Guard for the sake of tests running on all platforms
-    #if os(macOS)
+    #if canImport(Darwin)
     // Validating arclite library path when link-objc-runtime.
     validateLinkObjcRuntimeARCLiteLib(&parsedOptions,
                                       targetTriple: targetTriple,

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS)
+#if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #endif
 
-#if os(macOS) || os(Linux) || os(Android) || os(OpenBSD)
+#if canImport(Darwin) || os(Linux) || os(Android) || os(OpenBSD)
 // Adapted from llvm::sys::commandLineFitsWithinSystemLimits.
 func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
   let upperBound = sysconf(Int32(_SC_ARG_MAX))

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -12,7 +12,7 @@
 import TSCBasic
 import Foundation
 
-#if os(macOS)
+#if canImport(Darwin)
 import Darwin
 #endif
 
@@ -736,7 +736,7 @@ extension TSCBasic.FileSystem {
   /// - Returns: A `Date` value containing the last modification time.
   public func lastModificationTime(for file: VirtualPath) throws -> Date {
     try resolvingVirtualPath(file) { path in
-      #if os(macOS)
+      #if canImport(Darwin)
       var s = Darwin.stat()
       let err = stat(path.pathString, &s)
       guard err == 0 else {


### PR DESCRIPTION
They should reflect the semantics of what they intend to represent,
which is "Darwin-based platform".

rdar://85918430