### PR TITLE
[Explicit Modules] Use external dependency info to determine if discovered binary dependenceis are frameworks.

### DIFF
--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -400,15 +400,15 @@ enum ModuleDependenciesInputs {
   static var simpleDependencyGraphInput: String {
     """
     {
-      "mainModuleName": "main",
+      "mainModuleName": "simpleTestModule",
       "modules": [
         {
-          "swift": "main"
+          "swift": "simpleTestModule"
         },
         {
-          "modulePath": "main.swiftmodule",
+          "modulePath": "simpleTestModule.swiftmodule",
           "sourceFiles": [
-            "/main/main.swift"
+            "/main/simpleTestModule.swift"
           ],
           "directDependencies": [
             {
@@ -445,6 +445,23 @@ enum ModuleDependenciesInputs {
                 "-Xcc",
                 "-fapinotes-swift-version=5"
               ],
+            }
+          }
+        },
+        {
+          "swiftPrebuiltExternal" : "K"
+        },
+        {
+          "modulePath" : "/tmp/K.swiftmodule",
+          "directDependencies" : [
+            {
+              "swift": "A"
+            },
+          ],
+          "details" : {
+            "swiftPrebuiltExternal": {
+              "compiledModulePath": "/tmp/K.swiftmodule",
+              "isFramework": false
             }
           }
         },


### PR DESCRIPTION
The driver library's client may supply information about the current module's dependencies, incl. whether or not they are frameworks. With the dependency scanner no longer re-using source module information from a prior scan (https://github.com/apple/swift/pull/63201), such modules will be reported as prebuilt binary dependencies.

Moreover, add a check to avoid resolving the main module's source module information with a binary dependency, covering an edge case of a module having a dependency with the same name.