### PR TITLE
Remove Noisy Remark

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -433,7 +433,6 @@ extension ModuleDependencyGraph {
     precondition(self.phase != .buildingFromSwiftDeps)
 
     guard let whyIntegrate = whyIncrementallyFindNodesInvalidated(by: integrand) else {
-      info.reporter?.report("Ignoring unchanged existing external incremental dependency", integrand)
       return DirectlyInvalidatedNodeSet()
     }
     mutationSafetyPrecondition()
@@ -487,7 +486,8 @@ extension ModuleDependencyGraph {
   ///
   /// - Parameter fed: The external dependency, with fingerprint and origin info to be integrated
   /// - Returns: nil if no integration is needed, or else why the integration is happening
-  private func whyIncrementallyFindNodesInvalidated(by integrand: ExternalIntegrand
+  private func whyIncrementallyFindNodesInvalidated(
+    by integrand: ExternalIntegrand
   ) -> ExternalDependency.InvalidationReason? {
     accessSafetyPrecondition()
    switch integrand {


### PR DESCRIPTION
This remark is basically tripped by every swiftmodule in the SDK for
most projects. As it doesn't appear in tests anywhere and it provides
very little signal, best to strike it for now. If we discover it has
some diagnostic utility we can always revert this and add some tests.