### PR TITLE
Work around lld 13+ issue with --gc-sections for ELF by adding -z nostart-stop-gc

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -84,6 +84,17 @@ extension GenericUnixToolchain {
         #else
         commandLine.appendFlag("-fuse-ld=\(linker)")
         #endif
+        // Starting with lld 13, Swift stopped working with the lld
+        // --gc-sections implementation for ELF, unless -z nostart-stop-gc is
+        // also passed to lld:
+        //
+        // https://reviews.llvm.org/D96914
+        if linker == "lld" || linker.hasSuffix("ld.lld") {
+          commandLine.appendFlag(.Xlinker)
+          commandLine.appendFlag("-z")
+          commandLine.appendFlag(.Xlinker)
+          commandLine.appendFlag("nostart-stop-gc")
+        }
       }
 
       // Configure the toolchain.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2070,7 +2070,8 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       let lastJob = plannedJobs.last!
       XCTAssertTrue(lastJob.tool.name.contains("clang"))
-      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
+      XCTAssertTrue(lastJob.commandLine.contains(subsequence: [.flag("-fuse-ld=lld"),
+        .flag("-Xlinker"), .flag("-z"), .flag("-Xlinker"), .flag("nostart-stop-gc")]))
     }
   }
 


### PR DESCRIPTION
This is a Swift version of apple/swift#60544, which will fix apple/swift#60406. I ran the testsuite on linux x86_64 with this pull without a problem.  