### PR TITLE
TestUtilities: silence warning from updated swift-tools-support-core

### DIFF
--- a/Tests/TestUtilities/Fixture.swift
+++ b/Tests/TestUtilities/Fixture.swift
@@ -29,14 +29,12 @@ public enum Fixture {
     for file: String,
     on fileSystem: FileSystem = localFileSystem
   ) -> AbsolutePath? {
-    let packageRootPath = AbsolutePath(#file)
-      .parentDirectory
-      .parentDirectory
-      .parentDirectory
-    let fixturePath = packageRootPath
-      .appending(component: "TestInputs")
-      .appending(relativePath)
-      .appending(component: file)
+    let packageRootPath: AbsolutePath =
+        AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+    let fixturePath =
+        AbsolutePath(relativePath.pathString,
+                     relativeTo: packageRootPath.appending(component: "TestInputs"))
+            .appending(component: file)
 
     // Check that the fixture is really there.
     guard fileSystem.exists(fixturePath) else {


### PR DESCRIPTION
The `AbsolutePath.appending(_:RelativePath)` interface was deprecated in
favour of `AbsolutePath(_:relativeTo:)` which allows us to anchor the
relative path which is needed to properly form relative paths on
Windows.  This updates the API usage in swift-driver accordingly.