### PR TITLE
[5.7] On interrupt, after handling the compilation process set termination, restore the SIGINT default action.

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -37,6 +37,7 @@ func getExitCode(_ code: Int32) -> Int32 {
 #if os(Windows)
     TerminateProcess(GetCurrentProcess(), UINT(0xC0000000 | UINT(2)))
 #else
+    signal(SIGINT, SIG_DFL)
     kill(getpid(), SIGINT)
 #endif
     fatalError("Invalid state, could not kill process")


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1157
-----------------------------------------


Resolves rdar://98584872