### PR TITLE
Kill the process after cleanup on interrupt

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -21,7 +21,9 @@ let diagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHan
 var driverInterrupted = false
 func getExitCode(_ code: Int32) -> Int32 {
   if driverInterrupted {
-    return (SIGINT | 0x80)
+    intHandler = nil
+    kill(getpid(), SIGINT)
+    fatalError("Invalid state, could not kill process")
   }
   return code
 }


### PR DESCRIPTION
This is identical behavior on bash but when spawning the process using posix_spawn (like llbuild does) the exit code of (SIGINT | 0x80) == 130 gets encoded as an exit code rather than the uncaught signal.

rdar://77055430