### PR TITLE
SwiftDriver: introduce `-nostartfiles` option

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -158,13 +158,15 @@ extension GenericUnixToolchain {
         }
       }
 
-      let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-        .appending(
-          components: targetTriple.platformName() ?? "",
-          String(majorArchitectureName(for: targetTriple)),
-          "swiftrt.o"
-        )
-      commandLine.appendPath(swiftrtPath)
+      if !parsedOptions.hasArgument(.nostartfiles) {
+        let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+          .appending(
+            components: targetTriple.platformName() ?? "",
+            String(majorArchitectureName(for: targetTriple)),
+            "swiftrt.o"
+          )
+        commandLine.appendPath(swiftrtPath)
+      }
 
       // If we are linking statically, we need to add all
       // dependencies to a library search group to resolve

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -78,13 +78,15 @@ extension WebAssemblyToolchain {
         isShared: false
       )
 
-      let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-        .appending(
-          components: targetTriple.platformName() ?? "",
-          targetTriple.archName,
-          "swiftrt.o"
-        )
-      commandLine.appendPath(swiftrtPath)
+      if !parsedOptions.hasArgument(.nostartfiles) {
+        let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+          .appending(
+            components: targetTriple.platformName() ?? "",
+            targetTriple.archName,
+            "swiftrt.o"
+          )
+        commandLine.appendPath(swiftrtPath)
+      }
 
       let inputFiles: [Job.ArgTemplate] = inputs.compactMap { input in
         // Autolink inputs are handled specially

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -487,6 +487,7 @@ extension Option {
   public static let noVerifyEmittedModuleInterface: Option = Option("-no-verify-emitted-module-interface", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "Don't check that module interfaces emitted during compilation typecheck")
   public static let noWarningsAsErrors: Option = Option("-no-warnings-as-errors", .flag, attributes: [.frontend], helpText: "Don't treat warnings as errors")
   public static let noWholeModuleOptimization: Option = Option("-no-whole-module-optimization", .flag, attributes: [.frontend, .noInteractive], helpText: "Disable optimizing input files together instead of individually")
+  public static let nostartfiles: Option = Option("-nostartfiles", .flag, attributes: [.frontend, .doesNotAffectIncrementalBuild, .noInteractive, .helpHidden], helpText: "Do not link in the Swift language startup routines")
   public static let nostdimport: Option = Option("-nostdimport", .flag, attributes: [.frontend], helpText: "Don't search the standard library import path for modules")
   public static let numThreads: Option = Option("-num-threads", .separate, attributes: [.frontend, .doesNotAffectIncrementalBuild], metaVar: "<n>", helpText: "Enable multi-threading and specify number of threads")
   public static let extraClangOptionsOnly: Option = Option("-only-use-extra-clang-opts", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Options passed via -Xcc are sufficient for Clang configuration")
@@ -1172,6 +1173,7 @@ extension Option {
       Option.noVerifyEmittedModuleInterface,
       Option.noWarningsAsErrors,
       Option.noWholeModuleOptimization,
+      Option.nostartfiles,
       Option.nostdimport,
       Option.numThreads,
       Option.extraClangOptionsOnly,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6560,6 +6560,20 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(job.commandLine.contains(.path(.absolute(SDKROOT.appending(components: "usr", "lib", "swift", platform, arch, "swiftrt.obj")))))
     }
 
+    do {
+      var env = ProcessEnv.vars
+      env["SDKROOT"] = SDKROOT.nativePathString(escaped: false)
+
+      var driver = try Driver(args: [
+        "swiftc", "-emit-library", "-o", "library.dll", "library.obj", "-nostartfiles",
+      ], env: env)
+      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(jobs.count, 1)
+      let job = jobs.first!
+      XCTAssertEqual(job.kind, .link)
+      XCTAssertFalse(job.commandLine.contains(.path(.absolute(SDKROOT.appending(components: "usr", "lib", "swift", platform, arch, "swiftrt.obj")))))
+    }
+
     // Cannot test this due to `SDKROOT` escaping from the execution environment
     // into the `-print-target-info` step, which then resets the
     // `runtimeResourcePath` to be the SDK relative path rahter than the


### PR DESCRIPTION
This replicates the `-nostartfiles` option from clang and MSVC.  This
allows the registrar from being linked against, which is important for
the case where the swift driver is used for non-Swift targets (i.e.
C/C++).