### PR TITLE
SwiftDriver: pass along linker options to the linker driver

### DIFF
--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -92,6 +92,10 @@ extension WindowsToolchain {
       try commandLine.appendPath(VirtualPath(path: framework.argument.asSingle))
     }
 
+    try commandLine.appendAllExcept(includeList: [.linkerOption],
+                                    excludeList: [.l],
+                                    from: &parsedOptions)
+
     if let sdkPath = targetInfo.sdkPath?.path {
       commandLine.appendFlag("-I")
       commandLine.appendPath(VirtualPath.lookup(sdkPath))


### PR DESCRIPTION
Correct the handling for non-`-l` linker options on Windows.  We now
correctly forward the user-specified linker search paths to the linker
through the linker driver.