### PR TITLE
Tests: add an explicit triple for Darwin SDK tests

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3399,7 +3399,7 @@ final class SwiftDriverTests: XCTestCase {
       let sdkPath = getSDKPath(sdkDirName: sdkDirName)
       // Get around the check for SDK's existence
       try localFileSystem.createDirectory(sdkPath)
-      let args = [ "swiftc", "foo.swift", "-sdk", sdkPath.pathString ]
+      let args = [ "swiftc", "foo.swift", "-target", "x86_64-apple-macosx10.9", "-sdk", sdkPath.pathString ]
       try assertDriverDiagnostics(args: args) { driver, verifier in
         verifier.expect(.error("Swift does not support the SDK \(sdkPath.pathString)"))
       }
@@ -3409,7 +3409,7 @@ final class SwiftDriverTests: XCTestCase {
     func checkSDKOkay(sdkDirName: String) throws {
       let sdkPath = getSDKPath(sdkDirName: sdkDirName)
       try localFileSystem.createDirectory(sdkPath)
-      let args = [ "swiftc", "foo.swift", "-sdk", sdkPath.pathString ]
+      let args = [ "swiftc", "foo.swift", "-target", "x86_64-apple-macosx10.9", "-sdk", sdkPath.pathString ]
       try assertNoDiagnostics { de in let _ = try Driver(args: args, diagnosticsEngine: de) }
     }
 


### PR DESCRIPTION
This is required as the Windows toolchain uses `-sdk` for locating the
SDK which is required for loading the standard library.  Without this,
we would target the default target (Windows), but use the stub SDK,
which does not contain the standard library and thus fail to compile.
This allows the SwiftDriverTests.SwiftDriverTests/testDarwinSDKTooOld
test to pass on Windows.