### PR TITLE
Re-enable swiftinterface verification with compatibility headers

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -512,13 +512,6 @@ extension Driver {
       emitModuleSeparately || compilerMode == .singleCompile ||
       parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
                             negative: .noVerifyEmittedModuleInterface,
-                            default: false),
-
-      // Don't verify by default modules emitting a compatibility header. This is
-      // unsupported as the headers are merged after all archs are built. rdar://90864986
-      self.objcGeneratedHeaderPath == nil ||
-      parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
-                            negative: .noVerifyEmittedModuleInterface,
                             default: false)
     else { return }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5262,14 +5262,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(verifyJob.commandLine.contains(.flag("-check-api-availability-only")))
     }
 
-    // Don't verify modules with compatibility headers.
+    // Do verify modules with compatibility headers.
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-module", "-module-name",
                                      "foo", "-emit-module-interface",
                                      "-enable-library-evolution", "-emit-objc-header-path", "foo-Swift.h"],
                               env: envVars)
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.filter( { job in job.kind == .verifyModuleInterface}).count, 0)
+      XCTAssertEqual(plannedJobs.filter( { job in job.kind == .verifyModuleInterface}).count, 1)
     }
   }
 


### PR DESCRIPTION
Lift the workaround that disabled scheduling the swiftinterface verification task when a compatibility header is generated. This is an issue only when the header is also installed, we now expect the build system to disable the verification when it installs the header.

For more context, this issue lead to errors on missing headers and failures to build the underlying clang module at verification.

rdar://100989723