### PR TITLE
Revert "Add support for `-enable-regex-literals` flag"

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -206,9 +206,6 @@ extension Driver {
     try commandLine.appendAll(.coveragePrefixMap, from: &parsedOptions)
     try commandLine.appendLast(.warnConcurrency, from: &parsedOptions)
     try commandLine.appendAll(.moduleAlias, from: &parsedOptions)
-    if isFrontendArgSupported(.enableRegexLiterals) {
-      try commandLine.appendLast(.enableRegexLiterals, from: &parsedOptions)
-    }
 
     // Expand the -experimental-hermetic-seal-at-link flag
     if parsedOptions.hasArgument(.experimentalHermeticSealAtLink) {

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -327,7 +327,6 @@ extension Option {
   public static let enableOssaModules: Option = Option("-enable-ossa-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Always serialize SIL in ossa form. If this flag is not passed in, when optimizing ownership will be lowered before serializing SIL")
   public static let enableParameterizedProtocolTypes: Option = Option("-enable-parameterized-protocol-types", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental support for primary associated types and parameterized protocols")
   public static let enablePrivateImports: Option = Option("-enable-private-imports", .flag, attributes: [.helpHidden, .frontend, .noInteractive], helpText: "Allows this module's internal and private API to be accessed")
-  public static let enableRegexLiterals: Option = Option("-enable-regex-literals", .flag, attributes: [.frontend], helpText: "Enable the use of regular-expression literals")
   public static let enableRequirementMachineOpaqueArchetypes: Option = Option("-enable-requirement-machine-opaque-archetypes", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable more correct opaque archetype support, which is off by default because it might fail to produce a convergent rewrite system")
   public static let enableResilience: Option = Option("-enable-resilience", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Deprecated, use -enable-library-evolution instead")
   public static let enableSilOpaqueValues: Option = Option("-enable-sil-opaque-values", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable SIL Opaque Values")
@@ -993,7 +992,6 @@ extension Option {
       Option.enableOssaModules,
       Option.enableParameterizedProtocolTypes,
       Option.enablePrivateImports,
-      Option.enableRegexLiterals,
       Option.enableRequirementMachineOpaqueArchetypes,
       Option.enableResilience,
       Option.enableSilOpaqueValues,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3048,19 +3048,6 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertTrue(plannedJobs[0].commandLine.contains(.path(try VirtualPath(path: modulePath))))
   }
 
-  func testEnableRegexLiteralFlag() throws {
-    var driver = try Driver(args: ["swiftc", "foo.swift", "-enable-regex-literals"])
-    guard driver.isFrontendArgSupported(.enableRegexLiterals) else {
-      throw XCTSkip("Skipping: compiler does not support '-enable-regex-literals'")
-    }
-    let plannedJobs = try driver.planBuild()
-    XCTAssertEqual(plannedJobs.count, 2)
-    XCTAssertEqual(plannedJobs[0].kind, .compile)
-    XCTAssertEqual(plannedJobs[1].kind, .link)
-    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-frontend")))
-    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-enable-regex-literals")))
-  }
-
   func testImmediateMode() throws {
     do {
       var driver = try Driver(args: ["swift", "foo.swift"])


### PR DESCRIPTION
Reverts apple/swift-driver#1045 due to failures on several bots. (It looks like the test needs to be more flexible to accommodate non-Darwin platforms.)

Workaround for rdar://91190206.