### PR TITLE
[Explicit Modules] Query and then emit diagnostics from the dependency scanner

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -43,6 +43,18 @@ typedef struct swiftscan_module_details_s *swiftscan_module_details_t;
 typedef struct swiftscan_dependency_info_s *swiftscan_dependency_info_t;
 typedef struct swiftscan_dependency_graph_s *swiftscan_dependency_graph_t;
 typedef struct swiftscan_import_set_s *swiftscan_import_set_t;
+typedef struct swiftscan_diagnostic_info_s *swiftscan_diagnostic_info_t;
+
+typedef enum {
+  SWIFTSCAN_DIAGNOSTIC_SEVERITY_ERROR = 0,
+  SWIFTSCAN_DIAGNOSTIC_SEVERITY_WARNING = 1,
+  SWIFTSCAN_DIAGNOSTIC_SEVERITY_NOTE = 2,
+  SWIFTSCAN_DIAGNOSTIC_SEVERITY_REMARK = 3
+} swiftscan_diagnostic_severity_t;
+typedef struct {
+  swiftscan_diagnostic_info_t *diagnostics;
+  size_t count;
+} swiftscan_diagnostic_set_t;
 typedef struct {
   swiftscan_dependency_info_t *modules;
   size_t count;
@@ -210,6 +222,18 @@ typedef struct {
                                         swiftscan_scan_invocation_t);
   swiftscan_import_set_t
   (*swiftscan_import_set_create)(swiftscan_scanner_t, swiftscan_scan_invocation_t);
+  
+  //=== Scanner Diagnostics -------------------------------------------------===//
+  swiftscan_diagnostic_set_t*
+  (*swiftscan_scanner_diagnostics_query)(swiftscan_scanner_t);
+  void
+  (*swiftscan_scanner_diagnostics_reset)(swiftscan_scanner_t);
+  swiftscan_string_ref_t
+  (*swiftscan_diagnostic_get_message)(swiftscan_diagnostic_info_t);
+  swiftscan_diagnostic_severity_t
+  (*swiftscan_diagnostic_get_severity)(swiftscan_diagnostic_info_t);
+  void
+  (*swiftscan_diagnostics_set_dispose)(swiftscan_diagnostic_set_t*);
 
   //=== Scanner Cache Functions ---------------------------------------------===//
   void (*swiftscan_scanner_cache_serialize)(swiftscan_scanner_t scanner, const char * path);

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -116,6 +116,25 @@ public class InterModuleDependencyOracle {
       swiftScan.resetScannerCache()
     }
   }
+  
+  @_spi(Testing) public func supportsScannerDiagnostics() throws -> Bool {
+    guard let swiftScan = swiftScanLibInstance else {
+      fatalError("Attempting to reset scanner cache with no scanner instance.")
+    }
+    return swiftScan.supportsScannerDiagnostics()
+  }
+  
+  @_spi(Testing) public func getScannerDiagnostics() throws -> [ScannerDiagnosticPayload]? {
+    guard let swiftScan = swiftScanLibInstance else {
+      fatalError("Attempting to reset scanner cache with no scanner instance.")
+    }
+    guard swiftScan.supportsScannerDiagnostics() else {
+      return nil
+    }
+    let diags = try swiftScan.queryScannerDiagnostics()
+    try swiftScan.resetScannerDiagnostics()
+    return diags.isEmpty ? nil : diags
+  }
 
   private var hasScannerInstance: Bool { self.swiftScanLibInstance != nil }
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -21,6 +21,18 @@ extension Diagnostic.Message {
   static func warn_scanner_frontend_fallback() -> Diagnostic.Message {
     .warning("Fallback to `swift-frontend` dependency scanner invocation")
   }
+  static func scanner_diagnostic_error(_ message: String) -> Diagnostic.Message {
+    .error("Dependency scanning failure: \(message)")
+  }
+  static func scanner_diagnostic_warn(_ message: String) -> Diagnostic.Message {
+    .warning(message)
+  }
+  static func scanner_diagnostic_note(_ message: String) -> Diagnostic.Message {
+    .note(message)
+  }
+  static func scanner_diagnostic_remark(_ message: String) -> Diagnostic.Message {
+    .remark(message)
+  }
 }
 
 public extension Driver {
@@ -164,6 +176,23 @@ public extension Driver {
         try interModuleDependencyOracle.getDependencies(workingDirectory: cwd,
                                                         moduleAliases: moduleOutputInfo.aliases,
                                                         commandLine: command)
+      let possibleDiags = try interModuleDependencyOracle.getScannerDiagnostics()
+      if let diags = possibleDiags {
+        for diagnostic in diags {
+          switch diagnostic.severity {
+          case .error:
+            diagnosticEngine.emit(.scanner_diagnostic_error(diagnostic.message))
+          case .warning:
+            diagnosticEngine.emit(.scanner_diagnostic_warn(diagnostic.message))
+          case .note:
+            diagnosticEngine.emit(.scanner_diagnostic_note(diagnostic.message))
+          case .remark:
+            diagnosticEngine.emit(.scanner_diagnostic_remark(diagnostic.message))
+          case .ignored:
+            diagnosticEngine.emit(.scanner_diagnostic_error(diagnostic.message))
+          }
+        }
+      }
     } else {
       // Fallback to legacy invocation of the dependency scanner with
       // `swift-frontend -scan-dependencies`

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -54,6 +54,28 @@ public enum DependencyScanningError: Error, DiagnosticData {
   }
 }
 
+@_spi(Testing) public struct ScannerDiagnosticPayload {
+  @_spi(Testing) public let severity: Diagnostic.Behavior
+  @_spi(Testing) public let message: String
+}
+
+internal extension swiftscan_diagnostic_severity_t {
+  func toDiagnosticBehavior() -> Diagnostic.Behavior {
+    switch self {
+    case SWIFTSCAN_DIAGNOSTIC_SEVERITY_ERROR:
+      return Diagnostic.Behavior.error
+    case SWIFTSCAN_DIAGNOSTIC_SEVERITY_WARNING:
+      return Diagnostic.Behavior.warning
+    case SWIFTSCAN_DIAGNOSTIC_SEVERITY_NOTE:
+      return Diagnostic.Behavior.note
+    case SWIFTSCAN_DIAGNOSTIC_SEVERITY_REMARK:
+      return Diagnostic.Behavior.remark
+    default:
+      return Diagnostic.Behavior.error
+    }
+  }
+}
+
 /// Wrapper for libSwiftScan, taking care of initialization, shutdown, and dispatching dependency scanning queries.
 internal final class SwiftScan {
   /// The path to the libSwiftScan dylib.
@@ -232,6 +254,41 @@ internal final class SwiftScan {
   func resetScannerCache() {
     api.swiftscan_scanner_cache_reset(scanner)
   }
+  
+  @_spi(Testing) public func supportsScannerDiagnostics() -> Bool {
+    return api.swiftscan_scanner_diagnostics_query != nil &&
+           api.swiftscan_scanner_diagnostics_reset != nil &&
+           api.swiftscan_diagnostic_get_message != nil &&
+           api.swiftscan_diagnostic_get_severity != nil &&
+           api.swiftscan_diagnostics_set_dispose != nil
+  }
+  
+  @_spi(Testing) public func queryScannerDiagnostics() throws -> [ScannerDiagnosticPayload] {
+    var result: [ScannerDiagnosticPayload] = []
+    let diagnosticSetRefOrNull = api.swiftscan_scanner_diagnostics_query(scanner)
+    guard let diagnosticSetRef = diagnosticSetRefOrNull else {
+      // Seems heavy-handed to fail here
+      // throw DependencyScanningError.dependencyScanFailed
+      return []
+    }
+    defer { api.swiftscan_diagnostics_set_dispose(diagnosticSetRef) }
+    let diagnosticRefArray = Array(UnsafeBufferPointer(start: diagnosticSetRef.pointee.diagnostics,
+                                                       count: Int(diagnosticSetRef.pointee.count)))
+    
+    for diagnosticRefOrNull in diagnosticRefArray {
+      guard let diagnosticRef = diagnosticRefOrNull else {
+        throw DependencyScanningError.dependencyScanFailed
+      }
+      let message = try toSwiftString(api.swiftscan_diagnostic_get_message(diagnosticRef))
+      let severity = api.swiftscan_diagnostic_get_severity(diagnosticRef)
+      result.append(ScannerDiagnosticPayload(severity: severity.toDiagnosticBehavior(), message: message))
+    }
+    return result
+  }
+  
+  @_spi(Testing) public func resetScannerDiagnostics() throws {
+    api.swiftscan_scanner_diagnostics_reset(scanner)
+  }
 
   @_spi(Testing) public func canQuerySupportedArguments() -> Bool {
     return api.swiftscan_compiler_supported_arguments_query != nil &&
@@ -297,6 +354,18 @@ private extension swiftscan_functions_t {
     // Clang dependency captured PCM args
     self.swiftscan_clang_detail_get_captured_pcm_args =
       try loadOptional("swiftscan_clang_detail_get_captured_pcm_args")
+    
+    // Scanner diagnostic emission query
+    self.swiftscan_scanner_diagnostics_query =
+      try loadOptional("swiftscan_scanner_diagnostics_query")
+    self.swiftscan_scanner_diagnostics_reset =
+      try loadOptional("swiftscan_scanner_diagnostics_reset")
+    self.swiftscan_diagnostic_get_message =
+      try loadOptional("swiftscan_diagnostic_get_message")
+    self.swiftscan_diagnostic_get_severity =
+      try loadOptional("swiftscan_diagnostic_get_severity")
+    self.swiftscan_diagnostics_set_dispose =
+      try loadOptional("swiftscan_diagnostics_set_dispose")
 
     // MARK: Required Methods
     func loadRequired<T>(_ symbol: String) throws -> T {

--- a/TestInputs/ExplicitModuleBuilds/Swift/I.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/I.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name I
+import unknown_module
+public func funcI() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/S.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/S.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name S
+import W
+public func funcS() { }

--- a/TestInputs/ExplicitModuleBuilds/Swift/W.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/W.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name W
+import I
+public func funcW() { }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1059,6 +1059,79 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertFalse(args[0].hasSuffix(".resp"))
     }
   }
+  
+  func testDependencyScanningFailure() throws {
+    let (stdlibPath, shimsPath, toolchain, hostTriple) = try getDriverArtifactsForScanning()
+    
+    // The dependency oracle wraps an instance of libSwiftScan and ensures thread safety across
+    // queries.
+    let dependencyOracle = InterModuleDependencyOracle()
+    let scanLibPath = try Driver.getScanLibPath(of: toolchain,
+                                                hostTriple: hostTriple,
+                                                env: ProcessEnv.vars)
+    guard try dependencyOracle
+      .verifyOrCreateScannerInstance(fileSystem: localFileSystem,
+                                     swiftScanLibPath: scanLibPath) else {
+      XCTFail("Dependency scanner library not found")
+      return
+    }
+    guard try dependencyOracle.supportsScannerDiagnostics() else {
+      XCTSkip("libSwiftScan does not support diagnostics query.")
+      return
+    }
+    
+    try withTemporaryDirectory { path in
+      let main = path.appending(component: "testDependencyScanning.swift")
+      try localFileSystem.writeFileContents(main) {
+        $0 <<< "import S;"
+      }
+      
+      let cHeadersPath: AbsolutePath =
+      testInputsPath.appending(component: "ExplicitModuleBuilds")
+        .appending(component: "CHeaders")
+      let swiftModuleInterfacesPath: AbsolutePath =
+      testInputsPath.appending(component: "ExplicitModuleBuilds")
+        .appending(component: "Swift")
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+      var driver = try Driver(args: ["swiftc",
+                                     "-I", cHeadersPath.nativePathString(escaped: true),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", stdlibPath.nativePathString(escaped: true),
+                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-import-objc-header",
+                                     "-explicit-module-build",
+                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-disable-clang-target",
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                              env: ProcessEnv.vars)
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
+      var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
+      if scannerCommand.first == "-frontend" {
+        scannerCommand.removeFirst()
+      }
+      let _ =
+          try! dependencyOracle.getDependencies(workingDirectory: path,
+                                                commandLine: scannerCommand)
+      let potentialDiags = try! dependencyOracle.getScannerDiagnostics()
+      XCTAssertEqual(potentialDiags?.count, 5)
+      let diags = try XCTUnwrap(potentialDiags)
+      let error = diags[0]
+      XCTAssertEqual(error.message, "Unable to find module dependency: 'unknown_module'")
+      XCTAssertEqual(error.severity, .error)
+      let noteI = diags[1]
+      XCTAssertTrue(noteI.message.starts(with: "a dependency of Swift module 'I':"))
+      XCTAssertEqual(noteI.severity, .note)
+      let noteW = diags[2]
+      XCTAssertTrue(noteW.message.starts(with: "a dependency of Swift module 'W':"))
+      XCTAssertEqual(noteW.severity, .note)
+      let noteS = diags[3]
+      XCTAssertTrue(noteS.message.starts(with: "a dependency of Swift module 'S':"))
+      XCTAssertEqual(noteS.severity, .note)
+      let noteTest = diags[4]
+      XCTAssertEqual(noteTest.message, "a dependency of main module 'testDependencyScanning'")
+      XCTAssertEqual(noteTest.severity, .note)
+    }
+  }
 
   /// Test the libSwiftScan dependency scanning.
   func testDependencyScanning() throws {


### PR DESCRIPTION
The driver invokes the scanning action via a `libSwiftScan` API call. This PR adds the diagnostic query API which the driver uses to get the scanner's diagnostics after a scan and emits them for its clients.

The API entry-points added in https://github.com/apple/swift/pull/60999