### PR TITLE
Add capability to query '-print-target-info' in-process using libSwiftScan API

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -193,6 +193,8 @@ typedef struct {
 
   //=== Cleanup Functions ---------------------------------------------------===//
   void
+  (*swiftscan_string_dispose)(swiftscan_string_ref_t);
+  void
   (*swiftscan_string_set_dispose)(swiftscan_string_set_t *);
   void
   (*swiftscan_dependency_graph_dispose)(swiftscan_dependency_graph_t);

--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -207,6 +207,10 @@ typedef struct {
   void
   (*swiftscan_scan_invocation_dispose)(swiftscan_scan_invocation_t);
 
+  //=== Target Info Functions-------- ---------------------------------------===//
+  swiftscan_string_ref_t
+  (*swiftscan_compiler_target_info_query)(swiftscan_scan_invocation_t);
+
   //=== Functionality Query Functions ---------------------------------------===//
   swiftscan_string_set_t *
   (*swiftscan_compiler_supported_arguments_query)(void);

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -528,6 +528,7 @@ public struct Driver {
     self.hostTriple =
       try Self.computeHostTriple(&self.parsedOptions, diagnosticsEngine: diagnosticEngine,
                                  toolchain: self.toolchain, executor: self.executor,
+                                 fileSystem: fileSystem,
                                  swiftCompilerPrefixArgs: self.swiftCompilerPrefixArgs)
 
     // Classify and collect all of the input files.
@@ -2896,6 +2897,7 @@ extension Driver {
     diagnosticsEngine: DiagnosticsEngine,
     toolchain: Toolchain,
     executor: DriverExecutor,
+    fileSystem: FileSystem,
     swiftCompilerPrefixArgs: [String]) throws -> Triple {
 
     let frontendOverride = try FrontendOverride(&parsedOptions, diagnosticsEngine)

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -236,7 +236,7 @@ public extension Driver {
     return fallbackToFrontend
   }
 
-  private func sanitizeCommandForLibScanInvocation(_ command: inout [String]) {
+  static func sanitizeCommandForLibScanInvocation(_ command: inout [String]) {
     // Remove the tool executable to only leave the arguments. When passing the
     // command line into libSwiftScan, the library is itself the tool and only
     // needs to parse the remaining arguments.
@@ -257,10 +257,10 @@ public extension Driver {
     let isSwiftScanLibAvailable = !(try initSwiftScanLib())
     if isSwiftScanLibAvailable {
       let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory!
-      var command = try itemizedJobCommand(of: preScanJob,
-                                           useResponseFiles: .disabled,
-                                           using: executor.resolver)
-      sanitizeCommandForLibScanInvocation(&command)
+      var command = try Self.itemizedJobCommand(of: preScanJob,
+                                                useResponseFiles: .disabled,
+                                                using: executor.resolver)
+      Self.sanitizeCommandForLibScanInvocation(&command)
       imports =
         try interModuleDependencyOracle.getImports(workingDirectory: cwd,
                                                    moduleAliases: moduleOutputInfo.aliases,
@@ -293,10 +293,10 @@ public extension Driver {
     let isSwiftScanLibAvailable = !(try initSwiftScanLib())
     if isSwiftScanLibAvailable {
       let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory!
-      var command = try itemizedJobCommand(of: scannerJob,
-                                           useResponseFiles: .disabled,
-                                           using: executor.resolver)
-      sanitizeCommandForLibScanInvocation(&command)
+      var command = try Self.itemizedJobCommand(of: scannerJob,
+                                                useResponseFiles: .disabled,
+                                                using: executor.resolver)
+      Self.sanitizeCommandForLibScanInvocation(&command)
       dependencyGraph =
         try interModuleDependencyOracle.getDependencies(workingDirectory: cwd,
                                                         moduleAliases: moduleOutputInfo.aliases,
@@ -339,10 +339,10 @@ public extension Driver {
     let isSwiftScanLibAvailable = !(try initSwiftScanLib())
     if isSwiftScanLibAvailable {
       let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory!
-      var command = try itemizedJobCommand(of: batchScanningJob,
-                                           useResponseFiles: .disabled,
-                                           using: executor.resolver)
-      sanitizeCommandForLibScanInvocation(&command)
+      var command = try Self.itemizedJobCommand(of: batchScanningJob,
+                                                useResponseFiles: .disabled,
+                                                using: executor.resolver)
+      Self.sanitizeCommandForLibScanInvocation(&command)
       moduleVersionedGraphMap =
         try interModuleDependencyOracle.getBatchDependencies(workingDirectory: cwd,
                                                              moduleAliases: moduleOutputInfo.aliases,
@@ -485,8 +485,8 @@ public extension Driver {
                                                                   contents)
   }
 
-  fileprivate func itemizedJobCommand(of job: Job, useResponseFiles: ResponseFileHandling,
-                                      using resolver: ArgsResolver) throws -> [String] {
+  static func itemizedJobCommand(of job: Job, useResponseFiles: ResponseFileHandling,
+                                 using resolver: ArgsResolver) throws -> [String] {
     let (args, _) = try resolver.resolveArgumentList(for: job,
                                                      useResponseFiles: useResponseFiles)
     return args

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -187,7 +187,8 @@ extension Driver {
        fileSystem.exists(swiftScanLibPath) {
       print("- testPrintTargetInfo - Driver - libSwiftScan\(swiftScanLibPath.pathString)")
       let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
-      if libSwiftScanInstance.canQueryTargetInfo() {
+      if libSwiftScanInstance.canQueryTargetInfo(),
+         libSwiftScanInstance.supportsStringDispose() {
         print("- testPrintTargetInfo - Driver - libSwiftScan can query target info")
         let targetInfoData = try libSwiftScanInstance.queryTargetInfoJSON(invocationCommand: invocationCommand)
         print("- testPrintTargetInfo - Driver - target info data:")

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -181,12 +181,17 @@ extension Driver {
   static func queryTargetInfoInProcess(of toolchain: Toolchain,
                                        fileSystem: FileSystem,
                                        invocationCommand: [String]) throws -> FrontendTargetInfo? {
+    print("- testPrintTargetInfo - Driver - query target info in-process")
     let optionalSwiftScanLibPath = try toolchain.lookupSwiftScanLib()
     if let swiftScanLibPath = optionalSwiftScanLibPath,
        fileSystem.exists(swiftScanLibPath) {
+      print("- testPrintTargetInfo - Driver - libSwiftScan\(swiftScanLibPath.pathString)")
       let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
       if libSwiftScanInstance.canQueryTargetInfo() {
+        print("- testPrintTargetInfo - Driver - libSwiftScan can query target info")
         let targetInfoData = try libSwiftScanInstance.queryTargetInfoJSON(invocationCommand: invocationCommand)
+        print("- testPrintTargetInfo - Driver - target info data:")
+        print(targetInfoData)
         return try JSONDecoder().decode(FrontendTargetInfo.self, from: targetInfoData)
       }
     }
@@ -231,9 +236,11 @@ extension Driver {
 
   /// This method exists for testing purposes only
   @_spi(Testing) public func verifyBeingAbleToQueryTargetInfoInProcess(invocationCommand: [String]) throws -> Bool {
+    print("- testPrintTargetInfo - Driver - verifying")
     guard let targetInfo = try Self.queryTargetInfoInProcess(of: toolchain,
                                                              fileSystem: fileSystem,
                                                              invocationCommand: invocationCommand) else {
+      print("- testPrintTargetInfo - Driver - did not work")
       return false
     }
     print("libSwiftScan Compiler: \(targetInfo.compilerVersion)")

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -65,7 +65,6 @@ extension SwiftVersion: Codable {
 }
 
 /// Describes information about the target as provided by the Swift frontend.
-@dynamicMemberLookup
 public struct FrontendTargetInfo: Codable {
   struct CompatibilityLibrary: Codable {
     enum Filter: String, Codable {
@@ -116,9 +115,10 @@ public struct FrontendTargetInfo: Codable {
 
 // Make members of `FrontendTargetInfo.Paths` accessible on `FrontendTargetInfo`.
 extension FrontendTargetInfo {
-  @_spi(Testing) public subscript<T>(dynamicMember dynamicMember: KeyPath<FrontendTargetInfo.Paths, T>) -> T {
-    self.paths[keyPath: dynamicMember]
-  }
+  public var sdkPath: TextualVirtualPath? { paths.sdkPath }
+  public var runtimeLibraryPaths: [TextualVirtualPath] { paths.runtimeLibraryPaths }
+  public var runtimeLibraryImportPaths: [TextualVirtualPath] { paths.runtimeLibraryImportPaths }
+  public var runtimeResourcePath: TextualVirtualPath { paths.runtimeResourcePath }
 }
 
 extension Toolchain {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4770,7 +4770,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testPrintTargetInfo() throws {
     do {
-      var driver = try Driver(args: ["swift", "-print-target-info", "-target", "arm64-apple-ios12.0", "-sdk", "bar", "-resource-dir", "baz"])
+      var driver = try Driver(args: ["swift", "-print-target-info", "-sdk", "bar", "-resource-dir", "baz"])
       let plannedJobs = try driver.planBuild()
       XCTAssertTrue(plannedJobs.count == 1)
       let job = plannedJobs[0]
@@ -4779,6 +4779,18 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(job.commandLine.contains(.flag("-target")))
       XCTAssertTrue(job.commandLine.contains(.flag("-sdk")))
       XCTAssertTrue(job.commandLine.contains(.flag("-resource-dir")))
+    }
+
+    do {
+      let targetInfoArgs = ["-print-target-info", "-sdk", "bar", "-resource-dir", "baz"]
+      let driver = try Driver(args: ["swift"] + targetInfoArgs)
+      let swiftScanLibPath = try XCTUnwrap(driver.toolchain.lookupSwiftScanLib())
+      if localFileSystem.exists(swiftScanLibPath) {
+        let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
+        if libSwiftScanInstance.canQueryTargetInfo() {
+          XCTAssertTrue(try driver.verifyBeingAbleToQueryTargetInfoInProcess(invocationCommand: targetInfoArgs))
+        }
+      }
     }
 
     do {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4786,9 +4786,12 @@ final class SwiftDriverTests: XCTestCase {
       let driver = try Driver(args: ["swift"] + targetInfoArgs)
       let swiftScanLibPath = try XCTUnwrap(driver.toolchain.lookupSwiftScanLib())
       if localFileSystem.exists(swiftScanLibPath) {
+        print("- testPrintTargetInfo - libSwiftScan:\(swiftScanLibPath.pathString)")
         let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
         if libSwiftScanInstance.canQueryTargetInfo() {
+          print("- testPrintTargetInfo - libSwiftScan can query target info")
           XCTAssertTrue(try driver.verifyBeingAbleToQueryTargetInfoInProcess(invocationCommand: targetInfoArgs))
+          print("- testPrintTargetInfo - libSwiftScan test complete")
         }
       }
     }


### PR DESCRIPTION
Second attempt at landing https://github.com/apple/swift-driver/pull/911 after being reverted in https://github.com/apple/swift-driver/pull/1138.
----------------------------------------------------