### PR TITLE
[CMake Build] Build and link driver dependencies as static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ endif()
 
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)
+find_package(Threads)
+find_package(SQLite3 REQUIRED)
 find_package(Yams CONFIG REQUIRED)
 find_package(ArgumentParser CONFIG REQUIRED)
 find_package(SwiftSystem CONFIG REQUIRED)

--- a/Sources/CSwiftScan/CMakeLists.txt
+++ b/Sources/CSwiftScan/CMakeLists.txt
@@ -8,3 +8,10 @@
 
 add_library(CSwiftScan STATIC
   CSwiftScanImpl.c)
+
+set_property(GLOBAL APPEND PROPERTY SWIFTDRIVER_EXPORTS CSwiftScan)
+
+install(TARGETS CSwiftScan
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)


### PR DESCRIPTION
This will allow us to not install shared libraries of TSC, ArgumentParser, etc. into the toolchain when installing the driver.

This would also help avoid having to do things like:
https://github.com/apple/swift-driver/pull/963
https://github.com/apple/swift-driver/pull/953