### PR TITLE
SwiftDriverTests: adjust module count on Windows

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1128,7 +1128,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
          hostTriple.version(for: .macOS) >= Triple.Version(11, 0, 0) {
         expectedNumberOfDependencies = 11
       } else if driver.targetTriple.isWindows {
-        expectedNumberOfDependencies = 13
+        expectedNumberOfDependencies = 14
       } else {
         expectedNumberOfDependencies = 12
       }


### PR DESCRIPTION
A recent refactoring for Windows increased the module count for the
system modules and this resulted in the test suite failing due to the
difference.  This is technically backwards incompatible and expects that
the most recent toolchain is in use but it seems unclear how to account
for that easily.