### PR TITLE
5.7: set `swift-llbuild` branch to `release/5.7`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -121,7 +121,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("main")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("release/5.7")),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools


### PR DESCRIPTION
This allows packages depending on SwiftPM (and transitively on Swift Driver) to correctly resolve dependencies.