### PR TITLE
[5.6] Turn on emit-module-separately for whole-module builds by default

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2102,10 +2102,9 @@ extension Driver {
       // An option has been passed which requires a module, but the user hasn't
       // requested one. Generate a module, but treat it as an intermediate output.
       moduleOutputKind = .auxiliary
-    } else if compilerMode != .singleCompile &&
-      parsedOptions.hasArgument(.emitObjcHeader, .emitObjcHeaderPath,
-                                .emitModuleInterface, .emitModuleInterfacePath,
-                                .emitPrivateModuleInterfacePath) {
+    } else if parsedOptions.hasArgument(.emitObjcHeader, .emitObjcHeaderPath,
+                                        .emitModuleInterface, .emitModuleInterfacePath,
+                                        .emitPrivateModuleInterfacePath) {
       // An option has been passed which requires whole-module knowledge, but we
       // don't have that. Generate a module, but treat it as an intermediate
       // output.

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -145,7 +145,7 @@ extension Driver {
     case .singleCompile:
       return parsedOptions.hasFlag(positive: .emitModuleSeparatelyWMO,
                                    negative: .noEmitModuleSeparatelyWMO,
-                                   default: false) &&
+                                   default: true) &&
              compilerOutputType != .swiftModule // The main job already generates only the module files.
 
     default:

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -398,38 +398,39 @@ extension Driver {
     } else {
       addAllOutputsFor(input: nil)
 
-      // Outputs that only make sense when the whole module is processed
-      // together.
-      addOutputOfType(
-        outputType: .objcHeader,
-        finalOutputPath: objcGeneratedHeaderPath,
-        input: nil,
-        flag: "-emit-objc-header-path")
+      if !emitModuleSeparately {
+        // Outputs that only make sense when the whole module is processed
+        // together.
+        addOutputOfType(
+          outputType: .objcHeader,
+          finalOutputPath: objcGeneratedHeaderPath,
+          input: nil,
+          flag: "-emit-objc-header-path")
 
-      addOutputOfType(
-        outputType: .swiftInterface,
-        finalOutputPath: swiftInterfacePath,
-        input: nil,
-        flag: "-emit-module-interface-path")
+        addOutputOfType(
+          outputType: .swiftInterface,
+          finalOutputPath: swiftInterfacePath,
+          input: nil,
+          flag: "-emit-module-interface-path")
 
-      addOutputOfType(
-        outputType: .privateSwiftInterface,
-        finalOutputPath: swiftPrivateInterfacePath,
-        input: nil,
-        flag: "-emit-private-module-interface-path")
+        addOutputOfType(
+          outputType: .privateSwiftInterface,
+          finalOutputPath: swiftPrivateInterfacePath,
+          input: nil,
+          flag: "-emit-private-module-interface-path")
 
-      addOutputOfType(
-        outputType: .tbd,
-        finalOutputPath: tbdPath,
-        input: nil,
-        flag: "-emit-tbd-path")
+        addOutputOfType(
+          outputType: .tbd,
+          finalOutputPath: tbdPath,
+          input: nil,
+          flag: "-emit-tbd-path")
 
-      if let abiDescriptorPath = abiDescriptorPath,
-         !emitModuleSeparately {
-        addOutputOfType(outputType: .jsonABIBaseline,
-                        finalOutputPath: abiDescriptorPath.fileHandle,
-                        input: nil,
-                        flag: "-emit-abi-descriptor-path")
+        if let abiDescriptorPath = abiDescriptorPath {
+          addOutputOfType(outputType: .jsonABIBaseline,
+                          finalOutputPath: abiDescriptorPath.fileHandle,
+                          input: nil,
+                          flag: "-emit-abi-descriptor-path")
+        }
       }
     }
 


### PR DESCRIPTION
Scheduling a separate emit-module job for whole-module builds, combined with the integrated driver in the build system, will allow to parallelize what used to be essentially sequential builds. This mode unblocks building dependents early by duplicating some work in two processes, it requires more cpu work for a faster wall clock build time. Another advantage of this mode is the resulting swiftmodule is lighter from a classic whole-module build.

Cherry-pick from #922.

rdar://85976762