### PR TITLE
Implement 'getSingleFrontendInvocationFromDriverArguments' utility API

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -97,6 +97,9 @@ add_library(SwiftDriver
   Toolchains/WebAssemblyToolchain.swift
   Toolchains/WindowsToolchain.swift
 
+  ToolingInterface/SimpleExecutor.swift
+  ToolingInterface/ToolingUtil.swift
+
   Utilities/DOTJobGraphSerializer.swift
   Utilities/DOTModuleDependencyGraphSerializer.swift
   Utilities/DateAdditions.swift

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1247,7 +1247,7 @@ extension Driver {
   }
 
   /// Expand response files in the input arguments and return a new argument list.
-  @_spi(Testing) public static func expandResponseFiles(
+  public static func expandResponseFiles(
     _ args: [String],
     fileSystem: FileSystem,
     diagnosticsEngine: DiagnosticsEngine

--- a/Sources/SwiftDriver/ToolingInterface/SimpleExecutor.swift
+++ b/Sources/SwiftDriver/ToolingInterface/SimpleExecutor.swift
@@ -1,0 +1,64 @@
+//===------- SimpleExecutor.swift - Swift Driver Source Version-----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import protocol TSCBasic.FileSystem
+import struct TSCBasic.ProcessResult
+import class TSCBasic.Process
+
+/// A simple executor sufficient for managing processes required during
+/// build planning: e.g. querying frontend target info.
+///
+/// TODO: It would be nice if build planning did not involve an executor.
+/// We must hunt down all uses of an executor during planning and move
+/// relevant compiler functionality into libSwiftScan.
+internal class SimpleExecutor: DriverExecutor {
+  let resolver: ArgsResolver
+  let fileSystem: FileSystem
+  let env: [String: String]
+  
+  init(resolver: ArgsResolver, fileSystem: FileSystem, env: [String: String]) {
+    self.resolver = resolver
+    self.fileSystem = fileSystem
+    self.env = env
+  }
+  
+  func execute(job: Job,
+               forceResponseFiles: Bool,
+               recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws -> ProcessResult {
+    let arguments: [String] = try resolver.resolveArgumentList(for: job,
+                                                               useResponseFiles: .heuristic)
+    var childEnv = env
+    childEnv.merge(job.extraEnvironment, uniquingKeysWith: { (_, new) in new })
+    let process = try Process.launchProcess(arguments: arguments, env: childEnv)
+    return try process.waitUntilExit()
+  }
+  
+  func execute(workload: DriverExecutorWorkload, delegate: JobExecutionDelegate,
+               numParallelJobs: Int, forceResponseFiles: Bool,
+               recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws {
+    fatalError("Unsupported operation on current executor")
+  }
+  
+  func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
+    try Process.checkNonZeroExit(arguments: args, environment: environment)
+  }
+  
+  func description(of job: Job, forceResponseFiles: Bool) throws -> String {
+    let useResponseFiles : ResponseFileHandling = forceResponseFiles ? .forced : .heuristic
+    let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, useResponseFiles: useResponseFiles)
+    var result = args.map { $0.spm_shellEscaped() }.joined(separator: " ")
+    if usedResponseFile {
+      result += " # \(job.commandLine.joinedUnresolvedArguments)"
+    }
+    return result
+  }
+}

--- a/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
+++ b/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
@@ -1,0 +1,109 @@
+//===------- ToolingUtil.swift - Swift Driver Source Version--------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import class TSCBasic.DiagnosticsEngine
+import struct TSCBasic.Diagnostic
+import class TSCBasic.ProcessSet
+import enum TSCBasic.ProcessEnv
+import var TSCBasic.localFileSystem
+import SwiftOptions
+
+/// Generates the list of arguments that would be passed to the compiler
+/// frontend from the given driver arguments.
+///
+/// \param ArgList The driver arguments (i.e. normal arguments for \c swiftc).
+/// \param ForceNoOutputs If true, override the output mode to "-typecheck" and
+/// produce no outputs. For example, this disables "-emit-module" and "-c" and
+/// prevents the creation of temporary files.
+/// \param outputFrontendArgs Contains the resulting frontend invocation command
+/// \param emittedDiagnostics Contains the diagnostics emitted by the driver
+///
+/// \returns true on error
+///
+/// \note This function is not intended to create invocations which are
+/// suitable for use in REPL or immediate modes.
+public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
+                                                           outputFrontendArgs: inout [String],
+                                                           emittedDiagnostics: inout [Diagnostic],
+                                                           forceNoOutputs: Bool = false) -> Bool {
+  var args: [String] = []
+  args.append(contentsOf: argList)
+  
+  // When creating a CompilerInvocation, ensure that the driver creates a single
+  // frontend command.
+  args.append("-whole-module-optimization")
+  
+  // Explicitly disable batch mode to avoid a spurious warning when combining
+  // -enable-batch-mode with -whole-module-optimization.  This is an
+  // implementation detail.
+  args.append("-disable-batch-mode");
+  
+  // Prevent having a separate job for emit-module, we would like
+  // to just have one job
+  args.append("-no-emit-module-separately-wmo")
+
+  // Avoid using filelists
+  args.append("-driver-filelist-threshold");
+  args.append(String(Int.max));
+  
+  let diagnosticsEngine = DiagnosticsEngine()
+  defer { emittedDiagnostics = diagnosticsEngine.diagnostics }
+  
+  do {
+    args = try ["swiftc"] + Driver.expandResponseFiles(args,
+                                                       fileSystem: localFileSystem,
+                                                       diagnosticsEngine: diagnosticsEngine)
+
+    let optionTable = OptionTable()
+    var parsedOptions = try optionTable.parse(Array(args), for: .batch, delayThrows: true)
+    if forceNoOutputs {
+      // Clear existing output modes and supplementary outputs.
+      parsedOptions.eraseAllArguments(in: .modes)
+      parsedOptions.eraseSupplementaryOutputs()
+      parsedOptions.addOption(.typecheck, argument: .none)
+    }
+    
+    // Instantiate the driver, setting up the toolchain in the process, etc.
+    let resolver = try ArgsResolver(fileSystem: localFileSystem)
+    let executor = SimpleExecutor(resolver: resolver,
+                                  fileSystem: localFileSystem,
+                                  env: ProcessEnv.vars)
+    var driver = try Driver(args: parsedOptions.commandLine,
+                            diagnosticsEngine: diagnosticsEngine,
+                            executor: executor)
+    if diagnosticsEngine.hasErrors {
+      return true
+    }
+    
+    
+    let buildPlan = try driver.planBuild()
+    if diagnosticsEngine.hasErrors {
+      return true
+    }
+    let compileJobs = buildPlan.filter({ $0.kind == .compile })
+    guard let compileJob = compileJobs.spm_only else {
+      diagnosticsEngine.emit(.error_expected_one_frontend_job())
+      return true
+    }
+    if !compileJob.commandLine.starts(with: [.flag("-frontend")]) {
+      diagnosticsEngine.emit(.error_expected_frontend_command())
+      return true
+    }
+    outputFrontendArgs = try executor.description(of: compileJob,
+                                                  forceResponseFiles: false).components(separatedBy: " ")
+  } catch {
+    print("Unexpected error: \(error).")
+    return true
+  }
+
+  return false
+}

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -146,4 +146,12 @@ extension Diagnostic.Message {
   static func warning_option_overrides_another(overridingOption: Option, overridenOption: Option) -> Diagnostic.Message {
     .warning("ignoring '\(overridenOption.spelling)' because '\(overridingOption.spelling)' was also specified")
   }
+  
+  static func error_expected_one_frontend_job() -> Diagnostic.Message {
+    .error("unable to handle compilation, expected exactly one frontend job")
+  }
+  
+  static func error_expected_frontend_command() -> Diagnostic.Message {
+    .error("expected a swift frontend command")
+  }
 }

--- a/Sources/SwiftOptions/ParsedOptions.swift
+++ b/Sources/SwiftOptions/ParsedOptions.swift
@@ -134,8 +134,8 @@ extension ParsedOptions {
   }
 }
 
-extension ParsedOptions {
-  mutating func buildIndex() {
+public extension ParsedOptions {
+  internal mutating func buildIndex() {
     optionIndex.removeAll()
     for parsed in parsedOptions {
       optionIndex[parsed.option.canonical.spelling, default: []].append(parsed)
@@ -342,6 +342,24 @@ extension ParsedOptions {
     optionIndex.removeValue(forKey: option.spelling)
     if let group = option.group {
       groupIndex[group]?.removeAll { $0.option == option }
+    }
+  }
+  
+  /// Remove all arguments of a given group from parsed options.
+  public mutating func eraseAllArguments(in group: Option.Group) {
+    for parsedOption in parsedOptions {
+      if parsedOption.option.group == group {
+        eraseArgument(parsedOption.option)
+      }
+    }
+  }
+  
+  /// Remove all arguments with a .supplementaryOutput attribute
+  public mutating func eraseSupplementaryOutputs() {
+    for parsedOption in parsedOptions {
+      if parsedOption.option.attributes.contains(.supplementaryOutput) {
+        eraseArgument(parsedOption.option)
+      }
     }
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -1,0 +1,84 @@
+//===---- SwiftDriverToolingInterfaceTests.swift - Swift Driver Tests ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import SwiftDriver
+import SwiftOptions
+import TSCBasic
+import XCTest
+
+final class SwiftDriverToolingInterfaceTests: XCTestCase {
+  func testCreateCompilerInvocation() throws {
+    try withTemporaryDirectory { path in
+      let inputFile = path.appending(components: "test.swift")
+      try localFileSystem.writeFileContents(inputFile) { $0 <<< "public func foo()" }
+      
+      // Expected success scenarios:
+      do {
+        let testCommand = inputFile.description
+        var resultingFrontendArgs: [String] = []
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
+                                                                      outputFrontendArgs: &resultingFrontendArgs,
+                                                                      emittedDiagnostics: &emittedDiagnostics))
+      }
+      do {
+        let testCommand = "-emit-executable " + inputFile.description + " main.swift lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header -o t.out"
+        var resultingFrontendArgs: [String] = []
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
+                                                                      outputFrontendArgs: &resultingFrontendArgs,
+                                                                      emittedDiagnostics: &emittedDiagnostics))
+      }
+      do {
+        let testCommand = "-c " + inputFile.description + " main.swift lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header"
+        var resultingFrontendArgs: [String] = []
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
+                                                                      outputFrontendArgs: &resultingFrontendArgs,
+                                                                      emittedDiagnostics: &emittedDiagnostics))
+      }
+      do {
+        let testCommand = inputFile.description + " -enable-batch-mode"
+        var resultingFrontendArgs: [String] = []
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
+                                                                      outputFrontendArgs: &resultingFrontendArgs,
+                                                                      emittedDiagnostics: &emittedDiagnostics))
+      }
+      do { // Force no outputs
+        let testCommand = "-module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
+        var resultingFrontendArgs: [String] = []
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
+                                                                      outputFrontendArgs: &resultingFrontendArgs,
+                                                                      emittedDiagnostics: &emittedDiagnostics,
+                                                                      forceNoOutputs: true))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-module-interface-path"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-objc-header"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-objc-header-path"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-module-path"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-tbd-path"))
+      }
+      
+      // Expected failure scenarios:
+      do {
+        let testCommand = "-v" // No inputs
+        var resultingFrontendArgs: [String] = []
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertTrue(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
+                                                                     outputFrontendArgs: &resultingFrontendArgs,
+                                                                     emittedDiagnostics: &emittedDiagnostics))
+        let errorMessage = try XCTUnwrap(emittedDiagnostics.first?.message.text)
+        XCTAssertEqual(errorMessage, "unable to handle compilation, expected exactly one frontend job")
+      }
+    }
+  }
+}


### PR DESCRIPTION
This function currently exists in the legacy C++-based Swift Driver. This is a re-implementation of the same functionality which will eventually replace it.

A follow-up change will begin wiring up how to use this API from the C++ entry-point. 

Part of rdar://75851402