### PR TITLE
Tests: add some sleeps for file system modifications

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -1029,11 +1029,14 @@ extension IncrementalCompilationTests {
     checkDiagnostics: Bool = false,
     extraArguments: [String] = []
   ) throws {
+    Thread.sleep(forTimeInterval: 1)
+
     for (file, _) in self.inputPathsAndContents {
       try localFileSystem.removeFileTree(file)
       let linkTarget = tempDir.appending(component: "links").appending(component: file.basename)
       try localFileSystem.createSymbolicLink(file, pointingAt: linkTarget, relative: false)
     }
+
     try doABuild(
       "touch both symlinks; non-propagating",
       checkDiagnostics: checkDiagnostics,
@@ -1053,10 +1056,13 @@ extension IncrementalCompilationTests {
     checkDiagnostics: Bool = false,
     extraArguments: [String] = []
   ) throws {
+    Thread.sleep(forTimeInterval: 1)
+
     for (file, contents) in self.inputPathsAndContents {
       let linkTarget = tempDir.appending(component: "links").appending(component: file.basename)
       try! localFileSystem.writeFileContents(linkTarget) { $0 <<< contents }
     }
+
     try doABuild(
       "touch both symlink targets; non-propagating",
       checkDiagnostics: checkDiagnostics,


### PR DESCRIPTION
This adds a couple more strategic `sleep` invocations to ensure that
filesystems without nanosecond precision on file timestamps can be
accommodated.  This allows the incremental compilation tests to now pass
on Windows.