### PR TITLE
SwiftDriverTests: account for windows line endings

### DIFF
--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -14,6 +14,7 @@ import TSCBasic
 
 @_spi(Testing) import SwiftDriver
 import var Foundation.EXIT_SUCCESS
+import class Foundation.NSString
 
 @discardableResult
 internal func withHijackedErrorStream(
@@ -26,7 +27,7 @@ internal func withHijackedErrorStream(
     TSCBasic.stderrStream = try ThreadSafeOutputByteStream(LocalFileOutputByteStream(file.path))
     try body()
     TSCBasic.stderrStream.flush()
-    output = try localFileSystem.readFileContents(file.path).description
+    output = try "\(localFileSystem.readFileContents(file.path))".replacingOccurrences(of: "\r\n", with: "\n")
   }
   // Restore the error stream to what it was
   TSCBasic.stderrStream = errorStream


### PR DESCRIPTION
The hijacked error stream needs to account for string normalization of the line ending on Windows to ensure that the `.contains` match passes there.  This addresses the remaining test regressions on Windows.