### PR TITLE
[Dependency Scanning] Query scanner whether discovered binary Swift modules are frameworks

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -130,6 +130,8 @@ typedef struct {
   (*swiftscan_swift_binary_detail_get_module_doc_path)(swiftscan_module_details_t);
   swiftscan_string_ref_t
   (*swiftscan_swift_binary_detail_get_module_source_info_path)(swiftscan_module_details_t);
+  bool
+  (*swiftscan_swift_binary_detail_get_is_framework)(swiftscan_module_details_t);
 
   //=== Swift Placeholder Module Details query APIs -------------------------===//
   swiftscan_string_ref_t

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -141,7 +141,7 @@ public struct SwiftPrebuiltExternalModuleDetails: Codable {
   public init(compiledModulePath: TextualVirtualPath,
               moduleDocPath: TextualVirtualPath? = nil,
               moduleSourceInfoPath: TextualVirtualPath? = nil,
-              isFramework: Bool = false) throws {
+              isFramework: Bool) throws {
     self.compiledModulePath = compiledModulePath
     self.moduleDocPath = moduleDocPath
     self.moduleSourceInfoPath = moduleSourceInfoPath

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -128,6 +128,13 @@ public class InterModuleDependencyOracle {
       swiftScan.resetScannerCache()
     }
   }
+
+  @_spi(Testing) public func supportsBinaryFrameworkDependencies() throws -> Bool {
+    guard let swiftScan = swiftScanLibInstance else {
+      fatalError("Attempting to query supported scanner API with no scanner instance.")
+    }
+    return swiftScan.hasBinarySwiftModuleIsFramework
+  }
   
   @_spi(Testing) public func supportsScannerDiagnostics() throws -> Bool {
     guard let swiftScan = swiftScanLibInstance else {

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -200,9 +200,18 @@ private extension SwiftScan {
     let moduleSourceInfoPath =
       try getOptionalPathDetail(from: moduleDetailsRef,
                                 using: api.swiftscan_swift_binary_detail_get_module_source_info_path)
+
+    let isFramework: Bool
+    if hasBinarySwiftModuleIsFramework {
+      isFramework = api.swiftscan_swift_binary_detail_get_is_framework(moduleDetailsRef)
+    } else {
+      isFramework = false
+    }
+
     return try SwiftPrebuiltExternalModuleDetails(compiledModulePath: compiledModulePath,
                                                   moduleDocPath: moduleDocPath,
-                                                  moduleSourceInfoPath: moduleSourceInfoPath)
+                                                  moduleSourceInfoPath: moduleSourceInfoPath,
+                                                  isFramework: isFramework)
   }
 
   /// Construct a `SwiftPlaceholderModuleDetails` from a `swiftscan_module_details_t` reference

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -234,6 +234,10 @@ internal final class SwiftScan {
     return resultGraphMap
   }
 
+  @_spi(Testing) public var hasBinarySwiftModuleIsFramework : Bool {
+    api.swiftscan_swift_binary_detail_get_is_framework != nil
+  }
+
   @_spi(Testing) public var canLoadStoreScannerCache : Bool {
     api.swiftscan_scanner_cache_load != nil &&
     api.swiftscan_scanner_cache_serialize != nil &&
@@ -369,6 +373,10 @@ private extension swiftscan_functions_t {
       try loadOptional("swiftscan_diagnostic_get_severity")
     self.swiftscan_diagnostics_set_dispose =
       try loadOptional("swiftscan_diagnostics_set_dispose")
+
+    // isFramework on binary module dependencies
+    self.swiftscan_swift_binary_detail_get_is_framework =
+      try loadOptional("swiftscan_swift_binary_detail_get_is_framework")
 
     // MARK: Required Methods
     func loadRequired<T>(_ symbol: String) throws -> T {


### PR DESCRIPTION
This info is required so that it can be specified as input to compilation that uses such module as a dependency, in order to decide whether or not to insert an auto-linking directive for it.

Companion change to https://github.com/apple/swift/pull/62540

Part of rdar://102824777