### PR TITLE
Pass down SDK name to the compiler by default

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -377,8 +377,7 @@ public final class DarwinToolchain: Toolchain {
       commandLine.append(.flag(sdkInfo.sdkVersion(for: targetVariantTriple).sdkVersionString))
     }
 
-    if driver.isFrontendArgSupported(.targetSdkName) &&
-       env["ENABLE_RESTRICT_SWIFTMODULE_SDK"] != nil {
+    if driver.isFrontendArgSupported(.targetSdkName) {
       commandLine.append(.flag(Option.targetSdkName.spelling))
       commandLine.append(.flag(sdkInfo.canonicalName))
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3931,7 +3931,6 @@ final class SwiftDriverTests: XCTestCase {
   // Test cases ported from Driver/macabi-environment.swift
   func testDarwinSDKVersioning() throws {
     var envVars = ProcessEnv.vars
-    envVars["ENABLE_RESTRICT_SWIFTMODULE_SDK"] = "YES"
     envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)
 
     try withTemporaryDirectory { tmpDir in


### PR DESCRIPTION
The compiler uses the -target-sdk-name flag information to restrict which swiftmodules can be loaded and which should be ignored. This avoids preventable crash when swiftmodules are copied between mismatching SDKs.

rdar://83104265