### PR TITLE
SwiftDriver: change the response file emission

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1205,9 +1205,9 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(resolvedArgs[1].first, "@")
       let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[1].dropFirst()))
       let contents = try localFileSystem.readFileContents(responseFilePath).description
-      XCTAssertTrue(contents.hasPrefix("-frontend\n-interpret\nfoo.swift"))
-      XCTAssertTrue(contents.contains("-D\nTEST_20000"))
-      XCTAssertTrue(contents.contains("-D\nTEST_1"))
+      XCTAssertTrue(contents.hasPrefix("\"-frontend\"\n\"-interpret\"\n\"foo.swift\""))
+      XCTAssertTrue(contents.contains("\"-D\"\n\"TEST_20000\""))
+      XCTAssertTrue(contents.contains("\"-D\"\n\"TEST_1\""))
     }
     // Forced response file
     do {
@@ -1221,7 +1221,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(resolvedArgs[1].first, "@")
       let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[1].dropFirst()))
       let contents = try localFileSystem.readFileContents(responseFilePath).description
-      XCTAssertTrue(contents.hasPrefix("-frontend\n-interpret\nfoo.swift"))
+      XCTAssertTrue(contents.hasPrefix("\"-frontend\"\n\"-interpret\"\n\"foo.swift\""))
     }
 
     // No response file


### PR DESCRIPTION
This adjusts the response file emission to follow the clang behaviour.
Doing so allows the use of response files on Windows to be passed to
clang, which will default to POSIX style response files unless
explicitly passed `--rsp-quoting=windows`.  This allows for a single
path for the emission across platforms, and avoids having to deal with
the dynamic switching of the response file formats.  With this change,
ignoring the serialization issue, it is now possible to build
swift-driver with swift-driver.