### PR TITLE
Loosen restriction for building deprecated iOS targets

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -603,6 +603,7 @@ public struct Driver {
     try toolchain.validateArgs(&parsedOptions,
                                targetTriple: self.frontendTargetInfo.target.triple,
                                targetVariantTriple: self.frontendTargetInfo.targetVariant?.triple,
+                               compilerOutputType: self.compilerOutputType,
                                diagnosticsEngine: diagnosticEngine)
 
     // Compute debug information output.

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -66,7 +66,9 @@ public protocol Toolchain {
   /// Perform platform-specific argument validation.
   func validateArgs(_ parsedOptions: inout ParsedOptions,
                     targetTriple: Triple,
-                    targetVariantTriple: Triple?, diagnosticsEngine: DiagnosticsEngine) throws
+                    targetVariantTriple: Triple?,
+                    compilerOutputType: FileType?,
+                    diagnosticsEngine: DiagnosticsEngine) throws
 
   /// Adds platform-specific linker flags to the provided command line
   func addPlatformSpecificLinkerArgs(
@@ -214,8 +216,9 @@ extension Toolchain {
   }
 
   public func validateArgs(_ parsedOptions: inout ParsedOptions,
-                           targetTriple: Triple,
-                           targetVariantTriple: Triple?, diagnosticsEngine: DiagnosticsEngine) {}
+                           targetTriple: Triple, targetVariantTriple: Triple?,
+                           compilerOutputType: FileType?,
+                           diagnosticsEngine: DiagnosticsEngine) {}
 
   public func addPlatformSpecificCommonFrontendOptions(
     commandLine: inout [Job.ArgTemplate],

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -138,6 +138,7 @@ extension WindowsToolchain.ToolchainValidationError {
 
   public func validateArgs(_ parsedOptions: inout ParsedOptions,
                            targetTriple: Triple, targetVariantTriple: Triple?,
+                           compilerOutputType: FileType?,
                            diagnosticEngine: DiagnosticsEngine) throws {
     // TODO(compnerd) validate any options we can
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3039,6 +3039,16 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testValidDeprecatedTargets() throws {
+    var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "armv7-apple-ios13.0", "foo.swift"])
+    let plannedJobs = try driver.planBuild()
+    let emitModuleJob = plannedJobs.first(where: {$0.kind == .emitModule})
+    XCTAssertNotNil(emitModuleJob)
+    let currentJob = emitModuleJob!
+    XCTAssert(currentJob.commandLine.contains(.flag("-target")))
+    XCTAssert(currentJob.commandLine.contains(.flag("armv7-apple-ios13.0")))
+  }
+
   func testClangTargetForExplicitModule() throws {
     #if os(macOS)
     // Check -clang-target is on by defualt when explicit module is on.
@@ -3133,13 +3143,21 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "armv7-apple-ios12.0",
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "armv7-apple-ios12.1",
                                            "foo.swift"])) { error in
-      guard case DarwinToolchain.ToolchainValidationError.iOSVersionAboveMaximumDeploymentTarget(12) = error else {
+      guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR("iOS 11", "armv7") = error else {
         XCTFail()
         return
       }
     }
+
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-emit-module", "-c", "-target", 
+                                           "armv7s-apple-ios12.0", "foo.swift"])) { error in
+        guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR("iOS 11", "armv7s") = error else {
+          XCTFail()
+          return
+        }
+      }
 
     XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-ios13.0",
                                            "-target-variant", "x86_64-apple-macosx10.14",


### PR DESCRIPTION
This patch loosens the restriction for building deprecated iOS targets
to only when the user attempts to compile a binary or emit IR.
This allows the compiler to continue building swift modules and
interfaces for newer deployment targets.

The error message is also slightly modified to allow the same message to
apply to different platforms.

resolves: <rdar://87898177>