### PR TITLE
Remove use of deprecated STSC 'Lock'

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import class Foundation.NSLock
 import TSCBasic
 @_implementationOnly import Yams
 
@@ -25,7 +26,7 @@ public final class ArgsResolver {
   // FIXME: We probably need a dedicated type for this...
   private let temporaryDirectory: VirtualPath
 
-  private let lock = Lock()
+  private let lock = NSLock()
 
   public init(fileSystem: FileSystem, temporaryDirectory: VirtualPath? = nil) throws {
     self.pathMapping = [:]
@@ -201,4 +202,14 @@ public final class ArgsResolver {
       try fileSystem.removeFileTree(absPath)
     }
   }
+}
+
+fileprivate extension NSLock {
+    /// NOTE: Keep in sync with SwiftPM's 'Sources/Basics/NSLock+Extensions.swift'
+    /// Execute the given block while holding the lock.
+    func withLock<T> (_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
 }

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -63,9 +63,6 @@ internal final class SwiftScan {
   /// The handle to the dylib.
   let dylib: Loader.Handle
 
-  /// Lock protecting private state.
-  let lock: Lock = Lock()
-
   /// libSwiftScan API functions.
   let api: swiftscan_functions_t;
 


### PR DESCRIPTION
- SwiftScan use of it seems not needed anymore
- ArgsResolver use can use 'NSLock' directly