### PR TITLE
Tests: handle differences in quoting on Windows

### DIFF
--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -384,8 +384,13 @@ final class JobExecutorTests: XCTestCase {
                   commandLine: [.path(.absolute(.init("/with space"))),
                                 .path(.absolute(.init("/withoutspace")))],
                   inputs: [], primaryInputs: [], outputs: [])
+#if os(Windows)
+    XCTAssertEqual(try executor.description(of: job, forceResponseFiles: false),
+                   #""/path/to/the tool" "/with space" /withoutspace"#)
+#else
     XCTAssertEqual(try executor.description(of: job, forceResponseFiles: false),
                    "'/path/to/the tool' '/with space' /withoutspace")
+#endif
   }
 
   func testInputModifiedDuringMultiJobBuild() throws {
@@ -440,7 +445,12 @@ final class JobExecutorTests: XCTestCase {
       let resolvedCommandLine = try resolver.resolve(
         .squashedArgumentList(option: "--opt=", args: [.path(tmpPath), .path(tmpPath2)]))
       XCTAssertEqual(resolvedCommandLine, "--opt=\(path.appending(component: "one.txt").pathString) \(path.appending(component: "two.txt").pathString)")
+#if os(Windows)
+      XCTAssertEqual(resolvedCommandLine.spm_shellEscaped(),
+                     #""--opt=\#(path.appending(component: "one.txt").pathString) \#(path.appending(component: "two.txt").pathString)""#)
+#else
       XCTAssertEqual(resolvedCommandLine.spm_shellEscaped(), "'--opt=\(path.appending(component: "one.txt").pathString) \(path.appending(component: "two.txt").pathString)'")
+#endif
     }
   }
 

--- a/Tests/SwiftOptionsTests/OptionParsingTests.swift
+++ b/Tests/SwiftOptionsTests/OptionParsingTests.swift
@@ -21,8 +21,13 @@ final class SwiftDriverTests: XCTestCase {
         "input1", "-color-diagnostics", "-Ifoo", "-I", "bar spaces",
         "-I=wibble", "input2", "-module-name", "main",
         "-sanitize=a,b,c", "--", "-foo", "-bar"], for: .batch)
+#if os(Windows)
+      XCTAssertEqual(results.description,
+                     #"input1 -color-diagnostics -I foo -I "bar spaces" -I=wibble input2 -module-name main -sanitize=a,b,c -- -foo -bar"#)
+#else
       XCTAssertEqual(results.description,
                      "input1 -color-diagnostics -I foo -I 'bar spaces' -I=wibble input2 -module-name main -sanitize=a,b,c -- -foo -bar")
+#endif
     }
 
   func testParseErrors() {


### PR DESCRIPTION
Windows does not use the same quoting strategy at Unix platforms.
Adjust the expectations on Windows to match.