### PR TITLE
[5.6] Make `writeIncrementalBuildInformation` a public method.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1264,7 +1264,7 @@ extension Driver {
       recordedInputModificationDates: recordedInputModificationDates)
   }
 
-  private func writeIncrementalBuildInformation(_ jobs: [Job]) {
+  public func writeIncrementalBuildInformation(_ jobs: [Job]) {
     // In case the write fails, don't crash the build.
     // A mitigation to rdar://76359678.
     // If the write fails, import incrementality is lost, but it is not a fatal error.


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/979
----------------------------------
• Explanation: Build systems can use libSwiftDriver for planning target builds, instead of shelling out to `swiftc`. Incremental builds in such cases have to be managed by the build system by exercising a relevant API surface of libSwiftDriver's incremental machinery. In order to get correct incremental builds, the driver must serialize its incremental state after compilation, to ensure that successive incremental builds can do the right thing with up-to-date records of previous compilation. Today, this serialization is done automatically by the driver in its `run` method, but build systems may not use this method at all and instead have its own methods of job execution. As such, they require an ability to query the driver to serialize its state.

This nomination is for a change to the driver code that makes the serialization routine `public` API, in order for it to be usable from build system clients of libSwiftDriver, and changes no other code.

• Scope of Issue: Incremental builds when using libSwiftDriver may not behave correctly if the build system is not invoking the driver's `run` method at an appropriate time.

• Risk: None. 

• Pull Request: https://github.com/apple/swift-driver/pull/984 

• Resolves: rdar://87475567 

• Reviewed By: Ben Herzog, Xi Ge