### PR TITLE
Tests: remove stray space (NFC)

### DIFF
--- a/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
+++ b/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
@@ -180,7 +180,7 @@ fileprivate extension Array where Element == Change {
       let eol = "\n"
 #endif
 
-    let specOrGen = Change.allCases .map {
+    let specOrGen = Change.allCases.map {
       contains($0) ? "specific" : "general"
     }
     let output = zip(specOrGen, Change.allLociOfExposure)


### PR DESCRIPTION
This removes a stray space which was noticed while working on the
windows test suite coverage.