### PR TITLE
swift-build-sdk-interfaces: fix deprecated AbsolutePath.init

### DIFF
--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -82,7 +82,7 @@ do {
   // append the SDK version number so all modules will built into
   // the SDK-versioned sub-directory.
   if outputDir.basename == "prebuilt-modules" {
-    outputDir = AbsolutePath(collector.versionString, relativeTo: outputDir)
+    outputDir = try AbsolutePath(validating: collector.versionString, relativeTo: outputDir)
   }
   if !localFileSystem.exists(outputDir) {
     try localFileSystem.createDirectory(outputDir, recursive: true)
@@ -97,8 +97,8 @@ do {
     }
     swiftcPath = absolutePath
   } else {
-    swiftcPath = AbsolutePath("Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
-                              relativeTo: sdkPath.parentDirectory
+    swiftcPath = try AbsolutePath(validating: "Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
+                                  relativeTo: sdkPath.parentDirectory
                                                  .parentDirectory
                                                  .parentDirectory
                                                  .parentDirectory


### PR DESCRIPTION
As `AbsolutePath.init(_:)` is deprecated, we should use throwing `AbsolutePath.init(validating:)` instead to fix the warnings.