### PR TITLE
Remove non-fatal test error conditions in Linux testing

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -459,8 +459,6 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertEqual(try Driver(args: ["swiftc", "-j", "4"]).numParallelJobs, 4)
 
-      XCTAssertNil(try Driver(args: ["swiftc", "-j", "0"]).numParallelJobs)
-
       var env = ProcessEnv.vars
       env["SWIFTC_MAXIMUM_DETERMINISM"] = "1"
       XCTAssertEqual(try Driver(args: ["swiftc", "-j", "4"], env: env).numParallelJobs, 1)
@@ -2879,7 +2877,7 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // Calls using the driver to link a library shouldn't trigger an emit-module job, like in LLDB tests.
-      var driver = try Driver(args: ["swiftc", "-emit-library", "foo.swiftmodule", "foo.o", "-emit-module-path", "foo.swiftmodule", "-experimental-emit-module-separately", "-target", "x86_64-apple-macosx10.15"],
+      var driver = try Driver(args: ["swiftc", "-emit-library", "foo.swiftmodule", "foo.o", "-emit-module-path", "foo.swiftmodule", "-experimental-emit-module-separately", "-target", "x86_64-apple-macosx10.15", "-module-name", "Test"],
                               env: envVars)
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
@@ -5490,7 +5488,8 @@ final class SwiftDriverTests: XCTestCase {
   func testIndexFilePathHandling() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-index-file", "-index-file-path",
-                                     "bar.swift", "foo.swift", "bar.swift", "baz.swift"])
+                                     "bar.swift", "foo.swift", "bar.swift", "baz.swift",
+                                     "-module-name", "Test"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
       XCTAssertEqual(plannedJobs[0].kind, .compile)


### PR DESCRIPTION
In Linux testing (e.g. in our CI) these currently generate non-fatal 'error:' messages. This makes human scanning of CI logs more difficult than it should be