### PR TITLE
[5.7] ParsedOptions: save unknown driver flags that are recognizable for swift-frontend

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -309,6 +309,10 @@ extension Driver {
       commandLine.appendFlag("-frontend-parseable-output")
     }
 
+    savedUnknownDriverFlagsForSwiftFrontend.forEach {
+      commandLine.appendFlag($0)
+    }
+
     try toolchain.addPlatformSpecificCommonFrontendOptions(commandLine: &commandLine,
                                                            inputs: &inputs,
                                                            frontendTargetInfo: frontendTargetInfo,

--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -36,7 +36,7 @@ extension OptionTable {
   ///
   /// Throws an error if the command line contains any errors.
   public func parse(_ arguments: [String],
-                    for driverKind: DriverKind) throws -> ParsedOptions {
+                    for driverKind: DriverKind, delayThrows: Bool = false) throws -> ParsedOptions {
     var trie = PrefixTrie<Option>()
     // Add all options, ignoring the .noDriver ones
     for opt in options where !opt.attributes.contains(.noDriver) {
@@ -73,8 +73,12 @@ extension OptionTable {
       // there's an unmatched suffix at the end, and pop an error. Otherwise,
       // we'll treat the unmatched suffix as the argument to the option.
       guard let option = trie[argument] else {
-        throw OptionParseError.unknownOption(
-          index: index - 1, argument: argument)
+        if delayThrows {
+          parsedOptions.addUnknownFlag(index: index - 1, argument: argument)
+          continue
+        } else {
+          throw OptionParseError.unknownOption(index: index - 1, argument: argument)
+        }
       }
 
       let verifyOptionIsAcceptedByDriverKind = {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6253,6 +6253,15 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(mapA.entries, [VirtualPath.relative(.init("a.swift")).intern(): [:]])
     }
   }
+
+  func testSaveUnkownDriverFlags() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-typecheck", "a.swift", "b.swift", "-unlikely-flag-for-testing"])
+      let plannedJobs = try driver.planBuild()
+      let jobA = plannedJobs[0]
+      XCTAssertTrue(jobA.commandLine.contains("-unlikely-flag-for-testing"))
+    }
+  }
   
   func testCleaningUpOldCompilationOutputs() throws {
 #if !os(macOS)


### PR DESCRIPTION
This is to prevent driver being lagging behind swift-frontend. For any unknown
driver flags that are recognizable to the swift compiler, we should save these flags
and pass them down to the compiler because the compiler is ready to take them.