### PR TITLE
Make `writeIncrementalBuildInformation` a public method.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1264,7 +1264,7 @@ extension Driver {
       recordedInputModificationDates: recordedInputModificationDates)
   }
 
-  private func writeIncrementalBuildInformation(_ jobs: [Job]) {
+  public func writeIncrementalBuildInformation(_ jobs: [Job]) {
     // In case the write fails, don't crash the build.
     // A mitigation to rdar://76359678.
     // If the write fails, import incrementality is lost, but it is not a fatal error.


### PR DESCRIPTION
This allows `libSwiftDriver` clients to ask the driver to serialize its incremental state all at once: the module dependency graph and the build record.