### PR TITLE
[NFC] Replace isProvides Bool with an enum

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -109,7 +109,7 @@ extension ModuleDependencyGraph: ExportableGraph {
 // MARK: - Making dependency graph nodes exportable
 fileprivate protocol ExportableNode: Hashable {
   var key: DependencyKey {get}
-  var isProvides: Bool {get}
+  var definitionVsUse: DefinitionVsUse {get}
   func label(in: InternedStringTable) -> String
 }
 
@@ -117,8 +117,8 @@ extension SourceFileDependencyGraph.Node: ExportableNode {
 }
 
 extension ModuleDependencyGraph.Node: ExportableNode {
-  fileprivate var isProvides: Bool {
-    definitionLocation != .unknown
+  fileprivate var definitionVsUse: DefinitionVsUse {
+    definitionLocation == .unknown ? .use : .definition
   }
 }
 
@@ -128,7 +128,7 @@ extension ExportableNode {
   }
 
   fileprivate func label(in t: InternedStringTable) -> String {
-    "\(key.description(in: t)) \(isProvides ? "here" : "somewhere else")"
+    "\(key.description(in: t)) \(definitionVsUse == .definition ? "here" : "somewhere else")"
   }
 
   fileprivate var isExternal: Bool {
@@ -143,10 +143,14 @@ extension ExportableNode {
     key.designator.shape
   }
   fileprivate var fillColor: Color {
-    isProvides ? .azure : key.aspect == .interface ? .yellow : .white
+    switch (definitionVsUse, key.aspect) {
+      case (.definition,  _             ): return .azure
+      case (.use,        .interface     ): return .yellow
+      case (.use,        .implementation): return .white
+    }
   }
   fileprivate var style: Style? {
-    isProvides ? .solid : .dotted
+    definitionVsUse == .definition ? .solid : .dotted
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -118,8 +118,8 @@ extension ModuleDependencyGraph.Integrator {
   private mutating func integrate(
     oneNode integrand: SourceFileDependencyGraph.Node)
   {
-    guard integrand.isProvides else {
-      // depends are captured by recordWhatIsDependedUpon below
+    guard integrand.definitionVsUse == .definition else {
+      // Uses are captured by recordWhatIsDependedUpon below.
       return
     }
 
@@ -219,7 +219,8 @@ extension ModuleDependencyGraph.Integrator {
  private mutating func integrateWithNewNode(
     _ integrand: SourceFileDependencyGraph.Node
   ) -> Graph.Node {
-    precondition(integrand.isProvides, "Dependencies are arcs in the module graph")
+    precondition(integrand.definitionVsUse == .definition,
+                 "Dependencies are arcs in the module graph")
     let newNode = Graph.Node(
       key: integrand.key,
       fingerprint: integrand.fingerprint,

--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -167,7 +167,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
             foundNode = true
             XCTAssertEqual(node.key.aspect, .interface)
             XCTAssertTrue(node.defsIDependUpon.isEmpty)
-            XCTAssertFalse(node.isProvides)
+            XCTAssertEqual(node.definitionVsUse, .use)
           }
         }
         XCTAssertTrue(foundNode)

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -97,21 +97,21 @@ final class NonincrementalCompilationTests: XCTestCase {
           XCTAssertEqual(name.lookup(in: internedStringTable), "main.swiftdeps")
           XCTAssertEqual(node.fingerprint?.lookup(in: internedStringTable), "ec443bb982c3a06a433bdd47b85eeba2")
           XCTAssertEqual(node.defsIDependUpon, [2])
-          XCTAssertTrue(node.isProvides)
+          XCTAssertEqual(node.definitionVsUse, .definition)
         case let (1, .sourceFileProvide(name: name)):
           saw1 = true
           XCTAssertEqual(node.key.aspect, .implementation)
           XCTAssertEqual(name.lookup(in: internedStringTable), "main.swiftdeps")
           XCTAssertEqual(node.fingerprint?.lookup(in: internedStringTable), "ec443bb982c3a06a433bdd47b85eeba2")
           XCTAssertEqual(node.defsIDependUpon, [])
-          XCTAssertTrue(node.isProvides)
+          XCTAssertEqual(node.definitionVsUse, .definition)
         case let (2, .topLevel(name: name)):
           saw2 = true
           XCTAssertEqual(node.key.aspect, .interface)
           XCTAssertEqual(name.lookup(in: internedStringTable), "a")
           XCTAssertNil(node.fingerprint)
           XCTAssertEqual(node.defsIDependUpon, [])
-          XCTAssertFalse(node.isProvides)
+          XCTAssertEqual(node.definitionVsUse, .use)
         default:
           XCTFail()
         }
@@ -148,7 +148,7 @@ final class NonincrementalCompilationTests: XCTestCase {
           XCTAssertEqual(context.lookup(in: internedStringTable), "5hello1BV")
           XCTAssertEqual(name.lookup(in: internedStringTable), "init")
           XCTAssertEqual(node.defsIDependUpon, [])
-          XCTAssertFalse(node.isProvides)
+          XCTAssertEqual(node.definitionVsUse, .use)
         }
       }
       XCTAssertTrue(foundNode)
@@ -202,7 +202,7 @@ final class NonincrementalCompilationTests: XCTestCase {
           foundNode = true
           XCTAssertEqual(node.key.aspect, .interface)
           XCTAssertEqual(node.defsIDependUpon, [0])
-          XCTAssertTrue(node.isProvides)
+          XCTAssertEqual(node.definitionVsUse, .definition)
         }
       }
       XCTAssertTrue(foundNode)


### PR DESCRIPTION
For the sake of clarity, try an enum instead of a boolean for `isProvides`.