### PR TITLE
[5.7] Driver: provide a more suitable default for `emit-module.d`

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -3018,10 +3018,21 @@ extension Driver {
     
     // Emit-module discovered dependencies are always specified as a single-output
     // file
-    if type == .emitModuleDependencies,
-      let singleOutputPath = outputFileMap?.existingOutputForSingleInput(
-           outputType: type) {
-      return singleOutputPath
+    if type == .emitModuleDependencies {
+      if let path = outputFileMap?.existingOutputForSingleInput(outputType: type) {
+        return path
+      }
+
+      // If an explicit path is not provided by the output file map, attempt to
+      // synthesize a path from the master swift dependency path.  This is
+      // important as we may other emit this file at the location where the
+      // driver was invoked, which is normally the root of the package.
+      if let path = outputFileMap?.existingOutputForSingleInput(outputType: .swiftDeps) {
+        return VirtualPath.lookup(path)
+                    .parentDirectory
+                    .appending(component: "\(moduleName).\(type.rawValue)")
+                    .intern()
+      }
     }
 
     // If there is an output argument, derive the name from there.


### PR DESCRIPTION
Provide a fallback default for the `emit-module.d` file.  It has been
observed on Windows and Android that builds subsequent to #1056 would
emit files into the root of the source tree (specifically, `pwd`). If
there is no explicit location specified for the new output, and given
that there is no primary output associated with the command, the path
that defaults is simply a singular file name component, emitting that
file into the location that the driver was executed from (which comes
out to the root of the package for commandline invocations), dirtying
the source tree.

Rather than sinking the knowledge for the default into
`existingOutputForSingleInput`, where we have no access to the module
name, emit the logic inline and derive a name based on the Swift module
and place it as a peer.  This should help ensure that the serialized
diagnostics do not end up committed accidentally.