### PR TITLE
Tests: disable TSAN tests on Windows

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1962,9 +1962,22 @@ extension Driver {
         isShared: sanitizer != .fuzzer
       )
 
-      // TSan is explicitly not supported for 32 bits.
-      if sanitizer == .thread && !targetTriple.arch!.is64Bit {
-        sanitizerSupported = false
+      if sanitizer == .thread {
+        // TSAN is unavailable on Windows
+        if targetTriple.isWindows {
+          diagnosticEngine.emit(
+            .error_sanitizer_unavailable_on_target(
+              sanitizer: "thread",
+              target: targetTriple
+            )
+          )
+          continue
+        }
+
+        // TSan is explicitly not supported for 32 bits.
+        if !targetTriple.arch!.is64Bit {
+          sanitizerSupported = false
+        }
       }
 
       if !sanitizerSupported {

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -53,6 +53,10 @@ extension Diagnostic.Message {
     .error("unsupported option '\(arg)' for target '\(target.triple)'")
   }
 
+  static func error_sanitizer_unavailable_on_target(sanitizer: String, target: Triple) -> Diagnostic.Message {
+    .error("\(sanitizer) sanitizer is unavailable on target '\(target.triple)'")
+  }
+
   static var error_mode_cannot_emit_module: Diagnostic.Message {
     .error("this mode does not support emitting modules")
   }


### PR DESCRIPTION
TSAN is not supported on Windows at the current time.  This excludes the
tests on Windows as they cannot be supported.