### PR TITLE
[Dependency Scanning] Only specify Swift source-file inputs as inputs to the dependency scanning action.

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -193,7 +193,7 @@ public extension Driver {
     }
 
     // Pass on the input files
-    commandLine.append(contentsOf: inputFiles.map { .path($0.file) })
+    commandLine.append(contentsOf: inputFiles.filter { $0.type == .swift }.map { .path($0.file) })
     return (inputs, commandLine)
   }
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1032,6 +1032,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-I", stdlibPath.nativePathString(escaped: true),
                                      "-I", shimsPath.nativePathString(escaped: true),
+                                     "/tmp/Foo.o",
                                      "-import-objc-header",
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
@@ -1049,6 +1050,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       // Ensure we do not propagate the usual PCH-handling arguments to the scanner invocation
       XCTAssertFalse(scannerCommand.contains("-pch-output-dir"))
+      XCTAssertFalse(scannerCommand.contains("Foo.o"))
 
       // Here purely to dump diagnostic output in a reasonable fashion when things go wrong.
       let lock = NSLock()


### PR DESCRIPTION
Otherwise we give the scanner object files, and whatever else, and it gets confused.