### PR TITLE
Make the new TimePoint.seconds() input explicitly Int64

### DIFF
--- a/Sources/SwiftDriver/Utilities/DateAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/DateAdditions.swift
@@ -39,7 +39,7 @@ public struct TimePoint: Equatable, Comparable, Hashable {
 }
 
 extension TimePoint {
-  public static func seconds(_ value: Int) -> TimePoint {
+  public static func seconds(_ value: Int64) -> TimePoint {
     precondition(value >= 0,
                  "Duration value in seconds is \(value), but cannot be negative")
     return TimePoint(seconds: UInt64(value), nanoseconds: 0)
@@ -97,7 +97,7 @@ extension TimePoint{
     let result: UInt64 = (UInt64(ftTime.dwLowDateTime) << 0)
                        + (UInt64(ftTime.dwHighDateTime) << 32)
     // Windows ticks in 100 nanosecond intervals.
-    return .seconds(Int(result / 10_000_000))
+    return .seconds(Int64(result / 10_000_000))
     #else
     var tv = timeval()
     gettimeofday(&tv, nil)


### PR DESCRIPTION
else it breaks when compiling for 32-bit armv7 with large inputs.

I [recently hit this when cross-compiling trunk SPM for Android armv7 on my daily CI](https://github.com/buttaface/swift-android-sdk/runs/8302044832?check_suite_focus=true#step:6:7000), as `distantFuture` overflows `Int` on 32-bit platforms. I had to add this patch to get it to build again, buttaface/swift-android-sdk@043df19.

@CodaFi, you added `TimePoint`, let me know what you think of this tweak.