### PR TITLE
Add support for `-index-include-locals`.

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -345,6 +345,7 @@ extension Driver {
         commandLine.appendFlag(.indexSystemModules)
       }
       try commandLine.appendLast(.indexIgnoreClangModules, from: &parsedOptions)
+      try commandLine.appendLast(.indexIncludeLocals, from: &parsedOptions)
     }
 
     if parsedOptions.contains(.debugInfoStoreInvocation) ||

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -412,6 +412,7 @@ extension Option {
   public static let indexIgnoreClangModules: Option = Option("-index-ignore-clang-modules", .flag, attributes: [.frontend], helpText: "Avoid indexing clang modules (pcms)")
   public static let indexIgnoreStdlib: Option = Option("-index-ignore-stdlib", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Avoid emitting index data for the standard library.")
   public static let indexIgnoreSystemModules: Option = Option("-index-ignore-system-modules", .flag, attributes: [.noInteractive], helpText: "Avoid indexing system modules")
+  public static let indexIncludeLocals: Option = Option("-index-include-locals", .flag, attributes: [.frontend], helpText: "Include local definitions/references in the produced index data.")
   public static let indexStorePath: Option = Option("-index-store-path", .separate, attributes: [.frontend, .argumentIsPath], metaVar: "<path>", helpText: "Store indexing data to <path>")
   public static let indexSystemModules: Option = Option("-index-system-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Emit index data for imported serialized swift system modules")
   public static let indexUnitOutputPathFilelist: Option = Option("-index-unit-output-path-filelist", .separate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Specify index unit output paths in a file rather than on the command line")
@@ -1083,6 +1084,7 @@ extension Option {
       Option.indexIgnoreClangModules,
       Option.indexIgnoreStdlib,
       Option.indexIgnoreSystemModules,
+      Option.indexIncludeLocals,
       Option.indexStorePath,
       Option.indexSystemModules,
       Option.indexUnitOutputPathFilelist,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -416,6 +416,23 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testIndexIncludeLocals() throws {
+    // Make sure `-index-include-locals` is only passed to the frontend when
+    // requested, not by default.
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-index-store-path", "/tmp/idx") { driver in
+        let jobs = try driver.planBuild()
+        let commandLine = jobs[0].commandLine
+        XCTAssertTrue(commandLine.contains(.flag("-index-store-path")))
+        XCTAssertFalse(commandLine.contains(.flag("-index-include-locals")))
+    }
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-index-store-path", "/tmp/idx", "-index-include-locals") { driver in
+        let jobs = try driver.planBuild()
+        let commandLine = jobs[0].commandLine
+        XCTAssertTrue(commandLine.contains(.flag("-index-store-path")))
+        XCTAssertTrue(commandLine.contains(.flag("-index-include-locals")))
+    }
+  }
+
   func testMultiThreadingOutputs() throws {
     try assertDriverDiagnostics(args: "swiftc", "-c", "foo.swift", "bar.swift", "-o", "bar.ll", "-o", "foo.ll", "-num-threads", "2", "-whole-module-optimization") {
       $1.expect(.error("cannot specify -o when generating multiple output files"))


### PR DESCRIPTION
This flag is added to the frontend in https://github.com/apple/swift/pull/60000.