### PR TITLE
fix cross-module-optimization builds and add the option `-disable-cmo`

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -282,6 +282,8 @@ extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
+    addDisableCMOOption(commandLine: &commandLine)
+
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
       commandLine.appendFlag(.parseAsLibrary)
     }

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -97,6 +97,8 @@ extension Driver {
 
     addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: false)
 
+    addDisableCMOOption(commandLine: &commandLine)
+
     try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
     try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
     try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
@@ -143,6 +145,13 @@ extension Driver {
                                    default: true)
 
     case .singleCompile:
+      // Non library-evolution builds require a single job, because cross-module-optimization is enabled by default.
+      if !parsedOptions.hasArgument(.enableLibraryEvolution),
+         !parsedOptions.hasArgument(.disableCrossModuleOptimization),
+         let opt = parsedOptions.getLast(in: .O), opt.option != .Onone {
+        return false
+      }
+
       return parsedOptions.hasFlag(positive: .emitModuleSeparatelyWMO,
                                    negative: .noEmitModuleSeparatelyWMO,
                                    default: true) &&

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -300,6 +300,14 @@ extension Driver {
                                                            driver: self)
   }
 
+  /// Add options to disable cross-module-optimization.
+  mutating func addDisableCMOOption(commandLine: inout [Job.ArgTemplate]) {
+    if parsedOptions.hasArgument(.disableCrossModuleOptimization) {
+      commandLine.appendFlag(.Xllvm)
+      commandLine.appendFlag("-sil-disable-pass=cmo")
+    }
+  }
+
   mutating func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate],
                                                         primaryInputs: [TypedVirtualPath],
                                                         inputsGeneratingCodeCount: Int,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -61,6 +61,7 @@ extension Option {
   public static let continueBuildingAfterErrors: Option = Option("-continue-building-after-errors", .flag, attributes: [.frontend, .doesNotAffectIncrementalBuild], helpText: "Continue building, even after errors are encountered")
   public static let coveragePrefixMap: Option = Option("-coverage-prefix-map", .separate, attributes: [.frontend], metaVar: "<prefix=replacement>", helpText: "Remap source paths in coverage info")
   public static let CrossModuleOptimization: Option = Option("-cross-module-optimization", .flag, attributes: [.helpHidden, .frontend], helpText: "Perform cross-module optimization")
+  public static let disableCrossModuleOptimization: Option = Option("-disable-cmo", .flag, attributes: [.helpHidden, .frontend], helpText: "Disable cross-module optimization")
   public static let crosscheckUnqualifiedLookup: Option = Option("-crosscheck-unqualified-lookup", .flag, attributes: [.frontend, .noDriver], helpText: "Compare legacy DeclContext- to ASTScope-based unqualified name lookup (for debugging)")
   public static let c: Option = Option("-c", .flag, alias: Option.emitObject, attributes: [.frontend, .noInteractive], group: .modes)
   public static let debugAssertAfterParse: Option = Option("-debug-assert-after-parse", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Force an assertion failure after parsing", group: .debugCrash)
@@ -704,6 +705,7 @@ extension Option {
       Option.continueBuildingAfterErrors,
       Option.coveragePrefixMap,
       Option.CrossModuleOptimization,
+      Option.disableCrossModuleOptimization,
       Option.crosscheckUnqualifiedLookup,
       Option.c,
       Option.debugAssertAfterParse,


### PR DESCRIPTION
The driver splits the compile job into two jobs: one for creating the object file, one for emitting the swiftmodule.
For the swiftmodule-job the driver adds -experimental-skip-non-inlinable-function-bodies-without-types.
This breaks CMO, because in CMO, the inlinable-decision is not derived from the AST but done in the optimizer.

As a quick hack we could disable -experimental-skip-non-inlinable-function-bodies-without-types.
But for CMO, the two-job approach is highly problematic, because it risks the two compile jobs to get out of sync, e.g. by different command line options, indeterministic behavior, etc. This can result in unresolved symbol errors, which are very hard to debug.

This change also adds a new option `-disable-cmo` to disable cross-module-optimization. It can be used to go back to the old behavior.

rdar://89223981