### PR TITLE
Tests: fix use of deprecated `AbsolutePath.init` in tests

### DIFF
--- a/Tests/IncrementalTestFramework/Source.swift
+++ b/Tests/IncrementalTestFramework/Source.swift
@@ -41,9 +41,9 @@ public struct Source: Hashable, Comparable {
   public init?(named name: String,
               at relativePath: RelativePath,
               on fileSystem: FileSystem = localFileSystem) throws {
-    guard let absPath = Fixture.fixturePath(at: relativePath,
-                                            for: "\(name).swift",
-                                            on: fileSystem)
+    guard let absPath = try Fixture.fixturePath(at: relativePath,
+                                                for: "\(name).swift",
+                                                on: fileSystem)
     else {
       return nil
     }

--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -112,7 +112,7 @@ class APIDigesterTests: XCTestCase {
                                        "-output-file-map", ofmPath.pathString,
                                       ])
         let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
-        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/path/to/baseline.abi.json")))]))
+        try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/path/to/baseline.abi.json")))]))
       }
     }
     do {
@@ -136,7 +136,7 @@ class APIDigesterTests: XCTestCase {
                                        "-output-file-map", ofmPath.pathString,
                                       ])
         let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
-        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/path/to/sourceinfo.abi.json")))]))
+        try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/path/to/sourceinfo.abi.json")))]))
       }
     }
   }
@@ -149,8 +149,8 @@ class APIDigesterTests: XCTestCase {
       XCTAssertTrue(digesterJob.commandLine.contains("-dump-sdk"))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init(validating: "/path/to/sdk")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init(validating: "/some/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.api.json")))]))
 
@@ -165,8 +165,8 @@ class APIDigesterTests: XCTestCase {
       XCTAssertTrue(digesterJob.commandLine.contains("-dump-sdk"))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init(validating: "/path/to/sdk")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init(validating: "/some/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.abi.json")))]))
 
@@ -238,10 +238,10 @@ class APIDigesterTests: XCTestCase {
       let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareAPIBaseline })
       XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(.init("/baseline/path")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(.init(validating: "/baseline/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init(validating: "/path/to/sdk")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init(validating: "/some/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
                                                                    .path(.relative(.init("allowlist/path")))]))
@@ -257,7 +257,7 @@ class APIDigesterTests: XCTestCase {
                                      "-digester-breakage-allowlist-path", "allowlist/path"])
       let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareABIBaseline })
       XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-input-paths", .path(.absolute(.init("/baseline/path")))]))
+      try XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-input-paths", .path(.absolute(.init(validating: "/baseline/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
                                                                    .path(.relative(.init("allowlist/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains("-abi"))

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -22,7 +22,7 @@ class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker
   ///
   /// Ensure that a round-trip fails when the minor version number changes
   func testSerializedVersionChangeDetection() throws {
-    let mockPath = VirtualPath.absolute(AbsolutePath("/module-dependency-graph"))
+    let mockPath = try VirtualPath.absolute(AbsolutePath(validating: "/module-dependency-graph"))
     let fs = InMemoryFileSystem()
     let graph = Self.mockGraphCreator.mockUpAGraph()
     let currentVersion = ModuleDependencyGraph.serializedGraphVersion
@@ -54,7 +54,7 @@ class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker
   }
 
   func roundTrip(_ originalGraph: ModuleDependencyGraph) throws {
-    let mockPath = VirtualPath.absolute(AbsolutePath("/module-dependency-graph"))
+    let mockPath = try VirtualPath.absolute(AbsolutePath(validating: "/module-dependency-graph"))
     let fs = InMemoryFileSystem()
     try originalGraph.blockingConcurrentMutation {
       try originalGraph.write(to: mockPath, on: fs, compilerVersion: "Swift 99")

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import TestUtilities
 
 private var testInputsPath: AbsolutePath = {
-  var root: AbsolutePath = AbsolutePath(#file)
+  var root: AbsolutePath = try! AbsolutePath(validating: #file)
   while root.basename != "Tests" {
     root = root.parentDirectory
   }
@@ -244,7 +244,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
   func testModuleDependencyBuildCommandGenerationWithExternalFramework() throws {
     do {
       let externalDetails: ExternalTargetModuleDetailsMap =
-            [.swiftPrebuiltExternal("A"): ExternalTargetModuleDetails(path: AbsolutePath("/tmp/A.swiftmodule"),
+            [.swiftPrebuiltExternal("A"): ExternalTargetModuleDetails(path: try AbsolutePath(validating: "/tmp/A.swiftmodule"),
                                                       isFramework: true)]
       var driver = try Driver(args: ["swiftc", "-explicit-module-build",
                                      "-module-name", "testModuleDependencyBuildCommandGenerationWithExternalFramework",
@@ -946,7 +946,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                              env: ProcessEnv.vars)
       let sdkPath = try executor.checkNonZeroExit(
         args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
-      let stdLibPath = AbsolutePath(sdkPath).appending(component: "usr")
+      let stdLibPath = try AbsolutePath(validating: sdkPath).appending(component: "usr")
         .appending(component: "lib")
         .appending(component: "swift")
       return (stdLibPath, stdLibPath.appending(component: "shims"))

--- a/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
@@ -38,7 +38,7 @@ class IncrementalBuildPerformanceTests: XCTestCase {
       throw XCTSkip()
 #else
 
-    let packageRootPath = AbsolutePath(#file)
+    let packageRootPath = try AbsolutePath(validating: #file)
       .parentDirectory
       .parentDirectory
       .parentDirectory

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -20,7 +20,7 @@ import TestUtilities
 // MARK: - Instance variables and initialization
 final class IncrementalCompilationTests: XCTestCase {
 
-  var tempDir: AbsolutePath = AbsolutePath("/tmp")
+  var tempDir = try! AbsolutePath(validating: "/tmp")
 
   var derivedDataDir: AbsolutePath {
     tempDir.appending(component: "derivedData")

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -16,12 +16,12 @@ import TSCBasic
 #if os(macOS)
 internal func bundleRoot() -> AbsolutePath {
     for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-        return AbsolutePath(bundle.bundlePath).parentDirectory
+        return try! AbsolutePath(validating: bundle.bundlePath).parentDirectory
     }
     fatalError()
 }
 
-private let packageDirectory = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+private let packageDirectory = try! AbsolutePath(validating: #file).parentDirectory.parentDirectory.parentDirectory
 
 // The "default" here means lit.py will be invoked as an executable, while otherwise let's use
 // python 3 explicitly.
@@ -95,7 +95,7 @@ final class IntegrationTests: IntegrationTestCase {
         environment: ProcessEnv.vars.merging(extraEnv) { $1 }
       )
 
-      XCTAssertTrue(localFileSystem.isExecutableFile(AbsolutePath("debug/swift-driver", relativeTo: buildPath)), result)
+      try XCTAssertTrue(localFileSystem.isExecutableFile(AbsolutePath(validating: "debug/swift-driver", relativeTo: buildPath)), result)
     }
   #endif
   }
@@ -173,8 +173,8 @@ final class IntegrationTests: IntegrationTestCase {
       // you've cloned this package into a Swift compiler working directory,
       // that means it'll be the directory with build/, llvm/, swift/, and
       // swift-driver/ in it.
-      let litConfigDir = AbsolutePath(
-        litConfigPathString,
+      let litConfigDir = try AbsolutePath(
+        validating: litConfigPathString,
         relativeTo: swiftRootDir
       )
 

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1451,7 +1451,7 @@ extension Job {
                                       type: .swift)
     try! self.init(moduleName: "nothing",
                    kind: .compile,
-                   tool: ResolvedTool(path: AbsolutePath("/dummy"), supportsResponseFiles: false),
+                   tool: ResolvedTool(path: AbsolutePath(validating: "/dummy"), supportsResponseFiles: false),
                    commandLine: [],
                    inputs:  [input],
                    primaryInputs: [input],

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -247,9 +247,9 @@ final class NonincrementalCompilationTests: XCTestCase {
   func testReadAndWriteBuildRecord() throws {
     let version = "Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
     let options = "abbbfbcaf36b93e58efaadd8271ff142"
-    let file2: AbsolutePath = AbsolutePath("/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift")
-    let main: AbsolutePath = AbsolutePath("/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift")
-    let gazorp: AbsolutePath = AbsolutePath("/Volumes/gazorp.swift")
+    let file2: AbsolutePath = try AbsolutePath(validating: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/file2.swift")
+    let main: AbsolutePath = try AbsolutePath(validating: "/Volumes/AS/repos/swift-driver/sandbox/sandbox/sandbox/main.swift")
+    let gazorp: AbsolutePath = try AbsolutePath(validating: "/Volumes/gazorp.swift")
     let inputString =
       """
       version: "\(version)"

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -36,7 +36,7 @@ private func rebase(_ arcs: String..., at base: AbsolutePath) -> String {
 }
 
 private var testInputsPath: AbsolutePath = {
-  var root: AbsolutePath = AbsolutePath(#file)
+  var root = try! AbsolutePath(validating: #file)
   while root.basename != "Tests" {
     root = root.parentDirectory
   }
@@ -52,7 +52,7 @@ final class SwiftDriverTests: XCTestCase {
         let ld = $0.appending(component: executableName("ld64.lld"))
 
         try localFileSystem.writeFileContents(ld) { $0 <<< "" }
-        try localFileSystem.chmod(.executable, path: AbsolutePath(ld.nativePathString(escaped: false)))
+        try localFileSystem.chmod(.executable, path: AbsolutePath(validating: ld.nativePathString(escaped: false)))
 
         return ld
       }
@@ -201,7 +201,7 @@ final class SwiftDriverTests: XCTestCase {
   func testJoinedPathOptions() throws {
     var driver = try Driver(args: ["swiftc", "-c", "-I=/some/dir", "-F=other/relative/dir", "foo.swift"])
     let jobs = try driver.planBuild()
-    XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-I=", .absolute(.init("/some/dir")))))
+    try XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-I=", .absolute(.init(validating: "/some/dir")))))
     XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-F=", .relative(.init("other/relative/dir")))))
   }
 
@@ -213,9 +213,9 @@ final class SwiftDriverTests: XCTestCase {
     let jobs = try driver.planBuild()
     XCTAssertEqual(jobs[0].kind, .compile)
     // The relative ordering of -F and -Fsystem options should be preserved.
-    XCTAssertTrue(jobs[0].commandLine.contains(subsequence: [.flag("-F"), .path(.absolute(.init("/path/to/frameworks"))),
-                                                             .flag("-Fsystem"), .path(.absolute(.init("/path/to/systemframeworks"))),
-                                                             .flag("-F"), .path(.absolute(.init("/path/to/more/frameworks")))]))
+    try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: [.flag("-F"), .path(.absolute(.init(validating: "/path/to/frameworks"))),
+                                                             .flag("-Fsystem"), .path(.absolute(.init(validating: "/path/to/systemframeworks"))),
+                                                             .flag("-F"), .path(.absolute(.init(validating: "/path/to/more/frameworks")))]))
   }
 
   func testBatchModeDiagnostics() throws {
@@ -280,17 +280,17 @@ final class SwiftDriverTests: XCTestCase {
 
   func testInputFiles() throws {
     let driver1 = try Driver(args: ["swiftc", "a.swift", "/tmp/b.swift"])
-    XCTAssertEqual(driver1.inputFiles,
+    try XCTAssertEqual(driver1.inputFiles,
                    [ TypedVirtualPath(file: VirtualPath.relative(RelativePath("a.swift")).intern(), type: .swift),
-                     TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath("/tmp/b.swift")).intern(), type: .swift) ])
+                     TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath(validating: "/tmp/b.swift")).intern(), type: .swift) ])
 
     let workingDirectory = localFileSystem.currentWorkingDirectory!.appending(components: "wobble")
     let tempDirectory = localFileSystem.currentWorkingDirectory!.appending(components: "tmp")
 
     let driver2 = try Driver(args: ["swiftc", "a.swift", "-working-directory", workingDirectory.pathString, rebase("b.swift", at: tempDirectory)])
-    XCTAssertEqual(driver2.inputFiles,
-                   [ TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath(rebase("a.swift", at: workingDirectory))).intern(), type: .swift),
-                     TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath(rebase("b.swift", at: tempDirectory))).intern(), type: .swift) ])
+    try XCTAssertEqual(driver2.inputFiles,
+                   [ TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath(validating: rebase("a.swift", at: workingDirectory))).intern(), type: .swift),
+                     TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath(validating: rebase("b.swift", at: tempDirectory))).intern(), type: .swift) ])
 
     let driver3 = try Driver(args: ["swift", "-"])
     XCTAssertEqual(driver3.inputFiles, [ TypedVirtualPath(file: .standardInput, type: .swift )])
@@ -753,8 +753,8 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .emitModule)
         XCTAssertTrue(plannedJobs[1].kind == .compile)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.dia")))]))
+        try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
+        try XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.dia")))]))
       }
 
       // WMO
@@ -767,8 +767,8 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .compile)
         XCTAssertTrue(plannedJobs[1].kind == .emitModule)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
+        try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia")))]))
+        try XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
       }
     }
   }
@@ -797,8 +797,8 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .emitModule)
         XCTAssertTrue(plannedJobs[1].kind == .compile)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.d")))]))
+        try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
+        try XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.d")))]))
       }
 
       // WMO
@@ -811,15 +811,14 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .compile)
         XCTAssertTrue(plannedJobs[1].kind == .emitModule)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.d")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
+        try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.d")))]))
+        try XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
       }
     }
   }
 
   func testOutputFileMapLoading() throws {
-    let objroot: AbsolutePath =
-        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+    let objroot = try AbsolutePath(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
 
     let contents = """
     {
@@ -850,8 +849,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testFindingObjectPathFromllvmBCPath() throws {
-    let objroot: AbsolutePath =
-        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+    let objroot = try AbsolutePath(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
 
     let contents = """
     {
@@ -879,8 +877,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testOutputFileMapLoadingDocAndSourceinfo() throws {
-    let objroot: AbsolutePath =
-        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+    let objroot = try AbsolutePath(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
 
     let contents = """
     {
@@ -950,10 +947,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         var jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/main.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
-        XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/main.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/tmp/build1/second.o")))]))
+        try XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/tmp/build1/main.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init(validating: "/tmp/build2/second.o")))]))
+        try XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init(validating: "/tmp/build2/main.o")))]))
 
         // b) with filelists
         driver = try Driver(args: [
@@ -962,14 +959,14 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         jobs = try driver.planBuild()
-        XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build1/second.o"))])
-        XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build2/second.o"))])
-        XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[1]),
-                       [.absolute(.init("/tmp/build1/main.o"))])
-        XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[1]),
-                       [.absolute(.init("/tmp/build2/main.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
+                       [.absolute(.init(validating: "/tmp/build1/second.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
+                       [.absolute(.init(validating: "/tmp/build2/second.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[1]),
+                       [.absolute(.init(validating: "/tmp/build1/main.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[1]),
+                       [.absolute(.init(validating: "/tmp/build2/main.o"))])
 
 
         // 2. Batch mode (two primary files)
@@ -980,10 +977,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/main.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/main.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/tmp/build1/second.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/tmp/build1/main.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init(validating: "/tmp/build2/second.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init(validating: "/tmp/build2/main.o")))]))
 
         // b) with filelists
         driver = try Driver(args: [
@@ -993,10 +990,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         jobs = try driver.planBuild()
-        XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build1/second.o")), .absolute(.init("/tmp/build1/main.o"))])
-        XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build2/second.o")), .absolute(.init("/tmp/build2/main.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
+                       [.absolute(.init(validating: "/tmp/build1/second.o")), .absolute(.init(validating: "/tmp/build1/main.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
+                       [.absolute(.init(validating: "/tmp/build2/second.o")), .absolute(.init(validating: "/tmp/build2/main.o"))])
 
         // 3. Multi-threaded WMO
         // a) without filelists
@@ -1006,10 +1003,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/main.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/main.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/tmp/build1/second.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init(validating: "/tmp/build2/second.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/tmp/build1/main.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init(validating: "/tmp/build2/main.o")))]))
 
         // b) with filelists
         driver = try Driver(args: [
@@ -1019,10 +1016,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         jobs = try driver.planBuild()
-        XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build1/second.o")), .absolute(.init("/tmp/build1/main.o"))])
-        XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build2/second.o")), .absolute(.init("/tmp/build2/main.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
+                       [.absolute(.init(validating: "/tmp/build1/second.o")), .absolute(.init(validating: "/tmp/build1/main.o"))])
+        try XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
+                       [.absolute(.init(validating: "/tmp/build2/second.o")), .absolute(.init(validating: "/tmp/build2/main.o"))])
 
         // 4. Index-file (single primary)
         driver = try Driver(args: [
@@ -1033,8 +1030,8 @@ final class SwiftDriverTests: XCTestCase {
           "-index-unit-output-path", "/tmp/build2/second.o"
         ])
         jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init(validating: "/tmp/build1/second.o")))]))
+        try XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init(validating: "/tmp/build2/second.o")))]))
       }
     }
   }
@@ -1145,14 +1142,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[0].kind, .compile)
       XCTAssertTrue(plannedJobs[0].primaryInputs.map{ $0.file.description }.elementsEqual(["foo.swift",
                                                                                            "bar.swift"]))
-      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init("/tmp/foo.build/foo.swiftconstvalues")))]))
-      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init("/tmp/foo.build/bar.swiftconstvalues")))]))
+      try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init(validating: "/tmp/foo.build/foo.swiftconstvalues")))]))
+      try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init(validating: "/tmp/foo.build/bar.swiftconstvalues")))]))
       XCTAssertEqual(plannedJobs[0].outputs.filter({ $0.type == .swiftConstValues }).count, 2)
       XCTAssertEqual(plannedJobs[1].kind, .compile)
       XCTAssertTrue(plannedJobs[1].primaryInputs.map{ $0.file.description }.elementsEqual(["baz.swift"]))
       XCTAssertTrue(plannedJobs[1].commandLine.contains("-emit-const-values-path"))
       XCTAssertEqual(plannedJobs[1].outputs.filter({ $0.type == .swiftConstValues }).count, 1)
-      XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init("/tmp/foo.build/baz.swiftconstvalues")))]))
+      try XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init(validating: "/tmp/foo.build/baz.swiftconstvalues")))]))
       XCTAssertEqual(plannedJobs[2].kind, .link)
     }
 
@@ -1195,8 +1192,8 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
-      XCTAssertEqual(plannedJobs[0].outputs.first(where: { $0.type == .swiftConstValues })?.file,
-                     .absolute(.init("/tmp/foo.build/foo.master.swiftconstvalues")))
+      try XCTAssertEqual(plannedJobs[0].outputs.first(where: { $0.type == .swiftConstValues })?.file,
+                     .absolute(.init(validating: "/tmp/foo.build/foo.master.swiftconstvalues")))
       XCTAssertEqual(plannedJobs[1].kind, .link)
     }
   }
@@ -1220,7 +1217,7 @@ final class SwiftDriverTests: XCTestCase {
       
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertTrue(plannedJobs[0].kind == .emitModule)
-      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-serialize-diagnostics-path"), .path(.absolute(.init("/build/Foo-test.dia")))]))
+      try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-serialize-diagnostics-path"), .path(.absolute(.init(validating: "/build/Foo-test.dia")))]))
     }
   }
 
@@ -1721,7 +1718,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dynamiclib")))
       XCTAssertTrue(cmd.contains(.flag("-w")))
       XCTAssertTrue(cmd.contains(.flag("-L")))
-      XCTAssertTrue(cmd.contains(.path(.absolute(AbsolutePath("/tmp")))))
+      try XCTAssertTrue(cmd.contains(.path(.absolute(AbsolutePath(validating: "/tmp")))))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
@@ -1812,7 +1809,7 @@ final class SwiftDriverTests: XCTestCase {
       // linker, so be consistent with this
       XCTAssertFalse(cmd.contains(.flag("-w")))
       XCTAssertFalse(cmd.contains(.flag("-L")))
-      XCTAssertFalse(cmd.contains(.path(.absolute(AbsolutePath("/tmp")))))
+      try XCTAssertFalse(cmd.contains(.path(.absolute(AbsolutePath(validating: "/tmp")))))
 
       XCTAssertFalse(cmd.contains(.flag("-dylib")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
@@ -1842,7 +1839,7 @@ final class SwiftDriverTests: XCTestCase {
       // linker, so be consistent with this
       XCTAssertFalse(cmd.contains(.flag("-w")))
       XCTAssertFalse(cmd.contains(.flag("-L")))
-      XCTAssertFalse(cmd.contains(.path(.absolute(AbsolutePath("/tmp")))))
+      try XCTAssertFalse(cmd.contains(.path(.absolute(AbsolutePath(validating: "/tmp")))))
 
       XCTAssertFalse(cmd.contains(.flag("-dylib")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
@@ -2073,7 +2070,7 @@ final class SwiftDriverTests: XCTestCase {
         let linkJob = plannedJobs[3]
         let cmd = linkJob.commandLine
         XCTAssertTrue(cmd.contains(subsequence: ["-target", "wasm32-unknown-wasi"]))
-        XCTAssertTrue(cmd.contains(subsequence: ["--sysroot", .path(.absolute(.init("/sdk/path")))]))
+        try XCTAssertTrue(cmd.contains(subsequence: ["--sysroot", .path(.absolute(.init(validating: "/sdk/path")))]))
         XCTAssertTrue(cmd.contains(.path(.absolute(path.appending(components: "wasi", "wasm32", "swiftrt.o")))))
         XCTAssertTrue(commandContainsTemporaryPath(cmd, "foo.o"))
         XCTAssertTrue(commandContainsTemporaryPath(cmd, "bar.o"))
@@ -2166,7 +2163,7 @@ final class SwiftDriverTests: XCTestCase {
     let result = try process.waitUntilExit()
     guard result.exitStatus == .terminated(code: EXIT_SUCCESS) else { return nil }
     guard let path = String(bytes: try result.output.get(), encoding: .utf8) else { return nil }
-    return path.isEmpty ? nil : AbsolutePath(path.spm_chomp())
+    return path.isEmpty ? nil : try AbsolutePath(validating: path.spm_chomp())
 #endif
   }
 
@@ -2642,7 +2639,7 @@ final class SwiftDriverTests: XCTestCase {
         // Make sure the supplementary output map has an entry for the Swift file
         // under indexing and its indexData entry is the primary output file
         let entry = map.entries[VirtualPath.relative(RelativePath("foo5.swift")).intern()]!
-        XCTAssert(VirtualPath.lookup(entry[.indexData]!) == .absolute(AbsolutePath("/tmp/t.o")))
+        try XCTAssert(VirtualPath.lookup(entry[.indexData]!) == .absolute(AbsolutePath(validating: "/tmp/t.o")))
         return
       default:
         break
@@ -2757,7 +2754,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssert(!plannedJobs[0].commandLine.contains(.flag("-primary-file")))
 
         let emitModuleJob = plannedJobs.first(where: {$0.kind == .emitModule})!
-        XCTAssertEqual(emitModuleJob.outputs[3].file, VirtualPath.absolute(AbsolutePath("/tmp/salty/Test.swiftinterface")))
+        try XCTAssertEqual(emitModuleJob.outputs[3].file, VirtualPath.absolute(AbsolutePath(validating: "/tmp/salty/Test.swiftinterface")))
         XCTAssert(!emitModuleJob.commandLine.contains(.flag("-primary-file")))
 
         XCTAssertEqual(plannedJobs[2].kind, .link)
@@ -2776,7 +2773,7 @@ final class SwiftDriverTests: XCTestCase {
     let moduleJob = plannedJobs.first(where: { $0.kind == .emitModule })!
     XCTAssertTrue(moduleJob.commandLine.contains("-module-alias"))
     XCTAssertTrue(moduleJob.commandLine.contains("Car=Bar"))
-    XCTAssertEqual(moduleJob.outputs[0].file, .absolute(AbsolutePath("/tmp/dir/Foo.swiftmodule")))
+    try XCTAssertEqual(moduleJob.outputs[0].file, .absolute(AbsolutePath(validating: "/tmp/dir/Foo.swiftmodule")))
 
     XCTAssertEqual(driver.moduleOutputInfo.name, "Foo")
     XCTAssertNotNil(driver.moduleOutputInfo.aliases)
@@ -2921,7 +2918,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[2].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
       XCTAssertEqual(plannedJobs[2].outputs[0].file, .relative(RelativePath("Test.swiftmodule")))
       XCTAssertEqual(plannedJobs[2].outputs[1].file, .relative(RelativePath("Test.swiftdoc")))
-      XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(AbsolutePath("/foo/bar/Test.swiftsourceinfo")))
+      try XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(AbsolutePath(validating: "/foo/bar/Test.swiftsourceinfo")))
       if driver.targetTriple.isDarwin {
         XCTAssertEqual(plannedJobs[2].outputs[3].file, .relative(RelativePath("Test.abi.json")))
       }
@@ -2936,11 +2933,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertTrue(plannedJobs[2].tool.name.contains("swift"))
       XCTAssertEqual(plannedJobs[2].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
-      XCTAssertEqual(plannedJobs[2].outputs[0].file, .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root))))
-      XCTAssertEqual(plannedJobs[2].outputs[1].file, .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root))))
-      XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root))))
+      try XCTAssertEqual(plannedJobs[2].outputs[0].file, .absolute(AbsolutePath(validating: rebase("Test.swiftmodule", at: root))))
+      try XCTAssertEqual(plannedJobs[2].outputs[1].file, .absolute(AbsolutePath(validating: rebase("Test.swiftdoc", at: root))))
+      try XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(AbsolutePath(validating: rebase("Test.swiftsourceinfo", at: root))))
       if driver.targetTriple.isDarwin {
-        XCTAssertEqual(plannedJobs[2].outputs[3].file, .absolute(AbsolutePath(rebase("Test.abi.json", at: root))))
+        try XCTAssertEqual(plannedJobs[2].outputs[3].file, .absolute(AbsolutePath(validating: rebase("Test.abi.json", at: root))))
       }
     }
 
@@ -2984,7 +2981,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(matchTemporary(plannedJobs[0].outputs[0].file, "input.swiftmodule"))
       XCTAssertEqual(plannedJobs[1].kind, .mergeModule)
       XCTAssertTrue(matchTemporary(plannedJobs[1].inputs[0].file, "input.swiftmodule"))
-      XCTAssertEqual(plannedJobs[1].outputs[0].file, .absolute(AbsolutePath("/tmp/test.swiftmodule")))
+      try XCTAssertEqual(plannedJobs[1].outputs[0].file, .absolute(AbsolutePath(validating: "/tmp/test.swiftmodule")))
     }
   }
 
@@ -3003,11 +3000,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
       XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-parse-as-library")))
       XCTAssertEqual(plannedJobs[0].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
-      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root))))
+      try XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath(validating: rebase("Test.swiftmodule", at: root))))
+      try XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath(validating: rebase("Test.swiftdoc", at: root))))
+      try XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath(validating: rebase("Test.swiftsourceinfo", at: root))))
       if driver.targetTriple.isDarwin {
-        XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(AbsolutePath(rebase("Test.abi.json", at: root))))
+        try XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(AbsolutePath(validating: rebase("Test.abi.json", at: root))))
       }
 
       // We don't know the output file of the symbol graph, just make sure the flag is passed along.
@@ -3025,11 +3022,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.emitModule, .compile]))
       XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
       XCTAssertEqual(plannedJobs[0].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
-      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root))))
+      try XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath(validating: rebase("Test.swiftmodule", at: root))))
+      try XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath(validating: rebase("Test.swiftdoc", at: root))))
+      try XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath(validating: rebase("Test.swiftsourceinfo", at: root))))
       if driver.targetTriple.isDarwin {
-        XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(AbsolutePath(rebase("Test.abi.json", at: root))))
+        try XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(AbsolutePath(validating: rebase("Test.abi.json", at: root))))
       }
     }
 
@@ -3085,11 +3082,11 @@ final class SwiftDriverTests: XCTestCase {
       let emitModuleJob = plannedJobs.first(where: {$0.kind == .emitModule})!
       XCTAssertTrue(emitModuleJob.tool.name.contains("swift"))
       XCTAssertEqual(emitModuleJob.outputs.count, 3 + abiFileCount)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root)))}).count)
+      try XCTAssertEqual(1, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftmodule", at: root)))}).count)
+      try XCTAssertEqual(1, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftdoc", at: root)))}).count)
+      try XCTAssertEqual(1, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftsourceinfo", at: root)))}).count)
       if abiFileCount == 1 {
-        XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.abi.json", at: root)))}).count)
+        try XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.abi.json", at: root)))}).count)
       }
 
       // We don't know the output file of the symbol graph, just make sure the flag is passed along.
@@ -3108,11 +3105,11 @@ final class SwiftDriverTests: XCTestCase {
       let emitModuleJob = plannedJobs[0]
       XCTAssertTrue(emitModuleJob.tool.name.contains("swift"))
       XCTAssertEqual(emitModuleJob.outputs.count, 3 + abiFileCount)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root)))}).count)
+      try XCTAssertEqual(1, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftmodule", at: root)))}).count)
+      try XCTAssertEqual(1, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftdoc", at: root)))}).count)
+      try XCTAssertEqual(1, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftsourceinfo", at: root)))}).count)
       if abiFileCount == 1 {
-        XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.abi.json", at: root)))}).count)
+        try XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.abi.json", at: root)))}).count)
       }
     }
 
@@ -3133,11 +3130,11 @@ final class SwiftDriverTests: XCTestCase {
       let compileJob = plannedJobs.first(where: {$0.kind == .compile})!
       XCTAssertEqual(compileJob.outputs.count, 4 + abiFileCount)
       XCTAssertEqual(1, compileJob.outputs.filter({$0.type == .object}).count)
-      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root)))}).count)
-      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root)))}).count)
-      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root)))}).count)
+      try XCTAssertEqual(1, compileJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftmodule", at: root)))}).count)
+      try XCTAssertEqual(1, compileJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftdoc", at: root)))}).count)
+      try XCTAssertEqual(1, compileJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.swiftsourceinfo", at: root)))}).count)
       if abiFileCount == 1 {
-        XCTAssertEqual(abiFileCount, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.abi.json", at: root)))}).count)
+        try XCTAssertEqual(abiFileCount, compileJob.outputs.filter({try $0.file == .absolute(AbsolutePath(validating: rebase("Test.abi.json", at: root)))}).count)
       }
     }
 
@@ -3948,7 +3945,7 @@ final class SwiftDriverTests: XCTestCase {
           0x02
       ]
       try localFileSystem.writeFileContents(ld) { $0 <<< contents }
-      try localFileSystem.chmod(.executable, path: AbsolutePath(ld.pathString))
+      try localFileSystem.chmod(.executable, path: AbsolutePath(validating: ld.pathString))
 
       // Drop SWIFT_DRIVER_CLANG_EXEC from the environment so it doesn't
       // interfere with tool lookup.
@@ -4406,9 +4403,9 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
-      XCTAssertTrue(
+      try XCTAssertTrue(
         job.commandLine.contains(subsequence: ["-emit-loaded-module-trace-path",
-                                               .path(.absolute(.init("/some/path/to/the.trace.json")))])
+                                               .path(.absolute(.init(validating: "/some/path/to/the.trace.json")))])
       )
     }
   }
@@ -4601,7 +4598,7 @@ final class SwiftDriverTests: XCTestCase {
 
     var driver = try Driver(args: ["swiftc", "foo.swift", "-sdk", "/"])
     let plannedJobs = try driver.planBuild()
-    XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/")))]))
+    try XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init(validating: "/")))]))
   }
 
   func testDumpASTOverride() throws {
@@ -5990,7 +5987,7 @@ final class SwiftDriverTests: XCTestCase {
     // FIXME: On Linux, we might not have any Clang in the path. We need a
     // better override.
     var env = ProcessEnv.vars
-    let swiftHelp: AbsolutePath = AbsolutePath("/usr/bin/nonexistent-swift-help")
+    let swiftHelp = try AbsolutePath(validating: "/usr/bin/nonexistent-swift-help")
     env["SWIFT_DRIVER_SWIFT_HELP_EXEC"] = swiftHelp.pathString
     env["SWIFT_DRIVER_CLANG_EXEC"] = "/usr/bin/clang"
     var driver = try Driver(
@@ -6220,7 +6217,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(configs.count, 0)
     }
     do {
-      let configs = Driver.parseAdopterConfigs(AbsolutePath("/abc/c/a.json"))
+      let configs = try Driver.parseAdopterConfigs(AbsolutePath(validating: "/abc/c/a.json"))
       XCTAssertEqual(configs.count, 0)
     }
   }

--- a/Tests/TestUtilities/Fixture.swift
+++ b/Tests/TestUtilities/Fixture.swift
@@ -28,13 +28,12 @@ public enum Fixture {
     at relativePath: RelativePath,
     for file: String,
     on fileSystem: FileSystem = localFileSystem
-  ) -> AbsolutePath? {
-    let packageRootPath: AbsolutePath =
-        AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
-    let fixturePath =
-        AbsolutePath(relativePath.pathString,
-                     relativeTo: packageRootPath.appending(component: "TestInputs"))
-            .appending(component: file)
+  ) throws -> AbsolutePath? {
+    let packageRootPath = try AbsolutePath(validating: #file).parentDirectory.parentDirectory.parentDirectory
+    let fixturePath = try AbsolutePath(
+      validating: relativePath.pathString,
+      relativeTo: packageRootPath.appending(component: "TestInputs")
+    ).appending(component: file)
 
     // Check that the fixture is really there.
     guard fileSystem.exists(fixturePath) else {


### PR DESCRIPTION
This was also an opportunity to convert some of `Result`-returning properties to `get throws` effectful properties, which simplified some code.

cc @neonichu