### PR TITLE
[Explicit Module Builds] Serialize and re-use the inter-module dependency graph as incremental build state

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -235,22 +235,6 @@ public struct Driver {
   /// Only present when the driver will be writing the record.
   /// Only used for reading when compiling incrementally.
   @_spi(Testing) public let buildRecordInfo: BuildRecordInfo?
-
-  /// A build-record-relative path to the location of a serialized copy of the
-  /// driver's dependency graph.
-  ///
-  /// FIXME: This is a little ridiculous. We could probably just replace the
-  /// build record outright with a serialized format.
-  var driverDependencyGraphPath: VirtualPath? {
-    guard let recordInfo = self.buildRecordInfo else {
-      return nil
-    }
-    let filename = recordInfo.buildRecordPath.basenameWithoutExt
-    return recordInfo
-      .buildRecordPath
-      .parentDirectory
-      .appending(component: filename + ".priors")
-  }
   
   /// Whether to consider incremental compilation.
   let shouldAttemptIncrementalCompilation: Bool
@@ -1283,10 +1267,6 @@ extension Driver {
   public mutating func run(
     jobs: [Job]
   ) throws {
-    if parsedOptions.hasArgument(.v) {
-      try printVersion(outputStream: &stderrStream)
-    }
-
     let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)
 
     // If we're only supposed to print the jobs, do so now.
@@ -1450,6 +1430,15 @@ extension Driver {
           /// Ensure that a bogus dependency graph is not used next time.
           buildRecordInfo?.removeBuildRecord()
           return
+      }
+      do {
+        try incrementalCompilationState.writeInterModuleDependencyGraph(buildRecordInfo)
+      }
+      catch {
+        diagnosticEngine.emit(
+          .warning("next compile must run a full dependency scan; could not write inter-module dependency graph: \(error.localizedDescription)"))
+        buildRecordInfo?.removeInterModuleDependencyGraph()
+        return
       }
     }
     buildRecordInfo?.writeBuildRecord(

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ClangVersionedDependencyResolution.swift
@@ -178,7 +178,7 @@ private extension InterModuleDependencyGraph {
 
   /// Update the set of all PCMArgs against which a given clang module was re-scanned
   mutating func updateCapturedPCMArgClangDependencies(using pcmArgSetMap:
-                                                        [ModuleDependencyId : Set<[String]>]
+                                                      [ModuleDependencyId : Set<[String]>]
   ) throws {
     for (moduleId, newPCMArgs) in pcmArgSetMap {
       guard let moduleInfo = modules[moduleId] else {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import class Foundation.JSONEncoder
+import struct Foundation.Data
 
 /// A map from a module identifier to its info
 public typealias ModuleInfoMap = [ModuleDependencyId: ModuleInfo]
@@ -275,7 +276,7 @@ public struct InterModuleDependencyGraph: Codable {
 }
 
 internal extension InterModuleDependencyGraph {
-  func toJSONString() throws -> String {
+  func toJSONData() throws -> Data {
     let encoder = JSONEncoder()
 #if os(Linux) || os(Android)
     encoder.outputFormatting = [.prettyPrinted]
@@ -284,8 +285,11 @@ internal extension InterModuleDependencyGraph {
       encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
     }
 #endif
-    let data = try encoder.encode(self)
-    return String(data: data, encoding: .utf8)!
+    return try encoder.encode(self)
+  }
+
+  func toJSONString() throws -> String {
+    return try String(data: toJSONData(), encoding: .utf8)!
   }
 }
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -41,6 +41,116 @@ extension Diagnostic.Message {
   }
 }
 
+@_spi(Testing) public extension Driver {
+  /// Scan the current module's input source-files to compute its direct and transitive
+  /// module dependencies.
+  mutating func gatherModuleDependencies()
+  throws -> InterModuleDependencyGraph {
+    var dependencyGraph = try performDependencyScan()
+
+    if parsedOptions.hasArgument(.printPreprocessedExplicitDependencyGraph) {
+      try stdoutStream <<< dependencyGraph.toJSONString()
+      stdoutStream.flush()
+    }
+
+    if let externalTargetDetails = externalTargetModuleDetailsMap {
+      // Resolve external dependencies in the dependency graph, if any.
+      try dependencyGraph.resolveExternalDependencies(for: externalTargetDetails)
+    }
+
+    // Re-scan Clang modules at all the targets they will be built against.
+    // This is currently disabled because we are investigating it being unnecessary
+    // try resolveVersionedClangDependencies(dependencyGraph: &dependencyGraph)
+
+    // Set dependency modules' paths to be saved in the module cache.
+    try resolveDependencyModulePaths(dependencyGraph: &dependencyGraph)
+
+    if parsedOptions.hasArgument(.printExplicitDependencyGraph) {
+      let outputFormat = parsedOptions.getLastArgument(.explicitDependencyGraphFormat)?.asSingle
+      if outputFormat == nil || outputFormat == "json" {
+        try stdoutStream <<< dependencyGraph.toJSONString()
+      } else if outputFormat == "dot" {
+        DOTModuleDependencyGraphSerializer(dependencyGraph).writeDOT(to: &stdoutStream)
+      }
+      stdoutStream.flush()
+    }
+
+    return dependencyGraph
+  }
+
+  /// Update the given inter-module dependency graph to set module paths to be within the module cache,
+  /// if one is present, and for Swift modules to use the context hash in the file name.
+  private mutating func resolveDependencyModulePaths(dependencyGraph: inout InterModuleDependencyGraph)
+  throws {
+    // If a module cache path is specified, update all module dependencies
+    // to be output into it.
+    if let moduleCachePath = parsedOptions.getLastArgument(.moduleCachePath)?.asSingle {
+      try resolveDependencyModulePathsRelativeToModuleCache(dependencyGraph: &dependencyGraph,
+                                                            moduleCachePath: moduleCachePath)
+    }
+
+    // Set the output path to include the module's context hash
+    try resolveDependencyModuleFileNamesWithContextHash(dependencyGraph: &dependencyGraph)
+  }
+
+  /// For Swift module dependencies, set the output path to include the module's context hash
+  private mutating func resolveDependencyModuleFileNamesWithContextHash(dependencyGraph: inout InterModuleDependencyGraph)
+  throws {
+    for (moduleId, moduleInfo) in dependencyGraph.modules {
+      // Output path on the main module is determined by the invocation arguments.
+      guard moduleId.moduleName != dependencyGraph.mainModuleName else {
+        continue
+      }
+
+      let plainPath = VirtualPath.lookup(dependencyGraph.modules[moduleId]!.modulePath.path)
+      if case .swift(let swiftDetails) = moduleInfo.details {
+        guard let contextHash = swiftDetails.contextHash else {
+          throw Driver.Error.missingContextHashOnSwiftDependency(moduleId.moduleName)
+        }
+        let updatedPath = plainPath.parentDirectory.appending(component: "\(plainPath.basenameWithoutExt)-\(contextHash).\(plainPath.extension!)")
+        dependencyGraph.modules[moduleId]!.modulePath = TextualVirtualPath(path: updatedPath.intern())
+      }
+      // TODO: Remove this once toolchain is updated
+      else if case .clang(let clangDetails) = moduleInfo.details {
+        if !moduleInfo.modulePath.path.description.contains(clangDetails.contextHash) {
+          let contextHash = clangDetails.contextHash
+          let updatedPath = plainPath.parentDirectory.appending(component: "\(plainPath.basenameWithoutExt)-\(contextHash).\(plainPath.extension!)")
+          dependencyGraph.modules[moduleId]!.modulePath = TextualVirtualPath(path: updatedPath.intern())
+        }
+      }
+    }
+  }
+
+  /// Resolve all paths to dependency binary module files to be relative to the module cache path.
+  private mutating func resolveDependencyModulePathsRelativeToModuleCache(dependencyGraph: inout InterModuleDependencyGraph,
+                                                                          moduleCachePath: String)
+  throws {
+    for (moduleId, moduleInfo) in dependencyGraph.modules {
+      // Output path on the main module is determined by the invocation arguments.
+      if case .swift(let name) = moduleId {
+        if name == dependencyGraph.mainModuleName {
+          continue
+        }
+        let modulePath = VirtualPath.lookup(moduleInfo.modulePath.path)
+        // Use VirtualPath to get the OS-specific path separators right.
+        let modulePathInCache =
+            try VirtualPath(path: moduleCachePath).appending(component: modulePath.basename)
+        dependencyGraph.modules[moduleId]!.modulePath =
+            TextualVirtualPath(path: modulePathInCache.intern())
+      }
+      // TODO: Remove this once toolchain is updated
+      else if case .clang(_) = moduleId {
+        let modulePath = VirtualPath.lookup(moduleInfo.modulePath.path)
+        // Use VirtualPath to get the OS-specific path separators right.
+        let modulePathInCache =
+            try VirtualPath(path: moduleCachePath).appending(component: modulePath.basename)
+        dependencyGraph.modules[moduleId]!.modulePath =
+            TextualVirtualPath(path: modulePathInCache.intern())
+      }
+    }
+  }
+}
+
 public extension Driver {
   /// Precompute the dependencies for a given Swift compilation, producing a
   /// dependency graph including all Swift and C module files and

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct Foundation.Data
+import class Foundation.JSONDecoder
+
 import class TSCBasic.DiagnosticsEngine
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
@@ -46,6 +49,7 @@ import class Dispatch.DispatchQueue
   @_spi(Testing) public let timeBeforeFirstJob: TimePoint
   let diagnosticEngine: DiagnosticsEngine
   let compilationInputModificationDates: [TypedVirtualPath: TimePoint]
+  private var explicitModuleDependencyGraph: InterModuleDependencyGraph? = nil
 
   private var finishedJobResults = [JobResult]()
   // A confinement queue that protects concurrent access to the
@@ -70,7 +74,6 @@ import class Dispatch.DispatchQueue
     self.diagnosticEngine = diagnosticEngine
     self.compilationInputModificationDates = compilationInputModificationDates
   }
-
 
   convenience init?(
     actualSwiftVersion: String,
@@ -193,6 +196,13 @@ import class Dispatch.DispatchQueue
     try? fileSystem.removeFileTree(absPath)
   }
 
+  func removeInterModuleDependencyGraph() {
+    guard let absPath = interModuleDependencyGraphPath.absolutePath else {
+      return
+    }
+    try? fileSystem.removeFileTree(absPath)
+  }
+
   /// Before writing to the dependencies file path, preserve any previous file
   /// that may have been there. No error handling -- this is just a nicety, it
   /// doesn't matter if it fails.
@@ -203,9 +213,8 @@ import class Dispatch.DispatchQueue
   }
 
 
-// TODO: Incremental too many names, buildRecord BuildRecord outofdatemap
+  // TODO: Incremental too many names, buildRecord BuildRecord outofdatemap
   func populateOutOfDateBuildRecord(
-    inputFiles: [TypedVirtualPath],
     reporter: IncrementalCompilationState.Reporter?
   ) -> BuildRecord? {
     let contents: String
@@ -245,6 +254,29 @@ import class Dispatch.DispatchQueue
     return outOfDateBuildRecord
   }
 
+  func readOutOfDateInterModuleDependencyGraph(
+    buildRecord: BuildRecord?,
+    reporter: IncrementalCompilationState.Reporter?
+  ) -> InterModuleDependencyGraph? {
+    // If a valid build record could not be produced, do not bother here
+    guard buildRecord != nil else {
+      reporter?.report("Incremental compilation did not attempt to read inter-module dependency graph.")
+      return nil
+    }
+
+    let decodedGraph: InterModuleDependencyGraph
+    do {
+      let contents = try fileSystem.readFileContents(interModuleDependencyGraphPath).cString
+      decodedGraph = try JSONDecoder().decode(InterModuleDependencyGraph.self,
+                                              from: Data(contents.utf8))
+    } catch {
+      return nil
+    }
+    reporter?.report("Read inter-module dependency graph", interModuleDependencyGraphPath)
+
+    return decodedGraph
+  }
+
   func jobFinished(job: Job, result: ProcessResult) {
     self.confinementQueue.sync {
       finishedJobResults.append(JobResult(job, result))
@@ -261,6 +293,15 @@ import class Dispatch.DispatchQueue
     return buildRecordPath
       .parentDirectory
       .appending(component: filename + ".priors")
+  }
+
+  /// A build-record-relative path to the location of a serialized copy of the
+  /// driver's inter-module dependency graph.
+  var interModuleDependencyGraphPath: VirtualPath {
+    let filename = buildRecordPath.basenameWithoutExt
+    return buildRecordPath
+      .parentDirectory
+      .appending(component: filename + ".moduledeps")
   }
 
   /// Directory to emit dot files into

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
@@ -36,7 +36,7 @@ extension IncrementalCompilationState {
     fileprivate let moduleDependencyGraph: ModuleDependencyGraph
     
     fileprivate let reporter: Reporter?
-    
+
     init(skippedCompileGroups: [TypedVirtualPath: CompileJobGroup],
          _ moduleDependencyGraph: ModuleDependencyGraph,
          _ driver: inout Driver) {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -46,13 +46,15 @@ public final class IncrementalCompilationState {
   
   public let info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
 
+  internal let upToDateInterModuleDependencyGraph: InterModuleDependencyGraph?
 
   // MARK: - Creating IncrementalCompilationState
   /// Return nil if not compiling incrementally
   internal init(
     driver: inout Driver,
     jobsInPhases: JobsInPhases,
-    initialState: InitialStateForPlanning
+    initialState: InitialStateForPlanning,
+    interModuleDependencyGraph: InterModuleDependencyGraph?
   ) throws {
     let reporter = initialState.incrementalOptions.contains(.showIncremental)
       ? Reporter(diagnosticEngine: driver.diagnosticEngine,
@@ -67,6 +69,7 @@ public final class IncrementalCompilationState {
                             driver: driver, reporter: reporter).compute(batchJobFormer: &driver)
 
     self.info = initialState.graph.info
+    self.upToDateInterModuleDependencyGraph = interModuleDependencyGraph
     self.protectedState = ProtectedState(
       skippedCompileGroups: firstWave.initiallySkippedCompileGroups,
       initialState.graph,

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -47,9 +47,13 @@ extension IncrementalCompilationState {
     // FIXME: This should work without an output file map. We should have
     // another way to specify a build record and where to put intermediates.
     let maybeBuildRecord =
-      buildRecordInfo.populateOutOfDateBuildRecord(
-        inputFiles: driver.inputFiles,
-        reporter: reporter)
+      buildRecordInfo.populateOutOfDateBuildRecord(reporter: reporter)
+    let priorInterModuleDependencyGraph =
+      options.contains(.explicitModuleBuild) ?
+        try readAndValidatePriorInterModuleDependencyGraph(driver: &driver,
+                                                           buildRecordInfo: buildRecordInfo,
+                                                           maybeBuildRecord: maybeBuildRecord,
+                                                           reporter: reporter) : nil
 
     guard
       let initialState =
@@ -57,12 +61,16 @@ extension IncrementalCompilationState {
         .IncrementalDependencyAndInputSetup(
           options, outputFileMap,
           buildRecordInfo, maybeBuildRecord,
+          priorInterModuleDependencyGraph,
           reporter, driver.inputFiles,
           driver.fileSystem,
           driver.diagnosticEngine
         ).computeInitialStateForPlanning()
     else {
       Self.removeDependencyGraphFile(driver)
+      if options.contains(.explicitModuleBuild) {
+        Self.removeInterModuleDependencyGraphFile(driver)
+      }
       return nil
     }
 
@@ -92,7 +100,126 @@ extension IncrementalCompilationState {
       options.formUnion(.enableCrossModuleIncrementalBuild)
       options.formUnion(.readPriorsFromModuleDependencyGraph)
     }
+    if driver.parsedOptions.contains(.driverExplicitModuleBuild) {
+      options.formUnion(.explicitModuleBuild)
+    }
     return options
+  }
+}
+
+/// Validate if a prior inter-module dependency graph is still valid
+extension IncrementalCompilationState {
+  static func readAndValidatePriorInterModuleDependencyGraph(driver: inout Driver,
+                                                             buildRecordInfo: BuildRecordInfo,
+                                                             maybeBuildRecord: BuildRecord?,
+                                                             reporter: IncrementalCompilationState.Reporter?)
+  throws -> InterModuleDependencyGraph? {
+    // Attempt to read a serialized inter-module dependency graph from a prior build
+    guard let priorInterModuleDependencyGraph =
+        buildRecordInfo.readOutOfDateInterModuleDependencyGraph(buildRecord: maybeBuildRecord,
+                                                                reporter: reporter),
+          let priorImports = priorInterModuleDependencyGraph.mainModule.directDependencies?.map({ $0.moduleName }) else {
+      reporter?.reportExplicitBuildMustReScan("Could not read inter-module dependency graph at \(buildRecordInfo.interModuleDependencyGraphPath)")
+      return nil
+    }
+
+    // Verify that import sets match
+    let currentImports = try driver.performImportPrescan().imports
+    guard Set(priorImports) == Set(currentImports) else {
+      reporter?.reportExplicitBuildMustReScan("Target import set has changed.")
+      return nil
+    }
+
+    // Verify that each dependnecy is up-to-date with respect to its inputs
+    guard try verifyInterModuleDependenciesUpToDate(in: priorInterModuleDependencyGraph,
+                                                    buildRecordInfo: buildRecordInfo,
+                                                    reporter: reporter) else {
+      reporter?.reportExplicitBuildMustReScan("Not all dependencies are up-to-date.")
+      return nil
+    }
+
+    reporter?.report("Confirmed prior inter-module dependency graph is up-to-date at: \(buildRecordInfo.interModuleDependencyGraphPath)")
+    return priorInterModuleDependencyGraph
+  }
+
+  /// For each direct and transitive module dependency, check if any of the inputs are newer than the output
+  static func verifyInterModuleDependenciesUpToDate(in graph: InterModuleDependencyGraph,
+                                                    buildRecordInfo: BuildRecordInfo,
+                                                    reporter: IncrementalCompilationState.Reporter?) throws -> Bool {
+    // Verify that the specified input exists and is older than the specified output
+    let verifyInputOlderThanOutputModTime: (String, VirtualPath, VirtualPath, TimePoint) -> Bool =
+    { moduleName, inputPath, outputPath, outputModTime in
+      guard let inputModTime =
+              try? buildRecordInfo.fileSystem.lastModificationTime(for: inputPath) else {
+        reporter?.report("Unable to 'stat' \(inputPath.description)")
+        return false
+      }
+      if inputModTime > outputModTime {
+        reporter?.reportExplicitDependencyOutOfDate(moduleName,
+                                                    outputPath: outputPath.description,
+                                                    updatedInputPath: inputPath.description)
+        return false
+      }
+      return true
+    }
+
+    for module in graph.modules {
+      switch module.value.details {
+      case .swift(let swiftDetails):
+        if module.key.moduleName == graph.mainModuleName {
+          continue
+        }
+        guard let outputModTime = try? buildRecordInfo.fileSystem.lastModificationTime(for: VirtualPath.lookup(module.value.modulePath.path)) else {
+          reporter?.report("Unable to 'stat' \(module.value.modulePath.description)")
+          return false
+        }
+        if let moduleInterfacePath = swiftDetails.moduleInterfacePath {
+          if !verifyInputOlderThanOutputModTime(module.key.moduleName,
+                                                VirtualPath.lookup(moduleInterfacePath.path),
+                                                VirtualPath.lookup(module.value.modulePath.path),
+                                                outputModTime) {
+            return false
+          }
+        }
+        if let bridgingHeaderPath = swiftDetails.bridgingHeaderPath {
+          if !verifyInputOlderThanOutputModTime(module.key.moduleName,
+                                                VirtualPath.lookup(bridgingHeaderPath.path),
+                                                VirtualPath.lookup(module.value.modulePath.path),
+                                                outputModTime) {
+            return false
+          }
+        }
+        for bridgingSourceFile in swiftDetails.bridgingSourceFiles ?? [] {
+          if !verifyInputOlderThanOutputModTime(module.key.moduleName,
+                                                VirtualPath.lookup(bridgingSourceFile.path),
+                                                VirtualPath.lookup(module.value.modulePath.path),
+                                                outputModTime) {
+            return false
+          }
+        }
+      case .clang(_):
+        guard let outputModTime = try? buildRecordInfo.fileSystem.lastModificationTime(for: VirtualPath.lookup(module.value.modulePath.path)) else {
+          reporter?.report("Unable to 'stat' \(module.value.modulePath.description)")
+          return false
+        }
+        for inputSourceFile in module.value.sourceFiles ?? [] {
+          if !verifyInputOlderThanOutputModTime(module.key.moduleName,
+                                                try VirtualPath(path: inputSourceFile),
+                                                VirtualPath.lookup(module.value.modulePath.path),
+                                                outputModTime) {
+            return false
+          }
+        }
+      case .swiftPrebuiltExternal(_):
+        // TODO: We have to give-up here until we have a way to verify the timestamp of the binary module.
+        reporter?.report("Unable to verify binary module dependency: \(module.value.modulePath.description)")
+        return false;
+      case .swiftPlaceholder(_):
+        // TODO: This should never ever happen. Hard error?
+        return false;
+      }
+    }
+    return true
   }
 }
 
@@ -111,6 +238,8 @@ extension IncrementalCompilationState {
     @_spi(Testing) public let inputFiles: [TypedVirtualPath]
     @_spi(Testing) public let fileSystem: FileSystem
     @_spi(Testing) public let sourceFiles: SourceFiles
+    /// Opional inter-module dependency graph for Explicitly-Built module dependencies
+    @_spi(Testing) public let maybeInterModuleDependencyGraph: InterModuleDependencyGraph?
     
     /// The state managing incremental compilation gets mutated every time a compilation job completes.
     /// This queue ensures that the access and mutation of that state is thread-safe.
@@ -130,6 +259,9 @@ extension IncrementalCompilationState {
     @_spi(Testing) public var readPriorsFromModuleDependencyGraph: Bool {
       maybeBuildRecord != nil && options.contains(.readPriorsFromModuleDependencyGraph)
     }
+    @_spi(Testing) public var explicitModuleBuild: Bool {
+      options.contains(.explicitModuleBuild)
+    }
     @_spi(Testing) public var alwaysRebuildDependents: Bool {
       options.contains(.alwaysRebuildDependents)
     }
@@ -148,6 +280,7 @@ extension IncrementalCompilationState {
       _ outputFileMap: OutputFileMap,
       _ buildRecordInfo: BuildRecordInfo,
       _ buildRecord: BuildRecord?,
+      _ interModuleDependencyGraph: InterModuleDependencyGraph?,
       _ reporter: IncrementalCompilationState.Reporter?,
       _ inputFiles: [TypedVirtualPath],
       _ fileSystem: FileSystem,
@@ -156,6 +289,7 @@ extension IncrementalCompilationState {
       self.outputFileMap = outputFileMap
       self.buildRecordInfo = buildRecordInfo
       self.maybeBuildRecord = buildRecord
+      self.maybeInterModuleDependencyGraph = interModuleDependencyGraph
       self.reporter = reporter
       self.options = options
       self.inputFiles = inputFiles
@@ -187,8 +321,7 @@ extension IncrementalCompilationState {
         return nil
       }
 
-      guard
-        let (graph, inputsInvalidatedByExternals) =
+      guard let (graph, inputsInvalidatedByExternals) =
           computeGraphAndInputsInvalidatedByExternals()
       else {
         return nil
@@ -197,6 +330,7 @@ extension IncrementalCompilationState {
       return InitialStateForPlanning(
         graph: graph, buildRecordInfo: buildRecordInfo,
         maybeBuildRecord: maybeBuildRecord,
+        maybeInterModuleDependencyGraph: maybeInterModuleDependencyGraph,
         inputsInvalidatedByExternals: inputsInvalidatedByExternals,
         incrementalOptions: options, buildStartTime: buildStartTime,
         buildEndTime: buildEndTime)
@@ -211,7 +345,7 @@ extension IncrementalCompilationState {
     }
   }
 }
-  
+
 
 // MARK: - building/reading the ModuleDependencyGraph & scheduling externals for 1st wave
 extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -103,16 +103,21 @@ extension Driver {
     let initialIncrementalState =
       try IncrementalCompilationState.computeIncrementalStateForPlanning(driver: &self)
 
+    // For an explicit build, compute the inter-module dependency graph
+    let interModuleDependencyGraph = try computeInterModuleDependencyGraph(with: initialIncrementalState)
+
     // Compute the set of all jobs required to build this module
-    let jobsInPhases = try computeJobsForPhasedStandardBuild()
+    let jobsInPhases = try computeJobsForPhasedStandardBuild(with: interModuleDependencyGraph)
 
     // Determine the state for incremental compilation
     let incrementalCompilationState: IncrementalCompilationState?
     // If no initial state was computed, we will not be performing an incremental build
     if let initialState = initialIncrementalState {
       incrementalCompilationState =
-        try IncrementalCompilationState(driver: &self, jobsInPhases: jobsInPhases,
-                                        initialState: initialState)
+        try IncrementalCompilationState(driver: &self,
+                                        jobsInPhases: jobsInPhases,
+                                        initialState: initialState,
+                                        interModuleDependencyGraph: interModuleDependencyGraph)
     } else {
       incrementalCompilationState = nil
     }
@@ -128,9 +133,27 @@ extension Driver {
     )
   }
 
+  /// If performing an explicit module build, compute an inter-module dependency graph.
+  /// If performing an incremental build, and the initial incremental state contains a valid
+  /// graph already, it is safe to re-use without repeating the scan.
+  private mutating func computeInterModuleDependencyGraph(with initialIncrementalState:
+                                                          IncrementalCompilationState.InitialStateForPlanning?)
+  throws -> InterModuleDependencyGraph? {
+    let interModuleDependencyGraph: InterModuleDependencyGraph?
+    if parsedOptions.contains(.driverExplicitModuleBuild) {
+      interModuleDependencyGraph =
+        try initialIncrementalState?.maybeInterModuleDependencyGraph ??
+            gatherModuleDependencies()
+    } else {
+      interModuleDependencyGraph = nil
+    }
+    return interModuleDependencyGraph
+  }
+
   /// Construct a build plan consisting of *all* jobs required for building the current module (non-incrementally).
   /// At build time, incremental state will be used to distinguish which of these jobs must run.
-  mutating private func computeJobsForPhasedStandardBuild() throws -> JobsInPhases {
+  mutating private func computeJobsForPhasedStandardBuild(with dependencyGraph: InterModuleDependencyGraph?)
+  throws -> JobsInPhases {
     // Centralize job accumulation here.
     // For incremental compilation, must separate jobs happening before,
     // during, and after compilation.
@@ -151,7 +174,8 @@ extension Driver {
       jobsAfterCompiles.append(j)
     }
 
-    try addPrecompileModuleDependenciesJobs(addJob: addJobBeforeCompiles)
+    try addPrecompileModuleDependenciesJobs(dependencyGraph: dependencyGraph,
+                                            addJob: addJobBeforeCompiles)
     try addPrecompileBridgingHeaderJob(addJob: addJobBeforeCompiles)
     let linkerInputs = try addJobsFeedingLinker(
       addJobBeforeCompiles: addJobBeforeCompiles,
@@ -167,10 +191,16 @@ extension Driver {
                         afterCompiles: jobsAfterCompiles)
   }
 
-  private mutating func addPrecompileModuleDependenciesJobs(addJob: (Job) -> Void) throws {
+  private mutating func addPrecompileModuleDependenciesJobs(
+    dependencyGraph: InterModuleDependencyGraph?,
+    addJob: (Job) -> Void)
+  throws {
     // If asked, add jobs to precompile module dependencies
     guard parsedOptions.contains(.driverExplicitModuleBuild) else { return }
-    let modulePrebuildJobs = try generateExplicitModuleDependenciesJobs()
+    guard let dependencyGraph else {
+      fatalError("Attempting to plan explicit dependency build without a dependency graph")
+    }
+    let modulePrebuildJobs = try generateExplicitModuleDependenciesJobs(dependencyGraph: dependencyGraph)
     modulePrebuildJobs.forEach(addJob)
   }
 
@@ -617,10 +647,8 @@ extension Driver {
   /// of jobs required to build all dependencies.
   /// Preprocess the graph by resolving placeholder dependencies, if any are present and
   /// by re-scanning all Clang modules against all possible targets they will be built against.
-  public mutating func generateExplicitModuleDependenciesJobs() throws -> [Job] {
-    // Run the dependency scanner and update the dependency oracle with the results
-    let dependencyGraph = try gatherModuleDependencies()
-
+  public mutating func generateExplicitModuleDependenciesJobs(dependencyGraph: InterModuleDependencyGraph)
+  throws -> [Job] {
     // Plan build jobs for all direct and transitive module dependencies of the current target
     explicitDependencyBuildPlanner =
       try ExplicitDependencyBuildPlanner(dependencyGraph: dependencyGraph,
@@ -631,117 +659,7 @@ extension Driver {
 
     return try explicitDependencyBuildPlanner!.generateExplicitModuleDependenciesBuildJobs()
   }
-
-  @_spi(Testing) public mutating func gatherModuleDependencies()
-  throws -> InterModuleDependencyGraph {
-    var dependencyGraph = try performDependencyScan()
-
-    if parsedOptions.hasArgument(.printPreprocessedExplicitDependencyGraph) {
-      try stdoutStream <<< dependencyGraph.toJSONString()
-      stdoutStream.flush()
-    }
-
-    if let externalTargetDetails = externalTargetModuleDetailsMap {
-      // Resolve external dependencies in the dependency graph, if any.
-      try dependencyGraph.resolveExternalDependencies(for: externalTargetDetails)
-    }
-
-    // Re-scan Clang modules at all the targets they will be built against.
-    // This is currently disabled because we are investigating it being unnecessary
-    // try resolveVersionedClangDependencies(dependencyGraph: &dependencyGraph)
-
-    // Set dependency modules' paths to be saved in the module cache.
-    try resolveDependencyModulePaths(dependencyGraph: &dependencyGraph)
-
-    if parsedOptions.hasArgument(.printExplicitDependencyGraph) {
-      let outputFormat = parsedOptions.getLastArgument(.explicitDependencyGraphFormat)?.asSingle
-      if outputFormat == nil || outputFormat == "json" {
-        try stdoutStream <<< dependencyGraph.toJSONString()
-      } else if outputFormat == "dot" {
-        DOTModuleDependencyGraphSerializer(dependencyGraph).writeDOT(to: &stdoutStream)
-      }
-      stdoutStream.flush()
-    }
-
-    return dependencyGraph
-  }
-
-  /// Update the given inter-module dependency graph to set module paths to be within the module cache,
-  /// if one is present, and for Swift modules to use the context hash in the file name.
-  private mutating func resolveDependencyModulePaths(dependencyGraph: inout InterModuleDependencyGraph)
-  throws {
-    // If a module cache path is specified, update all module dependencies
-    // to be output into it.
-    if let moduleCachePath = parsedOptions.getLastArgument(.moduleCachePath)?.asSingle {
-      try resolveDependencyModulePathsRelativeToModuleCache(dependencyGraph: &dependencyGraph,
-                                                            moduleCachePath: moduleCachePath)
-    }
-
-    // Set the output path to include the module's context hash
-    try resolveDependencyModuleFileNamesWithContextHash(dependencyGraph: &dependencyGraph)
-  }
-
-  /// For Swift module dependencies, set the output path to include the module's context hash
-  private mutating func resolveDependencyModuleFileNamesWithContextHash(dependencyGraph: inout InterModuleDependencyGraph)
-  throws {
-    for (moduleId, moduleInfo) in dependencyGraph.modules {
-      // Output path on the main module is determined by the invocation arguments.
-      guard moduleId.moduleName != dependencyGraph.mainModuleName else {
-        continue
-      }
-
-      let plainPath = VirtualPath.lookup(dependencyGraph.modules[moduleId]!.modulePath.path)
-      if case .swift(let swiftDetails) = moduleInfo.details {
-        guard let contextHash = swiftDetails.contextHash else {
-          throw Driver.Error.missingContextHashOnSwiftDependency(moduleId.moduleName)
-        }
-        let updatedPath = plainPath.parentDirectory.appending(component: "\(plainPath.basenameWithoutExt)-\(contextHash).\(plainPath.extension!)")
-        dependencyGraph.modules[moduleId]!.modulePath = TextualVirtualPath(path: updatedPath.intern())
-      }
-      // TODO: Remove this once toolchain is updated
-      else if case .clang(let clangDetails) = moduleInfo.details {
-        if !moduleInfo.modulePath.path.description.contains(clangDetails.contextHash) {
-          let contextHash = clangDetails.contextHash
-          let updatedPath = plainPath.parentDirectory.appending(component: "\(plainPath.basenameWithoutExt)-\(contextHash).\(plainPath.extension!)")
-          dependencyGraph.modules[moduleId]!.modulePath = TextualVirtualPath(path: updatedPath.intern())
-        }
-      }
-    }
-  }
-
-  /// Resolve all paths to dependency binary module files to be relative to the module cache path.
-  private mutating func resolveDependencyModulePathsRelativeToModuleCache(dependencyGraph: inout InterModuleDependencyGraph,
-                                                                          moduleCachePath: String)
-  throws {
-    for (moduleId, moduleInfo) in dependencyGraph.modules {
-      // Output path on the main module is determined by the invocation arguments.
-      if case .swift(let name) = moduleId {
-        if name == dependencyGraph.mainModuleName {
-          continue
-        }
-        let modulePath = VirtualPath.lookup(moduleInfo.modulePath.path)
-        // Use VirtualPath to get the OS-specific path separators right.
-        let modulePathInCache =
-        try VirtualPath(path: moduleCachePath)
-          .appending(component: modulePath.basename)
-        dependencyGraph.modules[moduleId]!.modulePath =
-        TextualVirtualPath(path: modulePathInCache.intern())
-      }
-      // TODO: Remove this once toolchain is updated
-      else if case .clang(_) = moduleId {
-        let modulePath = VirtualPath.lookup(moduleInfo.modulePath.path)
-        // Use VirtualPath to get the OS-specific path separators right.
-        let modulePathInCache =
-        try VirtualPath(path: moduleCachePath)
-          .appending(component: modulePath.basename)
-        dependencyGraph.modules[moduleId]!.modulePath =
-        TextualVirtualPath(path: modulePathInCache.intern())
-      }
-    }
-  }
-
 }
-
 
 /// MARK: Planning
 extension Driver {
@@ -820,7 +738,12 @@ extension Driver {
 
     case .immediate:
       var jobs: [Job] = []
-      try addPrecompileModuleDependenciesJobs(addJob: { jobs.append($0) })
+      // Run the dependency scanner if this is an explicit module build
+      let moduleDependencyGraph =
+        try parsedOptions.contains(.driverExplicitModuleBuild) ?
+          gatherModuleDependencies() : nil
+      try addPrecompileModuleDependenciesJobs(dependencyGraph: moduleDependencyGraph,
+                                              addJob: { jobs.append($0) })
       jobs.append(try interpretJob(inputs: inputFiles))
       return (jobs, nil)
 

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -13,7 +13,6 @@
 import SwiftOptions
 
 import struct Foundation.Data
-import class Foundation.JSONEncoder
 import class Foundation.JSONDecoder
 
 import protocol TSCBasic.FileSystem

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -597,6 +597,8 @@ public struct TextualVirtualPath: Codable, Hashable {
       preconditionFailure("Path does not have a round-trippable textual representation")
     }
   }
+
+  internal var description: String { VirtualPath.lookup(path).description }
 }
 
 extension VirtualPath: CustomStringConvertible {

--- a/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/E.swiftinterface
@@ -2,3 +2,4 @@
 // swift-module-flags: -module-name E
 import Swift
 public func funcE()
+public let modlueEValue = 42

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -138,7 +138,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
       .map {TypedVirtualPath(file: $0, type: .swift)}
      return Self(options, outputFileMap,
                 BuildRecordInfo.mock(diagnosticsEngine, outputFileMap),
-                nil, nil, inputFiles, fileSystem,
+                nil, nil, nil, inputFiles, fileSystem,
                 diagnosticsEngine)
   }
 }


### PR DESCRIPTION
Building on top of https://github.com/apple/swift-driver/pull/621, on an incremental build, load a prior dependency graph, check if it is still valid:
1. import set of the current module has not changed
2. input files of every module in the prior graph are older than the output and if it is, re-use it, skipping invoking the dependency scanner again.

More concretely, computation of the initial incremental state in `computeIncrementalStateForPlanning` will attempt to read out and validate a prior serialized inter-module dependency graph. If validated, such graph will become a part of the initial incremental state itself.

During build planning, at the stage of computing inter-module dependencies, the dependency scanning action will be skipped if the initial incremental state contains a still-valid prior inter-module dependency graph. 

In both cases, if a prior graph is being re-used, or if a new graph was computed via a dependency scanning action, the graph will become a component of the incremental build state to be serialized after the build is complete. 

This change does not yet result in skipping the actual module build jobs in the planning output, which can be done with this, but this is left to a followup PR. 

There is also some notable overlap between this and what is already done for detecting changes in input files to the current compilation:
- Suppose a Swift module interface of a module dependency has changed. This means that, according to the above mechanism, a dependency scanning action must be performed on an incremental build. This will result in a new dependency graph and a subsequent re-build of the dependency. But, moreover, there is an existing mechanism in place to ensure that source-files also get re-built on changes to previously-recorded inputs to compilation so the source-files will also be re-built when a dependency changes. 

Once explicit builds become the default, we can consolidate the two approaches into one.

Partially resolves rdar://66801475