### PR TITLE
Explicitly tell the frontend to enable default cross-module-optimization

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -283,7 +283,13 @@ extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs)
     // FIXME: MSVC runtime flags
 
-    addDisableCMOOption(commandLine: &commandLine)
+    if Driver.canDoCrossModuleOptimization(parsedOptions: &parsedOptions) &&
+       // For historical reasons, -cross-module-optimization turns on "aggressive" CMO
+       // which is different from "default" CMO.
+       !parsedOptions.hasArgument(.CrossModuleOptimization) {
+      assert(!emitModuleSeparately, "Cannot emit module separately with cross-module-optimization")
+      commandLine.appendFlag("-enable-default-cmo")
+    }
 
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
       commandLine.appendFlag(.parseAsLibrary)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -315,14 +315,6 @@ extension Driver {
                                                            driver: self)
   }
 
-  /// Add options to disable cross-module-optimization.
-  mutating func addDisableCMOOption(commandLine: inout [Job.ArgTemplate]) {
-    if parsedOptions.hasArgument(.disableCrossModuleOptimization) {
-      commandLine.appendFlag(.Xllvm)
-      commandLine.appendFlag("-sil-disable-pass=cmo")
-    }
-  }
-
   mutating func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate],
                                                         primaryInputs: [TypedVirtualPath],
                                                         inputsGeneratingCodeCount: Int,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2976,6 +2976,7 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O" ])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1 + autoLinkExtractJob)
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
     }
 
     do {
@@ -2983,6 +2984,8 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O", "-enable-library-evolution" ])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
+      XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }
 
     do {
@@ -2990,6 +2993,8 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O", "-disable-cmo" ])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
+      XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }
 
     do {
@@ -2997,10 +3002,12 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo" ])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
+      XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }
 
     do {
-        // Don't use emit-module-separetely as a linker.
+      // Don't use emit-module-separetely as a linker.
       var driver = try Driver(args: ["swiftc", "foo.sil", "bar.sil", "-module-name", "Test", "-emit-module-path", "/foo/bar/Test.swiftmodule", "-emit-library", "-target", "x86_64-apple-macosx10.15", "-wmo", "-emit-module-separately-wmo"],
                                env: envVars)
       let plannedJobs = try driver.planBuild()


### PR DESCRIPTION
So far, the swift-frontend decided by itself if CMO can be enabled. This caused problems when used with an old driver, which doesn't consider CMO.
Now, the driver decides when to use default CMO.

Depends on the swift changes https://github.com/apple/swift/pull/58529