### PR TITLE
Track serialized diagnostics of emit-module jobs separately.

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -90,10 +90,11 @@ extension Driver {
     case .swiftModule:
       return compilerMode.isSingleCompilation && moduleOutputInfo.output?.isTopLevel ?? false
     case .swift, .image, .dSYM, .dependencies, .autolink, .swiftDocumentation, .swiftInterface,
-         .privateSwiftInterface, .swiftSourceInfoFile, .diagnostics, .objcHeader, .swiftDeps,
-         .remap, .tbd, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm,
-         .pch, .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
-         .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline, nil:
+         .privateSwiftInterface, .swiftSourceInfoFile, .diagnostics, .emitModuleDiagnostics,
+         .objcHeader, .swiftDeps, .remap, .tbd, .moduleTrace, .yamlOptimizationRecord,
+         .bitstreamOptimizationRecord, .pcm, .pch, .clangModuleMap, .jsonCompilerFeatures,
+         .jsonTargetInfo, .jsonSwiftArtifacts, .indexUnitOutputPath, .modDepCache,
+         .jsonAPIBaseline, .jsonABIBaseline, nil:
       return false
     }
   }
@@ -446,7 +447,7 @@ extension FileType {
       return .emitSupportedFeatures
 
     case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
-         .diagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
+          .diagnostics, .emitModuleDiagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
          .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
          .privateSwiftInterface, .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts,
          .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline:

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -39,14 +39,14 @@ extension Driver {
       return
     }
 
+    addSupplementalOutput(path: emitModuleSerializedDiagnosticsFilePath, flag: "-serialize-diagnostics-path", type: .emitModuleDiagnostics)
+
     // Skip files created by other jobs when emitting a module and building at the same time
     if emitModuleSeparately && compilerOutputType != .swiftModule {
       return
     }
 
     // Add outputs that can't be merged
-    addSupplementalOutput(path: serializedDiagnosticsFilePath, flag: "-serialize-diagnostics-path", type: .diagnostics)
-
     // Workaround for rdar://85253406
     // Ensure that the separate emit-module job does not emit `.d.` outputs.
     // If we have both individual source files and the emit-module file emit .d files, we

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -75,6 +75,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// Clang/Swift serialized diagnostics
   case diagnostics = "dia"
 
+  /// Serialized diagnostics produced by module-generation
+  case emitModuleDiagnostics = "emit-module.dia"
+
   /// Objective-C header
   case objcHeader = "h"
 
@@ -214,6 +217,9 @@ extension FileType: CustomStringConvertible {
     case .diagnostics:
       return "diagnostics"
 
+    case .emitModuleDiagnostics:
+      return "emit-module-diagnostics"
+
     case .jsonAPIBaseline:
       return "api-baseline-json"
 
@@ -232,7 +238,7 @@ extension FileType {
       return true
     case .object, .pch, .ast, .llvmIR, .llvmBitcode, .assembly, .swiftModule,
          .importedModules, .indexData, .remap, .dSYM, .autolink, .dependencies,
-         .swiftDocumentation, .pcm, .diagnostics, .objcHeader, .image,
+         .swiftDocumentation, .pcm, .diagnostics, .emitModuleDiagnostics, .objcHeader, .image,
          .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
          .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile, .jsonDependencies,
          .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures, .jsonSwiftArtifacts,
@@ -329,6 +335,8 @@ extension FileType {
       return "bitstream-opt-record"
     case .diagnostics:
       return "diagnostics"
+    case .emitModuleDiagnostics:
+      return "emit-module-diagnostics"
     case .indexUnitOutputPath:
       return "index-unit-output-path"
     case .jsonAPIBaseline:
@@ -351,7 +359,7 @@ extension FileType {
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
          .pcm, .swiftDeps, .remap, .indexData, .bitstreamOptimizationRecord,
-         .indexUnitOutputPath, .modDepCache:
+         .indexUnitOutputPath, .modDepCache, .emitModuleDiagnostics:
       return false
     }
   }
@@ -364,7 +372,7 @@ extension FileType {
       return true
     case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .autolink,
          .swiftModule, .swiftDocumentation, .swiftInterface, .privateSwiftInterface,
-         .swiftSourceInfoFile, .raw_sil, .raw_sib, .diagnostics, .objcHeader, .swiftDeps, .remap,
+         .swiftSourceInfoFile, .raw_sil, .raw_sib, .diagnostics, .emitModuleDiagnostics, .objcHeader, .swiftDeps, .remap,
          .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord, .modDepCache,
          .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies, .clangModuleMap,
          .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts, .indexUnitOutputPath, .jsonAPIBaseline,

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -19,6 +19,7 @@ extension Option {
   public static let emitModuleSeparately: Option = Option("-experimental-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job")
   public static let emitModuleSeparatelyWMO: Option = Option("-emit-module-separately-wmo", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job in wmo builds")
   public static let noEmitModuleSeparatelyWMO: Option = Option("-no-emit-module-separately-wmo", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job in wmo builds")
+  public static let emitModuleSerializeDiagnosticsPath: Option = Option("-emit-module-serialize-diagnostics-path", .separate, attributes: [.argumentIsPath, .supplementaryOutput], metaVar: "<path>", helpText: "Emit a serialized diagnostics file for the emit-module task to <path>")
   public static let useFrontendParseableOutput: Option = Option("-use-frontend-parseable-output", .flag, attributes: [.helpHidden], helpText: "Emit parseable-output from swift-frontend jobs instead of from the driver")
 
   // API digester operations


### PR DESCRIPTION
When serialized diagnostics are requested by the build system, it is expected to provide an output-file-map to specify per-file diagnostic output paths. The build system may also request serialized diagnostics module-wide in WMO compilation by specifying an output-file-map entry of module scope (`""`).

Emit-module jobs are always run at module scope, which means that if we want to get serialized diagnostics from the emit-module job, in WMO we do not know which path to use, because the module-scope path is specified for the WMO compilation job.

This change introduces a separate output path for the emit-module serialized diagnostics to be specified either:
- On the command-line with `-emit-module-serialize-diagnostics-path`
- In the output file-map using key `"emit-module-diagnostics": "…/…emit-module.dia"` at global (module) scope.

Resolves rdar://83110325