### PR TITLE
Revert "[5.8] Enable '-clang-target' by-default"

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -74,8 +74,10 @@ extension Driver {
 
     // Pass down -clang-target.
     // If not specified otherwise, we should use the same triple as -target
+    // TODO: enable -clang-target for implicit module build as well.
     if !parsedOptions.hasArgument(.disableClangTarget) &&
-        isFrontendArgSupported(.clangTarget) {
+        isFrontendArgSupported(.clangTarget) &&
+        parsedOptions.contains(.driverExplicitModuleBuild) {
       let clangTriple = parsedOptions.getLastArgument(.clangTarget)?.asSingle ?? targetTriple.triple
       commandLine.appendFlag(.clangTarget)
       commandLine.appendFlag(clangTriple)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3622,7 +3622,7 @@ final class SwiftDriverTests: XCTestCase {
     #endif
   }
 
-  func testEnableClangTargetForImplicitModule() throws {
+  func testDisableClangTargetForImplicitModule() throws {
     var envVars = ProcessEnv.vars
     envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)
 
@@ -3632,7 +3632,7 @@ final class SwiftDriverTests: XCTestCase {
     let plannedJobs = try driver.planBuild()
     XCTAssertEqual(plannedJobs.count, 2)
     XCTAssert(plannedJobs[0].commandLine.contains(.flag("-target")))
-    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-clang-target")))
+    XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-clang-target")))
   }
 
   func testPCHasCompileInput() throws {


### PR DESCRIPTION
Reverts apple/swift-driver#1251

Testing whether this change regressed source compatibility.