### PR TITLE
Specify "-rtlib=compiler-rt" on Linux as required for some of Swift's numeric conversion symbols.

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -291,6 +291,10 @@ extension GenericUnixToolchain {
         }
       }
 
+      // Use compiler-rt for Swift's numeric conversion symbols
+      commandLine.appendFlag("-rtlib=compiler-rt")
+      commandLine.appendFlag("-lunwind")
+
       // Run clang++ in verbose mode if "-v" is set
       try commandLine.appendLast(.v, from: &parsedOptions)
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1993,6 +1993,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(commandContainsTemporaryPath(cmd, "bar.o"))
       XCTAssertTrue(commandContainsTemporaryResponsePath(cmd, "Test.autolink"))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.so"))
+      XCTAssertTrue(cmd.contains(.flag("-rtlib=compiler-rt")))
 
       XCTAssertFalse(cmd.contains(.flag("-dylib")))
       XCTAssertFalse(cmd.contains(.flag("-static")))


### PR DESCRIPTION
Resolves rdar://104134160