### PR TITLE
Tests: introduce `AbsolutePath.nativePathString(escaped:)`

### DIFF
--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -25,14 +25,14 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
     """
     {
       "": {
-        "swift-dependencies": "\(workingDirectory.appending(component: "module.swiftdeps").pathString.nativePathString().escaped())"
+        "swift-dependencies": "\(workingDirectory.appending(component: "module.swiftdeps").nativePathString(escaped: true))"
       }
     """.appending(files.map { file in
       """
       ,
-      "\(file.pathString.nativePathString().escaped())": {
+      "\(file.nativePathString(escaped: true))": {
         "dependencies": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + ".d")",
-        "object": "\(transform(file.pathString.nativePathString().escaped()) + ".o")",
+        "object": "\(transform(file.nativePathString(escaped: true)) + ".o")",
         "swiftmodule": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + "~partial.swiftmodule")",
         "swift-dependencies": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + ".swiftdeps")"
         }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -601,7 +601,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let (stdLibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
 
       let srcBar = path.appending(component: "bar.swift")
-      let moduleBarPath = path.appending(component: "Bar.swiftmodule").pathString.nativePathString().escaped()
+      let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: true)
       try localFileSystem.writeFileContents(srcBar) {
         $0 <<< "public class KlassBar {}"
       }
@@ -610,14 +610,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-explicit-module-build",
                                      "-working-directory",
-                                     path.pathString.nativePathString().escaped(),      
-                                     srcBar.pathString.nativePathString().escaped(),
+                                     path.nativePathString(escaped: true),
+                                     srcBar.nativePathString(escaped: true),
                                      "-module-name",
                                      "Bar",
                                      "-emit-module",
                                      "-emit-module-path", moduleBarPath,
-                                     "-I", stdLibPath.pathString.nativePathString().escaped(),
-                                     "-I", shimsPath.pathString.nativePathString().escaped(),
+                                     "-I", stdLibPath.nativePathString(escaped: true),
+                                     "-I", shimsPath.nativePathString(escaped: true),
                               ] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       guard driver.isFrontendArgSupported(.moduleAlias) else {
@@ -644,12 +644,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       "-nonlib-dependency-scanner",
                                       "-explicit-module-build",
                                       "-working-directory",
-                                      path.pathString.nativePathString().escaped(),
-                                      srcFoo.pathString.nativePathString().escaped(),
+                                      path.nativePathString(escaped: true),
+                                      srcFoo.nativePathString(escaped: true),
                                       "-module-alias", "Car=Bar",
-                                      "-I", path.pathString.nativePathString().escaped(),
-                                      "-I", stdLibPath.pathString.nativePathString().escaped(),
-                                      "-I", shimsPath.pathString.nativePathString().escaped(),
+                                      "-I", path.nativePathString(escaped: true),
+                                      "-I", stdLibPath.nativePathString(escaped: true),
+                                      "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting)
       
       // Resulting graph should contain the real module name Bar
@@ -671,12 +671,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driverB = try Driver(args: ["swiftc",
                                       "-explicit-module-build",
                                       "-working-directory",
-                                      path.pathString.nativePathString().escaped(),
-                                      srcFoo.pathString.nativePathString().escaped(),
+                                      path.nativePathString(escaped: true),
+                                      srcFoo.nativePathString(escaped: true),
                                       "-module-alias", "Car=Bar",
-                                      "-I", path.pathString.nativePathString().escaped(),
-                                      "-I", stdLibPath.pathString.nativePathString().escaped(),
-                                      "-I", shimsPath.pathString.nativePathString().escaped(),
+                                      "-I", path.nativePathString(escaped: true),
+                                      "-I", stdLibPath.nativePathString(escaped: true),
+                                      "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting)
       
       // Resulting graph should contain the real module name Bar
@@ -718,11 +718,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driverA = try Driver(args: ["swiftc",
                                       "-nonlib-dependency-scanner",
                                       "-explicit-module-build",
-                                      srcFoo.pathString.nativePathString().escaped(),
+                                      srcFoo.nativePathString(escaped: true),
                                       "-module-alias", "Car=E",
-                                      "-I", swiftModuleInterfacesPath.pathString.nativePathString().escaped(),
-                                      "-I", stdLibPath.pathString.nativePathString().escaped(),
-                                      "-I", shimsPath.pathString.nativePathString().escaped(),
+                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                      "-I", stdLibPath.nativePathString(escaped: true),
+                                      "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting)
       guard driverA.isFrontendArgSupported(.moduleAlias) else {
         throw XCTSkip("Skipping: compiler does not support '-module-alias'")
@@ -746,12 +746,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // Module alias with the default scanner (driver scanner)
       var driverB = try Driver(args: ["swiftc",
                                       "-explicit-module-build",
-                                      srcFoo.pathString.nativePathString().escaped(),
+                                      srcFoo.nativePathString(escaped: true),
                                       "-module-alias", "Car=E",
-                                      "-working-directory", path.pathString.nativePathString().escaped(),
-                                      "-I", swiftModuleInterfacesPath.pathString.nativePathString().escaped(),
-                                      "-I", stdLibPath.pathString.nativePathString().escaped(),
-                                      "-I", shimsPath.pathString.nativePathString().escaped(),
+                                      "-working-directory", path.nativePathString(escaped: true),
+                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                      "-I", stdLibPath.nativePathString(escaped: true),
+                                      "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting)
       
       // Resulting graph should contain the real module name Bar
@@ -820,7 +820,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let srcBar = path.appending(component: "bar.swift")
-      let moduleBarPath = path.appending(component: "Bar.swiftmodule").pathString.nativePathString().escaped()
+      let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: true)
       try localFileSystem.writeFileContents(srcBar) {
         $0 <<< "public class KlassBar {}"
       }
@@ -833,12 +833,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       "-module-name",
                                       "Bar",
                                       "-working-directory",
-                                      path.pathString.nativePathString().escaped(),
+                                      path.nativePathString(escaped: true),
                                       "-emit-module",
                                       "-emit-module-path", moduleBarPath,
-                                      srcBar.pathString.nativePathString().escaped(),
-                                      "-I", stdLibPath.pathString.nativePathString().escaped(),
-                                      "-I", shimsPath.pathString.nativePathString().escaped(),
+                                      srcBar.nativePathString(escaped: true),
+                                      "-I", stdLibPath.nativePathString(escaped: true),
+                                      "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting,
                                env: ProcessEnv.vars)
       guard driver1.isFrontendArgSupported(.moduleAlias) else {
@@ -851,7 +851,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertTrue(FileManager.default.fileExists(atPath: moduleBarPath))
       
       let srcFoo = path.appending(component: "foo.swift")
-      let moduleFooPath = path.appending(component: "Foo.swiftmodule").pathString.nativePathString().escaped()
+      let moduleFooPath = path.appending(component: "Foo.swiftmodule").nativePathString(escaped: true)
 
       // Module Foo imports Car but it's mapped to Bar (real name)
       // `-module-alias Car=Bar` allows Car (alias) to be referenced
@@ -862,21 +862,20 @@ final class ExplicitModuleBuildTests: XCTestCase {
         $0 <<< "func run() -> Car.KlassBar? { return nil }"
       }
       var driver2 = try Driver(args: ["swiftc",
-                                      "-I",
-                                      path.pathString.nativePathString().escaped(),
+                                      "-I", path.nativePathString(escaped: true),
                                       "-explicit-module-build",
                                       "-module-name",
                                       "Foo",
                                       "-working-directory",
-                                      path.pathString.nativePathString().escaped(),
+                                      path.nativePathString(escaped: true),
                                       "-emit-module",
                                       "-emit-module-path",
                                       moduleFooPath,
                                       "-module-alias",
                                       "Car=Bar",
-                                      srcFoo.pathString.nativePathString().escaped(),
-                                      "-I", stdLibPath.pathString.nativePathString().escaped(),
-                                      "-I", shimsPath.pathString.nativePathString().escaped(),
+                                      srcFoo.nativePathString(escaped: true),
+                                      "-I", stdLibPath.nativePathString(escaped: true),
+                                      "-I", shimsPath.nativePathString(escaped: true),
                                       ] + sdkArgumentsForTesting,
                                env: ProcessEnv.vars)
       let jobs2 = try driver2.planBuild()
@@ -912,7 +911,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", cHeadersPath.nativePathString().escaped(),
                                      "-I", swiftModuleInterfacesPath.nativePathString().escaped(),
                                      "-explicit-module-build",
-                                     "-working-directory", path.pathString.nativePathString().escaped(),
+                                     "-working-directory", path.nativePathString(escaped: true),
                                      main.pathString.escaped()] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       let jobs = try driver.planBuild()
@@ -1054,7 +1053,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
                                      "-explicit-module-build",
-                                     "-working-directory", path.pathString.nativePathString().escaped(),
+                                     "-working-directory", path.nativePathString(escaped: true),
                                      main.pathString.escaped()] + lotsOfInputs + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       let scannerJob = try driver.dependencyScanningJob()
@@ -1110,7 +1109,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", shimsPath.pathString.escaped(),
                                      "-import-objc-header",
                                      "-explicit-module-build",
-                                     "-working-directory", path.pathString.nativePathString().escaped(),
+                                     "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
                                      main.pathString.escaped()] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
@@ -1201,7 +1200,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", stdlibPath.pathString.escaped(),
                                      "-I", shimsPath.pathString.escaped(),
                                      "-explicit-module-build",
-                                     "-working-directory", path.pathString.nativePathString().escaped(),
+                                     "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
                                      main.pathString.escaped()] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -467,7 +467,7 @@ final class JobExecutorTests: XCTestCase {
     #elseif os(Windows)
     let toolchain = WindowsToolchain(env: ProcessEnv.vars, executor: executor)
     if let path = try toolchain.defaultSDKPath(nil) {
-      return ["-sdk", path.pathString.nativePathString()]
+      return ["-sdk", path.nativePathString(escaped: false)]
     }
     return []
     #else

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -176,7 +176,7 @@ final class ParsableMessageTests: XCTestCase {
             "pid" : -1000,
           """))
 #if os(Windows)
-          let mainPath: String = workdir.appending(component: "main.swift").pathString.nativePathString().escaped()
+          let mainPath: String = workdir.appending(component: "main.swift").nativePathString(escaped: true)
 #else
           let mainPath: String = workdir.appending(component: "main.swift").pathString.replacingOccurrences(of: "/", with: "\\/")
 #endif
@@ -191,7 +191,7 @@ final class ParsableMessageTests: XCTestCase {
             "pid" : -1001,
           """))
 #if os(Windows)
-          let test1Path: String = workdir.appending(component: "test1.swift").pathString.nativePathString().escaped()
+          let test1Path: String = workdir.appending(component: "test1.swift").nativePathString(escaped: true)
 #else
           let test1Path: String = workdir.appending(component: "test1.swift").pathString.replacingOccurrences(of: "/", with: "\\/")
 #endif
@@ -206,7 +206,7 @@ final class ParsableMessageTests: XCTestCase {
             "pid" : -1002,
           """))
 #if os(Windows)
-          let test2Path: String = workdir.appending(component: "test2.swift").pathString.nativePathString().escaped()
+          let test2Path: String = workdir.appending(component: "test2.swift").nativePathString(escaped: true)
 #else
           let test2Path: String = workdir.appending(component: "test2.swift").pathString.replacingOccurrences(of: "/", with: "\\/")
 #endif

--- a/Tests/TestUtilities/OutputFileMapCreator.swift
+++ b/Tests/TestUtilities/OutputFileMapCreator.swift
@@ -37,7 +37,7 @@ public struct OutputFileMapCreator {
   }
 
   private func generateDict() -> [String: [String: String]] {
-    let master = ["swift-dependencies": derivedData.appending(component: "\(module)-master.swiftdeps").pathString.nativePathString()]
+    let master = ["swift-dependencies": derivedData.appending(component: "\(module)-master.swiftdeps").nativePathString(escaped: false)]
     let mainEntryDict = self.excludeMainEntry ? [:] : ["": master]
     func baseNameEntry(_ s: AbsolutePath) -> [String: String] {
       [

--- a/Tests/TestUtilities/PathExtensions.swift
+++ b/Tests/TestUtilities/PathExtensions.swift
@@ -28,3 +28,13 @@ extension String {
     }
   }
 }
+
+extension AbsolutePath {
+  public func nativePathString(escaped: Bool) -> String {
+    return URL(fileURLWithPath: self.pathString).withUnsafeFileSystemRepresentation {
+      let repr: String = String(cString: $0!)
+      if escaped { return repr.replacingOccurrences(of: "\\", with: "\\\\") }
+      return repr
+    }
+  }
+}


### PR DESCRIPTION
This adds a new helper function to create the native path string and
escape it in a single operation.  This reduces some of the verbosity
at the call sites.  The desire is to eventually remove the extension
on `String` and be able to simplify all the call sites.