### PR TITLE
Create discovered dependencies file for emit-module jobs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -281,6 +281,9 @@ public struct Driver {
   /// Path to the serialized diagnostics file of the emit-module task.
   let emitModuleSerializedDiagnosticsFilePath: VirtualPath.Handle?
 
+  /// Path to the discovered dependencies file of the emit-module task.
+  let emitModuleDependenciesFilePath: VirtualPath.Handle?
+
   /// Path to the Objective-C generated header.
   let objcGeneratedHeaderPath: VirtualPath.Handle?
 
@@ -707,6 +710,14 @@ public struct Driver {
     self.emitModuleSerializedDiagnosticsFilePath = try Self.computeSupplementaryOutputPath(
         &parsedOptions, type: .emitModuleDiagnostics, isOutputOptions: [.serializeDiagnostics],
         outputPath: .emitModuleSerializeDiagnosticsPath,
+        compilerOutputType: compilerOutputType,
+        compilerMode: compilerMode,
+        emitModuleSeparately: emitModuleSeparately,
+        outputFileMap: self.outputFileMap,
+        moduleName: moduleOutputInfo.name)
+    self.emitModuleDependenciesFilePath = try Self.computeSupplementaryOutputPath(
+        &parsedOptions, type: .emitModuleDependencies, isOutputOptions: [.emitDependencies],
+        outputPath: .emitModuleDependenciesPath,
         compilerOutputType: compilerOutputType,
         compilerMode: compilerMode,
         emitModuleSeparately: emitModuleSeparately,
@@ -3000,6 +3011,14 @@ extension Driver {
     // file
     if type == .emitModuleDiagnostics,
        let singleOutputPath = outputFileMap?.existingOutputForSingleInput(
+           outputType: type) {
+      return singleOutputPath
+    }
+    
+    // Emit-module discovered dependencies are always specified as a single-output
+    // file
+    if type == .emitModuleDependencies,
+      let singleOutputPath = outputFileMap?.existingOutputForSingleInput(
            outputType: type) {
       return singleOutputPath
     }

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -89,12 +89,12 @@ extension Driver {
       }
     case .swiftModule:
       return compilerMode.isSingleCompilation && moduleOutputInfo.output?.isTopLevel ?? false
-    case .swift, .image, .dSYM, .dependencies, .autolink, .swiftDocumentation, .swiftInterface,
-         .privateSwiftInterface, .swiftSourceInfoFile, .diagnostics, .emitModuleDiagnostics,
-         .objcHeader, .swiftDeps, .remap, .tbd, .moduleTrace, .yamlOptimizationRecord,
-         .bitstreamOptimizationRecord, .pcm, .pch, .clangModuleMap, .jsonCompilerFeatures,
-         .jsonTargetInfo, .jsonSwiftArtifacts, .indexUnitOutputPath, .modDepCache,
-         .jsonAPIBaseline, .jsonABIBaseline, nil:
+    case .swift, .image, .dSYM, .dependencies, .emitModuleDependencies, .autolink,
+         .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile,
+         .diagnostics, .emitModuleDiagnostics, .objcHeader, .swiftDeps, .remap, .tbd,
+         .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm, .pch,
+         .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
+         .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline, nil:
       return false
     }
   }
@@ -446,10 +446,11 @@ extension FileType {
     case .jsonCompilerFeatures:
       return .emitSupportedFeatures
 
-    case .swift, .dSYM, .autolink, .dependencies, .swiftDocumentation, .pcm,
-          .diagnostics, .emitModuleDiagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd,
-         .yamlOptimizationRecord, .bitstreamOptimizationRecord, .swiftInterface,
-         .privateSwiftInterface, .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts,
+    case .swift, .dSYM, .autolink, .dependencies, .emitModuleDependencies,
+         .swiftDocumentation, .pcm, .diagnostics, .emitModuleDiagnostics,
+         .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord,
+         .bitstreamOptimizationRecord, .swiftInterface, .privateSwiftInterface,
+         .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts,
          .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline:
       fatalError("Output type can never be a primary output")
     }

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -40,6 +40,8 @@ extension Driver {
     }
 
     addSupplementalOutput(path: emitModuleSerializedDiagnosticsFilePath, flag: "-serialize-diagnostics-path", type: .emitModuleDiagnostics)
+    
+    addSupplementalOutput(path: emitModuleDependenciesFilePath, flag: "-emit-dependencies-path", type: .emitModuleDependencies)
 
     // Skip files created by other jobs when emitting a module and building at the same time
     if emitModuleSeparately && compilerOutputType != .swiftModule {

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -77,6 +77,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
 
   /// Serialized diagnostics produced by module-generation
   case emitModuleDiagnostics = "emit-module.dia"
+  
+  /// Serialized diagnostics produced by module-generation
+  case emitModuleDependencies = "emit-module.d"
 
   /// Objective-C header
   case objcHeader = "h"
@@ -150,9 +153,10 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
 extension FileType: CustomStringConvertible {
   public var description: String {
     switch self {
-    case .swift, .sil, .sib, .image, .dSYM, .dependencies, .autolink,
-         .swiftModule, .swiftDocumentation, .swiftInterface, .swiftSourceInfoFile, .assembly,
-         .remap, .tbd, .pcm, .pch, .clangModuleMap:
+    case .swift, .sil, .sib, .image, .dSYM, .dependencies, .emitModuleDependencies,
+         .autolink, .swiftModule, .swiftDocumentation, .swiftInterface,
+         .swiftSourceInfoFile, .assembly, .remap, .tbd, .pcm, .pch,
+         .clangModuleMap:
       return rawValue
     case .object:
       return "object"
@@ -238,11 +242,13 @@ extension FileType {
       return true
     case .object, .pch, .ast, .llvmIR, .llvmBitcode, .assembly, .swiftModule,
          .importedModules, .indexData, .remap, .dSYM, .autolink, .dependencies,
-         .swiftDocumentation, .pcm, .diagnostics, .emitModuleDiagnostics, .objcHeader, .image,
-         .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
-         .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile, .jsonDependencies,
-         .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures, .jsonSwiftArtifacts,
-         .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline:
+         .emitModuleDependencies, .swiftDocumentation, .pcm, .diagnostics,
+         .emitModuleDiagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace,
+         .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
+         .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile,
+         .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures,
+         .jsonSwiftArtifacts, .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline,
+         .jsonABIBaseline:
       return false
     }
   }
@@ -275,6 +281,8 @@ extension FileType {
       return "dSYM"
     case .dependencies:
       return "dependencies"
+    case .emitModuleDependencies:
+      return "emit-module-dependencies"
     case .autolink:
       return "autolink"
     case .swiftModule:
@@ -350,11 +358,11 @@ extension FileType {
 extension FileType {
   var isTextual: Bool {
     switch self {
-    case .swift, .sil, .dependencies, .assembly, .ast, .raw_sil, .llvmIR,
-         .objcHeader, .autolink, .importedModules, .tbd, .moduleTrace,
-         .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface,
-         .jsonDependencies, .clangModuleMap, .jsonCompilerFeatures,
-         .jsonTargetInfo, .jsonSwiftArtifacts, .jsonAPIBaseline, .jsonABIBaseline:
+    case .swift, .sil, .dependencies, .emitModuleDependencies, .assembly, .ast,
+         .raw_sil, .llvmIR,.objcHeader, .autolink, .importedModules, .tbd,
+         .moduleTrace, .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface,
+         .jsonDependencies, .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo,
+         .jsonSwiftArtifacts, .jsonAPIBaseline, .jsonABIBaseline:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -370,13 +378,14 @@ extension FileType {
     switch self {
     case .assembly, .llvmIR, .llvmBitcode, .object:
       return true
-    case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .autolink,
-         .swiftModule, .swiftDocumentation, .swiftInterface, .privateSwiftInterface,
-         .swiftSourceInfoFile, .raw_sil, .raw_sib, .diagnostics, .emitModuleDiagnostics, .objcHeader, .swiftDeps, .remap,
-         .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord, .modDepCache,
-         .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies, .clangModuleMap,
-         .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts, .indexUnitOutputPath, .jsonAPIBaseline,
-         .jsonABIBaseline:
+    case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .emitModuleDependencies,
+         .autolink, .swiftModule, .swiftDocumentation, .swiftInterface,
+         .privateSwiftInterface, .swiftSourceInfoFile, .raw_sil, .raw_sib,
+         .diagnostics, .emitModuleDiagnostics, .objcHeader, .swiftDeps, .remap,
+         .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord,
+         .modDepCache, .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies,
+         .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
+         .indexUnitOutputPath, .jsonAPIBaseline, .jsonABIBaseline:
       return false
     }
   }

--- a/Sources/SwiftOptions/ExtraOptions.swift
+++ b/Sources/SwiftOptions/ExtraOptions.swift
@@ -20,6 +20,7 @@ extension Option {
   public static let emitModuleSeparatelyWMO: Option = Option("-emit-module-separately-wmo", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job in wmo builds")
   public static let noEmitModuleSeparatelyWMO: Option = Option("-no-emit-module-separately-wmo", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job in wmo builds")
   public static let emitModuleSerializeDiagnosticsPath: Option = Option("-emit-module-serialize-diagnostics-path", .separate, attributes: [.argumentIsPath, .supplementaryOutput], metaVar: "<path>", helpText: "Emit a serialized diagnostics file for the emit-module task to <path>")
+  public static let emitModuleDependenciesPath: Option = Option("-emit-module-dependencies-path", .separate, attributes: [.argumentIsPath, .supplementaryOutput], metaVar: "<path>", helpText: "Emit a discovered dependencies file for the emit-module task to <path>")
   public static let useFrontendParseableOutput: Option = Option("-use-frontend-parseable-output", .flag, attributes: [.helpHidden], helpText: "Emit parseable-output from swift-frontend jobs instead of from the driver")
 
   // API digester operations


### PR DESCRIPTION
Emit-module jobs might have different discovered dependencies and run in a different context where they need to get invalidated separately from the compile jobs.
With the new key "emit-module-dependencies" in the output file map the build system can specify that it expects a makefile-style dependency file at the given path.

rdar://91574616