### PR TITLE
remove unnecessary `TSCLibc` dependency

### DIFF
--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -11,7 +11,13 @@
 //===----------------------------------------------------------------------===//
 import SwiftDriverExecution
 import SwiftDriver
-import TSCLibc
+#if os(Windows)
+import CRT
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
 import TSCBasic
 import TSCUtility
 

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -11,8 +11,13 @@
 //===----------------------------------------------------------------------===//
 import SwiftDriverExecution
 import SwiftDriver
-
-import TSCLibc
+#if os(Windows)
+import CRT
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
 import TSCBasic
 import TSCUtility
 


### PR DESCRIPTION
These modules did not use any of the `TSCLibc` interfaces but relied on
the module's re-exported libc import.  Simply inline that and remove the
dependency on `TSCLibc`.  On Linux and Apple platforms, this does not
have much impact, however, Windows does not support static linking of
Swift content yet.  As a result, this avoids an unnecessary dynamic
library being linked and increasing the dirty memory of the process.