### PR TITLE
[Explicit Module Builds] Handle dependency scanners that produce `-o` arguments explicitly

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -176,9 +176,18 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         commandLine.appendFlag(.explicitInterfaceModuleBuild)
       }
 
-      // Set the output path
-      commandLine.appendFlag(.o)
-      commandLine.appendPath(VirtualPath.lookup(moduleInfo.modulePath.path))
+      // FIXME: This is a temporary measure meant to be deleted once supported toolchains'
+      // scanners always output commands with '-o'.
+      //
+      // If the dependency scanner did not append its own "-o", add it here.
+      // This is temporary and is meant to handle both: the scanner that
+      // appends '-o' and one that doesn't, until we have a toolchain snapshot with the scanner
+      // that appends '-o' always.
+      let outputFlagIndeces = commandLine.enumerated().compactMap { $1 == .flag("-o") ? $0 : nil }
+      if outputFlagIndeces.isEmpty {
+        commandLine.appendFlag(.o)
+        commandLine.appendPath(VirtualPath.lookup(moduleInfo.modulePath.path))
+      }
 
       jobs.append(Job(
         moduleName: moduleId.moduleName,

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -63,7 +63,7 @@ extension Diagnostic.Message {
     // try resolveVersionedClangDependencies(dependencyGraph: &dependencyGraph)
 
     // Set dependency modules' paths to be saved in the module cache.
-    try resolveDependencyModulePaths(dependencyGraph: &dependencyGraph)
+    // try resolveDependencyModulePaths(dependencyGraph: &dependencyGraph)
 
     if parsedOptions.hasArgument(.printExplicitDependencyGraph) {
       let outputFormat = parsedOptions.getLastArgument(.explicitDependencyGraphFormat)?.asSingle


### PR DESCRIPTION
- Only add `-o` when a swift interface dependency command does not already
- Stop resolving module paths to a hashed output path because toolchains have had scanners that do this automatically for a while

This is a half-measure which will help land the refactor in https://github.com/apple/swift/pull/63460.
The actual long-term driver solution will be landed in https://github.com/apple/swift-driver/pull/1282.