### PR TITLE
Tests: correct output file map entries

### DIFF
--- a/Tests/TestUtilities/OutputFileMapCreator.swift
+++ b/Tests/TestUtilities/OutputFileMapCreator.swift
@@ -37,7 +37,7 @@ public struct OutputFileMapCreator {
   }
 
   private func generateDict() -> [String: [String: String]] {
-    let master = ["swift-dependencies": "\(derivedData.pathString)/\(module)-master.swiftdeps"]
+    let master = ["swift-dependencies": derivedData.appending(component: "\(module)-master.swiftdeps").pathString.nativePathString()]
     let mainEntryDict = self.excludeMainEntry ? [:] : ["": master]
     func baseNameEntry(_ s: AbsolutePath) -> [String: String] {
       [


### PR DESCRIPTION
Correct the path separator for the output file map entries.  This
has no impact on the test coverage but does make it easier to copy-paste
values and to work with the values on Windows.