### PR TITLE
Tests: clean up remnants of the old string extensions

### DIFF
--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -31,10 +31,10 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       """
       ,
       "\(file.nativePathString(escaped: true))": {
-        "dependencies": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + ".d")",
+        "dependencies": "\(transform(file.basenameWithoutExt) + ".d")",
         "object": "\(transform(file.nativePathString(escaped: true)) + ".o")",
-        "swiftmodule": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + "~partial.swiftmodule")",
-        "swift-dependencies": "\(transform(file.basenameWithoutExt.nativePathString().escaped()) + ".swiftdeps")"
+        "swiftmodule": "\(transform(file.basenameWithoutExt) + "~partial.swiftmodule")",
+        "swift-dependencies": "\(transform(file.basenameWithoutExt) + ".swiftdeps")"
         }
       """
     }.joined(separator: "\n").appending("\n}"))

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -328,7 +328,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-explicit-module-build",
-                                     main.pathString.escaped()] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
 
       let jobs = try driver.planBuild()
       // Figure out which Triples to use.
@@ -479,7 +479,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-explicit-module-build",
-                                     main.pathString.escaped()] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
 
       let jobs = try driver.planBuild()
 
@@ -799,7 +799,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             "-import-prescan",
                             "-module-alias",
                             "Car=Bar",
-                            main.pathString.escaped()] + sdkArgumentsForTesting
+                            main.nativePathString(escaped: true)] + sdkArgumentsForTesting
 
       let deps =
         try! dependencyOracle.getImports(workingDirectory: path,
@@ -906,7 +906,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
-                                     main.pathString.escaped()] + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -1022,7 +1022,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                             "-I", stdLibPath.nativePathString(escaped: true),
                             "-I", shimsPath.nativePathString(escaped: true),
-                            main.pathString.escaped()] + sdkArgumentsForTesting
+                            main.nativePathString(escaped: true)] + sdkArgumentsForTesting
 
       let imports =
         try! dependencyOracle.getImports(workingDirectory: path,
@@ -1046,7 +1046,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
-                                     main.pathString.escaped()] + lotsOfInputs + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: true)] + lotsOfInputs + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       let scannerJob = try driver.dependencyScanningJob()
 
@@ -1095,13 +1095,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.pathString.escaped(),
-                                     "-I", shimsPath.pathString.escaped(),
+                                     "-I", stdlibPath.nativePathString(escaped: true),
+                                     "-I", shimsPath.nativePathString(escaped: true),
                                      "-import-objc-header",
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
-                                     main.pathString.escaped()] + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
@@ -1185,12 +1185,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.pathString.escaped(),
-                                     "-I", shimsPath.pathString.escaped(),
+                                     "-I", stdlibPath.nativePathString(escaped: true),
+                                     "-I", shimsPath.nativePathString(escaped: true),
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
-                                     main.pathString.escaped()] + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }

--- a/Tests/TestUtilities/PathExtensions.swift
+++ b/Tests/TestUtilities/PathExtensions.swift
@@ -14,22 +14,6 @@ import Foundation
 import TSCBasic
 import SwiftDriver
 
-extension String {
-  public func escaped() -> Self {
-#if os(Windows)
-    return self.replacingOccurrences(of: "\\", with: "\\\\")
-#else
-    return self
-#endif
-  }
-
-  public func nativePathString() -> Self {
-    return URL(fileURLWithPath: self).withUnsafeFileSystemRepresentation {
-      String(cString: $0!)
-    }
-  }
-}
-
 extension AbsolutePath {
   public func nativePathString(escaped: Bool) -> String {
     return URL(fileURLWithPath: self.pathString).withUnsafeFileSystemRepresentation {


### PR DESCRIPTION
This cleans up the remaining instances of the
`String.nativePathString()` and `String.escaped()` which were overly
broad extensions and poorly named in favour of the new
`AbsolutePath.nativePathString(escaped:)` and
`VirtualPath.nativePathString(escaped:)`.