### PR TITLE
[5.7] Fix SIGINT handler in swift-frontend

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -45,7 +45,9 @@ func getExitCode(_ code: Int32) -> Int32 {
 }
 
 do {
-
+  #if !os(Windows)
+  signal(SIGINT, SIG_IGN)
+  #endif
   let processSet = ProcessSet()
   interruptSignalSource.setEventHandler {
     // Terminate running compiler jobs and let the driver exit gracefully, remembering
@@ -53,6 +55,7 @@ do {
     processSet.terminate()
     driverInterrupted = true
   }
+  interruptSignalSource.resume()
 
   if ProcessEnv.vars["SWIFT_ENABLE_EXPLICIT_MODULE"] != nil {
     CommandLine.arguments.append("-explicit-module-build")


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1120
-----------------------------------------------------
motivation: fix regression where SIGINT would not terminate frontend processes

changes:
* call DispatchSourceSignal::resume
* call signal(SIGINT, SIG_IGN)

rdar://95862616