### PR TITLE
Use the versioned triple outside of Darwin.

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -601,7 +601,11 @@ def get_build_target(swiftc_path, args):
                                                    stderr=subprocess.PIPE,
                                                    universal_newlines=True).strip()
         args.target_info = json.loads(target_info_json)
-        return args.target_info['target']['unversionedTriple']
+        triple = args.target_info['target']['triple']
+        # Windows also wants unversionedTriple, but does not use this.
+        if platform.system() == 'Darwin':
+          triple = args.target_info['target']['unversionedTriple']
+        return triple
     except Exception as e:
         error(str(e))
 


### PR DESCRIPTION
Some platforms require the normal, versioned triple to be supplied for the target flag, as Swift modules use this versioned triple as a subdirectory. If the unversioned triple is used instead, the standard library won't be found on these platforms.

Instead, use the unversioned triple only on Darwin. This also should be a noop on Linux. This behavior matches apple/swift-package-manager#3576 and apple/swift-tools-support-core#229 which contain additional context.