### PR TITLE
Upgrade Swift Argument Parser to version 1.1.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
+          "revision": "f3c9084a71ef4376f2fabbdf1d3d90a49f1fabdb",
+          "version": "1.1.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
     // dependency version changes here with those projects.
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.2")),
     ]
 } else {
     package.dependencies += [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -162,7 +162,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
     // dependency version changes here with those projects.
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.2")),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
This PR upgrades the Swift Argument Parser dependency to version 1.1.2. This is the latest version of the dependency and supports new features like async/await via the `AsyncParsableCommand` type.

In order to upgrade this dependency, it must also be upgraded in swift-package-manager and sourcekit-lsp.

* swift-package-manager PR [#5540](https://github.com/apple/swift-package-manager/pull/5540)
* sourcekit-lsp PR [#555](https://github.com/apple/sourcekit-lsp/pull/555)

I believe the correct order to merge these PRs would be:

1. swift-driver
2. swift-package-manager (depends on swift-driver)
3. sourcekit-lsp (depends on swift-package-manager)
