### PR TITLE
Utilities: adjust install rules for apple/swift-llbuild#852

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -340,7 +340,7 @@ def install_libraries(args, build_dir, universal_lib_dir, toolchain_lib_dir, tar
 
   # Install the llbuild core shared libraries into the toolchain lib
   package_subpath = os.path.join(args.configuration, 'dependencies', 'llbuild')
-  for lib in ['libllbuildSwift', 'libllbuild']:
+  for lib in ['libllbuildSwift']:
     install_library(args, build_dir, package_subpath, lib, shared_lib_ext,
                     universal_lib_dir, toolchain_lib_dir,'llbuild', targets)
 


### PR DESCRIPTION
The libllbuild library has been converted into a static product and interalised into libllbuildSwift.  This avoids the distribution issues here.  Remove the library from the install set.