### PR TITLE
[5.6] Added Armv5 support

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -44,6 +44,7 @@ extension GenericUnixToolchain {
     //       'armv6', so just take a brute-force approach
     if triple.archName.contains("armv7") { return "armv7" }
     if triple.archName.contains("armv6") { return "armv6" }
+    if triple.archName.contains("armv5") { return "armv5" }
     return triple.archName
   }
 


### PR DESCRIPTION
Backported https://github.com/apple/swift-driver/pull/1027 for Swift 5.6 release.