### PR TITLE
Tests: adjust tests for improvements to path normalization in TSC

### DIFF
--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -388,7 +388,7 @@ final class JobExecutorTests: XCTestCase {
                   inputs: [], primaryInputs: [], outputs: [])
 #if os(Windows)
     XCTAssertEqual(try executor.description(of: job, forceResponseFiles: false),
-                   #""/path/to/the tool" "/with space" /withoutspace"#)
+                   #""\path\to\the tool" "\with space" \withoutspace"#)
 #else
     XCTAssertEqual(try executor.description(of: job, forceResponseFiles: false),
                    "'/path/to/the tool' '/with space' /withoutspace")

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -217,9 +217,9 @@ final class NonincrementalCompilationTests: XCTestCase {
   func testReadAndWriteBuildRecord() throws {
     let version = "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
     let options = "abbbfbcaf36b93e58efaadd8271ff142"
-    let file2 = "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"
-    let main = "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"
-    let gazorp = "/Volumes/gazorp.swift"
+    let file2: AbsolutePath = AbsolutePath("/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift")
+    let main: AbsolutePath = AbsolutePath("/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift")
+    let gazorp: AbsolutePath = AbsolutePath("/Volumes/gazorp.swift")
     let inputString =
       """
       version: "\(version)"
@@ -227,9 +227,9 @@ final class NonincrementalCompilationTests: XCTestCase {
       build_start_time: [1570318779, 32357931]
       build_end_time: [1580318779, 33357858]
       inputs:
-        "\(file2)": !dirty [1570318778, 0]
-        "\(main)": [1570083660, 0]
-        "\(gazorp)": !private [0, 0]
+        "\(file2.nativePathString(escaped: true))": !dirty [1570318778, 0]
+        "\(main.nativePathString(escaped: true))": [1570083660, 0]
+        "\(gazorp.nativePathString(escaped: true))": !private [0, 0]
 
       """
     let buildRecord = try XCTUnwrap (BuildRecord(contents: inputString, failedToReadOutOfDateMap: {_ in}))
@@ -241,20 +241,20 @@ final class NonincrementalCompilationTests: XCTestCase {
     XCTAssert(isCloseEnough(buildRecord.buildEndTime.legacyDriverSecsAndNanos,
                             [1580318779, 33357941]))
 
-    XCTAssertEqual(try! buildRecord.inputInfos[VirtualPath(path: file2 )]!.status,
+    XCTAssertEqual(try! buildRecord.inputInfos[VirtualPath(path: file2.pathString)]!.status,
                    .needsCascadingBuild)
     XCTAssert(try! isCloseEnough(
-                XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: file2 )])
+                XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: file2.pathString)])
                   .previousModTime.legacyDriverSecsAndNanos,
                 [1570318778, 0]))
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp)]).status,
+    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp.pathString)]).status,
                    .needsNonCascadingBuild)
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp)])
+    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp.pathString)])
                     .previousModTime.legacyDriverSecsAndNanos,
                    [0, 0])
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main  )]).status,
+    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main.pathString)]).status,
                    .upToDate)
-    XCTAssert(try! isCloseEnough(XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main  )])
+    XCTAssert(try! isCloseEnough(XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main.pathString)])
                                    .previousModTime.legacyDriverSecsAndNanos,
                                  [1570083660, 0]))
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -768,16 +768,19 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testOutputFileMapLoading() throws {
+    let objroot: AbsolutePath =
+        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+
     let contents = """
     {
       "": {
-        "swift-dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.swiftdeps"
+        "swift-dependencies": "\(objroot.appending(components: "master.swiftdeps").nativePathString(escaped: true))"
       },
       "/tmp/foo/Sources/foo/foo.swift": {
-        "dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.d",
-        "object": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.o",
-        "swiftmodule": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo~partial.swiftmodule",
-        "swift-dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swiftdeps"
+        "dependencies": "\(objroot.appending(components: "foo.d").nativePathString(escaped: true))",
+        "object": "\(objroot.appending(components: "foo.swift.o").nativePathString(escaped: true))",
+        "swiftmodule": "\(objroot.appending(components: "foo~partial.swiftmodule").nativePathString(escaped: true))",
+        "swift-dependencies": "\(objroot.appending(components: "foo.swiftdeps").nativePathString(escaped: true))"
       }
     }
     """
@@ -788,26 +791,29 @@ final class SwiftDriverTests: XCTestCase {
         let outputFileMap = try OutputFileMap.load(fileSystem: localFileSystem, file: .absolute(file.path), diagnosticEngine: diags)
 
         let object = try outputFileMap.getOutput(inputFile: VirtualPath.intern(path: "/tmp/foo/Sources/foo/foo.swift"), outputType: .object)
-        XCTAssertEqual(VirtualPath.lookup(object).name, "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.o")
+        XCTAssertEqual(VirtualPath.lookup(object).name, objroot.appending(components: "foo.swift.o").pathString)
 
         let masterDeps = try outputFileMap.getOutput(inputFile: VirtualPath.intern(path: ""), outputType: .swiftDeps)
-        XCTAssertEqual(VirtualPath.lookup(masterDeps).name, "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.swiftdeps")
+        XCTAssertEqual(VirtualPath.lookup(masterDeps).name, objroot.appending(components: "master.swiftdeps").pathString)
       }
     }
   }
 
   func testFindingObjectPathFromllvmBCPath() throws {
+    let objroot: AbsolutePath =
+        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+
     let contents = """
     {
       "": {
-        "swift-dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.swiftdeps"
+        "swift-dependencies": "\(objroot.appending(components: "master.swiftdeps").nativePathString(escaped: true))"
       },
       "/tmp/foo/Sources/foo/foo.swift": {
-        "dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.d",
-        "object": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.o",
-        "swiftmodule": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo~partial.swiftmodule",
-        "swift-dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swiftdeps",
-        "llvm-bc": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.bc"
+        "dependencies": "\(objroot.appending(components: "foo.d").nativePathString(escaped: true))",
+        "object": "\(objroot.appending(components: "foo.swift.o").nativePathString(escaped: true))",
+        "swiftmodule": "\(objroot.appending(components: "foo~partial.swiftmodule").nativePathString(escaped: true))",
+        "swift-dependencies": "\(objroot.appending(components: "foo.swiftdeps").nativePathString(escaped: true))",
+        "llvm-bc": "\(objroot.appending(components: "foo.swift.bc").nativePathString(escaped: true))"
       }
     }
     """
@@ -817,22 +823,25 @@ final class SwiftDriverTests: XCTestCase {
         let outputFileMap = try OutputFileMap.load(fileSystem: localFileSystem, file: .absolute(file.path), diagnosticEngine: diags)
 
         let obj = try outputFileMap.getOutput(inputFile: VirtualPath.intern(path: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.bc"), outputType: .object)
-        XCTAssertEqual(VirtualPath.lookup(obj).name, "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.o")
+        XCTAssertEqual(VirtualPath.lookup(obj).name, objroot.appending(components: "foo.swift.o").pathString)
       }
     }
   }
 
   func testOutputFileMapLoadingDocAndSourceinfo() throws {
+    let objroot: AbsolutePath =
+        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+
     let contents = """
     {
       "": {
-        "swift-dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.swiftdeps"
+        "swift-dependencies": "\(objroot.appending(components: "master.swiftdeps").nativePathString(escaped: true))"
       },
       "/tmp/foo/Sources/foo/foo.swift": {
-        "dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.d",
-        "object": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swift.o",
-        "swiftmodule": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo~partial.swiftmodule",
-        "swift-dependencies": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.swiftdeps"
+        "dependencies": "\(objroot.appending(components: "foo.d").nativePathString(escaped: true))",
+        "object": "\(objroot.appending(components: "foo.swift.o").nativePathString(escaped: true))",
+        "swiftmodule": "\(objroot.appending(components: "foo~partial.swiftmodule").nativePathString(escaped: true))",
+        "swift-dependencies": "\(objroot.appending(components: "foo.swiftdeps").nativePathString(escaped: true))"
       }
     }
     """
@@ -843,10 +852,10 @@ final class SwiftDriverTests: XCTestCase {
         let outputFileMap = try OutputFileMap.load(fileSystem: localFileSystem, file: .absolute(file.path), diagnosticEngine: diags)
 
         let doc = try outputFileMap.getOutput(inputFile: VirtualPath.intern(path: "/tmp/foo/Sources/foo/foo.swift"), outputType: .swiftDocumentation)
-        XCTAssertEqual(VirtualPath.lookup(doc).name, "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo~partial.swiftdoc")
+        XCTAssertEqual(VirtualPath.lookup(doc).name, objroot.appending(components: "foo~partial.swiftdoc").pathString)
 
         let source = try outputFileMap.getOutput(inputFile: VirtualPath.intern(path: "/tmp/foo/Sources/foo/foo.swift"), outputType: .swiftSourceInfoFile)
-        XCTAssertEqual(VirtualPath.lookup(source).name, "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo~partial.swiftsourceinfo")
+        XCTAssertEqual(VirtualPath.lookup(source).name, objroot.appending(components: "foo~partial.swiftsourceinfo").pathString)
       }
     }
   }
@@ -5781,14 +5790,15 @@ final class SwiftDriverTests: XCTestCase {
     // FIXME: On Linux, we might not have any Clang in the path. We need a
     // better override.
     var env = ProcessEnv.vars
-    env["SWIFT_DRIVER_SWIFT_HELP_EXEC"] = "/usr/bin/nonexistent-swift-help"
+    let swiftHelp: AbsolutePath = AbsolutePath("/usr/bin/nonexistent-swift-help")
+    env["SWIFT_DRIVER_SWIFT_HELP_EXEC"] = swiftHelp.pathString
     env["SWIFT_DRIVER_CLANG_EXEC"] = "/usr/bin/clang"
     var driver = try Driver(
       args: ["swiftc", "-help"],
       env: env)
     let jobs = try driver.planBuild()
     XCTAssert(jobs.count == 1)
-    XCTAssertEqual(jobs.first!.tool.name, "/usr/bin/nonexistent-swift-help")
+    XCTAssertEqual(jobs.first!.tool.name, swiftHelp.pathString)
   }
 
   func testSourceInfoFileEmitOption() throws {


### PR DESCRIPTION
When building with apple/swift-tools-support-core#310, we normalize more
paths which results in test failures.  Update the tests to accommodate
the new behaviour.