### PR TITLE
Separate two kinds of emit-module jobs into different categories: source emit-module and explicit dependency interface build

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -182,7 +182,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
 
       jobs.append(Job(
         moduleName: moduleId.moduleName,
-        kind: .emitModule,
+        kind: .compileModuleFromInterface,
         tool: try toolchain.resolvedTool(.swiftCompiler),
         commandLine: commandLine,
         inputs: inputs,

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -28,6 +28,7 @@ public struct Job: Codable, Equatable, Hashable {
 
     /// Generate a compiled Clang module.
     case generatePCM = "generate-pcm"
+    case compileModuleFromInterface = "compile-module-from-interface"
     case dumpPCM = "dump-pcm"
     case interpret
     case repl
@@ -189,6 +190,9 @@ extension Job : CustomStringConvertible {
     case .emitModule:
         return "Emitting module for \(moduleName)"
 
+    case .compileModuleFromInterface:
+        return "Compiling module interface for Swift module \(moduleName)"
+
     case .generatePCH:
         return join("Compiling bridging header", displayInputs.first?.file.basename)
 
@@ -259,7 +263,7 @@ extension Job.Kind {
   /// Whether this job kind uses the Swift frontend.
   public var isSwiftFrontend: Bool {
     switch self {
-    case .backend, .compile, .mergeModule, .emitModule, .generatePCH,
+    case .backend, .compile, .mergeModule, .emitModule, .compileModuleFromInterface, .generatePCH,
         .generatePCM, .dumpPCM, .interpret, .repl, .printTargetInfo,
         .versionRequest, .emitSupportedFeatures, .scanDependencies, .verifyModuleInterface:
         return true
@@ -275,7 +279,7 @@ extension Job.Kind {
     switch self {
     case .compile:
       return true
-    case .backend, .mergeModule, .emitModule, .generatePCH,
+    case .backend, .mergeModule, .emitModule, .generatePCH, .compileModuleFromInterface,
          .generatePCM, .dumpPCM, .interpret, .repl, .printTargetInfo,
          .versionRequest, .autolinkExtract, .generateDSYM,
          .help, .link, .verifyDebugInfo, .scanDependencies,

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -39,7 +39,7 @@ throws {
       let moduleInterfacePath =
         TypedVirtualPath(file: swiftModuleDetails.moduleInterfacePath!.path,
                          type: .swiftInterface)
-      XCTAssertEqual(job.kind, .emitModule)
+      XCTAssertEqual(job.kind, .compileModuleFromInterface)
       XCTAssertTrue(job.inputs.contains(moduleInterfacePath))
       if let compiledCandidateList = swiftModuleDetails.compiledModuleCandidates {
         for compiledCandidate in compiledCandidateList {


### PR DESCRIPTION
`.emitModule` is re-used for two kinds of jobs:
- Build all sources of a target into a binary module
- In Explicit Module Builds, compile a dependency module interface into a binary module

It is worthwhile to treat these separate kinds of jobs separately.

Resolves rdar://98842129