### PR TITLE
build: install the executable targets

### DIFF
--- a/Sources/swift-build-sdk-interfaces/CMakeLists.txt
+++ b/Sources/swift-build-sdk-interfaces/CMakeLists.txt
@@ -11,3 +11,6 @@ add_executable(swift-build-sdk-interfaces
 target_link_libraries(swift-build-sdk-interfaces PUBLIC
   SwiftDriver
   SwiftDriverExecution)
+
+install(TARGETS swift-build-sdk-interfaces
+  DESTINATION bin)

--- a/Sources/swift-driver/CMakeLists.txt
+++ b/Sources/swift-driver/CMakeLists.txt
@@ -11,3 +11,6 @@ add_executable(swift-driver
 target_link_libraries(swift-driver PUBLIC
   SwiftDriver
   SwiftDriverExecution)
+
+install(TARGETS swift-driver
+  DESTINATION bin)

--- a/Sources/swift-help/CMakeLists.txt
+++ b/Sources/swift-help/CMakeLists.txt
@@ -12,3 +12,6 @@ target_link_libraries(swift-help PUBLIC
   SwiftOptions
   ArgumentParser
   TSCBasic)
+
+install(TARGETS swift-help
+  DESTINATION bin)


### PR DESCRIPTION
This is the first and last step towards enabling swift-driver on
Windows.  The current swift-driver test suite passes on Windows, and
with the changes now merged, `swift build --use-integrated-swift-driver`
works.  This change will extract the tools so that we can package them
up.  This sets the stage for the last change needed in SPM and allows
experimenting with packaging now.