### PR TITLE
Clean up stale compiler outputs

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5714,6 +5714,54 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(mapA.entries, [VirtualPath.relative(.init("a.swift")).intern(): [:]])
     }
   }
+  
+  func testCleaningUpOldCompilationOutputs() throws {
+    // Build something, create an error, see if the .o and .swiftdeps files get cleaned up
+    try withTemporaryDirectory { tmpDir in
+      let main = tmpDir.appending(component: "main.swift")
+      let ofm = tmpDir.appending(component: "ofm")
+      OutputFileMapCreator.write(module: "mod",
+                                 inputPaths: [main],
+                                 derivedData: tmpDir,
+                                 to: ofm)
+      
+      try localFileSystem.writeFileContents(main) {
+        $0 <<< "// no errors here"
+        $0 <<< "func foo() {}"
+      }
+      /// return true if no error
+      func doBuild() throws -> Bool {
+        let sdkArguments = try XCTUnwrap(try Driver.sdkArgumentsForTesting())
+        var driver = try Driver(args: ["swiftc",
+                                       "-working-directory", tmpDir.pathString.nativePathString().escaped(),
+                                       "-module-name", "mod",
+                                       "-c",
+                                       "-incremental",
+                                       "-output-file-map", ofm.pathString.nativePathString().escaped(),
+                                       main.pathString.escaped()] + sdkArguments,
+                                env: ProcessEnv.vars)
+        let jobs = try driver.planBuild()
+        let failed: Bool
+        do {try driver.run(jobs: jobs)}
+        catch {return false}
+        return true
+      }
+      XCTAssertTrue(try doBuild())
+
+      let outputs = [
+        tmpDir.appending(component: "main.o"),
+        tmpDir.appending(component: "main.swiftdeps")
+        ]
+      XCTAssert(outputs.allSatisfy(localFileSystem.exists))
+      
+      try localFileSystem.writeFileContents(main) {
+        $0 <<< "#error(\"Yipes!\")"
+        $0 <<< "func foo() {}"
+      }
+      XCTAssertFalse(try doBuild())
+      XCTAssert(outputs.allSatisfy {!localFileSystem.exists($0)})
+    }
+  }
 }
 
 func assertString(

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5716,6 +5716,9 @@ final class SwiftDriverTests: XCTestCase {
   }
   
   func testCleaningUpOldCompilationOutputs() throws {
+#if !os(macOS)
+    throw XCTSkip("sdkArguments does not work on Linux")
+#else
     // Build something, create an error, see if the .o and .swiftdeps files get cleaned up
     try withTemporaryDirectory { tmpDir in
       let main = tmpDir.appending(component: "main.swift")
@@ -5761,6 +5764,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(try doBuild())
       XCTAssert(outputs.allSatisfy {!localFileSystem.exists($0)})
     }
+#endif
   }
 }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5744,7 +5744,6 @@ final class SwiftDriverTests: XCTestCase {
                                        main.pathString.escaped()] + sdkArguments,
                                 env: ProcessEnv.vars)
         let jobs = try driver.planBuild()
-        let failed: Bool
         do {try driver.run(jobs: jobs)}
         catch {return false}
         return true


### PR DESCRIPTION
When a compile job fails, remove all outputs except the diagnostics file.
rdar://19945961