### PR TITLE
SwiftDriver: repair the static linking support for Windows

### DIFF
--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -68,7 +68,7 @@ extension WindowsToolchain.ToolchainValidationError {
     case .swiftCompiler:
       return try lookup(executable: "swift-frontend.exe")
     case .staticLinker:
-      return try lookup(executable: "llvm-ar.exe")
+      return try lookup(executable: "lld-link.exe")
     case .dynamicLinker:
       return try lookup(executable: "clang.exe")
     case .clang:


### PR DESCRIPTION
This adds in the special case handling for static linking on Windows.
clang is unable to drive the static linking process and we must
replicate the C++ driver behaviour here.  Unfortunately, the librarian
is invoked as a modified linker invocation, and we have two different
implementations that we support (as well as the opportunity to use an
alternative).  This wires up `-use-ld=lld`, `-use-ld=lld.exe` and
`-use-ld=lld-link`, `-use-lld=lld-link.exe` to behave identically and
use lld.  The default linker remains the MSVC linker (link.exe), both of
which are invoked as the librarian by the second argument being `/LIB`.
This allows building static libraries with the swift-driver.  This was
not caught in previous testing due to the swift-package-manager not
actually generating a static library and instead attempting to create
the equivalent to CMake's object libraries.