### PR TITLE
SwiftDriver: avoid use of `fatalError` in the driver

### DIFF
--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -24,6 +24,7 @@ public final class WebAssemblyToolchain: Toolchain {
     case dynamicLibrariesUnsupportedForTarget(String)
     case sanitizersUnsupportedForTarget(String)
     case profilingUnsupportedForTarget(String)
+    case missingExternalDependency(String)
 
     public var description: String {
       switch self {
@@ -35,6 +36,8 @@ public final class WebAssemblyToolchain: Toolchain {
         return "sanitizers are unsupported for target '\(triple)'"
       case .profilingUnsupportedForTarget(let triple):
         return "profiling is unsupported for target '\(triple)'"
+      case .missingExternalDependency(let dependency):
+        return "missing external dependency '\(dependency)'"
       }
     }
   }


### PR DESCRIPTION
Present a diagnostic for the failure rather than invoking `fatalError`. This ensures that the user sees a proper diagnostic for the failure and also enables the test suite to run to completion in case of an error.