### PR TITLE
Tests: explicitly pass a SDK for environment inference tests

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3053,13 +3053,15 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testEnvironmentInferenceWarning() throws {
-    try assertDriverDiagnostics(args: ["swiftc", "-target", "x86_64-apple-ios13.0", "foo.swift"]) {
+    let sdkRoot = testInputsPath.appending(component: "SDKChecks").appending(component: "iPhoneOS.sdk")
+
+    try assertDriverDiagnostics(args: ["swiftc", "-target", "x86_64-apple-ios13.0", "foo.swift", "-sdk", sdkRoot.pathString]) {
       $1.expect(.warning("inferring simulator environment for target 'x86_64-apple-ios13.0'; use '-target x86_64-apple-ios13.0-simulator'"))
     }
-    try assertDriverDiagnostics(args: ["swiftc", "-target", "x86_64-apple-watchos6.0", "foo.swift"]) {
+    try assertDriverDiagnostics(args: ["swiftc", "-target", "x86_64-apple-watchos6.0", "foo.swift", "-sdk", sdkRoot.pathString]) {
       $1.expect(.warning("inferring simulator environment for target 'x86_64-apple-watchos6.0'; use '-target x86_64-apple-watchos6.0-simulator'"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "-target", "x86_64-apple-ios13.0-simulator", "foo.swift")
+    try assertNoDriverDiagnostics(args: "swiftc", "-target", "x86_64-apple-ios13.0-simulator", "foo.swift", "-sdk", sdkRoot.pathString)
   }
 
   func testDarwinToolchainArgumentValidation() throws {


### PR DESCRIPTION
This explicitly passes a SDK to the driver invocation as on Windows, the
default SDK does have a SDKSettings.json which does not match the macOS
one.  This results in a spurious warning which causes the test to fail.
Pass the SDKChecks SDK root as the SDK for test.  This allows
SwiftDriverTests.SwiftDriverTests/testEnvironmentInferenceWarning to
pass on Windows.