### PR TITLE
Using lld as default linker.

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -22,12 +22,12 @@ extension GenericUnixToolchain {
     case .arm, .aarch64, .armeb, .thumb, .thumbeb:
       // BFD linker has issues wrt relocation of the protocol conformance
       // section on these targets, it also generates COPY relocations for
-      // final executables, as such, unless specified, we default to gold
+      // final executables, as such, unless specified, we default to lld
       // linker.
-      return "gold"
+      return "lld"
     case .x86, .x86_64, .ppc64, .ppc64le, .systemz:
       // BFD linker has issues wrt relocations against protected symbols.
-      return "gold"
+      return "lld"
     default:
       // Otherwise, use the default BFD linker.
       return ""


### PR DESCRIPTION
`lld` is Swift toolchain builtin linker, but not used by default. 

If I want to use `lld`, I must install `gold` first and add `-use-ld=lld` flag.

`gold` is included in package `binutils` on Debian/Ubuntu, it is not installed by default.

On a minimal Linux OS, We can just install Swift toolchain.
