### PR TITLE
README: update platform status

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The goal of the new Swift driver is to provide a drop-in replacement for the exi
 * Platform support
   * [x] Teach the `DarwinToolchain` to also handle iOS, tvOS, watchOS
   * [x] Fill out the `GenericUnixToolchain` toolchain to get it working
-  * [ ] Implement a `WindowsToolchain`
+  * [x] Implement a `WindowsToolchain`
   * [x] Implement proper tokenization for response files
 * Compilation modes
   * [x] Batch mode


### PR DESCRIPTION
The Windows path is mature enough to support building swift-driver with swift-driver as the driver.  There is one remaining issue is a clang issue that was uncovered by the new driver.