### PR TITLE
Revert "Disfavor current working directory when looking up executables"

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -206,14 +206,13 @@ extension Toolchain {
   /// looks in the `executableDir`, `xcrunFind` or in the `searchPaths`.
   /// - Parameter executable: executable to look for [i.e. `swift`].
   func lookup(executable: String) throws -> AbsolutePath {
-    if let overrideString = envVar(forExecutable: executableName(executable)),
-       let path = try? AbsolutePath(validating: overrideString) {
-      return path
+    if let overrideString = envVar(forExecutable: executableName(executable)) {
+      return try AbsolutePath(validating: overrideString)
     } else if let toolDir = toolDirectory,
-              let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: nil, searchPaths: [toolDir]) {
+              let path = lookupExecutablePath(filename: executableName(executable), searchPaths: [toolDir]) {
       // Looking for tools from the tools directory.
       return path
-    } else if let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: nil, searchPaths: [executableDir]) {
+    } else if let path = lookupExecutablePath(filename: executableName(executable), searchPaths: [executableDir]) {
       return path
     } else if let path = try? xcrunFind(executable: executableName(executable)) {
       return path


### PR DESCRIPTION
This PR is causing a Windows build failure. 

Reverts apple/swift-driver#991