### PR TITLE
Refactor, representing no source via an enum

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -118,7 +118,7 @@ extension SourceFileDependencyGraph.Node: ExportableNode {
 
 extension ModuleDependencyGraph.Node: ExportableNode {
   fileprivate var isProvides: Bool {
-    !isExpat
+    definitionLocation != .unknown
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -19,15 +19,15 @@ extension ModuleDependencyGraph {
   public struct NodeFinder {
     @_spi(Testing) public typealias Graph = ModuleDependencyGraph
     
-    /// Maps dependencySource files and DependencyKeys to Nodes
-    fileprivate typealias NodeMap = TwoDMap<DependencySource?, DependencyKey, Node>
+    /// Maps definition locations and DependencyKeys to Nodes
+    fileprivate typealias NodeMap = TwoDMap<DefinitionLocation, DependencyKey, Node>
     fileprivate var nodeMap = NodeMap()
     
     /// Since dependency keys use baseNames, they are coarser than individual
     /// decls. So two decls might map to the same key. Given a use, which is
     /// denoted by a node, the code needs to find the files to recompile. So, the
     /// key indexes into the nodeMap, and that yields a submap of nodes keyed by
-    /// file. The set of keys in the submap are the files that must be recompiled
+    /// definition location. The set of keys in the submap are the files that must be recompiled
     /// for the use.
     /// (In a given file, only one node exists with a given key, but in the future
     /// that would need to change if/when we can recompile a smaller unit than a
@@ -40,19 +40,21 @@ extension ModuleDependencyGraph {
 // MARK: - finding
 
 extension ModuleDependencyGraph.NodeFinder {
-  @_spi(Testing) public func findNode(_ mapKey: (DependencySource?, DependencyKey)) -> Graph.Node? {
+  public typealias DefinitionLocation = ModuleDependencyGraph.DefinitionLocation
+  
+  @_spi(Testing) public func findNode(_ mapKey: (DefinitionLocation, DependencyKey)) -> Graph.Node? {
     nodeMap[mapKey]
   }
   func findCorrespondingImplementation(of n: Graph.Node) -> Graph.Node? {
     n.key.correspondingImplementation
-      .flatMap {findNode((n.dependencySource, $0))}
+      .flatMap {findNode((n.definitionLocation, $0))}
   }
   
-  @_spi(Testing) public func findNodes(for dependencySource: DependencySource?)
+  @_spi(Testing) public func findNodes(for definitionLocation: DefinitionLocation)
   -> [DependencyKey: Graph.Node]? {
-    nodeMap[dependencySource]
+    nodeMap[definitionLocation]
   }
-  @_spi(Testing) public func findNodes(for key: DependencyKey) -> [DependencySource?: Graph.Node]? {
+  @_spi(Testing) public func findNodes(for key: DependencyKey) -> [DefinitionLocation: Graph.Node]? {
     nodeMap[key]
   }
 
@@ -81,15 +83,15 @@ extension ModuleDependencyGraph.NodeFinder {
     }
     #if DEBUG
     for use in uses {
-      assert(self.verifyUseIsOK(use))
+      assert(self.verifyOKTODependUponSomeKey(use))
     }
     #endif
     return uses
   }
 
-  func mappings(of n: Graph.Node) -> [(DependencySource?, DependencyKey)] {
+  func mappings(of n: Graph.Node) -> [(DefinitionLocation, DependencyKey)] {
     nodeMap.compactMap { k, _ in
-      guard k.0 == n.dependencySource && k.1 == n.key else {
+      guard k.0 == n.definitionLocation && k.1 == n.key else {
         return nil
       }
       return k
@@ -102,8 +104,8 @@ extension ModuleDependencyGraph.NodeFinder {
 }
 
 fileprivate extension ModuleDependencyGraph.Node {
-  var mapKey: (DependencySource?, DependencyKey) {
-    return (dependencySource, key)
+  var mapKey: (DefinitionLocation, DependencyKey) {
+    return (definitionLocation, key)
   }
 }
 
@@ -119,7 +121,7 @@ extension ModuleDependencyGraph.NodeFinder {
   
   /// record def-use, return if is new use
   mutating func record(def: DependencyKey, use: Graph.Node) -> Bool {
-    assert(verifyUseIsOK(use))
+    assert(verifyOKTODependUponSomeKey(use))
     return usesByDef.insertValue(use, forKey: def)
   }
 }
@@ -147,11 +149,10 @@ extension ModuleDependencyGraph.NodeFinder {
 // MARK: - moving
 extension ModuleDependencyGraph.NodeFinder {
   /// When integrating a SourceFileDepGraph, there might be a node representing
-  /// a Decl that had previously been read as an expat, that is a node
-  /// representing a Decl in no known file (to that point). (Recall the the
-  /// Frontend processes name lookups as dependencies, but does not record in
-  /// which file the name was found.) In such a case, it is necessary to move
-  /// the node to the proper collection.
+  /// a Decl that previously no known definition location.
+  /// (Recall the the Frontend processes name lookups as dependencies, but does not record in
+  /// which file the name was found.) When the definition is found in a `SourceFileDepGraph`
+  /// it is necessary to "move" the node to the proper collection.
   ///
   /// Now that nodes are immutable, this function needs to replace the node
   mutating func replace(_ original: Graph.Node,
@@ -160,8 +161,9 @@ extension ModuleDependencyGraph.NodeFinder {
   ) -> Graph.Node {
     let replacement = Graph.Node(key: original.key,
                                  fingerprint: newFingerprint,
-                                 dependencySource: newDependencySource)
-    assert(original.isExpat, "Would have to search every use in usesByDef if original could be a use.")
+                                 definitionLocation: .known(newDependencySource))
+    assert(original.definitionLocation == .unknown,
+           "Would have to search every use in usesByDef if original could be a use.")
     if usesByDef.removeValue(original, forKey: original.key) != nil {
       usesByDef.insertValue(replacement, forKey: original.key)
     }
@@ -191,31 +193,28 @@ extension ModuleDependencyGraph.NodeFinder {
   }
   
   private func verifyUsesByDef() {
-    usesByDef.forEach { def, uses in
-      for use in uses {
-        // def may have disappeared from graph, nothing to do
-        verifyUseIsOK(use)
+    usesByDef.forEach { someKey, nodesDependingUponKey in
+      for nodeDependingUponKey in nodesDependingUponKey {
+        verifyOKTODependUponSomeKey(nodeDependingUponKey)
       }
     }
   }
 
   @discardableResult
-  private func verifyUseIsOK(_ n: Graph.Node) -> Bool {
-    verifyUsedIsNotExpat(n)
-    verifyNodeIsMapped(n)
+  private func verifyOKTODependUponSomeKey(_ n: Graph.Node) -> Bool {
+    verifyDependentNodeHasKnownDefinitionLocation(n)
+    verifyNodeCanBeFoundFromItsKey(n)
     return true
   }
   
-  private func verifyNodeIsMapped(_ n: Graph.Node) {
-    if findNode(n.mapKey) == nil {
-      fatalError("\(n) should be mapped")
-    }
+  private func verifyNodeCanBeFoundFromItsKey(_ n: Graph.Node) {
+    precondition(findNode(n.mapKey) == n)
   }
   
   @discardableResult
-  private func verifyUsedIsNotExpat(_ use: Graph.Node) -> Bool {
-    guard use.isExpat else { return true }
-    fatalError("An expat is not defined anywhere and thus cannot be used")
+  private func verifyDependentNodeHasKnownDefinitionLocation(_ use: Graph.Node) -> Bool {
+    guard case .unknown = use.definitionLocation else { return true }
+    fatalError("This declaration is not defined anywhere and thus cannot depend upon anything.")
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -78,8 +78,8 @@ extension ModuleDependencyGraph.Tracer {
     tracedUses.append(definition)
     
     // If this node is merely used, but not defined anywhere, nothing else
-    // can possibly depend upon it.
-    if definition.isExpat { return }
+    // can possibly depend upon it
+    if case .unknown = definition.definitionLocation { return }
     
     let pathLengthAfterArrival = traceArrival(at: definition);
     
@@ -115,7 +115,7 @@ extension ModuleDependencyGraph.Tracer {
   }
 
   private func printPath(_ path: [Graph.Node]) {
-    guard path.first?.dependencySource != path.last?.dependencySource
+    guard path.first?.definitionLocation != path.last?.definitionLocation
     else {
       return
     }
@@ -123,12 +123,12 @@ extension ModuleDependencyGraph.Tracer {
       [
         "Traced:",
         path.compactMap { node in
-          node.dependencySource.map {
-            source in
-            source.typedFile.type == .swift
-            ? "\(node.key.description(in: graph)) in \(source.file.basename)"
-            : "\(node.key.description(in: graph))"
+          guard case let .known(source) = node.definitionLocation else {
+            return nil
           }
+          return source.typedFile.type == .swift
+          ? "\(node.key.description(in: graph)) in \(source.file.basename)"
+          : "\(node.key.description(in: graph))"
         }
         .joined(separator: " -> ")
       ].joined(separator: " ")

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -27,7 +27,7 @@ extension ModuleDependencyGraph {
          fileNode.isTraced {
         return true
       }
-      if let nodes = nodeFinder.findNodes(for: dependencySource)?.values,
+      if let nodes = nodeFinder.findNodes(for: .known(dependencySource))?.values,
          nodes.contains(where: {$0.isTraced}) {
         return true
       }
@@ -94,7 +94,7 @@ extension ModuleDependencyGraph.NodeFinder {
     forMock dependencySource: DependencySource
   ) -> Graph.Node?  {
     let fileKey = DependencyKey(fileKeyForMockDependencySource: dependencySource)
-    return findNode((dependencySource, fileKey))
+    return findNode((.known(dependencySource), fileKey))
   }
 }
 

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1010,7 +1010,11 @@ extension ModuleDependencyGraph {
   ) -> [SwiftSourceFile] {
     var foundSources = [SwiftSourceFile]()
     for dependent in collectUntracedNodes(thatUse: fingerprintedExternalDependency, .testing) {
-      let dependencySource = dependent.dependencySource!
+      guard case let .known(dependencySource) = dependent.definitionLocation
+      else {
+        XCTFail("definition location should be known")
+        break
+      }
       foundSources.append(SwiftSourceFile(dependencySource.typedFile))
       // findSwiftDepsToRecompileWhenWholeSwiftDepChanges is reflexive
       // Don't return job twice.


### PR DESCRIPTION
Clarify what it means to have a nil `dependencySource` by replacing the optional with an enumeration.