### PR TITLE
Add package-collection subcommand to swift help

### DIFF
--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -47,7 +47,7 @@ enum HelpTopic: ExpressibleByArgument, CustomStringConvertible {
 }
 
 enum Subcommand: String, CaseIterable {
-  case build, package, packageRegistry = "package-registry", run, test
+  case build, package, packageRegistry = "package-registry", packageCollection = "package-collection", run, test
 
   var description: String {
     switch self {
@@ -57,6 +57,8 @@ enum Subcommand: String, CaseIterable {
       return "Create and work on packages"
     case .packageRegistry:
       return "Interact with package registry and manage related configuration"
+    case .packageCollection:
+      return "Interact with package collections"
     case .run:
       return "Run a program from a package"
     case .test:


### PR DESCRIPTION
Tis PR fixes the issue that`swift --help` did not list the subcommand `swift package-collection`. 