### PR TITLE
Only add '-fobjc-link-runtime' to the linker invocation when the driver is invoked with '-link-objc-runtime'

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -214,9 +214,14 @@ extension DarwinToolchain {
       commandLine.appendPath(VirtualPath.lookup(sdkPath))
     }
 
+    // -link-objc-runtime also implies -fobjc-link-runtime
+    if parsedOptions.hasFlag(positive: .linkObjcRuntime,
+                             negative: .noLinkObjcRuntime,
+                             default: false) {
+      commandLine.appendFlag("-fobjc-link-runtime")
+    }
+
     commandLine.appendFlags(
-      "-fobjc-link-runtime",
-      "-lobjc",
       "-lSystem"
     )
 


### PR DESCRIPTION
Otherwise, every single compiled program will end up linking it, and Foundation on top of it. 