### PR TITLE
swift-driver: repair the build after #980

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -16,13 +16,21 @@ import TSCLibc
 import TSCBasic
 import TSCUtility
 
+#if os(Windows)
+import WinSDK
+#endif
+
 var intHandler: InterruptHandler?
 let diagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
 var driverInterrupted = false
 func getExitCode(_ code: Int32) -> Int32 {
   if driverInterrupted {
     intHandler = nil
+#if os(Windows)
+    TerminateProcess(GetCurrentProcess(), UINT(0xC0000000 | UINT(2)))
+#else
     kill(getpid(), SIGINT)
+#endif
     fatalError("Invalid state, could not kill process")
   }
   return code


### PR DESCRIPTION
`kill` is a non-portable function from the Unix C library.  Replace the
functionality with Windows SDK's `TerminateProcess`.  Encode `SIGINT` as
a NT error for the process termination code.