### PR TITLE
build: re-resolve dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
-          "version": "1.0.2"
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       },
       {
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "main",
-          "revision": "9e05245f5acc2f92de65cb17f401ae8031d45324",
+          "revision": "40ee0e2a91d1bd3e37beb83baaea927f86346f1d",
           "version": null
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
         }
       },
       {
@@ -24,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": "main",
-          "revision": "769fea0d57022645eaa48fba016ba1b6d79d24f2",
+          "revision": "3f140d7e256f5ec7eaa93a44090fea831da6fb61",
           "version": null
         }
       },


### PR DESCRIPTION
This re-resolves the package, which updates the unpinned
swift-tools-support-core and swift-llbuild repositories.  This should
have no impact on other platforms, but enables building on Windows
without the need to explicitly re-resolve the package.