### PR TITLE
Change phrasing of '.compileModuleFromInterface' to be more consistent

### DIFF
--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -191,7 +191,7 @@ extension Job : CustomStringConvertible {
         return "Emitting module for \(moduleName)"
 
     case .compileModuleFromInterface:
-        return "Compiling module interface for Swift module \(moduleName)"
+        return "Compiling Swift module \(moduleName)"
 
     case .generatePCH:
         return join("Compiling bridging header", displayInputs.first?.file.basename)


### PR DESCRIPTION
This way it is more similar to GeneratePCM's "Compiling Clang module...".