### PR TITLE
Add “swift -e” support

### DIFF
--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -61,7 +61,7 @@ extension OptionTable {
         parsedOptions.addInput(argument)
 
         // In interactive mode, synthesize a "--" argument for all args after the first input.
-        if driverKind == .interactive && index < arguments.endIndex {
+        if driverKind == .interactive && index < arguments.endIndex && !parsedOptions.lookupWithoutConsuming(.e).isEmpty {
           parsedOptions.addOption(.DASHDASH, argument: .multiple(Array(arguments[index...])))
           break
         }

--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -45,6 +45,7 @@ extension OptionTable {
     }
 
     var parsedOptions = ParsedOptions()
+    var seenDashE = false
     var index = arguments.startIndex
     while index < arguments.endIndex {
       // Capture the next argument.
@@ -58,10 +59,16 @@ extension OptionTable {
 
       // If this is not a flag, record it as an input.
       if argument == "-" || argument.first! != "-" {
+        // If we've seen -e, this argument and all remaining ones are arguments to the -e script.
+        if driverKind == .interactive && seenDashE {
+          parsedOptions.addOption(.DASHDASH, argument: .multiple(Array(arguments[(index-1)...])))
+          break
+        }
+        
         parsedOptions.addInput(argument)
 
         // In interactive mode, synthesize a "--" argument for all args after the first input.
-        if driverKind == .interactive && index < arguments.endIndex && !parsedOptions.lookupWithoutConsuming(.e).isEmpty {
+        if driverKind == .interactive && index < arguments.endIndex {
           parsedOptions.addOption(.DASHDASH, argument: .multiple(Array(arguments[index...])))
           break
         }
@@ -89,6 +96,10 @@ extension OptionTable {
             index: index - 1, argument: argument, option: option,
             currentDriverKind: driverKind)
         }
+      }
+      
+      if option == .e {
+        seenDashE = true
       }
 
       // Translate the argument

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -246,6 +246,7 @@ extension Option {
   public static let emitDigesterBaselinePath: Option = Option("-emit-digester-baseline-path", .separate, attributes: [.noInteractive, .argumentIsPath, .supplementaryOutput], metaVar: "<path>", helpText: "Emit a baseline file for the module to <path> using the API digester")
   public static let emitDigesterBaseline: Option = Option("-emit-digester-baseline", .flag, attributes: [.noInteractive, .supplementaryOutput], helpText: "Emit a baseline file for the module using the API digester")
   public static let emitExecutable: Option = Option("-emit-executable", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit a linked executable", group: .modes)
+  public static let emitExtensionBlockSymbols: Option = Option("-emit-extension-block-symbols", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Emit 'swift.extension' symbols for extensions to external types instead of directly associating members and conformances with the extended nominal when generating symbol graphs")
   public static let emitFineGrainedDependencySourcefileDotFiles: Option = Option("-emit-fine-grained-dependency-sourcefile-dot-files", .flag, attributes: [.helpHidden, .frontend], helpText: "Emit dot files for every source file.")
   public static let emitFixitsPath: Option = Option("-emit-fixits-path", .separate, attributes: [.frontend, .noDriver], metaVar: "<path>", helpText: "Output compiler fixits as source edits to <path>")
   public static let emitImportedModules: Option = Option("-emit-imported-modules", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit a list of the imported modules", group: .modes)
@@ -394,6 +395,7 @@ extension Option {
   public static let driverExplicitModuleBuild: Option = Option("-explicit-module-build", .flag, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
   public static let explicitSwiftModuleMap: Option = Option("-explicit-swift-module-map-file", .separate, attributes: [.frontend, .noDriver], metaVar: "<path>", helpText: "Specify a JSON file containing information of explicit Swift modules")
   public static let externalPassPipelineFilename: Option = Option("-external-pass-pipeline-filename", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<pass_pipeline_file>", helpText: "Use the pass pipeline defined by <pass_pipeline_file>")
+  public static let e: Option = Option("-e", .joinedOrSeparate, attributes: [], helpText: "Executes a line of code provided on the command line")
   public static let FEQ: Option = Option("-F=", .joined, alias: Option.F, attributes: [.frontend, .argumentIsPath])
   public static let fileCompilationDir: Option = Option("-file-compilation-dir", .separate, attributes: [.frontend], metaVar: "<path>", helpText: "The compilation directory to embed in the debug info. Coverage mapping is not supported yet.")
   public static let filePrefixMap: Option = Option("-file-prefix-map", .separate, attributes: [.frontend], metaVar: "<prefix=replacement>", helpText: "Remap source paths in debug, coverage, and index info")
@@ -575,7 +577,8 @@ extension Option {
   public static let repl: Option = Option("-repl", .flag, attributes: [.helpHidden, .frontend, .noBatch], helpText: "REPL mode (the default if there is no input file)", group: .modes)
   public static let reportErrorsToDebugger: Option = Option("-report-errors-to-debugger", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Deprecated, will be removed in future versions.")
   public static let requireExplicitAvailabilityTarget: Option = Option("-require-explicit-availability-target", .separate, attributes: [.frontend, .noInteractive], metaVar: "<target>", helpText: "Suggest fix-its adding @available(<target>, *) to public declarations without availability")
-  public static let requireExplicitAvailability: Option = Option("-require-explicit-availability", .flag, attributes: [.frontend, .noInteractive], helpText: "Require explicit availability on public declarations")
+  public static let requireExplicitAvailabilityEQ: Option = Option("-require-explicit-availability=", .joined, attributes: [.frontend, .noInteractive], metaVar: "<error,warn,ignore>", helpText: "Set diagnostic level to report public declarations without an availability attribute")
+  public static let requireExplicitAvailability: Option = Option("-require-explicit-availability", .flag, attributes: [.frontend, .noInteractive], helpText: "Warn on public declarations without an availability attribute")
   public static let requireExplicitSendable: Option = Option("-require-explicit-sendable", .flag, attributes: [.frontend, .noInteractive], helpText: "Require explicit Sendable annotations on public declarations")
   public static let requirementMachineMaxConcreteNesting: Option = Option("-requirement-machine-max-concrete-nesting=", .joined, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Set the maximum concrete type nesting depth before giving up")
   public static let requirementMachineMaxRuleCount: Option = Option("-requirement-machine-max-rule-count=", .joined, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Set the maximum number of rules before giving up")
@@ -962,6 +965,7 @@ extension Option {
       Option.emitDigesterBaselinePath,
       Option.emitDigesterBaseline,
       Option.emitExecutable,
+      Option.emitExtensionBlockSymbols,
       Option.emitFineGrainedDependencySourcefileDotFiles,
       Option.emitFixitsPath,
       Option.emitImportedModules,
@@ -1110,6 +1114,7 @@ extension Option {
       Option.driverExplicitModuleBuild,
       Option.explicitSwiftModuleMap,
       Option.externalPassPipelineFilename,
+      Option.e,
       Option.FEQ,
       Option.fileCompilationDir,
       Option.filePrefixMap,
@@ -1291,6 +1296,7 @@ extension Option {
       Option.repl,
       Option.reportErrorsToDebugger,
       Option.requireExplicitAvailabilityTarget,
+      Option.requireExplicitAvailabilityEQ,
       Option.requireExplicitAvailability,
       Option.requireExplicitSendable,
       Option.requirementMachineMaxConcreteNesting,

--- a/Sources/SwiftOptions/ParsedOptions.swift
+++ b/Sources/SwiftOptions/ParsedOptions.swift
@@ -260,7 +260,7 @@ extension ParsedOptions {
   ///
   /// This operation does not consume any inputs.
   public var hasAnyInput: Bool {
-    return !lookupWithoutConsuming(.INPUT).isEmpty
+    return !lookupWithoutConsuming(.INPUT).isEmpty || !lookupWithoutConsuming(.e).isEmpty
   }
 
   /// Walk through all of the parsed options, modifying each one.


### PR DESCRIPTION
“swift -e” can be used to run code specified directly on the command line rather than passed through stdin or a source file. The values of the “-e” switches are each treated as one line of source code, which are concatenated together into a temporary main.swift file and passed to the frontend jobs.

Fixes rdar://17258540.