### PR TITLE
SwiftDriver: remove implicit dependency on TSCUtility

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -595,7 +595,8 @@ public struct Driver {
       if let digesterMode = DigesterMode(rawValue: modeArg) {
         mode = digesterMode
       } else {
-        diagnosticsEngine.emit(Error.invalidArgumentValue(Option.digesterMode.spelling, modeArg))
+        diagnosticsEngine.emit(.error(Error.invalidArgumentValue(Option.digesterMode.spelling, modeArg)),
+                               location: nil)
       }
     }
     self.digesterMode = mode
@@ -662,7 +663,8 @@ public struct Driver {
       Driver.isOptionFound($0, allOpts: supportedFrontendFlagsLocal)
     }
     self.savedUnknownDriverFlagsForSwiftFrontend.forEach {
-      diagnosticsEngine.emit(warning: "save unknown driver flag \($0) as additional swift-frontend flag")
+      diagnosticsEngine.emit(.warning("save unknown driver flag \($0) as additional swift-frontend flag"),
+                             location: nil)
     }
     self.supportedFrontendFeatures = try Self.computeSupportedCompilerFeatures(of: self.toolchain, env: env)
 
@@ -951,7 +953,8 @@ extension Driver {
         shouldComplain = self.inputFiles.filter { $0.type.isPartOfSwiftCompilation }.count > 1 && .singleCompile != compilerMode
       }
       if shouldComplain {
-        diagnosticEngine.emit(Error.cannotSpecify_OForMultipleOutputs)
+        diagnosticEngine.emit(.error(Error.cannotSpecify_OForMultipleOutputs),
+                              location: nil)
       }
     }
   }
@@ -2660,7 +2663,8 @@ extension Driver {
                                          diagnosticEngine: DiagnosticsEngine) {
     if parsedOptions.hasArgument(.suppressWarnings) &&
         parsedOptions.hasFlag(positive: .warningsAsErrors, negative: .noWarningsAsErrors, default: false) {
-      diagnosticEngine.emit(Error.conflictingOptions(.warningsAsErrors, .suppressWarnings))
+      diagnosticEngine.emit(.error(Error.conflictingOptions(.warningsAsErrors, .suppressWarnings)),
+                            location: nil)
     }
   }
 
@@ -2671,25 +2675,30 @@ extension Driver {
                                    diagnosticEngine: DiagnosticsEngine) {
     if moduleOutputInfo.output?.isTopLevel != true {
       for arg in parsedOptions.arguments(for: .emitDigesterBaseline, .emitDigesterBaselinePath, .compareToBaselinePath) {
-        diagnosticEngine.emit(Error.baselineGenerationRequiresTopLevelModule(arg.option.spelling))
+        diagnosticEngine.emit(.error(Error.baselineGenerationRequiresTopLevelModule(arg.option.spelling)),
+                              location: nil)
       }
     }
 
     if parsedOptions.hasArgument(.serializeBreakingChangesPath) && !parsedOptions.hasArgument(.compareToBaselinePath) {
-      diagnosticEngine.emit(Error.optionRequiresAnother(Option.serializeBreakingChangesPath.spelling,
-                                                        Option.compareToBaselinePath.spelling))
+      diagnosticEngine.emit(.error(Error.optionRequiresAnother(Option.serializeBreakingChangesPath.spelling,
+                                                               Option.compareToBaselinePath.spelling)),
+                            location: nil)
     }
     if parsedOptions.hasArgument(.digesterBreakageAllowlistPath) && !parsedOptions.hasArgument(.compareToBaselinePath) {
-      diagnosticEngine.emit(Error.optionRequiresAnother(Option.digesterBreakageAllowlistPath.spelling,
-                                                        Option.compareToBaselinePath.spelling))
+      diagnosticEngine.emit(.error(Error.optionRequiresAnother(Option.digesterBreakageAllowlistPath.spelling,
+                                                               Option.compareToBaselinePath.spelling)),
+                            location: nil)
     }
     if digesterMode == .abi && !parsedOptions.hasArgument(.enableLibraryEvolution) {
-      diagnosticEngine.emit(Error.optionRequiresAnother("\(Option.digesterMode.spelling) abi",
-                                                        Option.enableLibraryEvolution.spelling))
+      diagnosticEngine.emit(.error(Error.optionRequiresAnother("\(Option.digesterMode.spelling) abi",
+                                                               Option.enableLibraryEvolution.spelling)),
+                            location: nil)
     }
     if digesterMode == .abi && swiftInterfacePath == nil {
-      diagnosticEngine.emit(Error.optionRequiresAnother("\(Option.digesterMode.spelling) abi",
-                                                        Option.emitModuleInterface.spelling))
+      diagnosticEngine.emit(.error(Error.optionRequiresAnother("\(Option.digesterMode.spelling) abi",
+                                                               Option.emitModuleInterface.spelling)),
+                            location: nil)
     }
   }
 
@@ -2698,14 +2707,16 @@ extension Driver {
     // '-print-explicit-dependency-graph' requires '-explicit-module-build'
     if parsedOptions.hasArgument(.printExplicitDependencyGraph) &&
         !parsedOptions.hasArgument(.driverExplicitModuleBuild) {
-      diagnosticEngine.emit(Error.optionRequiresAnother(Option.printExplicitDependencyGraph.spelling,
-                                                        Option.driverExplicitModuleBuild.spelling))
+      diagnosticEngine.emit(.error(Error.optionRequiresAnother(Option.printExplicitDependencyGraph.spelling,
+                                                               Option.driverExplicitModuleBuild.spelling)),
+                            location: nil)
     }
     // '-explicit-dependency-graph-format=' requires '-print-explicit-dependency-graph'
     if parsedOptions.hasArgument(.explicitDependencyGraphFormat) &&
         !parsedOptions.hasArgument(.printExplicitDependencyGraph) {
-      diagnosticEngine.emit(Error.optionRequiresAnother(Option.explicitDependencyGraphFormat.spelling,
-                                                        Option.printExplicitDependencyGraph.spelling))
+      diagnosticEngine.emit(.error(Error.optionRequiresAnother(Option.explicitDependencyGraphFormat.spelling,
+                                                               Option.printExplicitDependencyGraph.spelling)),
+                            location: nil)
     }
     // '-explicit-dependency-graph-format=' only supports values 'json' and 'dot'
     if let formatArg = parsedOptions.getLastArgument(.explicitDependencyGraphFormat)?.asSingle {
@@ -2722,7 +2733,8 @@ extension Driver {
                                     diagnosticEngine: DiagnosticsEngine) {
     if parsedOptions.hasArgument(.profileGenerate) &&
         parsedOptions.hasArgument(.profileUse) {
-      diagnosticEngine.emit(Error.conflictingOptions(.profileGenerate, .profileUse))
+      diagnosticEngine.emit(.error(Error.conflictingOptions(.profileGenerate, .profileUse)),
+                            location: nil)
     }
 
     if let profileArgs = parsedOptions.getLastArgument(.profileUse)?.asMultiple,
@@ -2731,7 +2743,8 @@ extension Driver {
         if let path = try? AbsolutePath(validating: profilingData,
                                           relativeTo: workingDirectory) {
           if !fileSystem.exists(path) {
-            diagnosticEngine.emit(Error.missingProfilingData(profilingData))
+            diagnosticEngine.emit(.error(Error.missingProfilingData(profilingData)),
+                                  location: nil)
           }
         }
       }
@@ -2742,7 +2755,8 @@ extension Driver {
                                           diagnosticEngine: DiagnosticsEngine) {
     if parsedOptions.contains(.parseableOutput) &&
         parsedOptions.contains(.useFrontendParseableOutput) {
-      diagnosticEngine.emit(Error.conflictingOptions(.parseableOutput, .useFrontendParseableOutput))
+      diagnosticEngine.emit(.error(Error.conflictingOptions(.parseableOutput, .useFrontendParseableOutput)),
+                            location: nil)
     }
   }
 
@@ -2752,9 +2766,11 @@ extension Driver {
       if arg.contains("=") {
         diagnosticEngine.emit(.warning_cannot_assign_to_compilation_condition(name: arg))
       } else if arg.hasPrefix("-D") {
-        diagnosticEngine.emit(Error.conditionalCompilationFlagHasRedundantPrefix(arg))
+        diagnosticEngine.emit(.error(Error.conditionalCompilationFlagHasRedundantPrefix(arg)),
+                              location: nil)
       } else if !arg.sd_isSwiftIdentifier {
-        diagnosticEngine.emit(Error.conditionalCompilationFlagIsNotValidIdentifier(arg))
+        diagnosticEngine.emit(.error(Error.conditionalCompilationFlagIsNotValidIdentifier(arg)),
+                              location: nil)
       }
     }
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -344,13 +344,13 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
       graphIfPresent = try ModuleDependencyGraph.read(from: dependencyGraphPath, info: self)
     }
     catch let ModuleDependencyGraph.ReadError.mismatchedSerializedGraphVersion(expected, read) {
-      diagnosticEngine.emit(
-        warning: "Will not do cross-module incremental builds, wrong version of priors; expected \(expected) but read \(read) at '\(dependencyGraphPath)'")
+      diagnosticEngine.emit(.warning("Will not do cross-module incremental builds, wrong version of priors; expected \(expected) but read \(read) at '\(dependencyGraphPath)'"),
+                            location: nil)
       graphIfPresent = nil
     }
     catch {
-      diagnosticEngine.emit(
-        warning: "Could not read priors, will not do cross-module incremental builds: \(error.localizedDescription), at \(dependencyGraphPath)")
+      diagnosticEngine.emit(.warning("Could not read priors, will not do cross-module incremental builds: \(error.localizedDescription), at \(dependencyGraphPath)"),
+                            location: nil)
       graphIfPresent = nil
     }
     guard let graph = graphIfPresent, self.validateBuildRecord(graph.buildRecord) != nil else {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -365,8 +365,8 @@ extension ModuleDependencyGraph {
     for invalidatedInput in collectInputsUsingInvalidated(nodes: directlyInvalidatedNodes) {
       guard info.isPartOfBuild(invalidatedInput)
       else {
-        info.diagnosticEngine.emit(
-          warning: "Failed to find source file '\(invalidatedInput.typedFile.file.basename)' in command line, recovering with a full rebuild. Next build will be incremental.")
+        info.diagnosticEngine.emit(.warning("Failed to find source file '\(invalidatedInput.typedFile.file.basename)' in command line, recovering with a full rebuild. Next build will be incremental."),
+                                   location: nil)
         return nil
       }
       invalidatedInputs.insert(invalidatedInput)

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -421,7 +421,8 @@ public struct SDKPrebuiltModuleInputsCollector {
     return map.filter {
       // Remove modules without associated .swiftinterface files and diagnose.
       if $0.value.isEmpty {
-        diagEngine.emit(warning: "\($0.key) has no associated .swiftinterface files")
+        diagEngine.emit(.warning("\($0.key) has no associated .swiftinterface files"),
+                        location: nil)
         return false
       }
       return true
@@ -457,7 +458,7 @@ public struct SDKPrebuiltModuleInputsCollector {
           hasInterface.append(currentFile)
         }
         if currentFile.extension == "swiftmodule" {
-          diagEngine.emit(warning: "found \(currentFile)")
+          diagEngine.emit(.warning("found \(currentFile)"), location: nil)
           hasModule.append(currentFile)
         }
       }
@@ -721,7 +722,8 @@ extension Driver {
       var results: [TypedVirtualPath] = []
       modules.forEach { module in
         guard let allOutputs = outputMap[module] else {
-          diagnosticEngine.emit(error: "cannot find output paths for \(module)")
+          diagnosticEngine.emit(.error("cannot find output paths for \(module)"),
+                                location: nil)
           return
         }
         let allPaths = allOutputs.filter { output in
@@ -772,7 +774,8 @@ extension Driver {
         // contain this dependency.
         dependencies.forEach({ newModule in
           if !openModules.contains(newModule) {
-            diagnosticEngine.emit(note: "\(newModule) is discovered.")
+            diagnosticEngine.emit(.note("\(newModule) is discovered."),
+                                  location: nil)
             openModules.append(newModule)
           }
         })
@@ -792,7 +795,8 @@ extension Driver {
     // of mac native so those macabi-only modules cannot be found by the scanner.
     // We have to handle those modules separately without any dependency info.
     try unhandledModules.forEach { moduleName in
-      diagnosticEngine.emit(warning: "handle \(moduleName) has dangling jobs")
+      diagnosticEngine.emit(.warning("handle \(moduleName) has dangling jobs"),
+                            location: nil)
       try forEachInputOutputPair(moduleName) { input, output in
         danglingJobs.append(contentsOf: try generateSingleModuleBuildingJob(moduleName,
           prebuiltModuleDir, input, output, [], currentABIDir, baselineABIDir))


### PR DESCRIPTION
We were relying on the implicit import of the `DiagnosticsEngine` extension to emit the diagnostics.  Explicitly inline the casting to avoid the dependency.