### PR TITLE
Revert "SwiftDriver: implement response file handling for Windows"

### DIFF
--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -46,64 +46,6 @@ func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
   }
   return commandLineLength < effectiveArgMax
 }
-#elseif os(Windows)
-func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
-  func flattenWindowsCommandLine(_ arguments: [String]) -> String {
-    func argNeedsQuoting(_ argument: String) -> Bool {
-      if argument.isEmpty { return false }
-      let chars: Set<Character> = Set("\t \"&'()*<>\\`^|\n")
-      return argument.firstIndex(where: { chars.contains($0) }) != argument.endIndex
-    }
-
-    func quote(_ argument: String) -> String {
-      var unquoted: Substring = argument[...]
-      var quoted: String = #"""#
-      while !unquoted.isEmpty {
-        guard let firstNonBS = unquoted.firstIndex(where: { $0 != "\\" }) else {
-          // The rest of the string is backslashes. Escape all of them and exit.
-          (0 ..< (2 * unquoted.count)).forEach { _ in quoted += "\\" }
-          break
-        }
-
-        let bsCount = unquoted.distance(from: unquoted.startIndex, to: firstNonBS)
-        if unquoted[firstNonBS] == #"""# {
-          // This is an embedded quote. Escape all preceeding backslashes, then
-          // add one additional backslash to escape the quote.
-          (0 ..< (2 * bsCount + 1)).forEach { _ in quoted += "\\" }
-          quoted += #"""#
-        } else {
-          // This is just a normal character. Don't escape any of the preceding
-          // backslashes, just append them as they are and then append the
-          // character.
-          (0 ..< bsCount).forEach { _ in quoted += "\\" }
-          quoted += "\(unquoted[firstNonBS])"
-        }
-
-        unquoted = unquoted.dropFirst(bsCount + 1)
-      }
-      return quoted + #"""#
-    }
-
-    var quoted: String = ""
-    for arg in arguments {
-      if argNeedsQuoting(arg) {
-        quoted += quote(arg)
-      } else {
-        quoted += arg
-      }
-      quoted += " "
-    }
-    return quoted
-  }
-
-  let arguments: [String] = [path] + args
-  let commandLine = flattenWindowsCommandLine(arguments)
-  // `CreateProcessW` requires the length of `lpCommandLine` not exceed 32767
-  // characters, including the Unicode terminating null character.  We use a
-  // smaller value to reduce risk of getting invalid command line due to
-  // unaccounted factors.
-  return commandLine.count <= 32000
-}
 #else
 func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
   #warning("missing implementation for current platform")


### PR DESCRIPTION
Reverts apple/swift-driver#938

This seems to be causing errors in SWPM CI (perhaps an older Swift compiler is used there):
```
/Users/buildnode/jenkins/workspace/swift-package-manager-PR-macos-smoke-test/branch-main/swift-driver/Sources/SwiftDriver/Utilities/System.swift:60:32: error: multi-line string literal content must begin on a new line
```