### PR TITLE
Explicitly copy defsIDependUpon into an appropriately sized array when initializing SourceFileDependencyGraph.Node

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -227,10 +227,14 @@ extension SourceFileDependencyGraph {
       private mutating func finalizeNode() throws {
         guard let key = key else {return}
 
+        var defsIDependUpon = Array(unsafeUninitializedCapacity: defsNodeDependUpon.count) { destinationBuffer, initializedCount in
+                _ = destinationBuffer.initialize(from: defsNodeDependUpon)
+            initializedCount = defsNodeDependUpon.count
+        }
         let node = try Node(key: key,
                             fingerprint: fingerprint?.intern(in: internedStringTable),
                             sequenceNumber: nodeSequenceNumber,
-                            defsIDependUpon: defsNodeDependUpon,
+                            defsIDependUpon: defsIDependUpon,
                             definitionVsUse: definitionVsUse)
         self.key = nil
         self.defsNodeDependUpon.removeAll(keepingCapacity: true)


### PR DESCRIPTION
Previously, the removeAll call below the initializer would trigger CoW. If the scratch buffer was larger than the count, this would result in an unnecessarily large allocation. In a very large source file, the source-file-provides-implementation node may have multiple orders of magnitude more edges compared to any other node in the graph, which could lead to excessive memory usage and a large slowdown deallocating the array storage when tearing down the graph.

I tested this using the swiftdeps from an artificially generated swiftdeps with 50k empty struct declarations. Before this change, it took 31s to load and destroy, after this change it only took 0.25s.

rdar://95648282