### PR TITLE
Throw error for invalid double dash argument

### DIFF
--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -133,6 +133,10 @@ extension OptionTable {
         index += 1
 
       case .remaining:
+        if argument != option.spelling {
+          throw OptionParseError.unknownOption(
+            index: index - 1, argument: argument)
+        }
         parsedOptions.addOption(.DASHDASH, argument: .single("--"))
         arguments[index...].map { String($0) }.forEach { parsedOptions.addInput($0) }
         index = arguments.endIndex

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1013,7 +1013,7 @@ final class SwiftDriverTests: XCTestCase {
       // FIXME: Needs a better way to check that outputFileMap correctly loaded
       XCTAssertNoThrow(try Driver(args: [
         "swiftc",
-        "--output-file-map", outputFileMapRelative,
+        "-output-file-map", outputFileMapRelative,
         "main.swift", "util.swift",
       ]))
     }

--- a/Tests/SwiftOptionsTests/OptionParsingTests.swift
+++ b/Tests/SwiftOptionsTests/OptionParsingTests.swift
@@ -30,6 +30,12 @@ final class SwiftDriverTests: XCTestCase {
 #endif
     }
 
+  func testParsingRemaining() throws {
+    let options = OptionTable()
+    let results = try options.parse(["--", "input1", "input2"], for: .batch)
+    XCTAssertEqual(results.description, "-- input1 input2")
+  }
+
   func testParseErrors() {
     let options = OptionTable()
 
@@ -66,5 +72,8 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(error as? OptionParseError, .unsupportedOption(index: 0, argument: "-repl", option: .repl, currentDriverKind: .batch))
     }
 
+    XCTAssertThrowsError(try options.parse(["--invalid"], for: .batch)) { error in
+      XCTAssertEqual(error as? OptionParseError, .unknownOption(index: 0, argument: "--invalid"))
+    }
   }
 }


### PR DESCRIPTION
Previously `swiftc --invalid foo.swift` would be interpreted as
`swiftc -- foo.swift`. Now we fail in this case since `--invalid` is
likely to be a typo regardless of whether you meant to do `-- invalid`
or `--something-valid`.