### PR TITLE
Be more strict about invalid -module-name arguments

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2290,32 +2290,6 @@ extension Driver {
     return ""
   }
 
-  /// Whether we are going to be building an executable.
-  ///
-  /// FIXME: Why "maybe"? Why isn't this all known in advance as captured in
-  /// linkerOutputType?
-  private static func maybeBuildingExecutable(
-    _ parsedOptions: inout ParsedOptions,
-    linkerOutputType: LinkOutputType?
-  ) -> Bool {
-    switch linkerOutputType {
-    case .executable:
-      return true
-
-    case .dynamicLibrary, .staticLibrary:
-      return false
-
-    default:
-      break
-    }
-
-    if parsedOptions.hasArgument(.parseAsLibrary, .parseStdlib) {
-      return false
-    }
-
-    return parsedOptions.allInputs.count == 1
-  }
-
   /// Determine how the module will be emitted and the name of the module.
   private static func computeModuleInfo(
     _ parsedOptions: inout ParsedOptions,
@@ -2388,10 +2362,9 @@ extension Driver {
 
     func fallbackOrDiagnose(_ error: Diagnostic.Message) {
       moduleNameIsFallback = true
-      if compilerOutputType == nil || maybeBuildingExecutable(&parsedOptions, linkerOutputType: linkerOutputType) {
+      if compilerOutputType == nil || !parsedOptions.hasArgument(.moduleName) {
         moduleName = "main"
-      }
-      else {
+      } else {
         diagnosticsEngine.emit(error)
         moduleName = "__bad__"
       }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -734,6 +734,18 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-o", "+++.out"]).moduleOutputInfo.name, "main")
     XCTAssertEqual(try Driver(args: ["swift"]).moduleOutputInfo.name, "REPL")
     XCTAssertEqual(try Driver(args: ["swiftc", "foo.swift", "-emit-library", "-o", "libBaz.dylib"]).moduleOutputInfo.name, "Baz")
+
+    try assertDriverDiagnostics(
+      args: ["swiftc", "foo.swift", "-module-name", "", "file.foo.swift"]
+    ) {
+      $1.expect(.error("module name \"\" is not a valid identifier"))
+    }
+
+    try assertDriverDiagnostics(
+      args: ["swiftc", "foo.swift", "-module-name", "123", "file.foo.swift"]
+    ) {
+      $1.expect(.error("module name \"123\" is not a valid identifier"))
+    }
   }
 
   func testEmitModuleSeparatelyDiagnosticPath() throws {


### PR DESCRIPTION
In the case this argument is passed explicitly and invalid, it was previous ignored and fell back to 'main' even in cases where you might not want that like compiling object files. It doesn't seem necessary to allow invalid cases like this through regardless of what object type is being built.