### PR TITLE
SwiftDriver: unlearn about `DEVELOPER_DIR`

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -230,14 +230,6 @@ extension Toolchain {
       return try lookup(executable: executableName("swift"))
     } else if fallbackToExecutableDefaultPath {
       if self is WindowsToolchain {
-        if let DEVELOPER_DIR = env["DEVELOPER_DIR"] {
-          return AbsolutePath(DEVELOPER_DIR)
-                    .appending(component: "Toolchains")
-                    .appending(component: "unknown-Asserts-development.xctoolchain")
-                    .appending(component: "usr")
-                    .appending(component: "bin")
-                    .appending(component: executableName(executable))
-        }
         return try getToolPath(.swiftCompiler)
                 .parentDirectory
                 .appending(component: executable)

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -109,21 +109,9 @@ extension WindowsToolchain.ToolchainValidationError {
   }
 
   public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {
-    // The SDKROOT environment always takes precedent.  If SDKROOT is undefined,
-    // but we have DEVELOPER_DIR defined and a valid triple, compose the SDK
-    // root relative to the DEVELOPER_DIR.  The SDKs are always laid out as
-    // `[DeveloperDir]\Platforms\[OS].platform\Developer\SDKs\[OS].sdk`,
-    // allowing us to locate it relative to the DEVELOPER_DIR environment
-    // variable.
-
     // TODO(compnerd): replicate the SPM processing of the SDKInfo.plist
     if let SDKROOT = env["SDKROOT"] {
       return AbsolutePath(SDKROOT)
-    } else if let DEVELOPER_DIR = env["DEVELOPER_DIR"], let os = target?.os?.rawValue {
-      // FIXME(compnerd) we should capitalise the OS name, e.g. windows ->
-      // Windows; we get away with this for now as Windows has a
-      // case-insensitive file system.
-      return AbsolutePath("\(DEVELOPER_DIR)\\Platforms\\\(os).platform\\Developer\\SDKs\\\(os).sdk")
     }
     return nil
   }

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -48,8 +48,6 @@ private let cachedSDKPath: Result<String, Error>? = {
   #if os(Windows)
   if let sdk = ProcessEnv.vars["SDKROOT"] {
     return Result{sdk}
-  } else if let root = ProcessEnv.vars["DEVELOPER_DIR"] {
-    return Result{"\(root)\\Platforms\\Windows.platform\\Developer\\SDKs\\Windows.sdk"}
   }
   // Assume that if neither of the environment variables are set, we are
   // using a build-tree version of the swift frontend, and so we do not set


### PR DESCRIPTION
The toolchain should not really consult `DEVELOPER_DIR`.  While this was
initially useful, as the toolchain distribution grows and matures, it is
desirable to restore the ability to have disjoint and re-rooted installs
on Windows.  As a result, `DEVELOPER_DIR` would no longer be as valuable
for identifying the locations as the toolchain may be installed separate
from the SDKs.  This is inline with swift-package-manager which now also
has unlearnt this variable. `SDKROOT` remains as a means for the user to
specify the SDK implicitly through the environment.