### PR TITLE
Only emit ABI descriptors when Library Evolution is enabled

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -363,6 +363,9 @@ public struct Driver {
     guard let moduleOutput = moduleOutputInfo.output else {
       return nil
     }
+    guard parsedOptions.hasArgument(.enableLibraryEvolution) else {
+      return nil
+    }
     return TypedVirtualPath(file: VirtualPath.lookup(moduleOutput.outputPath)
       .replacingExtension(with: .jsonABIBaseline).intern(), type: .jsonABIBaseline)
   }()


### PR DESCRIPTION
These descriptors are not otherwise meaningful so this avoid unnecessary work when we do not require it.