### PR TITLE
PrebuiltModuleGen: Print an error instead of crashing when `SWIFT_EXEC` is invalid

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -792,7 +792,7 @@ extension Driver {
     // of mac native so those macabi-only modules cannot be found by the scanner.
     // We have to handle those modules separately without any dependency info.
     try unhandledModules.forEach { moduleName in
-      diagnosticEngine.emit(warning: "handle \(moduleName) as dangling jobs")
+      diagnosticEngine.emit(warning: "handle \(moduleName) has dangling jobs")
       try forEachInputOutputPair(moduleName) { input, output in
         danglingJobs.append(contentsOf: try generateSingleModuleBuildingJob(moduleName,
           prebuiltModuleDir, input, output, [], currentABIDir, baselineABIDir))

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -90,7 +90,12 @@ do {
   let swiftcPathRaw = ProcessEnv.vars["SWIFT_EXEC"]
   var swiftcPath: AbsolutePath
   if let swiftcPathRaw = swiftcPathRaw {
-    swiftcPath = try VirtualPath(path: swiftcPathRaw).absolutePath!
+    let virtualPath = try VirtualPath(path: swiftcPathRaw)
+    guard let absolutePath = virtualPath.absolutePath else {
+      diagnosticsEngine.emit(error: "value of SWIFT_EXEC is not a valid absolute path: \(swiftcPathRaw)")
+      exit(1)
+    }
+    swiftcPath = absolutePath
   } else {
     swiftcPath = AbsolutePath("Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
                               relativeTo: sdkPath.parentDirectory


### PR DESCRIPTION
Now users will see a diagnostic like this:

```
error: value of SWIFT_EXEC is not a valid absolute path: ../build/Ninja-RelWithDebInfoAssert/swift-macosx-arm64/bin/swiftc
```

Also, fix a diagnostic typo.