### PR TITLE
Replace Foundation.Date with TimePoint

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -12,7 +12,6 @@
 import TSCBasic
 import SwiftOptions
 
-import struct Foundation.Date
 import class Dispatch.DispatchQueue
 
 import enum TSCUtility.Diagnostics
@@ -179,7 +178,7 @@ public struct Driver {
   @_spi(Testing) public let inputFiles: [TypedVirtualPath]
 
   /// The last time each input file was modified, recorded at the start of the build.
-  @_spi(Testing) public let recordedInputModificationDates: [TypedVirtualPath: Date]
+  @_spi(Testing) public let recordedInputModificationDates: [TypedVirtualPath: TimePoint]
 
   /// The mapping from input files to output files for each kind.
   let outputFileMap: OutputFileMap?

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-import struct Foundation.Date
 import struct Foundation.Data
 import class Foundation.JSONDecoder
 import var Foundation.EXIT_SUCCESS
@@ -25,7 +24,7 @@ public protocol DriverExecutor {
   @discardableResult
   func execute(job: Job,
                forceResponseFiles: Bool,
-               recordedInputModificationDates: [TypedVirtualPath: Date]) throws -> ProcessResult
+               recordedInputModificationDates: [TypedVirtualPath: TimePoint]) throws -> ProcessResult
   
   /// Execute multiple jobs, tracking job status using the provided execution delegate.
   /// Pass in the `IncrementalCompilationState` to allow for incremental compilation.
@@ -33,7 +32,7 @@ public protocol DriverExecutor {
                delegate: JobExecutionDelegate,
                numParallelJobs: Int,
                forceResponseFiles: Bool,
-               recordedInputModificationDates: [TypedVirtualPath: Date]
+               recordedInputModificationDates: [TypedVirtualPath: TimePoint]
   ) throws
 
   /// Execute multiple jobs, tracking job status using the provided execution delegate.
@@ -41,7 +40,7 @@ public protocol DriverExecutor {
                delegate: JobExecutionDelegate,
                numParallelJobs: Int,
                forceResponseFiles: Bool,
-               recordedInputModificationDates: [TypedVirtualPath: Date]
+               recordedInputModificationDates: [TypedVirtualPath: TimePoint]
   ) throws
 
   /// Launch a process with the given command line and report the result.
@@ -86,7 +85,7 @@ extension DriverExecutor {
   func execute<T: Decodable>(job: Job,
                              capturingJSONOutputAs outputType: T.Type,
                              forceResponseFiles: Bool,
-                             recordedInputModificationDates: [TypedVirtualPath: Date]) throws -> T {
+                             recordedInputModificationDates: [TypedVirtualPath: TimePoint]) throws -> T {
     let result = try execute(job: job,
                              forceResponseFiles: forceResponseFiles,
                              recordedInputModificationDates: recordedInputModificationDates)
@@ -111,7 +110,7 @@ extension DriverExecutor {
     delegate: JobExecutionDelegate,
     numParallelJobs: Int,
     forceResponseFiles: Bool,
-    recordedInputModificationDates: [TypedVirtualPath: Date]
+    recordedInputModificationDates: [TypedVirtualPath: TimePoint]
   ) throws {
     try execute(
       workload: .all(jobs),

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -12,7 +12,6 @@
 
 import TSCBasic
 import SwiftOptions
-import struct Foundation.Date
 import class Dispatch.DispatchQueue
 
 /// Holds information required to read and write the build record (aka
@@ -38,9 +37,9 @@ import class Dispatch.DispatchQueue
   let fileSystem: FileSystem
   let currentArgsHash: String
   @_spi(Testing) public let actualSwiftVersion: String
-  @_spi(Testing) public let timeBeforeFirstJob: Date
+  @_spi(Testing) public let timeBeforeFirstJob: TimePoint
   let diagnosticEngine: DiagnosticsEngine
-  let compilationInputModificationDates: [TypedVirtualPath: Date]
+  let compilationInputModificationDates: [TypedVirtualPath: TimePoint]
 
   private var finishedJobResults = [JobResult]()
   // A confinement queue that protects concurrent access to the
@@ -53,9 +52,9 @@ import class Dispatch.DispatchQueue
     fileSystem: FileSystem,
     currentArgsHash: String,
     actualSwiftVersion: String,
-    timeBeforeFirstJob: Date,
+    timeBeforeFirstJob: TimePoint,
     diagnosticEngine: DiagnosticsEngine,
-    compilationInputModificationDates: [TypedVirtualPath: Date])
+    compilationInputModificationDates: [TypedVirtualPath: TimePoint])
   {
     self.buildRecordPath = buildRecordPath
     self.fileSystem = fileSystem
@@ -77,7 +76,7 @@ import class Dispatch.DispatchQueue
     outputFileMap: OutputFileMap?,
     incremental: Bool,
     parsedOptions: ParsedOptions,
-    recordedInputModificationDates: [TypedVirtualPath: Date]
+    recordedInputModificationDates: [TypedVirtualPath: TimePoint]
   ) {
     // Cannot write a buildRecord without a path.
     guard let buildRecordPath = Self.computeBuildRecordPath(
@@ -100,7 +99,7 @@ import class Dispatch.DispatchQueue
       fileSystem: fileSystem,
       currentArgsHash: currentArgsHash,
       actualSwiftVersion: actualSwiftVersion,
-      timeBeforeFirstJob: Date(),
+      timeBeforeFirstJob: .now(),
       diagnosticEngine: diagnosticEngine,
       compilationInputModificationDates: compilationInputModificationDates)
    }
@@ -165,7 +164,7 @@ import class Dispatch.DispatchQueue
         actualSwiftVersion: actualSwiftVersion,
         argsHash: currentArgsHash,
         timeBeforeFirstJob: timeBeforeFirstJob,
-        timeAfterLastJob: Date())
+        timeAfterLastJob: .now())
     }
 
     guard let contents = buildRecord.encode(currentArgsHash: currentArgsHash,

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -12,7 +12,6 @@
 
 import TSCBasic
 import SwiftOptions
-import struct Foundation.Date
 import class Dispatch.DispatchQueue
 
 // Initial incremental state computation
@@ -121,8 +120,8 @@ extension IncrementalCompilationState {
     @_spi(Testing) public let dependencyDotFilesIncludeExternals: Bool = true
     @_spi(Testing) public let dependencyDotFilesIncludeAPINotes: Bool = false
 
-    @_spi(Testing) public let buildStartTime: Date
-    @_spi(Testing) public let buildEndTime: Date
+    @_spi(Testing) public let buildStartTime: TimePoint
+    @_spi(Testing) public let buildEndTime: TimePoint
 
     // Do not try to reuse a graph from a different compilation, so check
     // the build record.
@@ -249,11 +248,10 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
       graphIfPresent = nil
     }
     catch let ModuleDependencyGraph.ReadError.timeTravellingPriors(priorsModTime: priorsModTime,
-                                                                   buildStartTime: buildStartTime,
-                                                                   priorsTimeIntervalSinceStart: priorsTimeIntervalSinceStart) {
+                                                                   buildStartTime: buildStartTime) {
       diagnosticEngine.emit(
         warning: "Will not do cross-module incremental builds, priors saved at \(priorsModTime)), " +
-        "but the previous build started at \(buildStartTime) [priorsTimeIntervalSinceStart: \(priorsTimeIntervalSinceStart)], at '\(dependencyGraphPath)'")
+        "but the previous build started at \(buildStartTime), at '\(dependencyGraphPath)'")
       graphIfPresent = nil
     }
     catch {

--- a/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-import struct Foundation.Date
 
 /// Contains information about the current status of an input to the incremental
 /// build.
@@ -24,9 +23,9 @@ import struct Foundation.Date
   /// The current status of the input file.
   /*@_spi(Testing)*/ public let status: Status
   /// The last known modification time of this input.
-  /*@_spi(Testing)*/ public let previousModTime: Date
+  /*@_spi(Testing)*/ public let previousModTime: TimePoint
 
-  /*@_spi(Testing)*/ public init(status: Status, previousModTime: Date) {
+  /*@_spi(Testing)*/ public init(status: Status, previousModTime: TimePoint) {
     self.status = status
     self.previousModTime = previousModTime
   }
@@ -119,7 +118,7 @@ fileprivate extension ProcessResult {
 
 // MARK: - reading
 public extension InputInfo {
-  init?(tag: String, previousModTime: Date,
+  init?(tag: String, previousModTime: TimePoint,
         failedToReadOutOfDateMap: (String) -> Void
   ) {
     guard let status = Status(identifier: tag) else {

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import TSCBasic
-import struct Foundation.Date
 
 /// A job represents an individual subprocess that should be invoked during compilation.
 public struct Job: Codable, Equatable, Hashable {
@@ -146,7 +145,7 @@ extension Job {
     }
   }
 
-  public func verifyInputsNotModified(since recordedInputModificationDates: [TypedVirtualPath: Date], fileSystem: FileSystem) throws {
+  public func verifyInputsNotModified(since recordedInputModificationDates: [TypedVirtualPath: TimePoint], fileSystem: FileSystem) throws {
     for input in inputs {
       if let recordedModificationTime = recordedInputModificationDates[input],
          try fileSystem.lastModificationTime(for: input.file) != recordedModificationTime {

--- a/Sources/SwiftDriver/Utilities/DateAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/DateAdditions.swift
@@ -10,27 +10,127 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.Date
-import protocol Foundation.LocalizedError
-import func Foundation.floor
+#if os(Windows)
+import WinSDK
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
 
-public extension Date {
-  init(legacyDriverSecsAndNanos secsAndNanos: [Int]) throws {
-  enum Errors: LocalizedError {
-    case needSecondsAndNanoseconds
+/// Represents a time point value with nanosecond precision.
+///
+/// - Warning: The accuracy of measured `TimePoint` values is an OS-dependent property.
+///            `TimePoint` does not correct for OS-level differences in e.g.
+///             clock epochs. This makes it unsuitable for serialization in
+///             products that are expected to transit between machines.
+public struct TimePoint: Equatable, Comparable, Hashable {
+  public var seconds: UInt64
+  public var nanoseconds: UInt32
+
+  public init(seconds: UInt64, nanoseconds: UInt32) {
+    self.seconds = seconds
+    self.nanoseconds = nanoseconds
   }
-  guard secsAndNanos.count == 2 else {
-    throw Errors.needSecondsAndNanoseconds
+
+  public static func < (lhs: TimePoint, rhs: TimePoint) -> Bool {
+    return (lhs.seconds, lhs.nanoseconds) < (rhs.seconds, rhs.nanoseconds)
+  }
+}
+
+extension TimePoint {
+  public static func seconds(_ value: Int) -> TimePoint {
+    precondition(value >= 0,
+                 "Duration value in seconds is \(value), but cannot be negative")
+    return TimePoint(seconds: UInt64(value), nanoseconds: 0)
+  }
+
+  public static func nanoseconds(_ value: Int) -> TimePoint {
+    precondition(value >= 0,
+                 "Duration value in nanoseconds is \(value), but cannot be negative")
+    let (seconds, nanos) = value.quotientAndRemainder(dividingBy: TimePoint.nanosecondsPerSecond)
+    return TimePoint(seconds: UInt64(seconds),
+                     nanoseconds: UInt32(nanos))
+  }
+}
+
+extension TimePoint: AdditiveArithmetic {
+  public static var zero: TimePoint {
+    return .seconds(0)
+  }
+
+  public static func + (lhs: TimePoint, rhs: TimePoint) -> TimePoint {
+    // Add raw operands
+    var seconds = lhs.seconds + rhs.seconds
+    var nanos = lhs.nanoseconds + rhs.nanoseconds
+    // Normalize nanoseconds
+    if nanos >= TimePoint.nanosecondsPerSecond {
+      nanos -= UInt32(TimePoint.nanosecondsPerSecond)
+      seconds += 1
     }
-    self = Self(legacyDriverSecs: secsAndNanos[0], nanos: secsAndNanos[1])
+    return TimePoint(seconds: seconds, nanoseconds: nanos)
   }
-  init(legacyDriverSecs secs: Int, nanos: Int) {
-    self = Date(timeIntervalSince1970: Double(secs) + Double(nanos) / 1e9)
+
+  public static func - (lhs: TimePoint, rhs: TimePoint) -> TimePoint {
+    // Subtract raw operands
+    var seconds = lhs.seconds - rhs.seconds
+    // Normalize nanoseconds
+    let nanos: UInt32
+    if lhs.nanoseconds >= rhs.nanoseconds {
+      nanos = lhs.nanoseconds - rhs.nanoseconds
+    } else {
+      // Subtract nanoseconds with carry - order of operations here
+      // is important to avoid overflow.
+      nanos = lhs.nanoseconds + UInt32(TimePoint.nanosecondsPerSecond) - rhs.nanoseconds
+      seconds -= 1
+    }
+    return TimePoint(seconds: seconds, nanoseconds: nanos)
   }
-  var legacyDriverSecsAndNanos: [Int] {
-    let totalSecs = timeIntervalSince1970
-    let secs  = Int(              floor(totalSecs))
-    let nanos = Int((totalSecs  - floor(totalSecs)) * 1e9)
-    return [secs, nanos]
+}
+
+extension TimePoint{
+  public static func now() -> TimePoint {
+    #if os(Windows)
+    var ftTime: FILETIME = FILETIME()
+    GetSystemTimePreciseAsFileTime(&ftTime)
+
+    let result: UInt64 = (UInt64(ftTime.dwLowDateTime) << 0)
+                       + (UInt64(ftTime.dwHighDateTime) << 32)
+    // Windows ticks in 100 nanosecond intervals.
+    return .seconds(Int(result / 10_000_000))
+    #else
+    var tv = timeval()
+    gettimeofday(&tv, nil)
+    return TimePoint(seconds: UInt64(tv.tv_sec),
+                     nanoseconds: UInt32(tv.tv_usec) * UInt32(Self.nanosecondsPerMicrosecond))
+    #endif
   }
+
+  public static var distantPast: TimePoint {
+    return .zero
+  }
+
+  public static var distantFuture: TimePoint {
+    // N.B. This is the seconds value of `Foundation.Date.distantFuture.timeIntervalSince1970`.
+    // At time of writing, this is January 1, 4001 at 12:00:00 AM GMT, which is
+    // far enough in the future that it's a reasonable time point for us to
+    // compare against.
+    //
+    // However, it is important to note that Foundation's value cannot be both
+    // fixed in time AND correct because of leap seconds and other calendrical
+    // oddities.
+    //
+    // Other candidates include std::chrono's std::time_point::max - which is
+    // about 9223372036854775807 - enough to comfortably bound the age of the
+    // universe.
+    return .seconds(64_092_211_200)
+  }
+}
+
+extension TimePoint {
+  fileprivate static let nanosecondsPerSecond: Int = 1_000_000_000
+  fileprivate static let nanosecondsPerMillisecond: Int = 1_000_000
+  fileprivate static let nanosecondsPerMicrosecond: Int = 1_000
+  fileprivate static let millisecondsPerSecond: Int = 1_000
+  fileprivate static let microsecondsPerSecond: Int = 1_000_000
 }

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -13,9 +13,6 @@ import TSCBasic
 import struct Foundation.Data
 import struct Foundation.TimeInterval
 import class Dispatch.DispatchQueue
-#if canImport(Darwin)
-import var Foundation.kCFAbsoluteTimeIntervalSince1970
-#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -16,7 +16,6 @@ import SwiftDriver
 
 import class Dispatch.DispatchQueue
 import class Foundation.OperationQueue
-import struct Foundation.Date
 import class Foundation.FileHandle
 import var Foundation.EXIT_SUCCESS
 import var Foundation.EXIT_FAILURE
@@ -79,7 +78,7 @@ public final class MultiJobExecutor {
     let forceResponseFiles: Bool
 
     /// The last time each input file was modified, recorded at the start of the build.
-    public let recordedInputModificationDates: [TypedVirtualPath: Date]
+    public let recordedInputModificationDates: [TypedVirtualPath: TimePoint]
 
     /// The diagnostics engine to use when reporting errors.
     let diagnosticsEngine: DiagnosticsEngine
@@ -106,7 +105,7 @@ public final class MultiJobExecutor {
       jobQueue: OperationQueue,
       processSet: ProcessSet?,
       forceResponseFiles: Bool,
-      recordedInputModificationDates: [TypedVirtualPath: Date],
+      recordedInputModificationDates: [TypedVirtualPath: TimePoint],
       diagnosticsEngine: DiagnosticsEngine,
       processType: ProcessProtocol.Type = Process.self,
       inputHandleOverride: FileHandle? = nil
@@ -254,7 +253,7 @@ public final class MultiJobExecutor {
   private let forceResponseFiles: Bool
 
   /// The last time each input file was modified, recorded at the start of the build.
-  private let recordedInputModificationDates: [TypedVirtualPath: Date]
+  private let recordedInputModificationDates: [TypedVirtualPath: TimePoint]
 
   /// The diagnostics engine to use when reporting errors.
   private let diagnosticsEngine: DiagnosticsEngine
@@ -273,7 +272,7 @@ public final class MultiJobExecutor {
     numParallelJobs: Int? = nil,
     processSet: ProcessSet? = nil,
     forceResponseFiles: Bool = false,
-    recordedInputModificationDates: [TypedVirtualPath: Date] = [:],
+    recordedInputModificationDates: [TypedVirtualPath: TimePoint] = [:],
     processType: ProcessProtocol.Type = Process.self,
     inputHandleOverride: FileHandle? = nil
   ) {

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -12,7 +12,6 @@
 
 import SwiftDriver
 import TSCBasic
-import struct Foundation.Date
 import class Foundation.FileHandle
 
 public final class SwiftDriverExecutor: DriverExecutor {
@@ -35,7 +34,7 @@ public final class SwiftDriverExecutor: DriverExecutor {
 
   public func execute(job: Job,
                       forceResponseFiles: Bool = false,
-                      recordedInputModificationDates: [TypedVirtualPath: Date] = [:]) throws -> ProcessResult {
+                      recordedInputModificationDates: [TypedVirtualPath: TimePoint] = [:]) throws -> ProcessResult {
     let useResponseFiles : ResponseFileHandling = forceResponseFiles ? .forced : .heuristic
     let arguments: [String] = try resolver.resolveArgumentList(for: job,
                                                                useResponseFiles: useResponseFiles)
@@ -68,7 +67,7 @@ public final class SwiftDriverExecutor: DriverExecutor {
                       delegate: JobExecutionDelegate,
                       numParallelJobs: Int = 1,
                       forceResponseFiles: Bool = false,
-                      recordedInputModificationDates: [TypedVirtualPath: Date] = [:]
+                      recordedInputModificationDates: [TypedVirtualPath: TimePoint] = [:]
   ) throws {
     let llbuildExecutor = MultiJobExecutor(
       workload: workload,

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -118,7 +118,7 @@ extension BuildRecordInfo {
       fileSystem: localFileSystem,
       currentArgsHash: "",
       actualSwiftVersion: "for-testing",
-      timeBeforeFirstJob: Date(),
+      timeBeforeFirstJob: .now(),
       diagnosticEngine: diagnosticEngine,
       compilationInputModificationDates: [:])
   }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 import XCTest
 import TSCBasic
+import Foundation
 
 @_spi(Testing) import SwiftDriver
 import SwiftOptions
@@ -1228,10 +1229,12 @@ extension IncrementalCompilationTests {
       return
     }
     let goodModTime = { start, end in
-      start.advanced(by: end.timeIntervalSince(start) / 2.0)
+      start + TimePoint(seconds: (end - start).seconds / 2, nanoseconds: .zero)
     }(buildRecord.buildStartTime, buildRecord.buildEndTime)
-    try setModTime(of: .absolute(priorsPath),
-                   to: goodModTime)
+
+    let ti = (TimeInterval(goodModTime.seconds) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(goodModTime.nanoseconds))
+    let goodModDate = Date(timeIntervalSinceReferenceDate: ti)
+    try setModTime(of: .absolute(priorsPath), to: goodModDate)
   }
 
   private func verifyNoPriors() {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -1232,8 +1232,7 @@ extension IncrementalCompilationTests {
       start + TimePoint(seconds: (end - start).seconds / 2, nanoseconds: .zero)
     }(buildRecord.buildStartTime, buildRecord.buildEndTime)
 
-    let ti = (TimeInterval(goodModTime.seconds) - kCFAbsoluteTimeIntervalSince1970) + (1.0e-9 * TimeInterval(goodModTime.nanoseconds))
-    let goodModDate = Date(timeIntervalSinceReferenceDate: ti)
+    let goodModDate = Date(timeIntervalSinceReferenceDate: TimeInterval(goodModTime.seconds))
     try setModTime(of: .absolute(priorsPath), to: goodModDate)
   }
 

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -215,6 +215,35 @@ final class NonincrementalCompilationTests: XCTestCase {
     XCTAssertEqual(sn.nanoseconds, 8000)
   }
 
+  func testZeroDuration() {
+    XCTAssertEqual(TimePoint.zero, TimePoint.seconds(0))
+    XCTAssertEqual(TimePoint.zero, TimePoint.nanoseconds(0))
+  }
+
+  func testDurationSecondsArithmetic() {
+    let x = TimePoint.seconds(1)
+    XCTAssertEqual(TimePoint.zero + x, x)
+    XCTAssertEqual(x + TimePoint.zero, x)
+    XCTAssertEqual(x - TimePoint.zero, x)
+
+    let y = TimePoint.nanoseconds(1)
+    let z = TimePoint.nanoseconds(2_000_000)
+    XCTAssertEqual(x + (y + z), (x + y) + z)
+  }
+
+  func testDurationComparison() {
+    let x = TimePoint.seconds(1)
+    let y = TimePoint.nanoseconds(500)
+
+    XCTAssertEqual(x < y, !(x >= y))
+  }
+
+  func testDurationOverflow() {
+    XCTAssertEqual(TimePoint.nanoseconds(1_000_000_000), TimePoint.seconds(1))
+    XCTAssertEqual(TimePoint.nanoseconds(500_000_000) + TimePoint.nanoseconds(500_000_000), TimePoint.seconds(1))
+    XCTAssertEqual(TimePoint.nanoseconds(1_500_000_000) + TimePoint.nanoseconds(500_000_000), TimePoint.seconds(2))
+  }
+
   func testReadAndWriteBuildRecord() throws {
     let version = "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
     let options = "abbbfbcaf36b93e58efaadd8271ff142"

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -27,21 +27,21 @@ final class NonincrementalCompilationTests: XCTestCase {
                    "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)")
     XCTAssertEqual(buildRecord.argsHash, "abbbfbcaf36b93e58efaadd8271ff142")
 
-    try XCTAssertEqual(buildRecord.buildStartTime,
-                       Date(legacyDriverSecsAndNanos: [1570318779, 32358000]))
-    try XCTAssertEqual(buildRecord.buildEndTime,
-                       Date(legacyDriverSecsAndNanos: [1570318779, 32358000]))
+    XCTAssertEqual(buildRecord.buildStartTime,
+                   TimePoint(seconds: 1570318779, nanoseconds: 32358000))
+    XCTAssertEqual(buildRecord.buildEndTime,
+                   TimePoint(seconds: 1570318779, nanoseconds: 32358010))
     try XCTAssertEqual(buildRecord.inputInfos,
                        [
                         VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"):
                           InputInfo(status: .needsCascadingBuild,
-                                    previousModTime: Date(legacyDriverSecsAndNanos: [1570318778, 0])),
+                                    previousModTime: TimePoint(seconds: 1570318778, nanoseconds: 0)),
                         VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"):
                           InputInfo(status: .upToDate,
-                                    previousModTime: Date(legacyDriverSecsAndNanos: [1570083660, 0])),
+                                    previousModTime: TimePoint(seconds: 1570083660, nanoseconds: 0)),
                         VirtualPath(path: "/Volumes/gazorp.swift"):
                           InputInfo(status: .needsNonCascadingBuild,
-                                    previousModTime:  Date(legacyDriverSecsAndNanos: [0, 0]))
+                                    previousModTime: .zero),
                        ])
   }
 
@@ -54,21 +54,21 @@ final class NonincrementalCompilationTests: XCTestCase {
                    "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)")
     XCTAssertEqual(buildRecord.argsHash, nil)
 
-    try XCTAssertEqual(buildRecord.buildStartTime,
-                       Date(legacyDriverSecsAndNanos: [1570318779, 32358000]))
-    try XCTAssertEqual(buildRecord.buildEndTime,
-                       Date(legacyDriverSecsAndNanos: [1570318779, 32358010]))
+    XCTAssertEqual(buildRecord.buildStartTime,
+                   TimePoint(seconds: 1570318779, nanoseconds: 32358000))
+    XCTAssertEqual(buildRecord.buildEndTime,
+                   TimePoint(seconds: 1570318779, nanoseconds: 32358010))
     try XCTAssertEqual(buildRecord.inputInfos,
                        [
                         VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift"):
                           InputInfo(status: .needsCascadingBuild,
-                                    previousModTime: Date(legacyDriverSecsAndNanos: [1570318778, 0])),
+                                    previousModTime: TimePoint(seconds: 1570318778, nanoseconds: 0)),
                         VirtualPath(path: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift"):
                           InputInfo(status: .upToDate,
-                                    previousModTime: Date(legacyDriverSecsAndNanos: [1570083660, 0])),
+                                    previousModTime: TimePoint(seconds: 1570083660, nanoseconds: 0)),
                         VirtualPath(path: "/Volumes/gazorp.swift"):
                           InputInfo(status: .needsNonCascadingBuild,
-                                    previousModTime:  Date(legacyDriverSecsAndNanos: [0, 0]))
+                                    previousModTime: .zero)
                        ])
   }
 
@@ -210,10 +210,11 @@ final class NonincrementalCompilationTests: XCTestCase {
   }
 
   func testDateConversion() {
-    let sn =  [0, 8000]
-    let d = try! Date(legacyDriverSecsAndNanos: sn)
-    XCTAssert(isCloseEnough(d.legacyDriverSecsAndNanos, sn))
+    let sn = TimePoint(seconds: 0, nanoseconds: 8000)
+    XCTAssertEqual(sn.seconds, 0)
+    XCTAssertEqual(sn.nanoseconds, 8000)
   }
+
   func testReadAndWriteBuildRecord() throws {
     let version = "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
     let options = "abbbfbcaf36b93e58efaadd8271ff142"
@@ -236,27 +237,23 @@ final class NonincrementalCompilationTests: XCTestCase {
     XCTAssertEqual(buildRecord.swiftVersion, version)
     XCTAssertEqual(buildRecord.argsHash, options)
     XCTAssertEqual(buildRecord.inputInfos.count, 3)
-    XCTAssert(isCloseEnough(buildRecord.buildStartTime.legacyDriverSecsAndNanos,
-                            [1570318779, 32357931]))
-    XCTAssert(isCloseEnough(buildRecord.buildEndTime.legacyDriverSecsAndNanos,
-                            [1580318779, 33357941]))
+    XCTAssertEqual(buildRecord.buildStartTime,
+                   TimePoint(seconds: 1570318779, nanoseconds: 32357931))
+    XCTAssertEqual(buildRecord.buildEndTime,
+                   TimePoint(seconds: 1580318779, nanoseconds: 33357858))
 
-    XCTAssertEqual(try! buildRecord.inputInfos[VirtualPath(path: file2.pathString)]!.status,
+    XCTAssertEqual(try buildRecord.inputInfos[VirtualPath(path: file2.pathString)]!.status,
                    .needsCascadingBuild)
-    XCTAssert(try! isCloseEnough(
-                XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: file2.pathString)])
-                  .previousModTime.legacyDriverSecsAndNanos,
-                [1570318778, 0]))
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp.pathString)]).status,
+    XCTAssertEqual(try XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: file2.pathString)]).previousModTime,
+                   TimePoint(seconds: 1570318778, nanoseconds: 0))
+    XCTAssertEqual(try XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp.pathString)]).status,
                    .needsNonCascadingBuild)
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp.pathString)])
-                    .previousModTime.legacyDriverSecsAndNanos,
-                   [0, 0])
-    XCTAssertEqual(try! XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main.pathString)]).status,
+    XCTAssertEqual(try XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: gazorp.pathString)]).previousModTime,
+                   .zero)
+    XCTAssertEqual(try XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main.pathString)]).status,
                    .upToDate)
-    XCTAssert(try! isCloseEnough(XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main.pathString)])
-                                   .previousModTime.legacyDriverSecsAndNanos,
-                                 [1570083660, 0]))
+    XCTAssertEqual(try XCTUnwrap(buildRecord.inputInfos[VirtualPath(path: main.pathString)]).previousModTime,
+                   TimePoint(seconds: 1570083660, nanoseconds: 0))
 
     let outputString = try XCTUnwrap (buildRecord.encode(currentArgsHash: options,
                                                          diagnosticEngine: DiagnosticsEngine()))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -311,8 +311,8 @@ final class SwiftDriverTests: XCTestCase {
       try localFileSystem.writeFileContents(main) { $0 <<< "print(hi)" }
       try localFileSystem.writeFileContents(util) { $0 <<< "let hi = \"hi\"" }
 
-      let mainMDate = try localFileSystem.getFileInfo(main).modTime
-      let utilMDate = try localFileSystem.getFileInfo(util).modTime
+      let mainMDate = try localFileSystem.lastModificationTime(for: .absolute(main))
+      let utilMDate = try localFileSystem.lastModificationTime(for: .absolute(util))
       let driver = try Driver(args: [
         "swiftc", main.pathString, utilRelative.pathString,
       ])
@@ -4717,14 +4717,14 @@ final class SwiftDriverTests: XCTestCase {
       struct MockExecutor: DriverExecutor {
         let resolver: ArgsResolver
 
-        func execute(job: Job, forceResponseFiles: Bool, recordedInputModificationDates: [TypedVirtualPath : Date]) throws -> ProcessResult {
+        func execute(job: Job, forceResponseFiles: Bool, recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws -> ProcessResult {
           return ProcessResult(arguments: [], environment: [:], exitStatus: .terminated(code: 0), output: .success(Array("bad JSON".utf8)), stderrOutput: .success([]))
         }
         func execute(workload: DriverExecutorWorkload,
                      delegate: JobExecutionDelegate,
                      numParallelJobs: Int,
                      forceResponseFiles: Bool,
-                     recordedInputModificationDates: [TypedVirtualPath : Date]) throws {
+                     recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws {
           fatalError()
         }
         func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {


### PR DESCRIPTION
A TimePoint functions like a Duration, but for products that cannot yet use the niceties in Swift 5.7 like the Swift driver. This type carries a 64-bit second value and a 32-bit nanosecond value. Like Duration, it does not represent any one OS clock value, but is rather just a "point in time".

Using this type, we can simplify and clean up quite a few places that were trafficking in Foundation.Date and prepare for a future world where we have Duration too. The driver uses time point values to compare file modification times to each other - hence why we can get away with ignoring the epoch. The one oddity is the build record, which serializes time point values. But build records, like the rest of the incremental state, are not actually meant to leave a given user's machine.
