### PR TITLE
[Dependency Scanning] Do not quote paths in the dependency scanner invocation command

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -331,8 +331,7 @@ public extension Driver {
   fileprivate func itemizedJobCommand(of job: Job, forceResponseFiles: Bool,
                                       using resolver: ArgsResolver) throws -> [String] {
     let (args, _) = try resolver.resolveArgumentList(for: job,
-                                                     forceResponseFiles: forceResponseFiles,
-                                                     quotePaths: true)
+                                                     forceResponseFiles: forceResponseFiles)
     return args
   }
 }


### PR DESCRIPTION
Since we are passing in the command-line to the scanner library with individual flags and paths as separate strings, this should not be necessary.
Depends on https://github.com/apple/swift/pull/60712

Part of rdar://98985453