### PR TITLE
IncrementalTestFramework: add filesystem workarounds

### DIFF
--- a/Tests/IncrementalTestFramework/Module.swift
+++ b/Tests/IncrementalTestFramework/Module.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
+import Foundation
 
 @_spi(Testing) import SwiftDriver
 import SwiftOptions
@@ -106,6 +107,7 @@ extension Module {
     }
     try createSourceDir()
     try removeUnwantedSources()
+    Thread.sleep(forTimeInterval: 1)
     try addNeededSources()
   }
 


### PR DESCRIPTION
Add a sleep before re-creating the files for the incremental tests.
For filesystems where the timestamp granularity is insufficient, we
would previously fail to re-compile sources as the timestamps would
be identical.  This allows the last of the incremental testsuite to
now pass on Windows.  There are some stability issues remaining for
investigation, a handful of skipped tests due to tools-support-core
and one concern - include path testing.  Once those have been given
a chance for investigation, it will likely be sufficient completion
for enabling swift-driver on Windows with SPM as well as the driver
binary in the installed image.