### PR TITLE
Driver: further generalise #1088

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -3014,21 +3014,9 @@ extension Driver {
     
     // Emit-module discovered dependencies are always specified as a single-output
     // file
-    if type == .emitModuleDependencies {
-      if let path = outputFileMap?.existingOutputForSingleInput(outputType: type) {
-        return path
-      }
-
-      // If an explicit path is not provided by the output file map, attempt to
-      // synthesize a path from the master swift dependency path.  This is
-      // important as we may other emit this file at the location where the
-      // driver was invoked, which is normally the root of the package.
-      if let path = outputFileMap?.existingOutputForSingleInput(outputType: .swiftDeps) {
-        return VirtualPath.lookup(path)
-                    .parentDirectory
-                    .appending(component: "\(moduleName).\(type.rawValue)")
-                    .intern()
-      }
+    if type == .emitModuleDependencies,
+       let path = outputFileMap?.existingOutputForSingleInput(outputType: type) {
+      return path
     }
 
     // If there is an output argument, derive the name from there.
@@ -3046,6 +3034,16 @@ extension Driver {
         .intern()
     }
 
+    // If an explicit path is not provided by the output file map, attempt to
+    // synthesize a path from the master swift dependency path.  This is
+    // important as we may otherwise emit this file at the location where the
+    // driver was invoked, which is normally the root of the package.
+    if let path = outputFileMap?.existingOutputForSingleInput(outputType: .swiftDeps) {
+      return VirtualPath.lookup(path)
+                  .parentDirectory
+                  .appending(component: "\(moduleName).\(type.rawValue)")
+                  .intern()
+    }
     return try VirtualPath.intern(path: moduleName.appendingFileTypeExtension(type))
   }
 


### PR DESCRIPTION
It seems that a similar problem has impacted the generation of
serialised diagnostics for modules.  Follow the adage of CS inherently
having 3 numbers: 0, 1, N and generalise the path to a penultimate
fallback.  We should always have the swift dependency information on
hand to locate the build directory as that is the "master dependency".
This should hopefully prevent accidental cases of files leaking into the
current directory.