### PR TITLE
Adopt to path API changes

### DIFF
--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -763,7 +763,7 @@ extension TSCBasic.FileSystem {
       // retrieve the mod time of the underlying file. This makes build systems
       // that regenerate lots of symlinks but do not otherwise alter the
       // contents of files - like Bazel - quite happy.
-      let path = resolveSymlinks(path)
+      let path = try resolveSymlinks(path)
       #if os(Windows)
       // The NT epoch is 1601, so we need to add a correction factor to bridge
       // between Foundation.Date's insistence on using the Mac epoch time of


### PR DESCRIPTION
We are moving to a better model for TSC's path APIs in https://github.com/apple/swift-tools-support-core/pull/353. The previous API is still available (but deprecated) as much as possible, but a small change is necessary here.