### PR TITLE
SwiftDriver: remove use of `spm_chomp`

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -20,7 +20,7 @@ extension DarwinToolchain {
     let result = try executor.checkNonZeroExit(
       args: "xcrun", "-toolchain", "default", "-f", "clang",
       environment: env
-    ).spm_chomp()
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
 
     return result.isEmpty ? nil : try AbsolutePath(validating: result)
   }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -126,7 +126,7 @@ public final class DarwinToolchain: Toolchain {
       let result = try executor.checkNonZeroExit(
         args: "xcrun", "-sdk", "macosx", "--show-sdk-path",
         environment: env
-      ).spm_chomp()
+      ).trimmingCharacters(in: .whitespacesAndNewlines)
       return try AbsolutePath(validating: result)
     }
 

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -293,7 +293,7 @@ extension Toolchain {
     let path = try executor.checkNonZeroExit(
       args: xcrun, "--find", executable,
       environment: env
-    ).spm_chomp()
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
     return try AbsolutePath(validating: path)
   }
 


### PR DESCRIPTION
This function was being imported through `TSCUtility`.  Replace the 3 uses of the function with an alternative to allow us to cleave the dependency.