### PR TITLE
Update the name of the swiftinterface verification job to name the target file

### DIFF
--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -233,7 +233,7 @@ extension Job : CustomStringConvertible {
       return "Scanning dependencies for module \(moduleName)"
 
     case .verifyModuleInterface:
-      return "Verifying emitted module interface for module \(moduleName)"
+      return join("Verifying emitted module interface", displayInputs.first?.file.basename)
 
     case .generateAPIBaseline:
       return "Generating API baseline file for module \(moduleName)"


### PR DESCRIPTION
This new diagnostic should distinguish between the verification of the public and the private swiftinterface. It should look like this:
```
Verifying emitted module interface MyFramework.private.swiftinterface
```

When building for two archs at a time, the same message will still appear twice (down from 4 times the same message). This appears to be common to all jobs named from the driver side, I'm not sure if we could improve this from the driver side or if it should be from the driver client side.

I didn't see tests for these so please let me know if I missed a testing opportunity.