### PR TITLE
SwiftDriverTests: introduce a `sleep` for file modification

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -12,6 +12,7 @@
 import XCTest
 import TSCBasic
 import TSCUtility
+import Foundation
 
 @_spi(Testing) import SwiftDriver
 import SwiftOptions
@@ -1078,6 +1079,7 @@ extension IncrementalCompilationTests {
 // MARK: - Incremental test perturbation helpers
 extension IncrementalCompilationTests {
   private func touch(_ name: String) {
+    Thread.sleep(forTimeInterval: 1)
     print("*** touching \(name) ***", to: &stderrStream); stderrStream.flush()
     let (path, contents) = try! XCTUnwrap(inputPathsAndContents.filter {$0.0.pathString.contains(name)}.first)
     try! localFileSystem.writeFileContents(path) { $0 <<< contents }


### PR DESCRIPTION
Introduce a sleep in the "touch" operation - a portable implementation
which rewrites contents to alter the mtime - though it can appear to
fail due to granularity of the time stamp.  The alteration would appear
as if it did not occur.  This sleep *before* the operation ensures that
enough time has passed between the writing of the file originally and
the rewrite which will adjust the mtime.  This may impact other
platforms (e.g. Linux) where file system mtimes can be truncated.
Darwin remains immune to this with the increased resolution for file
times with the APFS transition.

This enables a subset of the tests to now pass on Windows.  Although not
explored, it is possible that this also allows more stability for tests
which previously failed on Linux.

Special thanks to Artem Chikin for the discussion that led to
understanding the failure here!