### PR TITLE
[5.7] Set up an externally installed config file to specify block list for certain driver features

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -479,6 +479,13 @@ extension Driver {
     return []
   }
 
+  @_spi(Testing) public static func getAllConfiguredModules(withKey: String, _ configs: [AdopterConfig]) -> Set<String> {
+    let allModules = configs.flatMap {
+      return $0.key == withKey ? $0.moduleNames : []
+    }
+    return Set<String>(allModules)
+  }
+
   private mutating func addVerifyJobs(emitModuleJob: Job, addJob: (Job) -> Void )
   throws {
     // Turn this flag on by default with the env var or for public frameworks.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6011,6 +6011,10 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(configs.count, 1)
       XCTAssertEqual(configs[0].key, "SkipFeature1")
       XCTAssertEqual(configs[0].moduleNames, ["foo", "bar"])
+      let modules = Driver.getAllConfiguredModules(withKey: "SkipFeature1", configs)
+      XCTAssertTrue(modules.contains("foo"))
+      XCTAssertTrue(modules.contains("bar"))
+      XCTAssertTrue(Driver.getAllConfiguredModules(withKey: "SkipFeature2", configs).isEmpty)
     }
     try withTemporaryFile { file in
       try localFileSystem.writeFileContents(file.path) {


### PR DESCRIPTION
Instead of embedding a block list of module names to disable a certain feature, we should set up an externally installed config file for that purpose. Therefore, we don't need to rebuild swift-driver when the block list needs an update.

rdar://92407381