### PR TITLE
IncrementalDependencyAndInputSetup.swift: fix mutability warning

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -278,7 +278,7 @@ extension IncrementalCompilationState {
     }
 
     func computeInitialStateForPlanning(driver: inout Driver) throws -> InitialStateForPlanning? {
-      guard var priors = computeGraphAndInputsInvalidatedByExternals() else {
+      guard let priors = computeGraphAndInputsInvalidatedByExternals() else {
         return nil
       }
 


### PR DESCRIPTION
This is a warning that's currently caused by `priors` using a `var` binding:
```swift
IncrementalCompilation/IncrementalDependencyAndInputSetup.swift:281:17: warning: variable 'priors' was never mutated; consider changing to 'let' constant
      guard var priors = computeGraphAndInputsInvalidatedByExternals() else {
            ~~~ ^
            let
```