### PR TITLE
[5.8] Enable '-clang-target' by-default

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -74,10 +74,8 @@ extension Driver {
 
     // Pass down -clang-target.
     // If not specified otherwise, we should use the same triple as -target
-    // TODO: enable -clang-target for implicit module build as well.
     if !parsedOptions.hasArgument(.disableClangTarget) &&
-        isFrontendArgSupported(.clangTarget) &&
-        parsedOptions.contains(.driverExplicitModuleBuild) {
+        isFrontendArgSupported(.clangTarget) {
       let clangTriple = parsedOptions.getLastArgument(.clangTarget)?.asSingle ?? targetTriple.triple
       commandLine.appendFlag(.clangTarget)
       commandLine.appendFlag(clangTriple)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3622,7 +3622,7 @@ final class SwiftDriverTests: XCTestCase {
     #endif
   }
 
-  func testDisableClangTargetForImplicitModule() throws {
+  func testEnableClangTargetForImplicitModule() throws {
     var envVars = ProcessEnv.vars
     envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)
 
@@ -3632,7 +3632,7 @@ final class SwiftDriverTests: XCTestCase {
     let plannedJobs = try driver.planBuild()
     XCTAssertEqual(plannedJobs.count, 2)
     XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target")))
-    XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-clang-target")))
+    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-clang-target")))
   }
 
   func testPCHasCompileInput() throws {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1250
----------------------------------
This will result in the driver passing down '-clang-target' flag to the frontend, which will then ensure that all downstream module (Swift and Clang) compilation compiler sub-invocations are consistent with respect to the target triple used by their underlying instances of Clang. Resulting in all Clang module dependencies being built against the main module's target triple.