### PR TITLE
Fix 5.7 dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -135,7 +135,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("release/5.7")),
     .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "5.0.0")),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -138,7 +138,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("main")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("release/5.7")),
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "swift-llbuild"),
@@ -157,7 +157,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("release/5.7")),
     .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "4.0.0")),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate


### PR DESCRIPTION
Looks like a few references to `main` where missed in #1104 which breaks the 5.7 branch of SwiftPM.