### PR TITLE
SwiftDriver: migrate LLVM bitcode support from tools-support-core

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -34,6 +34,15 @@ add_library(SwiftDriver
   Execution/ParsableOutput.swift
   Execution/ProcessProtocol.swift
 
+  "IncrementalCompilation/Bitcode/Bitcode.swift"
+  "IncrementalCompilation/Bitcode/BitcodeElement.swift"
+  "IncrementalCompilation/Bitcode/Bits.swift"
+  "IncrementalCompilation/Bitcode/Bitstream.swift"
+  "IncrementalCompilation/Bitcode/BitstreamReader.swift"
+  "IncrementalCompilation/Bitcode/BitstreamVisitor.swift"
+  "IncrementalCompilation/Bitcode/BitstreamWriter.swift"
+  "IncrementalCompilation/Bitcode/BlockInfo.swift"
+
   "IncrementalCompilation/BuildRecord.swift"
   "IncrementalCompilation/BuildRecordInfo.swift"
   "IncrementalCompilation/DependencyGraphDotFileWriter.swift"

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitcode.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitcode.swift
@@ -1,0 +1,53 @@
+//===--------------- BitCode.swift - LLVM BitCode Helpers ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct TSCBasic.ByteString
+
+public struct Bitcode {
+  public let signature: Bitcode.Signature
+  public let elements: [BitcodeElement]
+  public let blockInfo: [UInt64:BlockInfo]
+}
+
+extension Bitcode {
+  public struct Signature: Equatable {
+    private var value: UInt32
+
+    public init(value: UInt32) {
+      self.value = value
+    }
+
+    public init(string: String) {
+      precondition(string.utf8.count == 4)
+      var result: UInt32 = 0
+      for byte in string.utf8.reversed() {
+        result <<= 8
+        result |= UInt32(byte)
+      }
+      self.value = result
+    }
+  }
+}
+
+extension Bitcode {
+  /// Traverse a bitstream using the specified `visitor`, which will receive
+  /// callbacks when blocks and records are encountered.
+  public static func read<Visitor: BitstreamVisitor>(bytes: ByteString, using visitor: inout Visitor) throws {
+    precondition(bytes.count > 4)
+    var reader = BitstreamReader(buffer: bytes)
+    try visitor.validate(signature: reader.readSignature())
+    try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID,
+                         abbrevWidth: 2,
+                         abbrevInfo: [],
+                         visitor: &visitor)
+  }
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitcodeElement.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitcodeElement.swift
@@ -1,0 +1,54 @@
+//===--------------- BitcodeElement.swift - LLVM Bitcode Elements --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public enum BitcodeElement {
+  public struct Block {
+    public var id: UInt64
+    public var elements: [BitcodeElement]
+  }
+
+  /// A record element.
+  ///
+  /// - Warning: A `Record` element's fields and payload only live as long as
+  ///            the `visit` function that provides them is called. To persist
+  ///            a record, always make a copy of it.
+  public struct Record {
+    public enum Payload {
+      case none
+      case array([UInt64])
+      case char6String(String)
+      case blob(ArraySlice<UInt8>)
+    }
+
+    public var id: UInt64
+    public var fields: UnsafeBufferPointer<UInt64>
+    public var payload: Payload
+  }
+
+  case block(Block)
+  case record(Record)
+}
+
+extension BitcodeElement.Record.Payload: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .none:
+      return "none"
+    case .array(let vals):
+      return "array(\(vals))"
+    case .char6String(let s):
+      return "char6String(\(s))"
+    case .blob(let s):
+      return "blob(\(s.count) bytes)"
+    }
+  }
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bits.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bits.swift
@@ -1,0 +1,113 @@
+//===--------------- Bits.swift - Bitstream helpers ----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct TSCBasic.ByteString
+
+struct Bits: RandomAccessCollection {
+  var buffer: ByteString
+
+  var startIndex: Int { return 0 }
+  var endIndex: Int { return buffer.count * 8 }
+
+  subscript(index: Int) -> UInt8 {
+    let byte = buffer.contents[index / 8]
+    return (byte >> UInt8(index % 8)) & 1
+  }
+
+  func readBits(atOffset offset: Int, count: Int) -> UInt64 {
+    precondition(count >= 0 && count <= 64)
+    precondition(offset >= 0)
+    precondition(offset &+ count >= offset)
+    precondition(offset &+ count <= self.endIndex)
+
+    return buffer.contents.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+      let upperBound = offset &+ count
+      let topByteIndex = upperBound >> 3
+      var result: UInt64 = 0
+      if upperBound & 7 != 0 {
+        let mask: UInt8 = (1 << UInt8(upperBound & 7)) &- 1
+        result = UInt64(bytes[topByteIndex] & mask)
+      }
+      for i in ((offset >> 3)..<(upperBound >> 3)).reversed() {
+        result <<= 8
+        result |= UInt64(bytes[i])
+      }
+      if offset & 7 != 0 {
+        result >>= UInt64(offset & 7)
+      }
+      return result
+    }
+  }
+}
+
+extension Bits {
+  struct Cursor {
+    enum Error: Swift.Error { case bufferOverflow }
+
+    let buffer: Bits
+    private var offset: Int = 0
+
+    init(buffer: Bits) {
+      self.buffer = buffer
+    }
+    
+    init(buffer: ByteString) {
+      self.init(buffer: Bits(buffer: buffer))
+    }
+
+    var isAtStart: Bool {
+      return offset == buffer.startIndex
+    }
+
+    var isAtEnd: Bool {
+      return offset == buffer.count
+    }
+
+    func peek(_ count: Int) throws -> UInt64 {
+      if buffer.count - offset < count { throw Error.bufferOverflow }
+      return buffer.readBits(atOffset: offset, count: count)
+    }
+
+    mutating func read(_ count: Int) throws -> UInt64 {
+      defer { offset += count }
+      return try peek(count)
+    }
+
+    mutating func read(bytes count: Int) throws -> ArraySlice<UInt8> {
+      precondition(count >= 0)
+      precondition(offset & 0b111 == 0)
+      let newOffset = offset &+ (count << 3)
+      precondition(newOffset >= offset)
+      if newOffset > buffer.count { throw Error.bufferOverflow }
+      defer { offset = newOffset }
+      return buffer.buffer.contents.dropFirst(offset >> 3).prefix((newOffset - offset) >> 3)
+    }
+
+    mutating func skip(bytes count: Int) throws {
+      precondition(count >= 0)
+      precondition(offset & 0b111 == 0)
+      let newOffset = offset &+ (count << 3)
+      precondition(newOffset >= offset)
+      if newOffset > buffer.count { throw Error.bufferOverflow }
+      offset = newOffset
+    }
+
+    mutating func advance(toBitAlignment align: Int) throws {
+      precondition(align > 0)
+      precondition(offset &+ (align&-1) >= offset)
+      precondition(align & (align &- 1) == 0)
+      if offset % align == 0 { return }
+      offset = (offset &+ align) & ~(align &- 1)
+      if offset > buffer.count { throw Error.bufferOverflow }
+    }
+  }
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitstream.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitstream.swift
@@ -1,0 +1,179 @@
+//===--------------- Bitstream.swift - LLVM Bitstream routines -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A top-level namespace for all bitstream-related structures.
+public enum Bitstream {}
+
+extension Bitstream {
+  /// An `Abbreviation` represents the encoding definition for a user-defined
+  /// record. An `Abbreviation` is the primary form of compression available in
+  /// a bitstream file.
+  public struct Abbreviation {
+    public enum Operand {
+      /// A literal value (emitted as a VBR8 field).
+      case literal(UInt64)
+
+      /// A fixed-width field.
+      case fixed(bitWidth: UInt8)
+
+      /// A VBR-encoded value with the provided chunk width.
+      case vbr(chunkBitWidth: UInt8)
+
+      /// An array of values. This expects another operand encoded
+      /// directly after indicating the element type.
+      /// The array will begin with a vbr6 value indicating the length of
+      /// the following array.
+      indirect case array(Operand)
+
+      /// A char6-encoded ASCII character.
+      case char6
+
+      /// Emitted as a vbr6 value, padded to a 32-bit boundary and then
+      /// an array of 8-bit objects.
+      case blob
+
+      var isPayload: Bool {
+        switch self {
+        case .array, .blob: return true
+        case .literal, .fixed, .vbr, .char6: return false
+        }
+      }
+
+      /// Whether this case is the `literal` case.
+      var isLiteral: Bool {
+        if case .literal = self { return true }
+        return false
+      }
+
+      /// The llvm::BitCodeAbbrevOp::Encoding value this
+      /// enum case represents.
+      /// - note: Must match the encoding in
+      ///         http://llvm.org/docs/BitCodeFormat.html#define-abbrev-encoding
+      var encodedKind: UInt8 {
+        switch self {
+        case .literal(_): return 0
+        case .fixed(_): return 1
+        case .vbr(_): return 2
+        case .array: return 3
+        case .char6: return 4
+        case .blob: return 5
+        }
+      }
+    }
+
+    public var operands: [Operand] = []
+
+    public init(_ operands: [Operand]) {
+      self.operands = operands
+    }
+  }
+}
+
+extension Bitstream {
+  /// An `AbbreviationID` is a fixed-width field that occurs at the start of
+  /// abbreviated data records and inside block definitions.
+  ///
+  /// Bitstream reserves 4 special abbreviation IDs for its own bookkeeping.
+  /// User defined IDs are expected to start at
+  /// `Bitstream.AbbreviationID.firstApplicationID`.
+  ///
+  /// - Warning: Creating your own abbreviations by hand is not recommended as
+  ///            you could potentially corrupt or collide with another
+  ///            abbreviation defined by `BitstreamWriter`. Always use
+  ///            `BitstreamWriter.defineBlockInfoAbbreviation(_:_:)`
+  ///            to register abbreviations.
+  public struct AbbreviationID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
+    public var rawValue: UInt64
+
+    public init(rawValue: UInt64) {
+      self.rawValue = rawValue
+    }
+
+    /// Marks the end of the current block.
+    public static let endBlock = Self(rawValue: 0)
+    /// Marks the beginning of a new block.
+    public static let enterSubblock = Self(rawValue: 1)
+    /// Marks the definition of a new abbreviation.
+    public static let defineAbbreviation = Self(rawValue: 2)
+    /// Marks the definition of a new unabbreviated record.
+    public static let unabbreviatedRecord = Self(rawValue: 3)
+    /// The first application-defined abbreviation ID.
+    public static let firstApplicationID = Self(rawValue: 4)
+
+    public var id: UInt64 {
+      self.rawValue
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.rawValue < rhs.rawValue
+    }
+  }
+}
+
+extension Bitstream {
+  /// A `BlockID` is a fixed-width field that occurs at the start of all blocks.
+  ///
+  /// Bistream reserves the first 7 block IDs for its own bookkeeping. User
+  /// defined IDs are expected to start at
+  /// `Bitstream.BlockID.firstApplicationID`.
+  ///
+  /// When defining new block IDs, it may be helpful to refer to them by
+  /// a user-defined literal. For example, the `dia` serialized diagnostics
+  /// format used by Clang would define constants for block IDs as follows:
+  ///
+  /// ```
+  /// extension Bitstream.BlockID {
+  ///     static let metadata     = Self.firstApplicationID
+  ///     static let diagnostics  = Self.firstApplicationID + 1
+  /// }
+  /// ```
+  public struct BlockID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
+    public var rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+
+    public static let blockInfo = Self(rawValue: 0)
+    public static let firstApplicationID = Self(rawValue: 8)
+
+    public var id: UInt8 {
+      self.rawValue
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.rawValue < rhs.rawValue
+    }
+
+    public static func + (lhs: Self, rhs: UInt8) -> Self {
+      return BlockID(rawValue: lhs.rawValue + rhs)
+    }
+  }
+}
+
+extension Bitstream {
+    /// A `BlockInfoCode` enumerates the bits that occur in the metadata for
+    /// a block or record. Of these bits, only `setBID` is required. If
+    /// a name is given to a block or record with `blockName` or
+    /// `setRecordName`, debugging tools like `llvm-bcanalyzer` can be used to
+    /// introspect the structure of blocks and records in the bitstream file.
+    public enum BlockInfoCode: UInt8 {
+        /// Indicates which block ID is being described.
+        case setBID = 1
+        /// An optional element that records which bytes of the record are the
+        /// name of the block.
+        case blockName = 2
+        /// An optional element that records the record ID number and the bytes
+        /// for the name of the corresponding record.
+        case setRecordName = 3
+    }
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamReader.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamReader.swift
@@ -1,0 +1,328 @@
+//===--------------- BitstreamReader.swift - LLVM Bitstream Reader -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct TSCBasic.ByteString
+
+private extension Bits.Cursor {
+  enum BitcodeError: Swift.Error {
+    case vbrOverflow
+  }
+
+  mutating func readVBR(_ width: Int) throws -> UInt64 {
+    precondition(width > 1)
+    let testBit = UInt64(1 << (width &- 1))
+    let mask = testBit &- 1
+
+    var result: UInt64 = 0
+    var offset: UInt64 = 0
+    var next: UInt64
+    repeat {
+      next = try self.read(width)
+      result |= (next & mask) << offset
+      offset += UInt64(width &- 1)
+      if offset > 64 { throw BitcodeError.vbrOverflow }
+    } while next & testBit != 0
+
+    return result
+  }
+}
+
+internal struct BitstreamReader {
+  enum Error: Swift.Error {
+    case invalidAbbrev
+    case nestedBlockInBlockInfo
+    case missingSETBID
+    case invalidBlockInfoRecord(recordID: UInt64)
+    case abbrevWidthTooSmall(width: Int)
+    case noSuchAbbrev(blockID: UInt64, abbrevID: Int)
+    case missingEndBlock(blockID: UInt64)
+  }
+
+  var cursor: Bits.Cursor
+  var blockInfo: [UInt64: BlockInfo] = [:]
+  var globalAbbrevs: [UInt64: [Bitstream.Abbreviation]] = [:]
+
+  init(buffer: ByteString) {
+    self.cursor = Bits.Cursor(buffer: buffer)
+  }
+
+  mutating func readSignature() throws -> Bitcode.Signature {
+    precondition(self.cursor.isAtStart)
+    let bits = try UInt32(self.cursor.read(MemoryLayout<UInt32>.size * 8))
+    return Bitcode.Signature(value: bits)
+  }
+
+  mutating func readAbbrevOp() throws -> Bitstream.Abbreviation.Operand {
+    let isLiteralFlag = try cursor.read(1)
+    if isLiteralFlag == 1 {
+      return .literal(try cursor.readVBR(8))
+    }
+
+    switch try cursor.read(3) {
+    case 0:
+      throw Error.invalidAbbrev
+    case 1:
+      return .fixed(bitWidth: UInt8(try cursor.readVBR(5)))
+    case 2:
+      return .vbr(chunkBitWidth: UInt8(try cursor.readVBR(5)))
+    case 3:
+      return .array(try readAbbrevOp())
+    case 4:
+      return .char6
+    case 5:
+      return .blob
+    case 6, 7:
+      throw Error.invalidAbbrev
+    default:
+      fatalError()
+    }
+  }
+
+  mutating func readAbbrev(numOps: Int) throws -> Bitstream.Abbreviation {
+    guard numOps > 0 else { throw Error.invalidAbbrev }
+
+    var operands: [Bitstream.Abbreviation.Operand] = []
+    operands.reserveCapacity(numOps)
+    for i in 0..<numOps {
+      operands.append(try readAbbrevOp())
+
+      if case .array = operands.last! {
+        guard i == numOps - 2 else { throw Error.invalidAbbrev }
+        break
+      } else if case .blob = operands.last! {
+        guard i == numOps - 1 else { throw Error.invalidAbbrev }
+      }
+    }
+
+    return Bitstream.Abbreviation(operands)
+  }
+
+  mutating func readSingleAbbreviatedRecordOperand(_ operand: Bitstream.Abbreviation.Operand) throws -> UInt64 {
+    switch operand {
+    case .char6:
+      let value = try cursor.read(6)
+      switch value {
+      case 0...25:
+        return value + UInt64(("a" as UnicodeScalar).value)
+      case 26...51:
+        return value + UInt64(("A" as UnicodeScalar).value) - 26
+      case 52...61:
+        return value + UInt64(("0" as UnicodeScalar).value) - 52
+      case 62:
+        return UInt64(("." as UnicodeScalar).value)
+      case 63:
+        return UInt64(("_" as UnicodeScalar).value)
+      default:
+        fatalError()
+      }
+    case .literal(let value):
+      return value
+    case .fixed(let width):
+      return try cursor.read(Int(width))
+    case .vbr(let width):
+      return try cursor.readVBR(Int(width))
+    case .array, .blob:
+      fatalError()
+    }
+  }
+
+  /// Computes a non-owning view of a `BitcodeElement.Record` that is valid for
+  /// the lifetime of the call to `body`.
+  ///
+  /// - Warning: If this function throws, the `body` block will not be called.
+  mutating func withAbbreviatedRecord(
+    _ abbrev: Bitstream.Abbreviation,
+    body: (BitcodeElement.Record) throws -> Void
+  ) throws {
+    let code = try readSingleAbbreviatedRecordOperand(abbrev.operands.first!)
+
+    let lastOperand = abbrev.operands.last!
+    let lastRegularOperandIndex: Int = abbrev.operands.endIndex - (lastOperand.isPayload ? 1 : 0)
+
+    // Safety: `lastRegularOperandIndex` is always at least 1. An abbreviation
+    // is required by the format to contain at least one operand. If that last
+    // operand is a payload (and thus we subtracted one from the total number of
+    // operands above), then that must mean it is either a trailing array
+    // or trailing blob. Both of these are preceded by their length field.
+    let fields = UnsafeMutableBufferPointer<UInt64>.allocate(capacity: lastRegularOperandIndex - 1)
+    defer { fields.deallocate() }
+
+    for (idx, op) in abbrev.operands[1..<lastRegularOperandIndex].enumerated() {
+      fields[idx] = try readSingleAbbreviatedRecordOperand(op)
+    }
+
+    let payload: BitcodeElement.Record.Payload
+    if !lastOperand.isPayload {
+      payload = .none
+    } else {
+      switch lastOperand {
+      case .array(let element):
+        let length = try cursor.readVBR(6)
+        if case .char6 = element {
+          // FIXME: Once the minimum deployment target bumps to macOS 11, use
+          // the more ergonomic stdlib API everywhere.
+          if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+            payload = try .char6String(String(unsafeUninitializedCapacity: Int(length)) { buffer in
+              for i in 0..<Int(length) {
+                buffer[i] = try UInt8(readSingleAbbreviatedRecordOperand(element))
+              }
+              return Int(length)
+            })
+          } else {
+            let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: Int(length))
+            defer { buffer.deallocate() }
+            for i in 0..<Int(length) {
+              buffer[i] = try UInt8(readSingleAbbreviatedRecordOperand(element))
+            }
+            payload = .char6String(String(decoding: buffer, as: UTF8.self))
+          }
+        } else {
+          var elements = [UInt64]()
+          for _ in 0..<length {
+            elements.append(try readSingleAbbreviatedRecordOperand(element))
+          }
+          payload = .array(elements)
+        }
+      case .blob:
+        let length = Int(try cursor.readVBR(6))
+        try cursor.advance(toBitAlignment: 32)
+        payload = .blob(try cursor.read(bytes: length))
+        try cursor.advance(toBitAlignment: 32)
+      default:
+        fatalError()
+      }
+    }
+
+    return try body(.init(id: code, fields: UnsafeBufferPointer(fields), payload: payload))
+  }
+
+  mutating func readBlockInfoBlock(abbrevWidth: Int) throws {
+    var currentBlockID: UInt64?
+    while true {
+      switch try cursor.read(abbrevWidth) {
+      case Bitstream.AbbreviationID.endBlock.rawValue:
+        try cursor.advance(toBitAlignment: 32)
+        // FIXME: check expected length
+        return
+
+      case Bitstream.AbbreviationID.enterSubblock.rawValue:
+        throw Error.nestedBlockInBlockInfo
+
+      case Bitstream.AbbreviationID.defineAbbreviation.rawValue:
+        guard let blockID = currentBlockID else {
+          throw Error.missingSETBID
+        }
+        let numOps = Int(try cursor.readVBR(5))
+        if globalAbbrevs[blockID] == nil { globalAbbrevs[blockID] = [] }
+        globalAbbrevs[blockID]!.append(try readAbbrev(numOps: numOps))
+
+      case Bitstream.AbbreviationID.unabbreviatedRecord.rawValue:
+        let code = try cursor.readVBR(6)
+        let numOps = try cursor.readVBR(6)
+        var operands = [UInt64]()
+        for _ in 0..<numOps {
+          operands.append(try cursor.readVBR(6))
+        }
+
+        switch code {
+        case UInt64(Bitstream.BlockInfoCode.setBID.rawValue):
+          guard operands.count == 1 else { throw Error.invalidBlockInfoRecord(recordID: code) }
+          currentBlockID = operands.first
+        case UInt64(Bitstream.BlockInfoCode.blockName.rawValue):
+          guard let blockID = currentBlockID else {
+            throw Error.missingSETBID
+          }
+          if blockInfo[blockID] == nil { blockInfo[blockID] = BlockInfo() }
+          blockInfo[blockID]!.name = String(bytes: operands.map { UInt8($0) }, encoding: .utf8) ?? "<invalid>"
+        case UInt64(Bitstream.BlockInfoCode.setRecordName.rawValue):
+          guard let blockID = currentBlockID else {
+            throw Error.missingSETBID
+          }
+          if blockInfo[blockID] == nil { blockInfo[blockID] = BlockInfo() }
+          guard let recordID = operands.first else {
+            throw Error.invalidBlockInfoRecord(recordID: code)
+          }
+          blockInfo[blockID]!.recordNames[recordID] = String(bytes: operands.dropFirst().map { UInt8($0) }, encoding: .utf8) ?? "<invalid>"
+        default:
+          throw Error.invalidBlockInfoRecord(recordID: code)
+        }
+
+      case let abbrevID:
+        throw Error.noSuchAbbrev(blockID: 0, abbrevID: Int(abbrevID))
+      }
+    }
+  }
+
+  mutating func readBlock<Visitor: BitstreamVisitor>(id: UInt64, abbrevWidth: Int, abbrevInfo: [Bitstream.Abbreviation], visitor: inout Visitor) throws {
+    var abbrevInfo = abbrevInfo
+
+    while !cursor.isAtEnd {
+      switch try cursor.read(abbrevWidth) {
+      case Bitstream.AbbreviationID.endBlock.rawValue:
+        try cursor.advance(toBitAlignment: 32)
+        // FIXME: check expected length
+        try visitor.didExitBlock()
+        return
+
+      case Bitstream.AbbreviationID.enterSubblock.rawValue:
+        let blockID = try cursor.readVBR(8)
+        let newAbbrevWidth = Int(try cursor.readVBR(4))
+        try cursor.advance(toBitAlignment: 32)
+        let blockLength = try cursor.read(32) * 4
+
+        switch blockID {
+        case 0:
+          try readBlockInfoBlock(abbrevWidth: newAbbrevWidth)
+        case 1...7:
+          // Metadata blocks we don't understand yet
+          fallthrough
+        default:
+          guard try visitor.shouldEnterBlock(id: blockID) else {
+            try cursor.skip(bytes: Int(blockLength))
+            break
+          }
+          try readBlock(
+            id: blockID, abbrevWidth: newAbbrevWidth,
+            abbrevInfo: globalAbbrevs[blockID] ?? [], visitor: &visitor)
+        }
+
+      case Bitstream.AbbreviationID.defineAbbreviation.rawValue:
+        let numOps = Int(try cursor.readVBR(5))
+        abbrevInfo.append(try readAbbrev(numOps: numOps))
+
+      case Bitstream.AbbreviationID.unabbreviatedRecord.rawValue:
+        let code = try cursor.readVBR(6)
+        let numOps = try cursor.readVBR(6)
+        let operands = UnsafeMutableBufferPointer<UInt64>.allocate(capacity: Int(numOps))
+        defer { operands.deallocate() }
+        for i in 0..<Int(numOps) {
+          operands[i] = try cursor.readVBR(6)
+        }
+        try visitor.visit(record: .init(id: code, fields: UnsafeBufferPointer(operands), payload: .none))
+
+      case let abbrevID:
+        guard Int(abbrevID) - 4 < abbrevInfo.count else {
+          throw Error.noSuchAbbrev(blockID: id, abbrevID: Int(abbrevID))
+        }
+        try withAbbreviatedRecord(abbrevInfo[Int(abbrevID) - 4]) { record in
+          try visitor.visit(record: record)
+        }
+      }
+    }
+
+    guard id == Self.fakeTopLevelBlockID else {
+      throw Error.missingEndBlock(blockID: id)
+    }
+  }
+
+  static let fakeTopLevelBlockID: UInt64 = ~0
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamVisitor.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamVisitor.swift
@@ -1,0 +1,23 @@
+//===----------- BitstreamVisitor.swift - LLVM Bitstream Visitor ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public protocol BitstreamVisitor {
+  /// Customization point to validate a bitstream's signature or "magic number".
+  func validate(signature: Bitcode.Signature) throws
+  /// Called when a new block is encountered. Return `true` to enter the block
+  /// and read its contents, or `false` to skip it.
+  mutating func shouldEnterBlock(id: UInt64) throws -> Bool
+  /// Called when a block is exited.
+  mutating func didExitBlock() throws
+  /// Called whenever a record is encountered.
+  mutating func visit(record: BitcodeElement.Record) throws
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamWriter.swift
@@ -1,0 +1,662 @@
+//===----------- BistreamWriter.swift - LLVM Bitstream Writer -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A `BitstreamWriter` is an object that is capable of emitting data in the
+/// [LLVM Bitstream](https://llvm.org/docs/BitCodeFormat.html#bitstream-format)
+/// format.
+///
+/// Defining A Container Format
+/// ===========================
+///
+/// While `BitstreamWriter` provides APIs to write raw bytes into a bitstream
+/// file, it is recommended that the higher-level structured API be used
+/// instead. Begin by identifying the top-level blocks your container will need.
+/// Most container formats will need a metadata block followed by a series of
+/// user-defined blocks. These can be given in an extension of
+/// `Bitstream.BlockID` as they will be referred to often. For example:
+///
+/// ```
+/// extension Bitstream.BlockID {
+///     static let metadata     = Self.firstApplicationID
+///     static let diagnostics  = Self.firstApplicationID + 1
+/// }
+/// ```
+///
+/// Next, identify the kinds of records needed in the format and assign them
+/// unique, stable identifiers. For example:
+/// 
+/// ```
+/// enum DiagnosticRecordID: UInt8 {
+///     case version        = 1
+///     case diagnostic     = 2
+///     case sourceRange    = 3
+///     case diagnosticFlag = 4
+///     case category       = 5
+///     case filename       = 6
+///     case fixIt          = 7
+/// }
+/// ```
+///
+/// Now, instantiate a `BitstreamWriter` and populate the leading "block info"
+/// block with records describing the data layout of sub-blocks and records. The following
+/// block info section describes the layout of the 'metadata' block which contains a single
+/// version record:
+///
+/// ```
+/// var versionAbbrev: Bitstream.AbbreviationID? = nil
+/// let recordWriter = BitstreamWriter()
+/// recordWriter.writeBlockInfoBlock {
+///     // Define the 'metadata' block and give it a name
+///     recordWriter.writeRecord(BitstreamWriter.BlockInfoCode.setBID) {
+///         $0.append(Bitstream.BlockID.metadata)
+///     }
+///     recordWriter.writeRecord(BitstreamWriter.BlockInfoCode.blockName) {
+///         $0.append("Meta")
+///     }
+///
+///     // Define the 'version' record and register its name
+///     recordWriter.writeRecord(BitstreamWriter.BlockInfoCode.setRecordName) {
+///         $0.append(DiagnosticRecordID.version)
+///         $0.append("Version")
+///     }
+///
+///     versionAbbrev = recordWriter.defineBlockInfoAbbreviation(.metadata, .init([
+///         .literalCode(DiagnosticRecordID.version),
+///         .fixed(bitWidth: 32)
+///     ]))
+///
+///     // Emit a block ID for the 'diagnostics' block as above and define the
+///     // layout of its records similarly...
+/// }
+/// ```
+///
+/// Finally, write any blocks containing the actual data to be serialized.
+///
+/// ```
+/// recordWriter.writeBlock(.metadata, newAbbrevWidth: 3) {
+///     recordWriter.writeRecord(versionAbbrev!) {
+///         $0.append(DiagnosticRecordID.version)
+///         $0.append(25 as UInt32)
+///     }
+/// }
+/// ```
+///
+/// The higher-level APIs will automatically ensure that `BitstreamWriter.data`
+/// is valid. Once serialization has completed, simply emit this data to a file.
+public final class BitstreamWriter {
+    /// The buffer of data being written to.
+    private(set) public var data: [UInt8]
+
+    /// The current value. Only bits < currentBit are valid.
+    private var currentValue: UInt32 = 0
+
+    /// Always between 0 and 31 inclusive, specifies the next bit to use.
+    private var currentBit: UInt8 = 0
+
+    /// The bit width used for abbreviated codes.
+    private var codeBitWidth: UInt8
+
+    /// The list of defined abbreviations.
+    private var currentAbbreviations = [Bitstream.Abbreviation]()
+
+    /// Represents an in-flight block currently being emitted.
+    struct Block {
+        /// The code width before we started emitting this block.
+        let previousCodeWidth: UInt8
+
+        /// The index into the data buffer where this block's length placeholder
+        /// lives.
+        let lengthPlaceholderByteIndex: Int
+
+        /// The previous set of abbreviations registered.
+        let previousAbbrevs: [Bitstream.Abbreviation]
+    }
+
+    /// This keeps track of the blocks that are being emitted.
+    private var blockScope = [Block]()
+
+    /// This contains information emitted to BLOCKINFO_BLOCK blocks.
+    /// These describe abbreviations that all blocks of the specified ID inherit.
+    final class BlockInfo {
+        var abbrevs = [Bitstream.Abbreviation]()
+    }
+    /// This maps BlockInfo IDs to their corresponding values.
+    private var blockInfoRecords = [UInt8: BlockInfo]()
+
+    /// When emitting blockinfo, this is the ID of the current block being
+    /// emitted.
+    private var currentBlockID: Bitstream.BlockID?
+
+    /// Creates a new BitstreamWriter with the provided data stream.
+    public init(data: [UInt8] = []) {
+        self.data = data
+        self.codeBitWidth = 2
+    }
+
+
+    public var bufferOffset: Int {
+        return data.count
+    }
+
+    /// \brief Retrieve the current position in the stream, in bits.
+    public var bitNumber: Int {
+        return bufferOffset * 8 + Int(currentBit)
+    }
+
+    public var isEmpty: Bool {
+        return self.data.isEmpty
+    }
+}
+
+// MARK: Data Writing Primitives
+
+extension BitstreamWriter {
+    /// Writes the provided UInt32 to the data stream directly.
+    public func write(_ int: UInt32) {
+        let index = data.count
+
+        // Add 4 bytes of zeroes to be overwritten.
+        data.append(0)
+        data.append(0)
+        data.append(0)
+        data.append(0)
+
+        overwriteBytes(int, byteIndex: index)
+    }
+
+    /// Writes the provided number of bits to the buffer.
+    ///
+    /// - Parameters:
+    ///   - int: The integer containing the bits you'd like to write
+    ///   - width: The number of low-bits of the integer you're writing to the
+    ///            buffer
+    public func writeVBR<IntType>(_ int: IntType, width: UInt8)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        let threshold = UInt64(1) << (UInt64(width) - 1)
+        var value = UInt64(int)
+
+        // Emit the bits with VBR encoding, (width - 1) bits at a time.
+        while value >= threshold {
+            let masked = (value & (threshold - 1)) | threshold
+            write(masked, width: width)
+            value >>= width - 1
+        }
+
+        write(value, width: width)
+    }
+
+    /// Writes the provided number of bits to the buffer.
+    ///
+    /// - Parameters:
+    ///   - int: The integer containing the bits you'd like to write
+    ///   - width: The number of low-bits of the integer you're writing to the
+    ///            buffer
+    public func write<IntType>(_ int: IntType, width: UInt8)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        precondition(width > 0, "cannot emit 0 bits")
+        precondition(width <= 32, "can only write at most 32 bits")
+
+        let intPattern = UInt32(int)
+
+        precondition(intPattern & ~(~(0 as UInt32) >> (32 - width)) == 0,
+                     "High bits set!")
+
+        // Mask the bits of the argument over the current bit we're tracking
+        let intMask = intPattern << currentBit
+        currentValue |= intMask
+
+        // If we haven't spilled past the temp buffer, just update the
+        // current bit.
+        if currentBit + width < 32 {
+            currentBit += width
+            return
+        }
+
+        // Otherwise, write the current value.
+        write(currentValue)
+
+        if currentBit > 0 {
+            // If we still have bits leftover, replace the current buffer with
+            // the low bits of the input, offset by the current bit.
+            // For example, when we're adding:
+            // 0b00000000_00000000_00000000_00000011
+            // to
+            // 0b01111111_11111111_11111111_11111111
+            //    ^ currentBit (31)
+            // We've already taken 1 bit off the end of the first number,
+            // leaving an extra 1 bit that needs to be represented for the next
+            // write.
+            // Subtract the currentBit from 32 to get the number of bits
+            // leftover and then shift to get rid of the already-recorded bits.
+            currentValue = UInt32(int) >> (32 - UInt32(currentBit))
+        } else {
+            // Otherwise, reset our buffer.
+            currentValue = 0
+        }
+        currentBit = (currentBit + width) & 31
+    }
+
+    public func alignIfNeeded() {
+        guard currentBit > 0 else { return }
+        write(currentValue)
+        assert(bufferOffset % 4 == 0, "buffer must be 32-bit aligned")
+        currentValue = 0
+        currentBit = 0
+    }
+
+    /// Writes a Bool as a 1-bit integer value.
+    public func write(_ bool: Bool) {
+        write(bool ? 1 as UInt : 0, width: 1)
+    }
+
+    /// Writes the provided BitCode Abbrev operand to the stream.
+    public func write(_ abbrevOp: Bitstream.Abbreviation.Operand) {
+        write(abbrevOp.isLiteral) // the Literal bit.
+        switch abbrevOp {
+        case .literal(let value):
+            // Literal values are 1 (for the Literal bit) and then a vbr8
+            // encoded literal.
+            writeVBR(value, width: 8)
+        case .fixed(let bitWidth):
+            // Fixed values are the encoding kind then the bitWidth as a vbr5
+            // value.
+            write(abbrevOp.encodedKind, width: 3)
+            writeVBR(bitWidth, width: 5)
+        case .vbr(let chunkBitWidth):
+            // VBR values are the encoding kind then the chunk width as a
+            // vbr5 value.
+            write(abbrevOp.encodedKind, width: 3)
+            writeVBR(chunkBitWidth, width: 5)
+        case .array(let eltOp):
+            // Arrays are encoded as the Array kind, then the element type
+            // directly after.
+            write(abbrevOp.encodedKind, width: 3)
+            write(eltOp)
+        case .char6, .blob:
+            // Blobs and Char6 are just their encoding kind.
+            write(abbrevOp.encodedKind, width: 3)
+        }
+    }
+
+    /// Writes the specified abbreviaion value to the stream, as a 32-bit quantity.
+    public func writeCode(_ code: Bitstream.AbbreviationID) {
+        writeCode(code.rawValue)
+    }
+
+    /// Writes the specified Code value to the stream, as a 32-bit quantity.
+    public func writeCode<IntType>(_ code: IntType)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        write(code, width: codeBitWidth)
+    }
+
+    /// Writes an ASCII character to the stream, as an 8-bit ascii value.
+    public func writeASCII(_ character: Character) {
+        precondition(character.unicodeScalars.count == 1, "character is not ASCII")
+        let c = UInt8(ascii: character.unicodeScalars.first!)
+        write(c, width: 8)
+    }
+}
+
+// MARK: Abbreviations
+
+extension BitstreamWriter {
+    /// Defines an abbreviation and returns the unique identifier for that
+    /// abbreviation.
+    public func defineAbbreviation(_ abbrev: Bitstream.Abbreviation) -> Bitstream.AbbreviationID {
+        encodeAbbreviation(abbrev)
+        currentAbbreviations.append(abbrev)
+        let rawValue = UInt64(currentAbbreviations.count - 1) +
+                                Bitstream.AbbreviationID.firstApplicationID.rawValue
+        return Bitstream.AbbreviationID(rawValue: rawValue)
+    }
+
+    /// Encodes the definition of an abbreviation to the stream.
+    private func encodeAbbreviation(_ abbrev: Bitstream.Abbreviation) {
+        writeCode(.defineAbbreviation)
+        writeVBR(UInt(abbrev.operands.count), width: 5)
+        for op in abbrev.operands {
+            write(op)
+        }
+    }
+}
+
+// MARK: Writing Records
+
+extension BitstreamWriter {
+    public struct RecordBuffer {
+        private(set) var values = [UInt32]()
+
+        fileprivate init() {
+            self.values = []
+            self.values.reserveCapacity(8)
+        }
+
+        fileprivate init<CodeType>(recordID: CodeType)
+            where CodeType: RawRepresentable, CodeType.RawValue: UnsignedInteger & ExpressibleByIntegerLiteral
+        {
+            self.values = [ UInt32(recordID.rawValue) ]
+        }
+
+        fileprivate init(block: Bitstream.BlockID) {
+            self.values = [ UInt32(block.rawValue) ]
+        }
+
+        fileprivate init(abbreviation: Bitstream.AbbreviationID) {
+            self.values = [ UInt32(abbreviation.rawValue) ]
+        }
+
+        public mutating func append<CodeType>(_ code: CodeType)
+            where CodeType: RawRepresentable, CodeType.RawValue: UnsignedInteger & ExpressibleByIntegerLiteral
+        {
+            values.append(UInt32(code.rawValue))
+        }
+
+        public mutating func append<IntType>(_ int: IntType)
+            where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+        {
+            values.append(UInt32(int))
+        }
+
+        public mutating func append(_ string: String) {
+            self.values.reserveCapacity(self.values.capacity + string.utf8.count)
+            for byte in string.utf8 {
+                values.append(UInt32(byte))
+            }
+        }
+    }
+
+    /// Writes an unabbreviated record to the stream.
+    public func writeRecord<CodeType>(_ code: CodeType, _ composeRecord: (inout RecordBuffer) -> Void)
+        where CodeType: RawRepresentable, CodeType.RawValue == UInt8
+    {
+        writeCode(.unabbreviatedRecord)
+        writeVBR(code.rawValue, width: 6)
+        var record = RecordBuffer()
+        composeRecord(&record)
+        writeVBR(UInt(record.values.count), width: 6)
+        for value in record.values {
+            writeVBR(value, width: 6)
+        }
+    }
+
+    /// Writes a record with the provided abbreviation ID and record contents.
+    /// Optionally, emits the provided blob if the abbreviation referenced
+    /// by that ID requires it.
+    public func writeRecord(
+        _ abbrevID: Bitstream.AbbreviationID,
+        _ composeRecord: (inout RecordBuffer) -> Void,
+        blob: String? = nil
+    ) {
+        let index = Bitstream.AbbreviationID.firstApplicationID.rawValue.distance(to: abbrevID.rawValue)
+        guard index < currentAbbreviations.count else {
+            fatalError("unregistered abbreviation \(index)")
+        }
+
+        let abbrev = currentAbbreviations[Int(index)]
+        var record = RecordBuffer()
+        composeRecord(&record)
+        let values = record.values
+        var valueIndex = 0
+        writeCode(abbrevID)
+        for op in abbrev.operands {
+            switch op {
+            case .array(let eltOp):
+                // First, emit the length as a VBR6
+                let length = UInt(values.count - valueIndex)
+                writeVBR(length, width: 6)
+
+                // Emit the remaining values using that encoding.
+                for idx in valueIndex..<values.count {
+                    writeAbbrevField(eltOp, value: values[idx])
+                }
+            case .blob:
+                guard let blob = blob else { fatalError("expected blob") }
+                // Blobs are encoded as a VBR6 length, then a sequence of
+                // 8-bit values.
+                let length = UInt(blob.utf8.count)
+                writeVBR(length, width: 6)
+                alignIfNeeded()
+
+                for char in blob.utf8 {
+                    write(char, width: 8)
+                }
+
+                // Ensure total length of the blob is a multiple of 4 by
+                // writing zeroes.
+                alignIfNeeded()
+            default:
+                // Otherwise, write this value using its encoding directly and
+                // increment the value index.
+                writeAbbrevField(op, value: values[valueIndex])
+                valueIndex += 1
+            }
+        }
+    }
+}
+
+// MARK: Writing Data
+
+extension BitstreamWriter {
+    /// Char6 is encoded using a special encoding that uses 0 to 64 to encode
+    /// English alphanumeric identifiers.
+    /// The ranges are specified as:
+    /// 'a' .. 'z' ---  0 .. 25
+    /// 'A' .. 'Z' --- 26 .. 51
+    /// '0' .. '9' --- 52 .. 61
+    ///        '.' --- 62
+    ///        '_' --- 63
+    private static let char6Map =
+        Array(zip("abcdefghijklmnopqrstuvwxyz" +
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+                    "0123456789._", (0 as UInt)...))
+
+    /// Writes a char6-encoded value.
+    public func writeChar6<IntType>(_ value: IntType)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        guard (0..<64).contains(value) else {
+            fatalError("invalid char6 value")
+        }
+        let v = BitstreamWriter.char6Map[Int(value)].1
+        write(v, width: 6)
+    }
+
+    /// Writes a value with the provided abbreviation encoding.
+    public func writeAbbrevField(_ op: Bitstream.Abbreviation.Operand, value: UInt32) {
+        switch op {
+        case .literal(let literalValue):
+            // Do not write anything
+            precondition(value == literalValue,
+                         "literal value must match abbreviated literal " +
+                            "(expected \(literalValue), got \(value))")
+        case .fixed(let bitWidth):
+            write(value, width: UInt8(bitWidth))
+        case .vbr(let chunkBitWidth):
+            writeVBR(value, width: UInt8(chunkBitWidth))
+        case .char6:
+            writeChar6(value)
+        case .blob, .array:
+            fatalError("cannot emit a field as array or blob")
+        }
+    }
+
+    /// Writes a block, beginning with the provided block code and the
+    /// abbreviation width
+    public func writeBlock(
+        _ blockID: Bitstream.BlockID,
+        newAbbrevWidth: UInt8? = nil,
+        emitRecords: () -> Void
+    ) {
+        enterSubblock(blockID, abbreviationBitWidth: newAbbrevWidth)
+        emitRecords()
+        endBlock()
+    }
+
+    public func writeBlob<S>(_ bytes: S, includeSize: Bool = true)
+        where S: Collection, S.Element == UInt8
+    {
+        if includeSize {
+            // Emit a vbr6 to indicate the number of elements present.
+            self.writeVBR(UInt8(bytes.count), width: 6)
+        }
+
+        // Flush to a 32-bit alignment boundary.
+        self.alignIfNeeded()
+
+        // Emit literal bytes.
+        for byte in bytes {
+            self.write(byte, width: 8)
+        }
+
+        // Align end to 32-bits.
+        while (self.bufferOffset & 3) != 0 {
+            self.write(0 as UInt8, width: 8)
+        }
+    }
+    
+
+    /// Writes the blockinfo block and allows emitting abbreviations
+    /// and records in it.
+    public func writeBlockInfoBlock(emitRecords: () -> Void) {
+        writeBlock(.blockInfo, newAbbrevWidth: 2) {
+            currentBlockID = nil
+            blockInfoRecords = [:]
+            emitRecords()
+        }
+    }
+}
+
+// MARK: Block Management
+
+extension BitstreamWriter {
+    /// Defines a scope under which a new block's contents can be defined.
+    ///
+    /// - Parameters:
+    ///   - blockID: The ID of the block to emit.
+    ///   - abbreviationBitWidth: The width of the largest abbreviation ID in this block.
+    ///   - defineSubBlock: A closure that is called to define the contents of the new block.
+    public func withSubBlock(
+        _ blockID: Bitstream.BlockID,
+        abbreviationBitWidth: UInt8? = nil,
+        defineSubBlock: () -> Void
+    ) {
+        self.enterSubblock(blockID, abbreviationBitWidth: abbreviationBitWidth)
+        defineSubBlock()
+        self.endBlock()
+    }
+
+    /// Marks the start of a new block record and switches to it.
+    ///
+    /// - Note: You must call `BitstreamWriter.endBlock()` once you are finished
+    ///         encoding data into the newly-created block, else the resulting
+    ///         bitstream file will become corrupted. It is recommended that
+    ///         you use `BitstreamWriter.withSubBlock(_:abbreviationBitWidth:defineSubBlock:)`
+    ///         instead.
+    ///
+    /// - Parameters:
+    ///   - blockID: The ID of the block to emit.
+    ///   - abbreviationBitWidth: The width of the largest abbreviation ID in this block.
+    public func enterSubblock(
+        _ blockID: Bitstream.BlockID,
+        abbreviationBitWidth: UInt8? = nil
+    ) {
+        // [ENTER_SUBBLOCK, blockid(vbr8), newabbrevlen(vbr4),
+        //                  <align32bits>, blocklen_32]
+        writeCode(.enterSubblock)
+
+        let newWidth = abbreviationBitWidth ?? codeBitWidth
+
+        writeVBR(blockID.rawValue,  width: 8)
+
+        writeVBR(newWidth, width: 4)
+        alignIfNeeded()
+
+        // Caller is responsible for filling in the blocklen_32 value
+        // after emitting the contents of the block.
+        let byteOffset = bufferOffset
+        write(0 as UInt, width: 32)
+
+        let block = Block(previousCodeWidth: codeBitWidth,
+                          lengthPlaceholderByteIndex: byteOffset,
+                          previousAbbrevs: currentAbbreviations)
+
+        codeBitWidth = newWidth
+        currentAbbreviations = []
+        blockScope.append(block)
+        if let blockInfo = blockInfoRecords[blockID.rawValue] {
+            currentAbbreviations.append(contentsOf: blockInfo.abbrevs)
+        }
+    }
+
+    /// Marks the end of a new block record.
+    public func endBlock() {
+        guard let block = blockScope.popLast() else {
+            fatalError("endBlock() called with no block registered")
+        }
+
+        let blockLengthInBytes = data.count - block.lengthPlaceholderByteIndex
+        let blockLengthIn32BitWords = UInt32(blockLengthInBytes / 4)
+
+        writeCode(.endBlock)
+        alignIfNeeded()
+
+        // Backpatch the block length now that we've finished it
+        overwriteBytes(blockLengthIn32BitWords,
+                       byteIndex: block.lengthPlaceholderByteIndex)
+
+        // Restore the inner block's code size and abbrev table.
+        codeBitWidth = block.previousCodeWidth
+        currentAbbreviations = block.previousAbbrevs
+    }
+
+    /// Defines an abbreviation within the blockinfo block for the provided
+    /// block ID.
+    public func defineBlockInfoAbbreviation(
+        _ blockID: Bitstream.BlockID,
+        _ abbrev: Bitstream.Abbreviation
+    ) -> Bitstream.AbbreviationID {
+        self.switch(to: blockID)
+        encodeAbbreviation(abbrev)
+        let info = getOrCreateBlockInfo(blockID.rawValue)
+        info.abbrevs.append(abbrev)
+        let rawValue = UInt64(info.abbrevs.count - 1) + Bitstream.AbbreviationID.firstApplicationID.rawValue
+        return Bitstream.AbbreviationID(rawValue: rawValue)
+    }
+
+
+    private func overwriteBytes(_ int: UInt32, byteIndex: Int) {
+        let i = int.littleEndian
+        data.withUnsafeMutableBytes { ptr in
+            ptr.storeBytes(of: i, toByteOffset: byteIndex, as: UInt32.self)
+        }
+    }
+
+    /// Gets the BlockInfo for the provided ID or creates it if it hasn't been
+    /// created already.
+    private func getOrCreateBlockInfo(_ id: UInt8) -> BlockInfo {
+        if let blockInfo = blockInfoRecords[id] { return blockInfo }
+        let info = BlockInfo()
+        blockInfoRecords[id] = info
+        return info
+    }
+
+    private func `switch`(to blockID: Bitstream.BlockID) {
+        if currentBlockID == blockID { return }
+        writeRecord(Bitstream.BlockInfoCode.setBID) {
+            $0.append(blockID)
+        }
+        currentBlockID = blockID
+    }
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BlockInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BlockInfo.swift
@@ -1,0 +1,16 @@
+//===----------- BlockInfo.swift - LLVM Bitstream Block Info --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public struct BlockInfo {
+  public var name: String = ""
+  public var recordNames: [UInt64:String] = [:]
+}

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -14,11 +14,6 @@ import SwiftOptions
 
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.ByteString
-import enum TSCUtility.BitcodeElement
-import enum TSCUtility.Bitstream
-import class TSCUtility.BitstreamWriter
-import protocol TSCUtility.BitstreamVisitor
-import struct TSCUtility.Bitcode
 import struct TSCUtility.Version
 import class Dispatch.DispatchQueue
 import struct Foundation.TimeInterval

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -12,11 +12,6 @@
 
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.ByteString
-import class TSCUtility.BitstreamWriter
-import enum TSCUtility.BitcodeElement
-import enum TSCUtility.Bitstream
-import protocol TSCUtility.BitstreamVisitor
-import struct TSCUtility.Bitcode
 
 /*@_spi(Testing)*/ public struct SourceFileDependencyGraph {
   public static let sourceFileProvidesInterfaceSequenceNumber: Int = 0


### PR DESCRIPTION
The swift-driver is the only consumer of the bitcode implementation in TSCUtility.  Migrate the code to the single user to allow us to deprecate the API in tools-support-core.  While there are no practical changes to the implementation, this does take the opportunity to split up the bitcode implementation into multiple files.