### PR TITLE
Tests: correct `-sdk` parameter for Windows

### DIFF
--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -449,8 +449,11 @@ final class JobExecutorTests: XCTestCase {
     let toolchain = DarwinToolchain(env: ProcessEnv.vars, executor: executor)
     return try ["-sdk", toolchain.sdk.get().pathString]
     #elseif os(Windows)
-    let toolchain = DarwinToolchain(env: ProcessEnv.vars, executor: executor)
-    return try ["-sdk", toolchain.sdk.get().pathString]
+    let toolchain = WindowsToolchain(env: ProcessEnv.vars, executor: executor)
+    if let path = try toolchain.defaultSDKPath(nil) {
+      return ["-sdk", path.pathString.nativePathString()]
+    }
+    return []
     #else
     return []
     #endif


### PR DESCRIPTION
A copy-paste error was accidentally introduced in the attempt to get the
full test suite running on Windows (even though it did not pass).  This
corrects that mistake.