### PR TITLE
[5.7] Explicitly copy defsIDependUpon into an appropriately sized array when initializing SourceFileDependencyGraph.Node

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -227,10 +227,14 @@ extension SourceFileDependencyGraph {
       private mutating func finalizeNode() throws {
         guard let key = key else {return}
 
+          let defsIDependUpon: [Int] = Array(unsafeUninitializedCapacity: defsNodeDependUpon.count) { destinationBuffer, initializedCount in
+            _ = destinationBuffer.initialize(from: defsNodeDependUpon)
+            initializedCount = defsNodeDependUpon.count
+        }
         let node = try Node(key: key,
                             fingerprint: fingerprint?.intern(in: internedStringTable),
                             sequenceNumber: nodeSequenceNumber,
-                            defsIDependUpon: defsNodeDependUpon,
+                            defsIDependUpon: defsIDependUpon,
                             definitionVsUse: definitionVsUse)
         self.key = nil
         self.defsNodeDependUpon.removeAll(keepingCapacity: true)


### PR DESCRIPTION
5.7 cherry pick of https://github.com/apple/swift-driver/pull/1119