### PR TITLE
Darwin: introduce a global override for debug prefix map entries 

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -342,6 +342,11 @@ extension Driver {
       commandLine.appendFlag(.debugInfoStoreInvocation)
     }
 
+    if let map = toolchain.globalDebugPathRemapping {
+      commandLine.appendFlag(.debugPrefixMap)
+      commandLine.appendFlag(map)
+    }
+
     try commandLine.appendLast(.trackSystemDependencies, from: &parsedOptions)
     try commandLine.appendLast(.CrossModuleOptimization, from: &parsedOptions)
     try commandLine.appendLast(.ExperimentalPerformanceAnnotations, from: &parsedOptions)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -129,6 +129,16 @@ public final class DarwinToolchain: Toolchain {
     !(env["RC_DEBUG_OPTIONS"]?.isEmpty ?? true)
   }
 
+  public var globalDebugPathRemapping: String? {
+    // This matches the behavior in Clang.
+    if let map = env["RC_DEBUG_PREFIX_MAP"] {
+      if map.contains("=") {
+        return map
+      }
+    }
+    return nil
+  }
+
   public func runtimeLibraryName(
     for sanitizer: Sanitizer,
     targetTriple: Triple,

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -102,6 +102,8 @@ public final class GenericUnixToolchain: Toolchain {
 
   public var shouldStoreInvocationInDebugInfo: Bool { false }
 
+  public var globalDebugPathRemapping: String? { nil }
+
   public func runtimeLibraryName(
     for sanitizer: Sanitizer,
     targetTriple: Triple,

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -60,6 +60,12 @@ public protocol Toolchain {
   /// When the compiler invocation should be stored in debug information.
   var shouldStoreInvocationInDebugInfo: Bool { get }
 
+  /// Specific toolchains should override this to provide additional
+  /// -debug-prefix-map entries. For example, Darwin has an
+  /// RC_DEBUG_PREFIX_MAP environment variable that is also understood
+  /// by Clang.
+  var globalDebugPathRemapping: String? { get }
+
   /// Constructs a proper output file name for a linker product.
   func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String
 

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -126,6 +126,8 @@ public final class WebAssemblyToolchain: Toolchain {
 
   public var shouldStoreInvocationInDebugInfo: Bool { false }
 
+  public var globalDebugPathRemapping: String? { nil }
+
   public func runtimeLibraryName(
     for sanitizer: Sanitizer,
     targetTriple: Triple,

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -130,6 +130,8 @@ extension WindowsToolchain.ToolchainValidationError {
     !env["RC_DEBUG_OPTIONS", default: ""].isEmpty
   }
 
+  public var globalDebugPathRemapping: String? { nil }
+    
   public func runtimeLibraryName(for sanitizer: Sanitizer, targetTriple: Triple,
                                  isShared: Bool) throws -> String {
     // TODO(compnerd) handle shared linking

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -488,6 +488,16 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(jobs[0].commandLine.contains(.flag("qux=")))
     }
 
+    do {
+      var env = ProcessEnv.vars
+      env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
+      env["RC_DEBUG_PREFIX_MAP"] = "old=new"
+      var driver = try Driver(args: ["swiftc", "-c", "-target", "arm64-apple-macos12", "foo.swift"], env: env)
+      let jobs = try driver.planBuild()
+      XCTAssertTrue(jobs[0].commandLine.contains(.flag("-debug-prefix-map")))
+      XCTAssertTrue(jobs[0].commandLine.contains(.flag("old=new")))
+    }
+
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-debug-prefix-map", "foo", "-debug-prefix-map", "bar") {
         $1.expect(.error("values for '-debug-prefix-map' must be in the format 'original=remapped', but 'foo' was provided"))
         $1.expect(.error("values for '-debug-prefix-map' must be in the format 'original=remapped', but 'bar' was provided"))


### PR DESCRIPTION
This patch adds a new Darwin Swift driver environment variable in the spirit of
RC_DEBUG_OPTIONS, called RC_DEBUG_PREFIX_MAP, which allows a meta build tool to
add one additional -fdebug-prefix-map entry without the knowledge of the build
system.

See also https://reviews.llvm.org/D119850

rdar://85224717