### PR TITLE
Attempt to workaround a missing `willset` symbol error.

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -99,13 +99,13 @@ extension IncrementalCompilationState.FirstWaveComputer {
           mandatoryCompileGroupsInOrder.flatMap {$0.allJobs()},
           showJobLifecycle: showJobLifecycle)
 
-        moduleDependencyGraph.phase = .buildingAfterEachCompilation
+        moduleDependencyGraph.setPhase(to: .buildingAfterEachCompilation)
         return (initiallySkippedCompileGroups: [:],
                 mandatoryJobsInOrder: mandatoryJobsInOrder)
       }
       return try everythingIsMandatory()
     }
-    moduleDependencyGraph.phase = .updatingAfterCompilation
+    moduleDependencyGraph.setPhase(to: .updatingAfterCompilation)
 
     let initiallySkippedInputs = computeInitiallySkippedCompilationInputs(
       inputsInvalidatedByExternals: inputsInvalidatedByExternals,

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -34,8 +34,11 @@ import SwiftOptions
   /// For debugging, something to write out files for visualizing graphs
   var dotFileWriter: DependencyGraphDotFileWriter?
 
-  @_spi(Testing) public var phase: Phase {
-    willSet { mutationSafetyPrecondition() }
+  @_spi(Testing) public fileprivate(set) var phase: Phase
+
+  @_spi(Testing) public func setPhase(to newPhase: Phase) {
+    mutationSafetyPrecondition()
+    self.phase = newPhase
   }
 
   /// The phase when the graph was created. Used to help diagnose later failures

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -955,7 +955,7 @@ extension ModuleDependencyGraph {
   -> [Int]
   {
     blockingConcurrentAccessOrMutation {
-      phase = .updatingAfterCompilation
+        setPhase(to: .updatingAfterCompilation)
     }
     let directlyInvalidatedNodes = getInvalidatedNodesForSimulatedLoad(
       swiftDepsIndex,


### PR DESCRIPTION
In some CI builds, we are running into a strange intermittent linking error about a missing symbol for `SwiftDriver.ModuleDependencyGraph.phase.willset` (`_$s11SwiftDriver21ModuleDependencyGraphC5phaseAC5PhaseOvw`) when linking tests.

For example:
https://ci.swift.org/job/oss-swift-incremental-RA-macos-apple-silicon/56/console
https://ci.swift.org/job/oss-swift-incremental-RA-macos/31/console

This is an attempt to work around that issue while we understand what is actually going on.