### PR TITLE
Remove deprecated 'externalTargetModulePathMap'

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -16,10 +16,6 @@ import struct TSCBasic.AbsolutePath
 import struct Foundation.Data
 import class Foundation.JSONEncoder
 
-/// A map from a module identifier to a path to its .swiftmodule file.
-/// Deprecated in favour of the below `ExternalTargetModuleDetails`
-public typealias ExternalTargetModulePathMap = [ModuleDependencyId: AbsolutePath]
-
 /// Details about an external target, including the path to its .swiftmodule file
 /// and whether it is a framework.
 public struct ExternalTargetModuleDetails {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -74,9 +74,9 @@ public extension Driver {
     // FIXME: MSVC runtime flags
 
     // Pass in external target dependencies to be treated as placeholder dependencies by the scanner
-    if let externalTargetPaths = externalTargetModuleDetailsMap?.mapValues({ $0.path }) {
+    if let externalTargetDetailsMap = externalTargetModuleDetailsMap {
       let dependencyPlaceholderMapFile =
-      try serializeExternalDependencyArtifacts(externalTargetPaths: externalTargetPaths)
+      try serializeExternalDependencyArtifacts(externalTargetDependencyDetails: externalTargetDetailsMap)
       commandLine.appendFlag("-placeholder-dependency-module-map-file")
       commandLine.appendPath(dependencyPlaceholderMapFile)
     }
@@ -87,12 +87,12 @@ public extension Driver {
   }
 
   /// Serialize a map of placeholder (external) dependencies for the dependency scanner.
-   private func serializeExternalDependencyArtifacts(externalTargetPaths: ExternalTargetModulePathMap)
+   private func serializeExternalDependencyArtifacts(externalTargetDependencyDetails: ExternalTargetModuleDetailsMap)
    throws -> VirtualPath {
      var placeholderArtifacts: [SwiftModuleArtifactInfo] = []
      // Explicit external targets
-     for (moduleId, binaryModulePath) in externalTargetPaths {
-       let modPath = TextualVirtualPath(path: VirtualPath.absolute(binaryModulePath).intern())
+     for (moduleId, dependencyDetails) in externalTargetDependencyDetails {
+       let modPath = TextualVirtualPath(path: VirtualPath.absolute(dependencyDetails.path).intern())
        placeholderArtifacts.append(
            SwiftModuleArtifactInfo(name: moduleId.moduleName,
                                    modulePath: modPath))
@@ -102,7 +102,7 @@ public extension Driver {
      let contents = try encoder.encode(placeholderArtifacts)
      return VirtualPath.createUniqueTemporaryFileWithKnownContents(.init("\(moduleOutputInfo.name)-external-modules.json"),
                                                                    contents)
-   }
+  }
 
   /// Returns false if the lib is available and ready to use
   private func initSwiftScanLib() throws -> Bool {


### PR DESCRIPTION
Clients should have transitioned to 'externalTargetModuleDetailsMap'.