### PR TITLE
[Dependency Scanning] Adapt to upcoming dependency scanner API change s with the output path.

### DIFF
--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -67,7 +67,9 @@ enum ModuleDependenciesInputs {
                 "-remove-preceeding-explicit-module-build-incompatible-options",
                 "-fno-implicit-modules",
                 "-emit-module",
-                "-fmodule-name=c_simd"
+                "-fmodule-name=c_simd",
+                "-o",
+                "<replace-me>"
               ]
             }
           }


### PR DESCRIPTION
https://github.com/apple/swift/pull/60882 adds functionality to the Clang scan-deps invocation that produces placeholder paths as '<replace-me>'s in the generated command-line. The first step to adapting to these changes is to teach the driver to substitute the expected file paths.

Once the scanner changes land, we will revisit the driver specifying these paths in favour of having the scanning action being able to determine the correct output location from the get-go.