### PR TITLE
Toolchains: introduce `clangxx` tool (NFC)

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -71,6 +71,8 @@ public final class DarwinToolchain: Toolchain {
       return try lookup(executable: "dsymutil")
     case .clang:
       return try lookup(executable: "clang")
+    case .clangxx:
+      return try lookup(executable: "clang++")
     case .swiftAutolinkExtract:
       return try lookup(executable: "swift-autolink-extract")
     case .lldb:

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -73,6 +73,8 @@ public final class GenericUnixToolchain: Toolchain {
       return try lookup(executable: "clang")
     case .clang:
       return try lookup(executable: "clang")
+    case .clangxx:
+      return try lookup(executable: "clang++")
     case .swiftAutolinkExtract:
       return try lookup(executable: "swift-autolink-extract")
     case .dsymutil:

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -19,6 +19,7 @@ public enum Tool: Hashable {
   case staticLinker(LTOKind?)
   case dynamicLinker
   case clang
+  case clangxx
   case swiftAutolinkExtract
   case dsymutil
   case lldb

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -97,6 +97,8 @@ public final class WebAssemblyToolchain: Toolchain {
       return try lookup(executable: "clang")
     case .clang:
       return try lookup(executable: "clang")
+    case .clangxx:
+      return try lookup(executable: "clang++")
     case .swiftAutolinkExtract:
       return try lookup(executable: "swift-autolink-extract")
     case .dsymutil:

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -73,6 +73,8 @@ extension WindowsToolchain.ToolchainValidationError {
       return try lookup(executable: "clang.exe")
     case .clang:
       return try lookup(executable: "clang.exe")
+    case .clangxx:
+      return try lookup(executable: "clang++.exe")
     case .swiftAutolinkExtract:
       return try lookup(executable: "swift-autolink-extract.exe")
     case .lldb:


### PR DESCRIPTION
This introduces a new `clangxx` tool which maps to `clang++`.  This is
required to ensure that we are able to support linking against the C++
runtime with C++ interop is enabled.