### PR TITLE
Disfavor current working directory when looking up executables

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -209,10 +209,10 @@ extension Toolchain {
     if let overrideString = envVar(forExecutable: executableName(executable)) {
       return try AbsolutePath(validating: overrideString)
     } else if let toolDir = toolDirectory,
-              let path = lookupExecutablePath(filename: executableName(executable), searchPaths: [toolDir]) {
+              let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: nil, searchPaths: [toolDir]) {
       // Looking for tools from the tools directory.
       return path
-    } else if let path = lookupExecutablePath(filename: executableName(executable), searchPaths: [executableDir]) {
+    } else if let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: nil, searchPaths: [executableDir]) {
       return path
     } else if let path = try? xcrunFind(executable: executableName(executable)) {
       return path

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -206,8 +206,9 @@ extension Toolchain {
   /// looks in the `executableDir`, `xcrunFind` or in the `searchPaths`.
   /// - Parameter executable: executable to look for [i.e. `swift`].
   func lookup(executable: String) throws -> AbsolutePath {
-    if let overrideString = envVar(forExecutable: executableName(executable)) {
-      return try AbsolutePath(validating: overrideString)
+    if let overrideString = envVar(forExecutable: executableName(executable)),
+       let path = try? AbsolutePath(validating: overrideString) {
+      return path
     } else if let toolDir = toolDirectory,
               let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: nil, searchPaths: [toolDir]) {
       // Looking for tools from the tools directory.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6435,9 +6435,9 @@ final class SwiftDriverTests: XCTestCase {
           XCTAssertEqual(jobs.first!.tool.name, customSwiftFrontend.pathString)
         }
 
-        // test if current working directory is searched
+        // test if current working directory is searched before PATH
         do {
-          var driver = try Driver(args: ["swiftc", "-print-target-info"], env: ["PATH": ""])
+          var driver = try Driver(args: ["swiftc", "-print-target-info"], env: ["PATH": toolsDirectory.pathString])
           let jobs = try driver.planBuild()
           XCTAssertEqual(jobs.count, 1)
           XCTAssertEqual(jobs.first!.tool.name, anotherSwiftFrontend.pathString)


### PR DESCRIPTION
Calling the driver from the `/usr/bin` directory of a toolchain will use that toolchain even if the called driver is from another toolchain. I thought this should be regarded as a bug?