### PR TITLE
tests: enable IncrementalCompilationTests.testAutolinkOutputPath on W…

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -135,9 +135,6 @@ extension IncrementalCompilationTests {
   /// autolink job.
   /// Much of the code below is taking from testLinking(), but uses the output file map code here.
   func testAutolinkOutputPath() throws {
-#if os(Windows)
-    throw XCTSkip("Driver.init fatalError")
-#else
     var env = ProcessEnv.vars
     env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
@@ -157,7 +154,6 @@ extension IncrementalCompilationTests {
     let autoOut = autoOuts[0]
     let expected = AbsolutePath(derivedDataPath, "\(module).autolink")
     XCTAssertEqual(autoOut.file.absolutePath, expected)
-#endif
   }
 }
 


### PR DESCRIPTION
…indows

This enables a previously disabled test on Windows.  This was disabled
to get a full running test suite to make it easier to improve the
swift-driver on Windows.  As we now reach the point where there are two
areas of the driver (incremental compilation, incremental importing)
which remain problematic, we can now enable this test as the work of
addressing the test failures allows this to pass.