### PR TITLE
Replace `AbsolutePath.appending(_:)` for deprecations

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -529,7 +529,7 @@ extension Driver {
     // Create directories for each Swift module
     try inputMap.forEach {
       assert(!$0.value.isEmpty)
-      let moduleDir = prebuiltModuleDir.appending(RelativePath($0.key + ".swiftmodule"))
+      let moduleDir = AbsolutePath("\($0.key).swiftmodule", relativeTo: prebuiltModuleDir)
       if !localFileSystem.exists(moduleDir) {
         try localFileSystem.createDirectory(moduleDir)
       }
@@ -539,8 +539,9 @@ extension Driver {
     let outputMap: [String: [PrebuiltModuleOutput]] =
       Dictionary.init(uniqueKeysWithValues: inputMap.map { key, value in
       let outputPaths: [PrebuiltModuleInput] = value.map {
-        let path = prebuiltModuleDir.appending(RelativePath(key + ".swiftmodule"))
-          .appending(RelativePath($0.path.file.basenameWithoutExt + ".swiftmodule"))
+        let path = AbsolutePath("\($0.path.file.basenameWithoutExt).swiftmodule",
+                                relativeTo: AbsolutePath("\(key).swiftmodule",
+                                                         relativeTo: prebuiltModuleDir))
         return PrebuiltModuleOutput(TypedVirtualPath(file: VirtualPath.absolute(path).intern(),
                                                      type: .swiftModule), $0.arch)
       }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -96,7 +96,7 @@ public final class DarwinToolchain: Toolchain {
 
   /// Path to the StdLib inside the SDK.
   public func sdkStdlib(sdk: AbsolutePath) -> AbsolutePath {
-    sdk.appending(RelativePath("usr/lib/swift"))
+    AbsolutePath("usr/lib/swift", relativeTo: sdk)
   }
 
   public func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String {

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -97,7 +97,7 @@ extension WindowsToolchain.ToolchainValidationError {
   }
 
   public func sdkStdlib(sdk: AbsolutePath) -> AbsolutePath {
-    sdk.appending(RelativePath("usr/lib/swift"))
+    AbsolutePath("usr/lib/swift", relativeTo: sdk)
   }
 
   public func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String {

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -73,7 +73,7 @@ do {
   // append the SDK version number so all modules will built into
   // the SDK-versioned sub-directory.
   if outputDir.basename == "prebuilt-modules" {
-    outputDir = outputDir.appending(RelativePath(collector.versionString))
+    outputDir = AbsolutePath(collector.versionString, relativeTo: outputDir)
   }
   if !localFileSystem.exists(outputDir) {
     try localFileSystem.createDirectory(outputDir, recursive: true)
@@ -83,10 +83,12 @@ do {
   if let swiftcPathRaw = swiftcPathRaw {
     swiftcPath = try VirtualPath(path: swiftcPathRaw).absolutePath!
   } else {
-    swiftcPath = sdkPath.parentDirectory.parentDirectory.parentDirectory
-      .parentDirectory.parentDirectory.appending(RelativePath("Toolchains"))
-      .appending(RelativePath("XcodeDefault.xctoolchain")).appending(RelativePath("usr"))
-      .appending(RelativePath("bin")).appending(RelativePath("swiftc"))
+    swiftcPath = AbsolutePath("Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
+                              relativeTo: sdkPath.parentDirectory
+                                                 .parentDirectory
+                                                 .parentDirectory
+                                                 .parentDirectory
+                                                 .parentDirectory)
   }
   if !localFileSystem.exists(swiftcPath) {
     diagnosticsEngine.emit(error: "cannot find swift compiler: \(swiftcPath.pathString)")

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -95,7 +95,7 @@ final class IntegrationTests: IntegrationTestCase {
         environment: ProcessEnv.vars.merging(extraEnv) { $1 }
       )
 
-      XCTAssertTrue(localFileSystem.isExecutableFile(buildPath.appending(RelativePath("debug/swift-driver"))), result)
+      XCTAssertTrue(localFileSystem.isExecutableFile(AbsolutePath("debug/swift-driver", relativeTo: buildPath)), result)
     }
   #endif
   }

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -76,12 +76,12 @@ extension DarwinToolchain {
   /// macOS resource directory, for testing only.
   var resourcesDirectory: Result<AbsolutePath, Swift.Error> {
     return Result {
-      try getToolPath(.swiftCompiler).appending(RelativePath("../../lib/swift/macosx"))
+      try AbsolutePath("../../lib/swift/macosx", relativeTo: getToolPath(.swiftCompiler))
     }
   }
 
   var clangRT: Result<AbsolutePath, Error> {
-    resourcesDirectory.map { $0.appending(RelativePath("../clang/lib/darwin/libclang_rt.osx.a")) }
+    resourcesDirectory.map { AbsolutePath("../clang/lib/darwin/libclang_rt.osx.a", relativeTo: $0) }
   }
 
   var compatibility50: Result<AbsolutePath, Error> {


### PR DESCRIPTION
Replace instances of `AbsolutePath.appending(RelativePath(_:))` with
`AbsolutePath(_:relativeTo:)` in light of the deprecation of the old
spelling.  This is particularly important for Windows which will now
properly normalize and canonicalize the path when constructed in the
new spelling.