### PR TITLE
SwiftDriver: use `clang++` as linker driver with C++ Interop

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -102,13 +102,17 @@ extension GenericUnixToolchain {
       // Windows rather than msvcprt).  When C++ interop is enabled, we will need to
       // surface this via a driver flag.  For now, opt for the simpler approach of
       // just using `clang` and avoid a dependency on the C++ runtime.
-      var clangPath = try getToolPath(.clang)
+      var clangPath = try parsedOptions.hasArgument(.enableExperimentalCxxInterop)
+                          ? getToolPath(.clangxx)
+                          : getToolPath(.clang)
       if let toolsDirPath = parsedOptions.getLastArgument(.toolsDirectory) {
         // FIXME: What if this isn't an absolute path?
         let toolsDir = try AbsolutePath(validating: toolsDirPath.asSingle)
 
         // If there is a clang in the toolchain folder, use that instead.
-        if let tool = lookupExecutablePath(filename: "clang", searchPaths: [toolsDir]) {
+        if let tool = lookupExecutablePath(filename: parsedOptions.hasArgument(.enableExperimentalCxxInterop)
+                                                        ? "clang++" : "clang",
+                                           searchPaths: [toolsDir]) {
           clangPath = tool
         }
 

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -47,7 +47,9 @@ extension WindowsToolchain {
       return try lookup(executable: librarian)
     }
 
-    var clang = try getToolPath(.clang)
+    var clang = try parsedOptions.hasArgument(.enableExperimentalCxxInterop)
+                    ? getToolPath(.clangxx)
+                    : getToolPath(.clang)
 
     let targetTriple = targetInfo.target.triple
     if !targetTriple.triple.isEmpty {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6060,6 +6060,22 @@ final class SwiftDriverTests: XCTestCase {
     }
 #endif
   }
+
+  func testCxxLinking() throws {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+      throw XCTSkip("Darwin does not use clang as the linker driver")
+#else
+      VirtualPath.resetTemporaryFileStore()
+      var driver = try Driver(args: [
+        "swiftc", "-enable-experimental-cxx-interop", "-emit-library", "-o", "library.dll", "library.obj"
+      ])
+      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(jobs.count, 1)
+      let job = jobs.first!
+      XCTAssertEqual(job.kind, .link)
+      XCTAssertTrue(job.tool.name.hasSuffix(executableName("clang++")))
+#endif
+  }
 }
 
 func assertString(


### PR DESCRIPTION
This adjusts the linker job construction to switch the linker driver to
the C++ compiler driver as the linker driver when C++ interop is
enabled.  This allows us to ensure that we properly link against the C++
runtime which should be assumed to be needed with C++ interop.  This is
required for further exploration of C++ interop.