### PR TITLE
Rephrase use of 'guard let' not supported by older compilers.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -197,10 +197,11 @@ extension Driver {
   throws {
     // If asked, add jobs to precompile module dependencies
     guard parsedOptions.contains(.driverExplicitModuleBuild) else { return }
-    guard let dependencyGraph else {
+    guard let resolvedDependencyGraph = dependencyGraph else {
       fatalError("Attempting to plan explicit dependency build without a dependency graph")
     }
-    let modulePrebuildJobs = try generateExplicitModuleDependenciesJobs(dependencyGraph: dependencyGraph)
+    let modulePrebuildJobs =
+        try generateExplicitModuleDependenciesJobs(dependencyGraph: resolvedDependencyGraph)
     modulePrebuildJobs.forEach(addJob)
   }
 


### PR DESCRIPTION
'guard let X else {}' works with latest Swift compilers (such as one used in swift-driver CI) but isn't supported in some older compilres used in CI and other bots.