### PR TITLE
Remove last trace of `TSCUtility`

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -26,7 +26,23 @@ import struct TSCBasic.RelativePath
 import var TSCBasic.localFileSystem
 import var TSCBasic.stderrStream
 import var TSCBasic.stdoutStream
-import enum TSCUtility.Diagnostics
+
+extension Driver {
+  /// Stub Error for terminating the process.
+  public enum ErrorDiagnostics: Swift.Error {
+    case emitted
+  }
+}
+
+extension Driver.ErrorDiagnostics: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .emitted:
+      return "errors were encountered"
+    }
+  }
+}
+
 
 /// The Swift driver.
 public struct Driver {
@@ -1839,7 +1855,7 @@ extension Driver {
         if let originalPath = swiftFiles[basename] {
           diagnosticsEngine.emit(.error_two_files_same_name(basename: basename, firstPath: originalPath, secondPath: input))
           diagnosticsEngine.emit(.note_explain_two_files_same_name)
-          throw Diagnostics.fatalError
+          throw ErrorDiagnostics.emitted
         } else {
           swiftFiles[basename] = input
         }
@@ -1852,7 +1868,7 @@ extension Driver {
       if let mainPath = swiftFiles["main.swift"] {
         diagnosticsEngine.emit(.error_two_files_same_name(basename: "main.swift", firstPath: mainPath, secondPath: "-e"))
         diagnosticsEngine.emit(.note_explain_two_files_same_name)
-        throw Diagnostics.fatalError
+        throw ErrorDiagnostics.emitted
       }
       
       try withTemporaryDirectory(dir: fileSystem.tempDirectory, removeTreeOnDeinit: false) { absPath in
@@ -2878,7 +2894,7 @@ extension Triple {
       return WindowsToolchain.self
     default:
       diagnosticsEngine.emit(.error_unknown_target(triple))
-      throw Diagnostics.fatalError
+      throw Driver.ErrorDiagnostics.emitted
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -14,7 +14,6 @@ import class TSCBasic.LocalFileOutputByteStream
 import class TSCBasic.TerminalController
 import struct TSCBasic.RelativePath
 import var TSCBasic.stderrStream
-import enum TSCUtility.Diagnostics
 
 /// Whether we should produce color diagnostics by default.
 fileprivate func shouldColorDiagnostics() -> Bool {
@@ -474,7 +473,7 @@ extension Driver {
     if parsedOptions.hasArgument(.updateCode) {
       guard compilerMode == .standardCompile else {
         diagnosticEngine.emit(.error_update_code_not_supported(in: compilerMode))
-        throw Diagnostics.fatalError
+        throw ErrorDiagnostics.emitted
       }
       assert(primaryInputs.count == 1, "Standard compile job had more than one primary input")
       let input = primaryInputs[0]


### PR DESCRIPTION
Replace use of `Diagnostic.fatalError` with a
`SwiftDriver.Diagnostics.errorsEmitted` type which removes the final reference to `TSCUtility` in the actual shipping code.  References within the test suite may remain for now.