### PR TITLE
Disable parallel testing on all platforms

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -151,7 +151,7 @@ def add_rpath(rpath, binary, verbose):
     print(stdout)
 
 def should_test_parallel():
-  return platform.system() != 'Linux'
+  return False
 
 def handle_invocation(args):
   swiftpm_args = get_swiftpm_options(args)


### PR DESCRIPTION
Parallel testing fails on macOS as well as Linux.
Disabling it on all platforms.

https://ci.swift.org/job/oss-swift-package-macos//426/console

Mitigates rdar://92961248