### PR TITLE
[Explicit Module Builds] On an incremental build, skip re-building module dependencies when they are up-to-date

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -53,7 +53,7 @@ extension IncrementalCompilationState {
     /// Record about existence and time of the last compile.
     let maybeBuildRecord: BuildRecord?
     /// Record about the compiled module's module dependencies from the last compile.
-    let maybeInterModuleDependencyGraph: InterModuleDependencyGraph?
+    let maybeUpToDatePriorInterModuleDependencyGraph: InterModuleDependencyGraph?
     /// A set of inputs invalidated by external changes.
     let inputsInvalidatedByExternals: TransitivelyInvalidatedSwiftSourceFileSet
     /// Compiler options related to incremental builds.

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -330,7 +330,7 @@ extension IncrementalCompilationState {
       return InitialStateForPlanning(
         graph: graph, buildRecordInfo: buildRecordInfo,
         maybeBuildRecord: maybeBuildRecord,
-        maybeInterModuleDependencyGraph: maybeInterModuleDependencyGraph,
+        maybeUpToDatePriorInterModuleDependencyGraph: maybeInterModuleDependencyGraph,
         inputsInvalidatedByExternals: inputsInvalidatedByExternals,
         incrementalOptions: options, buildStartTime: buildStartTime,
         buildEndTime: buildEndTime)

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -142,7 +142,7 @@ extension Driver {
     let interModuleDependencyGraph: InterModuleDependencyGraph?
     if parsedOptions.contains(.driverExplicitModuleBuild) {
       interModuleDependencyGraph =
-        try initialIncrementalState?.maybeInterModuleDependencyGraph ??
+        try initialIncrementalState?.maybeUpToDatePriorInterModuleDependencyGraph ??
             gatherModuleDependencies()
     } else {
       interModuleDependencyGraph = nil

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -887,11 +887,6 @@ extension IncrementalCompilationTests {
       implicitBuildRemarks
       readInterModuleGraph
       interModuleDependencyGraphUpToDate
-      // TODO: We can do better, but for now make sure the jobs are still run
-      // even if the graph is up-to-date
-      compilingExplicitClangDependency("SwiftShims")
-      compilingExplicitSwiftDependency("Swift")
-      compilingExplicitSwiftDependency("SwiftOnoneSupport")
     }
 
     touch("main")


### PR DESCRIPTION
In an all-or-nothing coarse-grained fashion, for now.