### PR TITLE
SwiftDriver: on FreeBSD, use lld, not gold

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -17,7 +17,8 @@ import struct TSCBasic.AbsolutePath
 
 extension GenericUnixToolchain {
   private func defaultLinker(for targetTriple: Triple) -> String? {
-    if targetTriple.os == .openbsd || targetTriple.environment == .android {
+    if targetTriple.os == .openbsd || targetTriple.os == .freeBSD ||
+        targetTriple.environment == .android {
       return "lld"
     }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2104,6 +2104,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(lastJob.commandLine.contains(subsequence: [.flag("-fuse-ld=lld"),
         .flag("-Xlinker"), .flag("-z"), .flag("-Xlinker"), .flag("nostart-stop-gc")]))
     }
+
+    do {
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-unknown-freebsd"], env: env)
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      let lastJob = plannedJobs.last!
+      XCTAssertTrue(lastJob.tool.name.contains("clang"))
+      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
+    }
   }
 
   func testWebAssemblyUnsupportedFeatures() throws {


### PR DESCRIPTION
This is equivalent to passing `-use-ld=lld` to the driver.