### PR TITLE
Recover functionality of passing down unrecognized frontend-only options

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -689,7 +689,7 @@ public struct Driver {
       Driver.isOptionFound($0, allOpts: supportedFrontendFlagsLocal)
     }
     self.savedUnknownDriverFlagsForSwiftFrontend.forEach {
-      diagnosticsEngine.emit(.warning("save unknown driver flag \($0) as additional swift-frontend flag"),
+      diagnosticsEngine.emit(.warning("Passing compiler-frontend-only flag '\($0)' as additional 'swift-frontend' flag (Use '-Xfrontend' to avoid warning)"),
                              location: nil)
     }
     self.supportedFrontendFeatures = try Self.computeSupportedCompilerFeatures(of: self.toolchain, env: env)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6051,6 +6051,14 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testFrontendOnlyOptionWarning() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-enable-cross-import-overlays", "foo.swift"])
+      XCTAssertEqual(driver.diagnosticEngine.diagnostics.first?.message.text,
+      "Passing compiler-frontend-only flag '-enable-cross-import-overlays' as additional 'swift-frontend' flag (Use '-Xfrontend' to avoid warning)")
+    }
+  }
+
   func testVFSOverlay() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-c", "-vfsoverlay", "overlay.yaml", "foo.swift"])


### PR DESCRIPTION
Once '-e' got introduced, we started failing to detect when the driver was specified a frontend-only option and passing it down to the frontend, if such frontend-only option started with '-e...'. This is because we do a prefix match on the options trie and treat an unrecognized suffix as the argument to it, and later detect whether or not such an option is recognized.

We can restore the functionality for flags that the driver is aware of as being frontend-only flags, by not skipping such flags when constructing the trie and detecting them explicitly (`.noDriver`) and processing them as any other unknown flag to be checked whether or not it can be passed down to the frontend.

And reword the diagnostic a bit to indicate to the user that `-Xfrontend` can get rid of the warning.