### PR TITLE
SwiftDriver: enable response files on LinkJobs

### DIFF
--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -64,7 +64,6 @@ extension Driver {
       targetInfo: frontendTargetInfo
     )
 
-    // TODO: some, but not all, linkers support response files.
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .link,
@@ -73,7 +72,10 @@ extension Driver {
       displayInputs: inputs,
       inputs: inputs,
       primaryInputs: [],
-      outputs: [.init(file: outputFile.intern(), type: .image)]
+      outputs: [.init(file: outputFile.intern(), type: .image)],
+      // FIXME: newer ld64 supports response files as well, though really,
+      // Darwin should use clang as the linker driver like the other targets
+      supportsResponseFiles: !frontendTargetInfo.target.triple.isDarwin
     )
   }
 }


### PR DESCRIPTION
The non-Darwin targets use clang as the linker driver.  As a result, the
non-Darwin targets implicitly support response files (clang will expand
it if the linker does not support response files or file lists).
Unfortunately, the Darwin target manually invokes ld, which requires
re-implementing the handling there.  To complicate things further, older
ld64 does not support response files, but does support linker file
lists, while newer ld64 supports both.  Ideally, Darwin would also use
clang as the linker driver to homogenise the paths.

This is required for Windows support as the command line limit is much
lower on Windows than on Linux - nearing 4k which is possible to exceed
when building a larger project (e.g. swift-driver).