### PR TITLE
Remove Minor Version Constraints

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -157,11 +157,11 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
-    .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "5.0.0")),
+    .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
     // dependency version changes here with those projects.
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.1"),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
Several dependencies are marked `upToNextMinor` even though they no longer point at 0‐prefixed versions. They are not kept in sync across toolchain packages very well over time, and it causes issues for clients attempting to use them together.