### PR TITLE
[5.7] Work around lld 13+ issue with --gc-sections for ELF by adding -z nostart-stop-gc

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -84,6 +84,17 @@ extension GenericUnixToolchain {
         #else
         commandLine.appendFlag("-fuse-ld=\(linker)")
         #endif
+        // Starting with lld 13, Swift stopped working with the lld
+        // --gc-sections implementation for ELF, unless -z nostart-stop-gc is
+        // also passed to lld:
+        //
+        // https://reviews.llvm.org/D96914
+        if linker == "lld" || linker.hasSuffix("ld.lld") {
+          commandLine.appendFlag(.Xlinker)
+          commandLine.appendFlag("-z")
+          commandLine.appendFlag(.Xlinker)
+          commandLine.appendFlag("nostart-stop-gc")
+        }
       }
 
       // Configure the toolchain.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1923,7 +1923,8 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       let lastJob = plannedJobs.last!
       XCTAssertTrue(lastJob.tool.name.contains("clang"))
-      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
+      XCTAssertTrue(lastJob.commandLine.contains(subsequence: [.flag("-fuse-ld=lld"),
+        .flag("-Xlinker"), .flag("-z"), .flag("-Xlinker"), .flag("nostart-stop-gc")]))
     }
   }
 


### PR DESCRIPTION
Cherrypick of #1153

__Explanation:__ [lld 13 changed how `--gc-sections` works last year](https://reviews.llvm.org/D96914), which was then [flipped on by default](https://reviews.llvm.org/rG6d2d3bd0a61f5fc7fd9f61f48bc30e9ca77cc619), and causes all Swift code on ELF platforms not to link with lld 13 and 14 anymore if stripping is enabled.

__Scope:__ Only affects lld for these ELF platforms

__SR Issue:__ apple/swift#60406

__Risk:__ low, since it only affects ELF platforms for this one linker

__Testing:__ I [just built the last August 2 source snapshot of the 5.7 toolchain for Android AArch64](https://github.com/buttaface/termux-packages/actions/runs/2886129294), where lld 14 is the default linker, with [this patch](https://github.com/buttaface/termux-packages/blob/swift-devel/packages/swift/swift-lld-gc.patch) and it works well.
 
__Reviewer:__ @compnerd