### PR TITLE
SwiftDriver: remove unused references to `Version`

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -14,7 +14,6 @@ import SwiftOptions
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
-import struct TSCUtility.Version
 
 extension DarwinToolchain {
   internal func findXcodeClangPath() throws -> AbsolutePath? {

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -17,7 +17,6 @@ import func Foundation.free
 
 import protocol TSCBasic.DiagnosticData
 import struct TSCBasic.AbsolutePath
-import struct TSCUtility.Version
 import struct TSCBasic.Diagnostic
 
 public enum DependencyScanningError: Error, DiagnosticData {


### PR DESCRIPTION
`TSCUtility.Version` is not used in these source files anymore.  Remove the reference to make it easier to identify what valid ties to `TSCUtility` remain in the package.