### PR TITLE
Driver: use a proper error rather than `fatalError`

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -19,6 +19,7 @@ import struct TSCUtility.Version
 /// The Swift driver.
 public struct Driver {
   public enum Error: Swift.Error, Equatable, DiagnosticData {
+    case unknownOrMissingSubcommand(String)
     case invalidDriverName(String)
     case invalidInput(String)
     case noInputFiles
@@ -49,6 +50,8 @@ public struct Driver {
 
     public var description: String {
       switch self {
+      case .unknownOrMissingSubcommand(let subcommand):
+        return "unknown or missing subcommand '\(subcommand)'"
       case .invalidDriverName(let driverName):
         return "invalid driver name: \(driverName)"
       case .invalidInput(let input):

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -67,7 +67,7 @@ do {
                          ?? Process.findExecutable(subcommand)
 
     if subcommandPath == nil || !localFileSystem.exists(subcommandPath!) {
-      fatalError("cannot find subcommand executable '\(subcommand)'")
+      throw Driver.Error.unknownOrMissingSubcommand(subcommand)
     }
 
     // Execute the subcommand.


### PR DESCRIPTION
`fatalError` is more akin to an assertion rather than a "condition
failed, please exit".  The improper use here would, upon a typo on
Windows, induce the Doctor to try to categorise the fault and then
emit a minidump.  This is both frustrating and unnecessary.  Add a
new error case and use it to emit the message and exit gracefully.