### PR TITLE
Fix accidental use of new feature in -e

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1795,7 +1795,7 @@ extension Driver {
     fileSystem: FileSystem
   ) throws -> [TypedVirtualPath] {
     var swiftFiles = [String: String]() // [Basename: Path]
-    var paths = try parsedOptions.allInputs.map { input in
+    var paths: [TypedVirtualPath] = try parsedOptions.allInputs.map { input in
       // Standard input is assumed to be Swift code.
       if input == "-" {
         return TypedVirtualPath(file: .standardInput, type: .swift)


### PR DESCRIPTION
The change in #1188 accidentally used a 5.7 feature (multi-statement closure result type inference), but it needs to support at least 5.6 for the earlyswiftdriver pass. Add an explicit type to avoid this problem.