### PR TITLE
SwiftDriver: explicitly indicate the TSCUtility interfaces

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 import Foundation
 import SwiftOptions
+
+import enum TSCUtility.Diagnostics
+import struct TSCUtility.Version
 
 /// The Swift driver.
 public struct Driver {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 import Foundation
 
 /// A map from a module identifier to a path to its .swiftmodule file.

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
@@ -12,9 +12,9 @@
 
 import Dispatch
 import TSCBasic
-import TSCUtility
 import SwiftOptions
 
+import struct TSCUtility.Version
 
 extension IncrementalCompilationState {
   /// Encapsulates the data necessary to make incremental build scheduling decisions and protects it from concurrent access.

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 import Foundation
 import SwiftOptions
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -12,7 +12,6 @@
 
 import Dispatch
 import TSCBasic
-import TSCUtility
 import SwiftOptions
 
 /// An instance of `IncrementalCompilationState` encapsulates the data necessary

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -12,9 +12,14 @@
 
 import Foundation
 import TSCBasic
-import TSCUtility
 import SwiftOptions
 
+import enum TSCUtility.BitcodeElement
+import enum TSCUtility.Bitstream
+import class TSCUtility.BitstreamWriter
+import protocol TSCUtility.BitstreamVisitor
+import struct TSCUtility.Bitcode
+import struct TSCUtility.Version
 
 // MARK: - ModuleDependencyGraph
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -10,7 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
+
+import class TSCUtility.BitstreamWriter
+import enum TSCUtility.BitcodeElement
+import enum TSCUtility.Bitstream
+import protocol TSCUtility.BitstreamVisitor
+import struct TSCUtility.Bitcode
 
 /*@_spi(Testing)*/ public struct SourceFileDependencyGraph {
   public static let sourceFileProvidesInterfaceSequenceNumber: Int = 0

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 import SwiftOptions
+
+import struct TSCUtility.Version
 
 extension DarwinToolchain {
   internal func findXcodeClangPath() throws -> AbsolutePath? {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
+
+import enum TSCUtility.Diagnostics
 
 /// Whether we should produce color diagnostics by default.
 fileprivate func shouldColorDiagnostics() -> Bool {

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-import TSCUtility
 
 extension Driver {
   mutating func generatePCHJob(input: TypedVirtualPath, output: TypedVirtualPath) throws -> Job {

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -12,9 +12,13 @@
 
 @_implementationOnly import CSwiftScan
 
-import TSCUtility
 import TSCBasic
 import Foundation
+
+import class TSCUtility.DLHandle
+import func TSCUtility.dlopen
+import func TSCUtility.dlsym
+import struct TSCUtility.Version
 
 public enum DependencyScanningError: Error, DiagnosticData {
   case missingRequiredSymbol(String)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 import TSCBasic
-import TSCUtility
 import Foundation
 import SwiftOptions
+
+import struct TSCUtility.Version
 
 /// Toolchain for Darwin-based platforms, such as macOS and iOS.
 ///

--- a/Sources/SwiftDriver/Utilities/VersionExtensions.swift
+++ b/Sources/SwiftDriver/Utilities/VersionExtensions.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCUtility
+import struct TSCUtility.Version
 
 // TODO: maybe move this to TSC.
 extension Version {

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -19,7 +19,6 @@ import Darwin
 import Glibc
 #endif
 import TSCBasic
-import TSCUtility
 
 let diagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
 

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -19,11 +19,13 @@ import Darwin
 import Glibc
 #endif
 import TSCBasic
-import TSCUtility
 
 #if os(Windows)
 import WinSDK
 #endif
+
+import enum TSCUtility.Diagnostics
+import typealias TSCUtility.InterruptHandler
 
 var intHandler: InterruptHandler?
 let diagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])

--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -12,7 +12,6 @@
 
 import XCTest
 import TSCBasic
-import TSCUtility
 @_spi(Testing) import SwiftDriver
 
 class APIDigesterTests: XCTestCase {

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -13,7 +13,6 @@
 import XCTest
 @_spi(Testing) import SwiftDriver
 import TSCBasic
-import TSCUtility
 
 class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker {
   static let maxIndex = 12

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -12,8 +12,9 @@
 
 @_spi(Testing) import SwiftDriver
 import TSCBasic
-import TSCUtility
 import XCTest
+
+import struct TSCUtility.Version
 
 // MARK: - utilities for unit testing
 extension ModuleDependencyGraph {

--- a/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
@@ -4,7 +4,6 @@
 import XCTest
 @_spi(Testing) import SwiftDriver
 import TSCBasic
-import TSCUtility
 
 class IncrementalBuildPerformanceTests: XCTestCase {
   enum WhatToMeasure { case readingSwiftDeps, writing, readingPriors }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 import TSCBasic
-import TSCUtility
 import Foundation
 
 @_spi(Testing) import SwiftDriver

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 import TSCBasic
-import TSCUtility
 import Foundation
 
 @_spi(Testing) import SwiftDriver

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 import TSCBasic
-import TSCUtility
 import Foundation
 
 @_spi(Testing) import SwiftDriver


### PR DESCRIPTION
This explicitly identifies the TSCUtility interfaces that SwiftDriver
depends on.  This helps identify a "burn down list" of interfaces that
remain in TSC(Utility) which are in use.  As these interfaces are
replaced, we can easily monitor the remaining interfaces that are in
use.