### PR TITLE
Prohibit IR Generation for 32bit watchos when deployment target > 9.0

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -235,9 +235,17 @@ public final class DarwinToolchain: Toolchain {
             ToolchainValidationError
               .invalidDeploymentTargetForIR("iOS 11", targetTriple.archName)
       }
-    } else if targetTriple.isWatchOS,
-              targetTriple.version(for: .watchOS(.device)) < Triple.Version(2, 0, 0) {
-      throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget("watchOS 2.0")
+    } else if targetTriple.isWatchOS {
+      if targetTriple.version(for: .watchOS(.device)) < Triple.Version(2, 0, 0) {
+        throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget("watchOS 2.0")
+      }
+      if targetTriple.arch?.is32Bit == true,
+         targetTriple.version(for: .watchOS(.device)) >= Triple.Version(8, 7, 0),
+         compilerOutputType != .swiftModule {
+        throw
+            ToolchainValidationError
+              .invalidDeploymentTargetForIR("watchOS 8.7", targetTriple.archName)
+      }
     }
   }
     

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3362,7 +3362,7 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
-  func testValidDeprecatedTargets() throws {
+  func testValidDeprecatedTargetiOS() throws {
     var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "armv7-apple-ios13.0", "foo.swift"])
     let plannedJobs = try driver.planBuild()
     let emitModuleJob = plannedJobs.first(where: {$0.kind == .emitModule})
@@ -3370,6 +3370,16 @@ final class SwiftDriverTests: XCTestCase {
     let currentJob = emitModuleJob!
     XCTAssert(currentJob.commandLine.contains(.flag("-target")))
     XCTAssert(currentJob.commandLine.contains(.flag("armv7-apple-ios13.0")))
+  }
+    
+  func testValidDeprecatedTargetWatchOS() throws {
+    var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "armv7k-apple-watchos10.0", "foo.swift"])
+    let plannedJobs = try driver.planBuild()
+    let emitModuleJob = plannedJobs.first(where: {$0.kind == .emitModule})
+    XCTAssertNotNil(emitModuleJob)
+    let currentJob = emitModuleJob!
+    XCTAssert(currentJob.commandLine.contains(.flag("-target")))
+    XCTAssert(currentJob.commandLine.contains(.flag("armv7k-apple-watchos10.0")))
   }
 
   func testClangTargetForExplicitModule() throws {
@@ -3476,11 +3486,19 @@ final class SwiftDriverTests: XCTestCase {
 
     XCTAssertThrowsError(try Driver(args: ["swiftc", "-emit-module", "-c", "-target", 
                                            "armv7s-apple-ios12.0", "foo.swift"])) { error in
-        guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR("iOS 11", "armv7s") = error else {
-          XCTFail()
-          return
-        }
+      guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR("iOS 11", "armv7s") = error else {
+        XCTFail()
+        return
       }
+    }
+
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-emit-module", "-c", "-target",
+                                             "armv7k-apple-watchos12.0", "foo.swift"])) { error in
+      guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR("watchOS 8.7", "armv7k") = error else {
+        XCTFail()
+        return
+      }
+    }
 
     XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-ios13.0",
                                            "-target-variant", "x86_64-apple-macosx10.14",


### PR DESCRIPTION
watchOS 9 doesn't support 32bit architectures, however we should still
allow the compiler to generate swift modules for these target triples
for back deployment support.