### PR TITLE
Mostly explicit import tools-support-core APIs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -9,11 +9,23 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 import SwiftOptions
 
 import class Dispatch.DispatchQueue
 
+import TSCBasic // <<<
+import class TSCBasic.DiagnosticsEngine
+import enum TSCBasic.ProcessEnv
+import protocol TSCBasic.DiagnosticData
+import protocol TSCBasic.FileSystem
+import protocol TSCBasic.OutputByteStream
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.Diagnostic
+import struct TSCBasic.FileInfo
+import struct TSCBasic.RelativePath
+import var TSCBasic.localFileSystem
+import var TSCBasic.stderrStream
+import var TSCBasic.stdoutStream
 import enum TSCUtility.Diagnostics
 import struct TSCUtility.Version
 

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -10,10 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import struct Foundation.Data
 import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
+
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import struct TSCBasic.RelativePath
 
 /// Mapping of input file paths to specific output files.
 public struct OutputFileMap: Hashable, Codable {

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 
 #if canImport(Darwin)
 import Darwin.C
@@ -21,6 +20,13 @@ import Glibc
 #else
 #error("Missing libc or equivalent")
 #endif
+
+import TSCBasic // <<<
+import class TSCBasic.DiagnosticsEngine
+import struct TSCBasic.Diagnostic
+import struct TSCBasic.ProcessResult
+import var TSCBasic.stderrStream
+import var TSCBasic.stdoutStream
 
 /// Delegate for printing execution information on the command-line.
 @_spi(Testing) public final class ToolExecutionDelegate: JobExecutionDelegate {

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -11,7 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 import class Foundation.NSLock
-import TSCBasic
+
+import TSCBasic // <<<
+import func TSCBasic.withTemporaryDirectory
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+
 @_implementationOnly import Yams
 
 /// How the resolver is to handle usage of response files

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import struct TSCBasic.ProcessResult
+
 import struct Foundation.Data
 import class Foundation.JSONDecoder
 import var Foundation.EXIT_SUCCESS

--- a/Sources/SwiftDriver/Execution/ProcessProtocol.swift
+++ b/Sources/SwiftDriver/Execution/ProcessProtocol.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import class TSCBasic.Process
+import struct TSCBasic.ProcessResult
+
 import class Foundation.FileHandle
 import struct Foundation.Data
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import func TSCBasic.determineTempDirectory
 
 /// A map from a module identifier to a set of module dependency graphs
 /// Used to compute distinct graphs corresponding to different target versions for a given clang module

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -9,7 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import struct TSCBasic.SHA256
+import struct TSCBasic.AbsolutePath
+
 import struct Foundation.Data
 import class Foundation.JSONEncoder
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import func TSCBasic.topologicalSort
 
 @_spi(Testing) public extension InterModuleDependencyGraph {
   /// For targets that are built alongside the driver's current module, the scanning action will report them as

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+
 import Dispatch
 
 // An inter-module dependency oracle, responsible for responding to queries about

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -10,7 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import TSCBasic // <<<
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.Diagnostic
+import var TSCBasic.localFileSystem
+import var TSCBasic.stdoutStream
+
 import SwiftOptions
 import struct Foundation.Data
 import class Foundation.JSONEncoder

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecord.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecord.swift
@@ -9,7 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import class TSCBasic.DiagnosticsEngine
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.Diagnostic
+
 @_implementationOnly import Yams
 
 /// Holds the info about inputs needed to plan incremenal compilation

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -10,7 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import struct TSCBasic.ProcessResult
+import struct TSCBasic.SHA256
+
 import SwiftOptions
 import class Dispatch.DispatchQueue
 

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import TSCBasic // <<<
+import protocol TSCBasic.WritableByteStream
 
 // MARK: - Asking to write dot files / interface
 public struct DependencyGraphDotFileWriter {

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import Dispatch
 
 /// A filename from another module

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import protocol TSCBasic.FileSystem
+
 import class Dispatch.DispatchQueue
 
 extension IncrementalCompilationState {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import TSCBasic
 import SwiftOptions
 
+import protocol TSCBasic.FileSystem
 import struct TSCUtility.Version
 
 extension IncrementalCompilationState {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -9,9 +9,14 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
 import protocol Foundation.LocalizedError
+
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.Diagnostic
+import struct TSCBasic.ProcessResult
 
 /// In a separate file to ensure that ``IncrementalCompilationState/protectedState``
 /// can only be accessed via ``IncrementalCompilationState/blockingConcurrentMutation(_:)`` and

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import TSCBasic
 import SwiftOptions
 
 /// An instance of `IncrementalCompilationState` encapsulates the data necessary

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -10,9 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import SwiftOptions
 import class Dispatch.DispatchQueue
+
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.FileSystem
 
 // Initial incremental state computation
 extension IncrementalCompilationState {

--- a/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import struct TSCBasic.ProcessResult
 
 /// Contains information about the current status of an input to the incremental
 /// build.

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -10,9 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import SwiftOptions
 
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.ByteString
 import enum TSCUtility.BitcodeElement
 import enum TSCUtility.Bitstream
 import class TSCUtility.BitstreamWriter

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import class TSCBasic.DiagnosticsEngine
 
 // MARK: - DependencySource
 /// Points to the source of dependencies, i.e. the file read to obtain the information.

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
-
 extension ModuleDependencyGraph {
 
   // MARK: Integrator - state & creation

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 
 // MARK: - ModuleDependencyGraph.Node
 extension ModuleDependencyGraph {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import class TSCBasic.DiagnosticsEngine
 
 extension ModuleDependencyGraph {
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -9,8 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.ByteString
 import class TSCUtility.BitstreamWriter
 import enum TSCUtility.BitcodeElement
 import enum TSCUtility.Bitstream

--- a/Sources/SwiftDriver/IncrementalCompilation/SwiftSourceFile.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SwiftSourceFile.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
-
 /// Because the incremental compilation system treats files containing Swift source code specially,
 /// it is helpful to statically distinguish them wherever an input must be swift source code.
 public struct SwiftSourceFile: Hashable {

--- a/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
+++ b/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
-
 enum DigesterMode: String {
   case api, abi
 

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import struct TSCBasic.RelativePath
 
 // On ELF/WASM platforms there's no built in autolinking mechanism, so we
 // pull the info we need from the .o files directly and pass them as an

--- a/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
+++ b/Sources/SwiftDriver/Jobs/CommandLineArguments.swift
@@ -9,8 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
+
+import struct TSCBasic.AbsolutePath
 
 /// Utilities for manipulating a list of command line arguments, including
 /// constructing one from a set of ParsedOptions.

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -9,8 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
+
+import struct TSCBasic.RelativePath
 
 extension Driver {
   /// Add the appropriate compile mode option to the command line for a compile job.

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -9,9 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
 
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 import struct TSCUtility.Version
 
 extension DarwinToolchain {

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -10,10 +10,14 @@
 //
 //===----------------------------------------------------------------------===////
 
-import TSCBasic
 import SwiftOptions
 import struct Foundation.Data
 import class Foundation.JSONDecoder
+
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.RelativePath
+import var TSCBasic.localFileSystem
 
 /// Describes information about the compiler's supported arguments and features
 @_spi(Testing) public struct SupportedCompilerFeatures: Codable {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -9,8 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 
+import class TSCBasic.LocalFileOutputByteStream
+import class TSCBasic.TerminalController
+import struct TSCBasic.RelativePath
+import var TSCBasic.stderrStream
 import enum TSCUtility.Diagnostics
 
 /// Whether we should produce color diagnostics by default.

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import struct TSCBasic.RelativePath
 
 extension Driver {
   mutating func generatePCHJob(input: TypedVirtualPath, output: TypedVirtualPath) throws -> Job {

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -9,8 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
+
+import func TSCBasic.lookupExecutablePath
+import struct TSCBasic.AbsolutePath
 
 extension GenericUnixToolchain {
   private func defaultLinker(for targetTriple: Triple) -> String? {

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import protocol TSCBasic.DiagnosticData
+import protocol TSCBasic.FileSystem
 
 /// A job represents an individual subprocess that should be invoked during compilation.
 public struct Job: Codable, Equatable, Hashable {

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 
 extension Driver {
   internal var relativeOutputFileForImage: RelativePath {

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
+import struct TSCBasic.RelativePath
 
 extension Driver {
   mutating func mergeModuleJob(inputs providedInputs: [TypedVirtualPath],

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import SwiftOptions
 import class Foundation.JSONDecoder
+
+import TSCBasic // <<<
+import protocol TSCBasic.DiagnosticData
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.Diagnostic
+import var TSCBasic.localFileSystem
+import var TSCBasic.stdoutStream
 
 public enum PlanningError: Error, DiagnosticData {
   case replReceivedInput

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -9,10 +9,19 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 import SwiftOptions
 import class Foundation.JSONEncoder
 import class Foundation.JSONSerialization
+
+import TSCBasic // <<<
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.WritableByteStream
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import struct TSCBasic.ProcessResult
+import struct TSCBasic.RelativePath
+import var TSCBasic.localFileSystem
+import var TSCBasic.stderrStream
 
 func getModuleFlags(_ path: VirtualPath, _ ignorable: Bool) throws -> [String] {
   let data = try localFileSystem.readFileContents(path).cString

--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -9,8 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-import TSCBasic
+
 import SwiftOptions
 
 extension Toolchain {

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -9,8 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
+
+import protocol TSCBasic.FileSystem
 
 extension Toolchain {
   // MARK: - Path computation

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -9,8 +9,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
+
+import func TSCBasic.lookupExecutablePath
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
 
 extension WebAssemblyToolchain {
   public func addPlatformSpecificLinkerArgs(

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import SwiftOptions
+
+import func TSCBasic.lookupExecutablePath
+import struct TSCBasic.AbsolutePath
 
 private func architecture(for triple: Triple) -> String {
   // The concept of a "major" arch name only applies to Linux triples

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -11,10 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 @_implementationOnly import CSwiftScan
-import TSCBasic
-import struct TSCUtility.Version
+
 import func Foundation.strdup
 import func Foundation.free
+
+import protocol TSCBasic.DiagnosticData
+import struct TSCBasic.AbsolutePath
+import struct TSCUtility.Version
 
 public enum DependencyScanningError: Error, DiagnosticData {
   case missingRequiredSymbol(String)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -9,13 +9,20 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
 
-import struct TSCUtility.Version
 import struct Foundation.Data
 import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
+
+import protocol TSCBasic.FileSystem
+import protocol TSCBasic.DiagnosticData
+import class TSCBasic.DiagnosticsEngine
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.Diagnostic
+import var TSCBasic.localFileSystem
+import struct TSCUtility.Version
 
 /// Toolchain for Darwin-based platforms, such as macOS and iOS.
 ///

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -9,7 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
 
 /// Toolchain for Unix-like systems.
 public final class GenericUnixToolchain: Toolchain {

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -10,9 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import SwiftOptions
 import class Foundation.Bundle
+
+import func TSCBasic.getEnvSearchPaths
+import func TSCBasic.lookupExecutablePath
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
 
 public enum Tool: Hashable {
   case swiftCompiler

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -9,8 +9,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
+
+import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.DiagnosticData
+import protocol TSCBasic.FileSystem
+import var TSCBasic.localFileSystem
 
 /// Toolchain for WebAssembly-based systems.
 public final class WebAssemblyToolchain: Toolchain {

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
 import SwiftOptions
+
+import class TSCBasic.DiagnosticsEngine
+import protocol TSCBasic.DiagnosticData
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
 
 extension WindowsToolchain {
   public enum ToolchainValidationError: Error, DiagnosticData {

--- a/Sources/SwiftDriver/Utilities/DOTJobGraphSerializer.swift
+++ b/Sources/SwiftDriver/Utilities/DOTJobGraphSerializer.swift
@@ -9,7 +9,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
 
 /// Serializes the job graph to a .dot file
 @_spi(Testing) public struct DOTJobGraphSerializer {

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -9,8 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import SwiftOptions
+
+import struct TSCBasic.Diagnostic
 
 extension Diagnostic.Message {
   static var error_static_emit_executable_disallowed: Diagnostic.Message {

--- a/Sources/SwiftDriver/Utilities/RelativePathAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/RelativePathAdditions.swift
@@ -9,7 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 
 extension RelativePath {
   /// Retrieve the basename of the relative path without any extensions,

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
 import struct Foundation.Data
 import struct Foundation.TimeInterval
 import class Dispatch.DispatchQueue
@@ -17,6 +17,16 @@ import class Dispatch.DispatchQueue
 #if canImport(Darwin)
 import Darwin
 #endif
+
+import enum TSCBasic.SystemError
+import func TSCBasic.resolveSymlinks
+import protocol TSCBasic.FileSystem
+import protocol TSCBasic.WritableByteStream
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import struct TSCBasic.FileInfo
+import struct TSCBasic.RelativePath
+import var TSCBasic.localFileSystem
 
 /// A virtual path.
 public enum VirtualPath: Hashable {

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic
-import enum TSCUtility.Diagnostics
 import SwiftDriver
 
 import class Dispatch.DispatchQueue
@@ -20,6 +18,15 @@ import class Foundation.FileHandle
 import var Foundation.EXIT_SUCCESS
 import var Foundation.EXIT_FAILURE
 import var Foundation.SIGINT
+
+import class TSCBasic.DiagnosticsEngine
+import class TSCBasic.Process
+import class TSCBasic.ProcessSet
+import protocol TSCBasic.DiagnosticData
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.Diagnostic
+import struct TSCBasic.ProcessResult
+import enum TSCUtility.Diagnostics
 
 // We either import the llbuildSwift shared library or the llbuild framework.
 #if canImport(llbuildSwift)

--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -11,8 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDriver
-import TSCBasic
 import class Foundation.FileHandle
+
+import class TSCBasic.DiagnosticsEngine
+import class TSCBasic.Process
+import class TSCBasic.ProcessSet
+import enum TSCBasic.ProcessEnv
+import func TSCBasic.exec
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.ProcessResult
 
 public final class SwiftDriverExecutor: DriverExecutor {
   let diagnosticsEngine: DiagnosticsEngine

--- a/Sources/SwiftDriverExecution/llbuild.swift
+++ b/Sources/SwiftDriverExecution/llbuild.swift
@@ -13,10 +13,11 @@
 // FIXME: This is slightly modified from the SwiftPM version,
 // consider moving this to llbuild.
 
-import TSCBasic
 import struct Foundation.Data
 import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
+
+import protocol TSCBasic.FileSystem
 
 // We either import the llbuildSwift shared library or the llbuild framework.
 #if canImport(llbuildSwift)

--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import TSCBasic
+
+import protocol TSCBasic.DiagnosticData
 
 public enum OptionParseError : Error, Equatable, DiagnosticData {
   case unknownOption(index: Int, argument: String)

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -18,7 +18,15 @@ import Darwin
 #else
 import Glibc
 #endif
-import TSCBasic
+
+import TSCBasic // <<<
+import class TSCBasic.DiagnosticsEngine
+import class TSCBasic.ProcessSet
+import enum TSCBasic.ProcessEnv
+import func TSCBasic.withTemporaryFile
+import struct TSCBasic.AbsolutePath
+import var TSCBasic.localFileSystem
+import var TSCBasic.stderrStream
 
 let diagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])
 

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -18,7 +18,6 @@ import Darwin
 #else
 import Glibc
 #endif
-import TSCBasic
 
 import Dispatch
 
@@ -26,6 +25,13 @@ import Dispatch
 import WinSDK
 #endif
 
+import enum TSCBasic.ProcessEnv
+import func TSCBasic.exec
+import class TSCBasic.DiagnosticsEngine
+import class TSCBasic.Process
+import class TSCBasic.ProcessSet
+import protocol TSCBasic.DiagnosticData
+import var TSCBasic.localFileSystem
 import enum TSCUtility.Diagnostics
 
 let interruptSignalSource = DispatchSource.makeSignalSource(signal: SIGINT)

--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -10,8 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 import SwiftOptions
-import TSCBasic
 import ArgumentParser
+
+import enum TSCBasic.ProcessEnv
+import func TSCBasic.exec
+import class TSCBasic.Process
+import var TSCBasic.localFileSystem
 
 enum HelpTopic: ExpressibleByArgument, CustomStringConvertible {
   case driver(DriverKind)


### PR DESCRIPTION
Switch to explicitly importing the tools-support-core API surface to identify what we are depending on.  This will help ween swift-driver off of swift-tools-support-core in the long run.