### PR TITLE
Tests: ensure that the path will be relative

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -303,10 +303,11 @@ final class SwiftDriverTests: XCTestCase {
 #if os(Windows)
     throw XCTSkip("TSCUtility.RelativePath failure")
 #else
-    try withTemporaryDirectory { path in
-      guard let cwd = localFileSystem.currentWorkingDirectory else {
-        fatalError()
-      }
+    guard let cwd = localFileSystem.currentWorkingDirectory else {
+      fatalError()
+    }
+
+    try withTemporaryDirectory(dir: cwd, removeTreeOnDeinit: true) { path in
       let main = path.appending(component: "main.swift")
       let util = path.appending(component: "util.swift")
       let utilRelative = util.relative(to: cwd)
@@ -1134,10 +1135,11 @@ final class SwiftDriverTests: XCTestCase {
 #if os(Windows)
     throw XCTSkip("TSCUtility.RelativePath failure")
 #else
-    try withTemporaryDirectory { path in
-      guard let cwd = localFileSystem.currentWorkingDirectory else {
-        fatalError()
-      }
+    guard let cwd = localFileSystem.currentWorkingDirectory else {
+      fatalError()
+    }
+
+    try withTemporaryDirectory(dir: cwd, removeTreeOnDeinit: true) { path in
       let outputFileMap = path.appending(component: "outputFileMap.json")
       try localFileSystem.writeFileContents(outputFileMap) {
         $0 <<< """


### PR DESCRIPTION
There is no guarantee that the path between the temporary directory and
current working directory can be represented with a relative path.  This
is particularly important on Windows where the paths may reside on
different volumes, which have separate roots.  Alter the two instances
in the test to use the current directory for the temporary storage, and
ensure that we clean up afterwards as we are likely in the source tree.