### PR TITLE
SwiftDriverTests: exclude explicit triple

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1252,7 +1252,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
 
       let baseCommandLine = ["swiftc",
-                             "-target", "x86_64-apple-macosx11.0",
                              "-I", cHeadersPath.nativePathString(escaped: true),
                              "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                              main.nativePathString(escaped: true)] + sdkArgumentsForTesting


### PR DESCRIPTION
The explicit triple sets an OS, which then requires that the value for `-sdk` match.  Because Windows uses a `-sdk` parameter, this will fail on Windows due to a mismatch for the SDKs.  By excluding the triple, a host specific value is used which allows this to match and pass.