### PR TITLE
[5.6] SwiftDriver: address TODO about abnormal process termination

### DIFF
--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -123,10 +123,13 @@ extension DriverExecutor {
     switch exitStatus {
       case .terminated(let code):
         returnCode = Int(code)
-      #if !os(Windows)
+#if os(Windows)
+      case .abnormal(let exception):
+        returnCode = Int(exception)
+#else
       case .signalled(let signal):
         returnCode = Int(signal)
-      #endif
+#endif
     }
     return returnCode
   }

--- a/Sources/SwiftDriver/Execution/ParsableOutput.swift
+++ b/Sources/SwiftDriver/Execution/ParsableOutput.swift
@@ -16,6 +16,7 @@ import Foundation
   public enum Kind {
     case began(BeganMessage)
     case finished(FinishedMessage)
+    case abnormal(AbnormalExitMessage)
     case signalled(SignalledMessage)
     case skipped(SkippedMessage)
   }
@@ -133,6 +134,27 @@ import Foundation
   }
 }
 
+@_spi(Testing) public struct AbnormalExitMessage: Encodable {
+  let pid: Int
+  let process: ActualProcess
+  let output: String?
+  let exception: UInt32
+
+  public init(pid: Int, realPid: Int, output: String?, exception: UInt32) {
+    self.pid = pid
+    self.process = ActualProcess(realPid: realPid)
+    self.output = output
+    self.exception = exception
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case pid
+    case process
+    case output
+    case exception
+  }
+}
+
 @_spi(Testing) public struct SignalledMessage: Encodable {
   let pid: Int
   let process: ActualProcess
@@ -173,6 +195,9 @@ import Foundation
       try msg.encode(to: encoder)
     case .finished(let msg):
       try container.encode("finished", forKey: .kind)
+      try msg.encode(to: encoder)
+    case .abnormal(let msg):
+      try container.encode("abnormal-exit", forKey: .kind)
       try msg.encode(to: encoder)
     case .signalled(let msg):
       try container.encode("signalled", forKey: .kind)

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -122,7 +122,10 @@ fileprivate class ModuleCompileDelegate: JobExecutionDelegate {
           stderrStream.flush()
         }
       }
-#if !os(Windows)
+#if os(Windows)
+    case .abnormal(let exception):
+      diagnosticsEngine.emit(.remark("\(job.moduleName) exception: \(exception)"))
+#else
     case .signalled:
       diagnosticsEngine.emit(.remark("\(job.moduleName) interrupted"))
 #endif

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -117,6 +117,25 @@ final class ParsableMessageTests: XCTestCase {
     """)
   }
 
+  func testAbnormalExitMessage() throws {
+    let exit = AbnormalExitMessage(pid: 1024, realPid: 1024, output: nil, exception: 0x8000_0003)
+    let message = ParsableMessage(name: "compile", kind: .abnormal(exit))
+    let encoded = try message.toJSON()
+    let string = String(data: encoded, encoding: .utf8)!
+
+    XCTAssertEqual(string, """
+    {
+      "exception" : 2147483651,
+      "kind" : "abnormal-exit",
+      "name" : "compile",
+      "pid" : 1024,
+      "process" : {
+        "real_pid" : 1024
+      }
+    }
+    """)
+  }
+
   func testBeganBatchMessages() throws {
     do {
       try withTemporaryDirectory { path in


### PR DESCRIPTION
This adds the handling for abnormal process termination on Windows.
With this, we can now track processes which exit abnormally, indicating
failure.  This was identified by the saveTemps test which now passes on
Windows.  Add an additional test case for the new message type to
differentiate the abnormal exit due to an exception from a signalled
exit which is limited to Unixish platforms.