### PR TITLE
Remove `incrementalCompilationState` from `ToolExecutionDelegate`.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1402,7 +1402,6 @@ extension Driver {
     return ToolExecutionDelegate(
       mode: mode,
       buildRecordInfo: buildRecordInfo,
-      incrementalCompilationState: incrementalCompilationState,
       showJobLifecycle: showJobLifecycle,
       argsResolver: executor.resolver,
       diagnosticEngine: diagnosticEngine)

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -42,7 +42,6 @@ import Glibc
 
   public let mode: Mode
   public let buildRecordInfo: BuildRecordInfo?
-  public let incrementalCompilationState: IncrementalCompilationState?
   public let showJobLifecycle: Bool
   public let diagnosticEngine: DiagnosticsEngine
   public var anyJobHadAbnormalExit: Bool = false
@@ -53,13 +52,11 @@ import Glibc
 
   @_spi(Testing) public init(mode: ToolExecutionDelegate.Mode,
                              buildRecordInfo: BuildRecordInfo?,
-                             incrementalCompilationState: IncrementalCompilationState?,
                              showJobLifecycle: Bool,
                              argsResolver: ArgsResolver,
                              diagnosticEngine: DiagnosticsEngine) {
     self.mode = mode
     self.buildRecordInfo = buildRecordInfo
-    self.incrementalCompilationState = incrementalCompilationState
     self.showJobLifecycle = showJobLifecycle
     self.diagnosticEngine = diagnosticEngine
     self.argsResolver = argsResolver

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -153,7 +153,6 @@ final class ParsableMessageTests: XCTestCase {
           let args : [String] = try resolver.resolveArgumentList(for: compileJob, forceResponseFiles: false)
           let toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                    buildRecordInfo: nil,
-                                                   incrementalCompilationState: nil,
                                                    showJobLifecycle: false,
                                                    argsResolver: resolver,
                                                    diagnosticEngine: DiagnosticsEngine())
@@ -241,7 +240,6 @@ final class ParsableMessageTests: XCTestCase {
           args = try resolver.resolveArgumentList(for: compileJob!, forceResponseFiles: false)
           toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                buildRecordInfo: nil,
-                                               incrementalCompilationState: nil,
                                                showJobLifecycle: false,
                                                argsResolver: resolver,
                                                diagnosticEngine: DiagnosticsEngine())
@@ -319,7 +317,6 @@ final class ParsableMessageTests: XCTestCase {
                                                    forceResponseFiles: false)
           toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                buildRecordInfo: nil,
-                                               incrementalCompilationState: nil,
                                                showJobLifecycle: false,
                                                argsResolver: resolver,
                                                diagnosticEngine: DiagnosticsEngine())


### PR DESCRIPTION
The incremental state is never used/referenced from this delegate and the existence of this reference may complicate things with respect to the incremental state's lifetime.

rdar://95990331