### PR TITLE
Use python3 not legacy python

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 from distutils import file_util


### PR DESCRIPTION
On most systems python is python2, and on macOS this fails if you don't have a python2 install or a python3 install that is overriding python.