### PR TITLE
[5.7] swiftinterface verification: disable verification for modules with generated headers

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5073,6 +5073,16 @@ final class SwiftDriverTests: XCTestCase {
       let verifyJob = plannedJobs.first(where: { $0.kind == .verifyModuleInterface })!
       XCTAssertFalse(verifyJob.commandLine.contains(.flag("-check-api-availability-only")))
     }
+
+    // Don't verify modules with compatibility headers.
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
+                                     "foo", "-emit-module-interface",
+                                     "-enable-library-evolution", "-emit-objc-header-path", "foo-Swift.h"],
+                              env: envVars)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.filter( { job in job.kind == .verifyModuleInterface}).count, 0)
+    }
   }
 
   func testPCHGeneration() throws {


### PR DESCRIPTION
Swiftinterface verification is incompatible with modules using generated headers. Let's disable the by default verification in such a case.

Cherry-pick of #1060
rdar://91711963