### PR TITLE
Revert "Only add '-fobjc-link-runtime' to the linker invocation when the driver is invoked with '-link-objc-runtime'"

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -214,14 +214,9 @@ extension DarwinToolchain {
       commandLine.appendPath(VirtualPath.lookup(sdkPath))
     }
 
-    // -link-objc-runtime also implies -fobjc-link-runtime
-    if parsedOptions.hasFlag(positive: .linkObjcRuntime,
-                             negative: .noLinkObjcRuntime,
-                             default: false) {
-      commandLine.appendFlag("-fobjc-link-runtime")
-    }
-
     commandLine.appendFlags(
+      "-fobjc-link-runtime",
+      "-lobjc",
       "-lSystem"
     )
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1653,8 +1653,6 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
-      // Handling of '-lobjc' is now in the Clang linker driver.
-      XCTAssertFalse(cmd.contains(.flag("-lobjc")))
     }
 
     do {
@@ -1728,39 +1726,6 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
-    }
-
-    do {
-      // -fobjc-link-runtime default
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15"], env: env)
-      let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(3, plannedJobs.count)
-      let linkJob = plannedJobs[2]
-      XCTAssertEqual(linkJob.kind, .link)
-      let cmd = linkJob.commandLine
-      XCTAssertFalse(cmd.contains(.flag("-fobjc-link-runtime")))
-    }
-
-    do {
-      // -fobjc-link-runtime enable
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15", "-link-objc-runtime"], env: env)
-      let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(3, plannedJobs.count)
-      let linkJob = plannedJobs[2]
-      XCTAssertEqual(linkJob.kind, .link)
-      let cmd = linkJob.commandLine
-      XCTAssertTrue(cmd.contains(.flag("-fobjc-link-runtime")))
-    }
-
-    do {
-      // -fobjc-link-runtime disable override
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15", "-link-objc-runtime", "-no-link-objc-runtime"], env: env)
-      let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(3, plannedJobs.count)
-      let linkJob = plannedJobs[2]
-      XCTAssertEqual(linkJob.kind, .link)
-      let cmd = linkJob.commandLine
-      XCTAssertFalse(cmd.contains(.flag("-fobjc-link-runtime")))
     }
 
     do {


### PR DESCRIPTION
Reverts apple/swift-driver#1224