### PR TITLE
Add ability to override/disable response file use in ArgsResolver

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1380,7 +1380,7 @@ extension Driver {
       // In verbose mode, print out the job
       if parsedOptions.contains(.v) {
         let arguments: [String] = try executor.resolver.resolveArgumentList(for: inPlaceJob,
-                                                                            forceResponseFiles: forceResponseFiles)
+                                                                            useResponseFiles: forceResponseFiles ? .forced : .heuristic)
         stdoutStream <<< arguments.map { $0.spm_shellEscaped() }.joined(separator: " ") <<< "\n"
         stdoutStream.flush()
       }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -125,7 +125,7 @@ public extension Driver {
     if isSwiftScanLibAvailable {
       let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory!
       var command = try itemizedJobCommand(of: preScanJob,
-                                           forceResponseFiles: forceResponseFiles,
+                                           useResponseFiles: .disabled,
                                            using: executor.resolver)
       sanitizeCommandForLibScanInvocation(&command)
       imports =
@@ -154,7 +154,7 @@ public extension Driver {
     if isSwiftScanLibAvailable {
       let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory!
       var command = try itemizedJobCommand(of: scannerJob,
-                                           forceResponseFiles: forceResponseFiles,
+                                           useResponseFiles: .disabled,
                                            using: executor.resolver)
       sanitizeCommandForLibScanInvocation(&command)
       dependencyGraph =
@@ -183,7 +183,7 @@ public extension Driver {
     if isSwiftScanLibAvailable {
       let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory!
       var command = try itemizedJobCommand(of: batchScanningJob,
-                                           forceResponseFiles: forceResponseFiles,
+                                           useResponseFiles: .disabled,
                                            using: executor.resolver)
       sanitizeCommandForLibScanInvocation(&command)
       moduleVersionedGraphMap =
@@ -328,10 +328,10 @@ public extension Driver {
                                                                   contents)
   }
 
-  fileprivate func itemizedJobCommand(of job: Job, forceResponseFiles: Bool,
+  fileprivate func itemizedJobCommand(of job: Job, useResponseFiles: ResponseFileHandling,
                                       using resolver: ArgsResolver) throws -> [String] {
     let (args, _) = try resolver.resolveArgumentList(for: job,
-                                                     forceResponseFiles: forceResponseFiles)
+                                                     useResponseFiles: useResponseFiles)
     return args
   }
 }

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -579,7 +579,7 @@ class ExecuteJobRule: LLBuildRule {
     var pid = 0
     do {
       let arguments: [String] = try resolver.resolveArgumentList(for: job,
-                                                                 forceResponseFiles: context.forceResponseFiles)
+                                                                 useResponseFiles: context.forceResponseFiles ? .forced : .heuristic)
 
 
       let process : ProcessProtocol

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -35,8 +35,9 @@ public final class SwiftDriverExecutor: DriverExecutor {
   public func execute(job: Job,
                       forceResponseFiles: Bool = false,
                       recordedInputModificationDates: [TypedVirtualPath: Date] = [:]) throws -> ProcessResult {
+    let useResponseFiles : ResponseFileHandling = forceResponseFiles ? .forced : .heuristic
     let arguments: [String] = try resolver.resolveArgumentList(for: job,
-                                                               forceResponseFiles: forceResponseFiles)
+                                                               useResponseFiles: useResponseFiles)
 
     try job.verifyInputsNotModified(since: recordedInputModificationDates,
                                     fileSystem: fileSystem)
@@ -86,7 +87,8 @@ public final class SwiftDriverExecutor: DriverExecutor {
   }
 
   public func description(of job: Job, forceResponseFiles: Bool) throws -> String {
-    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, forceResponseFiles: forceResponseFiles)
+    let useResponseFiles : ResponseFileHandling = forceResponseFiles ? .forced : .heuristic
+    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, useResponseFiles: useResponseFiles)
     var result = args.map { $0.spm_shellEscaped() }.joined(separator: " ")
 
     if usedResponseFile {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1054,8 +1054,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let (args, _) = try resolver.resolveArgumentList(for: scannerJob,
-                                                       forceResponseFiles: false,
-                                                       quotePaths: true)
+                                                       useResponseFiles: .disabled)
       XCTAssertTrue(args.count > 1)
       XCTAssertFalse(args[0].hasSuffix(".resp"))
     }

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -150,7 +150,7 @@ final class ParsableMessageTests: XCTestCase {
                                          "-working-directory", workdir.pathString])
           let jobs = try driver.planBuild()
           let compileJob = jobs[0]
-          let args : [String] = try resolver.resolveArgumentList(for: compileJob, forceResponseFiles: false)
+          let args : [String] = try resolver.resolveArgumentList(for: compileJob, useResponseFiles: .disabled)
           let toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                    buildRecordInfo: nil,
                                                    showJobLifecycle: false,
@@ -237,7 +237,7 @@ final class ParsableMessageTests: XCTestCase {
                                          "-working-directory", "/WorkDir"])
           let jobs = try driver.planBuild()
           compileJob = jobs[0]
-          args = try resolver.resolveArgumentList(for: compileJob!, forceResponseFiles: false)
+          args = try resolver.resolveArgumentList(for: compileJob!)
           toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                buildRecordInfo: nil,
                                                showJobLifecycle: false,
@@ -313,8 +313,7 @@ final class ParsableMessageTests: XCTestCase {
                                          "-working-directory", "/WorkDir"])
           let jobs = try driver.planBuild()
           compileJob = jobs[0]
-          args  = try resolver.resolveArgumentList(for: compileJob!,
-                                                   forceResponseFiles: false)
+          args  = try resolver.resolveArgumentList(for: compileJob!)
           toolDelegate = ToolExecutionDelegate(mode: .parsableOutput,
                                                buildRecordInfo: nil,
                                                showJobLifecycle: false,


### PR DESCRIPTION
This change deprecates `ArgsResolver` API that takes a boolean `forceResponseFiles` in favor of a new API that takes an `ResponseFileHandling` enum. This enum allows the previous behaviors of `.forced` and `.heuristic` (`true` and `false`, respectively of `forceResponseFiles`), and adds an option to override disable use of response files completely (`.disabled`).

This is useful in the example of dependency scanning when it is done via a C interface to a compiler library: even for exceedingly-long command-line argument lists, using response files is not necessary since we just pass in an address of an already-allocated memory buffer containing the argument list, directly.

Resolves rdar://99296444