### PR TITLE
Always emitting private swift interfaces if public interfaces are emitted

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2292,6 +2292,18 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testPrivateInterfacePathImplicit() throws {
+    var driver1 = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
+                                   "foo", "-emit-module-interface",
+                                   "-enable-library-evolution"])
+
+    let plannedJobs = try driver1.planBuild()
+    XCTAssertEqual(plannedJobs.count, 2)
+    let emitInterfaceJob = plannedJobs[0]
+    XCTAssertTrue(emitInterfaceJob.commandLine.contains(.flag("-emit-module-interface-path")))
+    XCTAssertTrue(emitInterfaceJob.commandLine.contains(.flag("-emit-private-module-interface-path")))
+  }
+
   func testSingleThreadedWholeModuleOptimizationCompiles() throws {
     var envVars = ProcessEnv.vars
     envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)


### PR DESCRIPTION
With the introduction of features like @_spi_available, we may print public and private interfaces differently even from the same codebase without @_spi. For this reason, we should always print private interfaces so that we don’t mix the public interfaces with private Clang modules.

rdar://91061334