### PR TITLE
ParsedOptions: save unknown driver flags that are recognizable for swift-frontend

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -340,6 +340,9 @@ public struct Driver {
   /// A collection of all the flags the selected toolchain's `swift-frontend` supports
   public let supportedFrontendFlags: Set<String>
 
+  /// A list of unknown driver flags that are recognizable to `swift-frontend`
+  public let savedUnknownDriverFlagsForSwiftFrontend: [String]
+
   /// A collection of all the features the selected toolchain's `swift-frontend` supports
   public let supportedFrontendFeatures: Set<String>
 
@@ -383,10 +386,10 @@ public struct Driver {
       .replacingExtension(with: .jsonABIBaseline).intern(), type: .jsonABIBaseline)
   }()
 
-  public func isFrontendArgSupported(_ opt: Option) -> Bool {
-    var current = opt.spelling
+  public static func isOptionFound(_ opt: String, allOpts: Set<String>) -> Bool {
+    var current = opt
     while(true) {
-      if supportedFrontendFlags.contains(current) {
+      if allOpts.contains(current) {
         return true
       }
       if current.starts(with: "-") {
@@ -395,6 +398,10 @@ public struct Driver {
         return false
       }
     }
+  }
+
+  public func isFrontendArgSupported(_ opt: Option) -> Bool {
+    return Driver.isOptionFound(opt.spelling, allOpts: supportedFrontendFlags)
   }
 
   @_spi(Testing)
@@ -494,7 +501,7 @@ public struct Driver {
 
     self.driverKind = try Self.determineDriverKind(args: &args)
     self.optionTable = OptionTable()
-    self.parsedOptions = try optionTable.parse(Array(args), for: self.driverKind)
+    self.parsedOptions = try optionTable.parse(Array(args), for: self.driverKind, delayThrows: true)
     self.showJobLifecycle = parsedOptions.contains(.driverShowJobLifecycle)
 
     // Determine the compilation mode.
@@ -662,6 +669,13 @@ public struct Driver {
                                                 diagnosticsEngine: diagnosticEngine,
                                                 fileSystem: fileSystem, executor: executor,
                                                 env: env)
+    let supportedFrontendFlagsLocal = self.supportedFrontendFlags
+    self.savedUnknownDriverFlagsForSwiftFrontend = try self.parsedOptions.saveUnknownFlags {
+      Driver.isOptionFound($0, allOpts: supportedFrontendFlagsLocal)
+    }
+    self.savedUnknownDriverFlagsForSwiftFrontend.forEach {
+      diagnosticsEngine.emit(warning: "save unknown driver flag \($0) as additional swift-frontend flag")
+    }
     self.supportedFrontendFeatures = try Self.computeSupportedCompilerFeatures(of: self.toolchain, env: env)
 
     self.enabledSanitizers = try Self.parseSanitizerArgValues(

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -309,6 +309,10 @@ extension Driver {
       commandLine.appendFlag("-frontend-parseable-output")
     }
 
+    savedUnknownDriverFlagsForSwiftFrontend.forEach {
+      commandLine.appendFlag($0)
+    }
+
     try toolchain.addPlatformSpecificCommonFrontendOptions(commandLine: &commandLine,
                                                            inputs: &inputs,
                                                            frontendTargetInfo: frontendTargetInfo,

--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -36,7 +36,7 @@ extension OptionTable {
   ///
   /// Throws an error if the command line contains any errors.
   public func parse(_ arguments: [String],
-                    for driverKind: DriverKind) throws -> ParsedOptions {
+                    for driverKind: DriverKind, delayThrows: Bool = false) throws -> ParsedOptions {
     var trie = PrefixTrie<Option>()
     // Add all options, ignoring the .noDriver ones
     for opt in options where !opt.attributes.contains(.noDriver) {
@@ -73,8 +73,12 @@ extension OptionTable {
       // there's an unmatched suffix at the end, and pop an error. Otherwise,
       // we'll treat the unmatched suffix as the argument to the option.
       guard let option = trie[argument] else {
-        throw OptionParseError.unknownOption(
-          index: index - 1, argument: argument)
+        if delayThrows {
+          parsedOptions.addUnknownFlag(index: index - 1, argument: argument)
+          continue
+        } else {
+          throw OptionParseError.unknownOption(index: index - 1, argument: argument)
+        }
       }
 
       let verifyOptionIsAcceptedByDriverKind = {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6273,6 +6273,15 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(mapA.entries, [VirtualPath.relative(.init("a.swift")).intern(): [:]])
     }
   }
+
+  func testSaveUnkownDriverFlags() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-typecheck", "a.swift", "b.swift", "-unlikely-flag-for-testing"])
+      let plannedJobs = try driver.planBuild()
+      let jobA = plannedJobs[0]
+      XCTAssertTrue(jobA.commandLine.contains("-unlikely-flag-for-testing"))
+    }
+  }
   
   func testCleaningUpOldCompilationOutputs() throws {
 #if !os(macOS)


### PR DESCRIPTION
This is to prevent driver being lagging behind swift-frontend. For any unknown
driver flags that are recognizable to the swift compiler, we should save these flags
and pass them down to the compiler because the compiler is ready to take them.