### PR TITLE
SwiftDriver: avoid `-lSystem` on Darwin

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -221,10 +221,6 @@ extension DarwinToolchain {
       commandLine.appendFlag("-fobjc-link-runtime")
     }
 
-    commandLine.appendFlags(
-      "-lSystem"
-    )
-
     let targetTriple = targetInfo.target.triple
     commandLine.appendFlag("--target=\(targetTriple.triple)")
     if let variantTriple = targetInfo.targetVariant?.triple {

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -179,7 +179,7 @@ final class JobExecutorTests: XCTestCase {
           .path(.temporary(RelativePath("main.o"))),
           .path(.absolute(try toolchain.clangRT.get())),
           "--sysroot", .path(.absolute(try toolchain.sdk.get())),
-          "-lobjc", "-lSystem", .flag("--target=\(hostTriple.triple)"),
+          "-lobjc", .flag("--target=\(hostTriple.triple)"),
           "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
           "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),
           "-rpath", "/usr/lib/swift", "-o",
@@ -249,7 +249,7 @@ final class JobExecutorTests: XCTestCase {
         commandLine: [
           .path(.temporary(RelativePath("main.o"))),
           "--sysroot", .path(.absolute(try toolchain.sdk.get())),
-          "-lobjc", "-lSystem", .flag("--target=\(hostTriple.triple)"),
+          "-lobjc", .flag("--target=\(hostTriple.triple)"),
           "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
           "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),
           "-o", .path(.absolute(exec)),


### PR DESCRIPTION
Now that we use the proper linker driver (`clang`), we no longer need to handle the explicit standard library linking.  Delegate this to the linker driver which will properly link to libSystem instead.  This simplifies some of the logic and further harmonises the beahviour across the various platforms.