### PR TITLE
[Incremental Builds] Produce an empty first wave if only job to run is verify module interface job.

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -331,6 +331,14 @@ extension IncrementalCompilationTests {
     XCTAssertTrue(mandatoryJobs.isEmpty)
   }
 
+    func testNullBuildNoVerify() throws {
+      let extraArguments = ["-experimental-emit-module-separately", "-emit-module", "-emit-module-interface", "-enable-library-evolution", "-verify-emitted-module-interface"]
+      try buildInitialState(extraArguments: extraArguments)
+      let driver = try checkNullBuild(extraArguments: extraArguments)
+      let mandatoryJobs = try XCTUnwrap(driver.incrementalCompilationState?.mandatoryJobsInOrder)
+      XCTAssertTrue(mandatoryJobs.isEmpty)
+    }
+
   func testSymlinkModification() throws {
     // Remap
     // main.swift -> links/main.swift


### PR DESCRIPTION
Existing check decides to skip all compilation if there are no compile jobs and no post-compile job depends on before-compile jobs' outputs. This change refines the check to also ensure we do not run before-compile jobs whose only dependents are interface verification jobs. Otherwise, we would have an emit-module job, followed by verify-module-interface jobs on a null incremental build.

Resolves rdar://89913538