### PR TITLE
Consign the YAML Build Record to the Legacy Incremental Build Path

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -76,17 +76,16 @@ extension IncrementalCompilationState.FirstWaveComputer {
   throws -> (initiallySkippedCompileGroups: [TypedVirtualPath: CompileJobGroup],
              mandatoryJobsInOrder: [Job])
   {
-    precondition(sourceFiles.disappeared.isEmpty, "unimplemented")
-
     let compileGroups =
       Dictionary(uniqueKeysWithValues:
                   jobsInPhases.compileGroups.map { ($0.primaryInput, $0) })
-    guard let buildRecord = maybeBuildRecord else {
+    let buildRecord = self.moduleDependencyGraph.buildRecord
+    guard !buildRecord.inputInfos.isEmpty else {
       func everythingIsMandatory()
         throws -> (initiallySkippedCompileGroups: [TypedVirtualPath: CompileJobGroup],
                    mandatoryJobsInOrder: [Job])
       {
-        let mandatoryCompileGroupsInOrder = sourceFiles.currentInOrder.compactMap {
+        let mandatoryCompileGroupsInOrder = self.inputFiles.swiftSourceFiles.compactMap {
           input -> CompileJobGroup? in
           compileGroups[input.typedFile]
         }
@@ -166,7 +165,7 @@ extension IncrementalCompilationState.FirstWaveComputer {
       }
     }
 
-    let inputsMissingFromGraph = sourceFiles.currentInOrder.filter { sourceFile in
+    let inputsMissingFromGraph = self.inputFiles.swiftSourceFiles.filter { sourceFile in
       !moduleDependencyGraph.containsNodes(forSourceFile: sourceFile)
     }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -21,9 +21,7 @@ extension IncrementalCompilationState {
     let jobsInPhases: JobsInPhases
     let inputsInvalidatedByExternals: TransitivelyInvalidatedSwiftSourceFileSet
     let inputFiles: [TypedVirtualPath]
-    let sourceFiles: SourceFiles
     let buildRecordInfo: BuildRecordInfo
-    let maybeBuildRecord: BuildRecord?
     let fileSystem: FileSystem
     let showJobLifecycle: Bool
     let alwaysRebuildDependents: Bool
@@ -41,11 +39,7 @@ extension IncrementalCompilationState {
       self.jobsInPhases = jobsInPhases
       self.inputsInvalidatedByExternals = initialState.inputsInvalidatedByExternals
       self.inputFiles = driver.inputFiles
-      self.sourceFiles = SourceFiles(
-        inputFiles: inputFiles,
-        buildRecord: initialState.maybeBuildRecord)
       self.buildRecordInfo = initialState.buildRecordInfo
-      self.maybeBuildRecord = initialState.maybeBuildRecord
       self.fileSystem = driver.fileSystem
       self.showJobLifecycle = driver.showJobLifecycle
       self.alwaysRebuildDependents = initialState.incrementalOptions.contains(

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
@@ -148,14 +148,14 @@ extension IncrementalCompilationState.ProtectedState {
       .flatMap {$0.allJobs()}
   }
 
-  @_spi(Testing) public func writeGraph(to path: VirtualPath,
+  func writeGraph(to path: VirtualPath,
                   on fs: FileSystem,
-                  compilerVersion: String,
+                  buildRecord: BuildRecordInfo,
                   mockSerializedGraphVersion: Version? = nil
   ) throws {
     accessSafetyPrecondition()
     try moduleDependencyGraph.write(to: path, on: fs,
-                                    compilerVersion: compilerVersion,
+                                    buildRecord: buildRecord,
                                     mockSerializedGraphVersion: mockSerializedGraphVersion)
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
@@ -150,7 +150,7 @@ extension IncrementalCompilationState.ProtectedState {
 
   func writeGraph(to path: VirtualPath,
                   on fs: FileSystem,
-                  buildRecord: BuildRecordInfo,
+                  buildRecord: BuildRecord,
                   mockSerializedGraphVersion: Version? = nil
   ) throws {
     accessSafetyPrecondition()

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -50,18 +50,12 @@ extension IncrementalCompilationState {
     let graph: ModuleDependencyGraph
     /// Information about the last known compilation, incl. the location of build artifacts such as the dependency graph.
     let buildRecordInfo: BuildRecordInfo
-    /// Record about existence and time of the last compile.
-    let maybeBuildRecord: BuildRecord?
     /// Record about the compiled module's module dependencies from the last compile.
     let maybeUpToDatePriorInterModuleDependencyGraph: InterModuleDependencyGraph?
     /// A set of inputs invalidated by external changes.
     let inputsInvalidatedByExternals: TransitivelyInvalidatedSwiftSourceFileSet
     /// Compiler options related to incremental builds.
     let incrementalOptions: IncrementalCompilationState.Options
-    /// The last time this compilation was started. Used to compare against e.g. input file mod dates.
-    let buildStartTime: TimePoint
-    /// The last time this compilation finished. Used to compare against output file mod dates
-    let buildEndTime: TimePoint
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -393,22 +393,16 @@ extension IncrementalCompilationState {
     }
   }
 
-  func writeDependencyGraph(_ buildRecordInfo: BuildRecordInfo?) throws {
-    // If the cross-module build is not enabled, the status quo dictates we
-    // not emit this file.
-    guard info.isCrossModuleIncrementalBuildEnabled else {
-      return
-    }
-    guard
-      let recordInfo = buildRecordInfo
-    else {
-      throw WriteDependencyGraphError.noBuildRecordInfo
-    }
-    try blockingConcurrentMutationToProtectedState {
+  func writeDependencyGraph(
+    to path: VirtualPath,
+    _ buildRecord: BuildRecord
+  ) throws {
+    precondition(info.isCrossModuleIncrementalBuildEnabled)
+    try blockingConcurrentAccessOrMutationToProtectedState {
       try $0.writeGraph(
-        to: recordInfo.dependencyGraphPath,
+        to: path,
         on: info.fileSystem,
-        buildRecord: recordInfo)
+        buildRecord: buildRecord)
     }
   }
   
@@ -488,7 +482,12 @@ extension OutputFileMap {
 // MARK: SourceFiles
 
 /// Handy information about the source files in the current invocation
-@_spi(Testing) public struct SourceFiles {
+///
+/// Usages of this structure are deprecated and should be removed on sight. For
+/// large driver jobs, it is extremely expensive both in terms of memory and
+/// compilation latency to instantiate as it rematerializes the entire input set
+/// multiple times.
+struct SourceFiles {
   /// The current (.swift) files in same order as the invocation
   let currentInOrder: [SwiftSourceFile]
 
@@ -501,10 +500,10 @@ extension OutputFileMap {
   /// The files that were in the previous but not in the current invocation
   let disappeared: [SwiftSourceFile]
 
-  init(inputFiles: [TypedVirtualPath], buildRecord: BuildRecord?) {
+  init(inputFiles: [TypedVirtualPath], buildRecord: BuildRecord) {
     self.currentInOrder = inputFiles.swiftSourceFiles
     self.currentSet = Set(currentInOrder)
-    guard let buildRecord = buildRecord else {
+    guard !buildRecord.inputInfos.isEmpty else {
       self.previousSet = Set()
       self.disappeared = []
       return

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -414,7 +414,7 @@ extension IncrementalCompilationState {
       try $0.writeGraph(
         to: recordInfo.dependencyGraphPath,
         on: info.fileSystem,
-        compilerVersion: recordInfo.actualSwiftVersion)
+        buildRecord: recordInfo)
     }
   }
   

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -64,9 +64,12 @@ public final class IncrementalCompilationState {
     reporter?.reportOnIncrementalImports(
       initialState.incrementalOptions.contains(.enableCrossModuleIncrementalBuild))
 
-    let firstWave =
-      try FirstWaveComputer(initialState: initialState, jobsInPhases: jobsInPhases,
-                            driver: driver, reporter: reporter).compute(batchJobFormer: &driver)
+    let firstWave = try FirstWaveComputer(
+      initialState: initialState,
+      jobsInPhases: jobsInPhases,
+      driver: driver,
+      reporter: reporter)
+      .compute(batchJobFormer: &driver)
 
     self.info = initialState.graph.info
     self.upToDateInterModuleDependencyGraph = interModuleDependencyGraph

--- a/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/InputInfo.swift
@@ -115,21 +115,3 @@ fileprivate extension ProcessResult {
     return false
   }
 }
-
-// MARK: - reading
-public extension InputInfo {
-  init?(tag: String, previousModTime: TimePoint,
-        failedToReadOutOfDateMap: (String) -> Void
-  ) {
-    guard let status = Status(identifier: tag) else {
-      failedToReadOutOfDateMap("no previous build state in build record")
-      return nil
-    }
-    self.init(status: status, previousModTime: previousModTime)
-  }
-}
-
-// MARK: - writing
-extension InputInfo {
-  var tag: String { status.identifier }
-}

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -23,6 +23,11 @@ import struct Foundation.TimeInterval
 /// Holds all the dependency relationships in this module, and declarations in other modules that
 /// are depended-upon.
 /*@_spi(Testing)*/ public final class ModuleDependencyGraph: InternedStringTableHolder {
+  /// The build record information associated with this module dependency graph.
+  ///
+  /// This data reflects the result of the _prior_ compilation. Consult
+  /// ``BuildRecordInfo`` for data from the in-flight compilation session.
+  @_spi(Testing) public let buildRecord: BuildRecord
 
   /// Supports finding nodes in two ways.
   @_spi(Testing) public var nodeFinder: NodeFinder
@@ -53,14 +58,17 @@ import struct Foundation.TimeInterval
   /// are serialized, so must all the mods to this table be.
   @_spi(Testing) public let internedStringTable: InternedStringTable
 
-  private init(_ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup,
-               _ phase: Phase,
-              _ internedStringTable: InternedStringTable,
-              _ nodeFinder: NodeFinder,
-              _ fingerprintedExternalDependencies: Set<FingerprintedExternalDependency>
+  private init(
+    _ buildRecord: BuildRecord,
+    _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup,
+    _ phase: Phase,
+    _ internedStringTable: InternedStringTable,
+    _ nodeFinder: NodeFinder,
+    _ fingerprintedExternalDependencies: Set<FingerprintedExternalDependency>
   ) {
+    self.buildRecord = buildRecord
     self.currencyCache = ExternalDependencyCurrencyCache(
-      info.fileSystem, buildStartTime: info.buildStartTime)
+      info.fileSystem, buildStartTime: buildRecord.buildStartTime)
     self.info = info
     self.dotFileWriter = info.emitDependencyDotFileAfterEveryImport
       ? DependencyGraphDotFileWriter(info)
@@ -72,23 +80,27 @@ import struct Foundation.TimeInterval
     self.fingerprintedExternalDependencies = fingerprintedExternalDependencies
   }
 
-  private convenience init(_ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup,
-              _ phase: Phase
+  private convenience init(
+    _ buildRecord: BuildRecord,
+    _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup,
+    _ phase: Phase
   ) {
     assert(phase != .updatingFromAPrior,
            "If updating from prior, should be supplying more ingredients")
-    self.init(info, phase, InternedStringTable(info.incrementalCompilationQueue),
+    self.init(buildRecord, info, phase, InternedStringTable(info.incrementalCompilationQueue),
               NodeFinder(),
               Set())
   }
   
   public static func createFromPrior(
+    _ buildRecord: BuildRecord,
     _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup,
     _ internedStringTable: InternedStringTable,
     _ nodeFinder: NodeFinder,
     _ fingerprintedExternalDependencies: Set<FingerprintedExternalDependency>
   ) -> Self {
-    self.init(info,
+    self.init(buildRecord,
+              info,
               .updatingFromAPrior,
               internedStringTable,
               nodeFinder,
@@ -96,19 +108,22 @@ import struct Foundation.TimeInterval
   }
   
   public static func createForBuildingFromSwiftDeps(
+    _ buildRecord: BuildRecord,
     _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
   ) -> Self {
-    self.init(info, .buildingFromSwiftDeps)
+    self.init(buildRecord, info, .buildingFromSwiftDeps)
   }
   public static func createForBuildingAfterEachCompilation(
+    _ buildRecord: BuildRecord,
     _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
   ) -> Self {
-    self.init(info, .buildingAfterEachCompilation)
+    self.init(buildRecord, info, .buildingAfterEachCompilation)
   }
   public static func createForSimulatingCleanBuild(
+    _ buildRecord: BuildRecord,
     _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
   ) -> Self {
-    self.init(info, .updatingAfterCompilation)
+    self.init(buildRecord, info, .updatingAfterCompilation)
   }
 }
 
@@ -166,10 +181,10 @@ extension ModuleDependencyGraph {
     input: SwiftSourceFile
   ) -> TransitivelyInvalidatedSwiftSourceFileSet? {
     // do not try to read swiftdeps of a new input
-    if info.sourceFiles.isANewInput(input) {
+    guard self.buildRecord.inputInfos[input.typedFile.file] != nil else {
       return TransitivelyInvalidatedSwiftSourceFileSet()
     }
-    return collectInputsRequiringCompilationAfterProcessing(input: input)
+    return self.collectInputsRequiringCompilationAfterProcessing(input: input)
   }
 }
 
@@ -618,7 +633,8 @@ extension ModuleDependencyGraph {
   /// - Minor number 1: Don't serialize the `inputDependencySourceMap`
   /// - Minor number 2: Use `.swift` files instead of `.swiftdeps` in ``DependencySource``
   /// - Minor number 3: Use interned strings, including for fingerprints and use empty dependency source file for no DependencySource
-  @_spi(Testing) public static let serializedGraphVersion = Version(1, 3, 0)
+  /// - Minor number 4: Absorb the data in the ``BuildRecord`` into the module dependency graph.
+  @_spi(Testing) public static let serializedGraphVersion = Version(1, 4, 0)
 
   /// The IDs of the records used by the module dependency graph.
   fileprivate enum RecordID: UInt64 {
@@ -628,6 +644,8 @@ extension ModuleDependencyGraph {
     case useIDNode          = 4
     case externalDepNode    = 5
     case identifierNode     = 6
+    case buildRecord        = 7
+    case inputInfo          = 8
 
     /// The human-readable name of this record.
     ///
@@ -648,6 +666,10 @@ extension ModuleDependencyGraph {
         return "EXTERNAL_DEP_NODE"
       case .identifierNode:
         return "IDENTIFIER_NODE"
+      case .buildRecord:
+        return "BUILD_RECORD"
+      case .inputInfo:
+        return "INPUT_INFO"
       }
     }
   }
@@ -658,6 +680,7 @@ extension ModuleDependencyGraph {
     case malformedMetadataRecord
     case mismatchedSerializedGraphVersion(expected: Version, read: Version)
     case unexpectedMetadataRecord
+    case unexpectedBuildRecord
     case malformedFingerprintRecord
     case malformedIdentifierRecord
     case malformedModuleDepGraphNodeRecord
@@ -665,6 +688,8 @@ extension ModuleDependencyGraph {
     case malforedUseIDRecord
     case malformedMapRecord
     case malformedExternalDepNodeRecord
+    case malformedBuildRecord
+    case malformedInputInfo
     case unknownRecord
     case unexpectedSubblock
     case bogusNameOrContext
@@ -675,7 +700,6 @@ extension ModuleDependencyGraph {
     
     fileprivate init(forMalformed kind: RecordID) {
       switch kind {
-        
       case .metadata:
         self = .malformedMetadataRecord
       case .moduleDepGraphNode:
@@ -688,6 +712,10 @@ extension ModuleDependencyGraph {
         self = .malformedExternalDepNodeRecord
       case .identifierNode:
         self = .malformedIdentifierRecord
+      case .buildRecord:
+        self = .malformedBuildRecord
+      case .inputInfo:
+        self = .malformedInputInfo
       }
     }
   }
@@ -724,6 +752,11 @@ extension ModuleDependencyGraph {
       var majorVersion: UInt64?
       var minorVersion: UInt64?
       var compilerVersionString: String?
+      var argsHash: String?
+      var buildStartTime: TimePoint = .distantPast
+      var buildEndTime: TimePoint = .distantFuture
+      var inputInfos: [VirtualPath: InputInfo] = [:]
+      var expectedInputInfos: Int = 0
 
       private var currentDefKey: DependencyKey? = nil
       private var nodeUses: [(DependencyKey, Int)] = []
@@ -753,7 +786,15 @@ extension ModuleDependencyGraph {
 
       func finalizeGraph() -> ModuleDependencyGraph {
         mutationSafetyPrecondition()
-        let graph = ModuleDependencyGraph.createFromPrior(info,
+        let record = BuildRecord(
+          argsHash: self.argsHash!,
+          swiftVersion: self.compilerVersionString!,
+          buildStartTime: self.buildStartTime,
+          buildEndTime: self.buildEndTime,
+          inputInfos: self.inputInfos)
+        assert(self.inputInfos.count == self.expectedInputInfos)
+        let graph = ModuleDependencyGraph.createFromPrior(record,
+                                                          info,
                                                           internedStringTable,
                                                           nodeFinder,
                                                           fingerprintedExternalDependencies)
@@ -855,18 +896,57 @@ extension ModuleDependencyGraph {
           guard self.majorVersion == nil, self.minorVersion == nil, self.compilerVersionString == nil else {
             throw ReadError.unexpectedMetadataRecord
           }
-          guard record.fields.count == 3,
-                case .blob(let compilerVersionBlob) = record.payload
-          else { throw malformedError }
+          guard
+            record.fields.count == 3,
+            case .blob(let compilerVersionBlob) = record.payload
+          else {
+            throw malformedError
+          }
 
           self.majorVersion = record.fields[0]
           self.minorVersion = record.fields[1]
           let stringCount = record.fields[2]
           internedStringTable.reserveCapacity(Int(stringCount))
           self.compilerVersionString = String(decoding: compilerVersionBlob, as: UTF8.self)
-        case .moduleDepGraphNode:
-           guard record.fields.count == 6
+        case .buildRecord:
+          guard self.argsHash == nil, self.buildStartTime == .distantPast, self.buildEndTime == .distantFuture else {
+            throw ReadError.unexpectedBuildRecord
+          }
+          guard
+            record.fields.count == 7,
+            case .blob(let argHashBlob) = record.payload
           else {
+            throw malformedError
+          }
+          self.buildStartTime = TimePoint(
+            lower: UInt32(record.fields[0]),
+            upper: UInt32(record.fields[1]),
+            nanoseconds: UInt32(record.fields[2]))
+          self.buildEndTime = TimePoint(
+            lower: UInt32(record.fields[3]),
+            upper: UInt32(record.fields[4]),
+            nanoseconds: UInt32(record.fields[5]))
+          self.expectedInputInfos = Int(record.fields[6])
+          self.argsHash = String(decoding: argHashBlob, as: UTF8.self)
+        case .inputInfo:
+          guard
+            record.fields.count == 5,
+            let path = try nonemptyInternedString(field: 4)
+          else {
+            throw malformedError
+          }
+          let modTime = TimePoint(
+            lower: UInt32(record.fields[0]),
+            upper: UInt32(record.fields[1]),
+            nanoseconds: UInt32(record.fields[2]))
+          let status = try InputInfo.Status(code: UInt32(record.fields[3]))
+          let pathString = path.lookup(in: internedStringTable)
+          let pathHandle = try VirtualPath.intern(path: pathString)
+          self.inputInfos[VirtualPath.lookup(pathHandle)] = InputInfo(
+            status: status,
+            previousModTime: modTime)
+        case .moduleDepGraphNode:
+          guard record.fields.count == 6 else {
             throw malformedError
           }
           let key = try dependencyKey(kindCodeField: 0,
@@ -1016,7 +1096,7 @@ extension ModuleDependencyGraph {
   @_spi(Testing) public func write(
     to path: VirtualPath,
     on fileSystem: FileSystem,
-    buildRecord: BuildRecordInfo,
+    buildRecord: BuildRecord,
     mockSerializedGraphVersion: Version? = nil
   ) throws {
     let data = ModuleDependencyGraph.Serializer.serialize(
@@ -1035,7 +1115,7 @@ extension ModuleDependencyGraph {
 
   @_spi(Testing) public final class Serializer: InternedStringTableHolder {
     public let internedStringTable: InternedStringTable
-    let buildRecord: BuildRecordInfo
+    let buildRecord: BuildRecord
     let serializedGraphVersion: Version
     let stream = BitstreamWriter()
     private var abbreviations = [RecordID: Bitstream.AbbreviationID]()
@@ -1043,7 +1123,7 @@ extension ModuleDependencyGraph {
     private var lastNodeID: Int = 0
 
     private init(internedStringTable: InternedStringTable,
-                 buildRecord: BuildRecordInfo,
+                 buildRecord: BuildRecord,
                  serializedGraphVersion: Version) {
       self.internedStringTable = internedStringTable
       self.buildRecord = buildRecord
@@ -1086,6 +1166,8 @@ extension ModuleDependencyGraph {
         self.emitRecordID(.useIDNode)
         self.emitRecordID(.externalDepNode)
         self.emitRecordID(.identifierNode)
+        self.emitRecordID(.buildRecord)
+        self.emitRecordID(.inputInfo)
       }
     }
 
@@ -1096,7 +1178,33 @@ extension ModuleDependencyGraph {
         $0.append(serializedGraphVersion.minorForWriting)
         $0.append(min(UInt(internedStringTable.count), UInt(UInt32.max)))
       },
-      blob: self.buildRecord.actualSwiftVersion)
+      blob: self.buildRecord.swiftVersion)
+    }
+
+    private func writeBuildRecord() {
+      self.stream.writeRecord(self.abbreviations[.buildRecord]!, {
+        $0.append(RecordID.buildRecord)
+        $0.append(self.buildRecord.buildStartTime)
+        $0.append(self.buildRecord.buildEndTime)
+        $0.append(UInt32(self.buildRecord.inputInfos.count))
+      },
+      blob: self.buildRecord.argsHash)
+
+      let sortedInputInfo = self.buildRecord.inputInfos.sorted {
+        $0.key.name < $1.key.name
+      }
+
+      for (input, inputInfo) in sortedInputInfo {
+        let inputID = input.name.intern(in: self.internedStringTable)
+        let pathID = self.lookupIdentifierCode(for: inputID)
+
+        self.stream.writeRecord(self.abbreviations[.inputInfo]!) {
+          $0.append(RecordID.inputInfo)
+          $0.append(inputInfo.previousModTime)
+          $0.append(inputInfo.status.code)
+          $0.append(pathID)
+        }
+      }
     }
 
     private func lookupIdentifierCode(for string: InternedString?) -> UInt32 {
@@ -1111,6 +1219,14 @@ extension ModuleDependencyGraph {
     private func populateCaches(from graph: ModuleDependencyGraph) {
       graph.nodeFinder.forEachNode { node in
         self.cacheNodeID(for: node)
+      }
+
+      let sortedInputInfo = self.buildRecord.inputInfos.sorted {
+        $0.key.name < $1.key.name
+      }
+
+      for (input, _) in sortedInputInfo {
+        _ = input.name.intern(in: self.internedStringTable)
       }
 
       for str in internedStringTable.strings {
@@ -1142,6 +1258,38 @@ extension ModuleDependencyGraph {
         .fixed(bitWidth: 32),
         // Frontend version
         .blob,
+      ])
+      self.abbreviate(.buildRecord, [
+        .literal(RecordID.buildRecord.rawValue),
+        // Build start time seconds - lower bits
+        .fixed(bitWidth: 32),
+        // Build start time seconds - upper bits
+        .fixed(bitWidth: 32),
+        // Build start time nanoseconds
+        .fixed(bitWidth: 32),
+        // Build end time seconds - lower bits
+        .fixed(bitWidth: 32),
+        // Build end time seconds - upper bits
+        .fixed(bitWidth: 32),
+        // Build end time nanoseconds
+        .fixed(bitWidth: 32),
+        // Expected input count
+        .fixed(bitWidth: 32),
+        // Argument hash
+        .blob,
+      ])
+      self.abbreviate(.inputInfo, [
+        .literal(RecordID.inputInfo.rawValue),
+        // Known modification time seconds - lower bits
+        .fixed(bitWidth: 32),
+        // Known modification time seconds - upper bits
+        .fixed(bitWidth: 32),
+        // Known modification time nanoseconds
+        .fixed(bitWidth: 32),
+        // Input status
+        .fixed(bitWidth: 3),
+        // path ID
+        .vbr(chunkBitWidth: 13),
       ])
       self.abbreviate(.moduleDepGraphNode,
         [Bitstream.Abbreviation.Operand.literal(RecordID.moduleDepGraphNode.rawValue)] +
@@ -1183,7 +1331,7 @@ extension ModuleDependencyGraph {
 
     public static func serialize(
       _ graph: ModuleDependencyGraph,
-      _ buildRecord: BuildRecordInfo,
+      _ buildRecord: BuildRecord,
       _ serializedGraphVersion: Version
     ) -> ByteString {
       graph.accessSafetyPrecondition()
@@ -1200,7 +1348,9 @@ extension ModuleDependencyGraph {
         serializer.writeMetadata()
 
         serializer.populateCaches(from: graph)
-        
+
+        serializer.writeBuildRecord()
+
         func write(key: DependencyKey, to buffer: inout BitstreamWriter.RecordBuffer) {
           buffer.append(key.designator.code)
           buffer.append(key.aspect.code)
@@ -1363,5 +1513,61 @@ fileprivate extension Version {
     let r = UInt32(Int64(minor))
     assert(Int(r) == Int(minor))
     return r
+  }
+}
+
+fileprivate extension BitstreamWriter.RecordBuffer {
+  mutating func append(_ time: TimePoint) {
+    func split(_ value: UInt64) -> (UInt32, UInt32) {
+      let lowerHalf = UInt32((value & 0x0000_0000_FFFF_FFFF))
+      let upperHalf = UInt32((value & 0xFFFF_FFFF_0000_0000) >> 32)
+      return (lowerHalf, upperHalf)
+    }
+    let (lower, upper) = split(time.seconds.littleEndian)
+    self.append(lower)
+    self.append(upper)
+    let nanos = time.nanoseconds.littleEndian
+    self.append(nanos)
+  }
+}
+
+fileprivate extension TimePoint {
+  init(
+    lower: UInt32,
+    upper: UInt32,
+    nanoseconds: UInt32
+  ) {
+    let seconds = UInt64(lower) | (UInt64(upper) << 32)
+    self.init(seconds: seconds, nanoseconds: nanoseconds)
+  }
+}
+
+fileprivate extension InputInfo.Status {
+  init(code: UInt32) throws {
+    switch code {
+    case 0:
+      self = .upToDate
+    case 1:
+      self = .needsNonCascadingBuild
+    case 2:
+      self = .needsCascadingBuild
+    case 3:
+      self = .newlyAdded
+    default:
+      throw ModuleDependencyGraph.ReadError.unknownKind
+    }
+  }
+
+  var code: UInt32 {
+    switch self {
+    case .upToDate:
+      return 0
+    case .needsNonCascadingBuild:
+      return 1
+    case .needsCascadingBuild:
+      return 2
+    case .newlyAdded:
+      return 3
+    }
   }
 }

--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -19,13 +19,14 @@ import TestUtilities
 class CrossModuleIncrementalBuildTests: XCTestCase {
   func makeOutputFileMap(
     in workingDirectory: AbsolutePath,
+    module: String,
     for files: [AbsolutePath],
     outputTransform transform: (String) -> String = { $0 }
   ) -> String {
     """
     {
       "": {
-        "swift-dependencies": "\(workingDirectory.appending(component: "module.swiftdeps").nativePathString(escaped: true))"
+        "swift-dependencies": "\(workingDirectory.appending(component: "\(module).swiftdeps").nativePathString(escaped: true))"
       }
     """.appending(files.map { file in
       """
@@ -53,7 +54,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
 
       let ofm = path.appending(component: "ofm.json")
       try localFileSystem.writeFileContents(ofm) {
-        $0 <<< self.makeOutputFileMap(in: path, for: [ magic ]) {
+        $0 <<< self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ]) {
           $0 + "-some_suffix"
         }
       }
@@ -75,7 +76,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       }
 
       try localFileSystem.writeFileContents(ofm) {
-        $0 <<< self.makeOutputFileMap(in: path, for: [ magic ]) {
+        $0 <<< self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ]) {
           $0 + "-some_other_suffix"
         }
       }
@@ -102,7 +103,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
 
         let ofm = path.appending(component: "ofm.json")
         try localFileSystem.writeFileContents(ofm) {
-          $0 <<< self.makeOutputFileMap(in: path, for: [ magic ])
+          $0 <<< self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ])
         }
 
         var driver = try Driver(args: [
@@ -127,7 +128,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
 
       let ofm = path.appending(component: "ofm2.json")
       try localFileSystem.writeFileContents(ofm) {
-        $0 <<< self.makeOutputFileMap(in: path, for: [ main ])
+        $0 <<< self.makeOutputFileMap(in: path, module: "theModule", for: [ main ])
       }
 
       var driver = try Driver(args: [

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -110,14 +110,15 @@ fileprivate extension DependencyKey {
 
 extension BuildRecordInfo {
   static func mock(
-    _ diagnosticEngine: DiagnosticsEngine,
-    _ outputFileMap: OutputFileMap
-    ) -> Self {
+    diagnosticEngine: DiagnosticsEngine,
+    outputFileMap: OutputFileMap,
+    compilerVersion: String
+  ) -> Self {
     self.init(
       buildRecordPath: try! VirtualPath(path: "no-build-record"),
       fileSystem: localFileSystem,
       currentArgsHash: "",
-      actualSwiftVersion: "for-testing",
+      actualSwiftVersion: compilerVersion,
       timeBeforeFirstJob: .now(),
       diagnosticEngine: diagnosticEngine,
       compilationInputModificationDates: [:])
@@ -131,15 +132,18 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     fileSystem: FileSystem = localFileSystem,
     diagnosticEngine: DiagnosticsEngine = DiagnosticsEngine()
   ) -> Self {
-    let diagnosticsEngine = DiagnosticsEngine()
     // Must set input files in order to avoid graph deserialization from culling
     let inputFiles = outputFileMap.entries.keys
       .filter {VirtualPath.lookup($0).extension == FileType.swift.rawValue }
       .map {TypedVirtualPath(file: $0, type: .swift)}
-     return Self(options, outputFileMap,
-                BuildRecordInfo.mock(diagnosticsEngine, outputFileMap),
+    let buildRecord = BuildRecordInfo.mock(
+      diagnosticEngine: diagnosticEngine,
+      outputFileMap: outputFileMap,
+      compilerVersion: "for-testing")
+    return Self(options, outputFileMap,
+                buildRecord,
                 nil, nil, nil, inputFiles, fileSystem,
-                diagnosticsEngine)
+                diagnosticEngine)
   }
 }
 

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -142,7 +142,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
       compilerVersion: "for-testing")
     return Self(options, outputFileMap,
                 buildRecord,
-                nil, nil, nil, inputFiles, fileSystem,
+                nil, inputFiles, fileSystem,
                 diagnosticEngine)
   }
 }
@@ -176,19 +176,18 @@ struct MockModuleDependencyGraphCreator {
   }
 
   func mockUpAGraph() -> ModuleDependencyGraph {
-    .createForBuildingFromSwiftDeps(info)
+    .createForBuildingFromSwiftDeps(info.buildRecordInfo.buildRecord([], []), info)
   }
 }
 
 
 extension OutputFileMap {
   static func mock(maxIndex: Int) -> Self {
-    OutputFileMap( entries: (0...maxIndex) .reduce(into: [:]) {
+    OutputFileMap(entries: (0...maxIndex) .reduce(into: [:]) {
       entries, index in
       let inputHandle = SwiftSourceFile(mock: index).fileHandle
       let swiftDepsHandle = SwiftSourceFile(mock: index).fileHandle
       entries[inputHandle] = [.swiftDeps: swiftDepsHandle]
-    }
-    )
+    })
   }
 }

--- a/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
@@ -79,14 +79,14 @@ class IncrementalBuildPerformanceTests: XCTestCase {
         measure {
           _ = ModuleDependencyGraph.Serializer.serialize(
             g,
-            "mock compiler version",
+            info.buildRecordInfo,
             ModuleDependencyGraph.serializedGraphVersion)
         }
       case .readingPriors:
         readSwiftDeps(for: inputs, into: g)
         let data = ModuleDependencyGraph.Serializer.serialize(
           g,
-          "mock compiler version",
+          info.buildRecordInfo,
           ModuleDependencyGraph.serializedGraphVersion)
         measure {
           try? XCTAssertNoThrow(ModuleDependencyGraph.deserialize(data, info: info))

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -553,11 +553,11 @@ extension IncrementalCompilationTests {
         from: .absolute(priorsPath),
         info: info)
       let priorsModTime = try localFileSystem.getFileInfo(priorsPath).modTime
-      let compilerVersion = try XCTUnwrap(driver.buildRecordInfo).actualSwiftVersion
+      let buildRecord = try XCTUnwrap(driver.buildRecordInfo)
       let incrementedVersion = ModuleDependencyGraph.serializedGraphVersion.withAlteredMinor
       try priorsWithOldVersion?.write(to: .absolute(priorsPath),
                                 on: localFileSystem,
-                                compilerVersion: compilerVersion,
+                                buildRecord: buildRecord,
                                 mockSerializedGraphVersion: incrementedVersion)
       return priorsModTime
     }


### PR DESCRIPTION
This PR fixes a pretty harrowing set of Linux bugs we've observed on and off over the years with the incremental build.

The build record and the module dependency graph are currently emitted by "cross-module incremental builds" alongside a "swiftdeps" YAML file that summarizes the compilation session that occurred before this one. This has a number of downsides
- We have a hard dependency on a YAML library for just this one thing
- With two input files comes a quad-state of cases to handle (if priors desyncs from build record and vice versa... bad things happen)
- Moreover, we have observed that mod times returned to us on ext4 on older Ubuntus have a pretty high (probably << 1/100) chance of telling us that the priors file was somehow emitted _before_ the compilation session ended.

There's no reason to emit two files when we can just emit one. To start, bump the serialized dependency graph format and absorb the information from the build record into it. Then, teach all the things that instantiate a ModuleDependencyGraph to also hand it a build record. Where they get that build record from is their business, but we can also make our own now.

-------

Time Traveling priors occur when a file system cache lies to us about the state of the incremental build. Since I'd rather not deal with three operating system's worth of file systems abstractions to fix that particular problem, let's make sure this can never happen again by relegating one of the priors files to the legacy incremental build path.

The idea is that the "incremental imports" flag controls things here:

Incremental Imports Enabled: Read and write Module.priors bitstream files
Incremental Imports Disabled: Read and write Module.swiftdeps YAML files

The only notable thing needed to make this work is the old fallback that used to "disable" incremental compilation by bailing out of the entire incremental build now instead constructs an empty module dependency graph and fires off a "clean" incremental build. This should be a pretty significant optimization as it now means that on the happy path we can reach a steady state in the incremental build in one build instead of two.

I've also cleaned up and fixed a number of incremental build tests that happened to be passing in configurations where it was somehow acceptable to read stale, or in the worst case incorrect, priors files paired with the correct build record files. Finally, I've deleted tests that had anything to do with the time traveling priors phenomenon.