### PR TITLE
Revert "Remove support for linking arclite"

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2804,10 +2804,6 @@ extension Driver {
         diagnosticsEngine.emit(.error_hermetic_seal_requires_lto)
       }
     }
-    if parsedOptions.hasArgument(.linkObjcRuntime) ||
-        parsedOptions.hasArgument(.noLinkObjcRuntime) {
-      diagnosticsEngine.emit(.warning_darwin_link_objc_deprecated())
-    }
   }
   
   private static func validateSanitizerAddressUseOdrIndicatorFlag(

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -16,6 +16,38 @@ import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
 
 extension DarwinToolchain {
+  internal func findXcodeClangPath() throws -> AbsolutePath? {
+    let result = try executor.checkNonZeroExit(
+      args: "xcrun", "-toolchain", "default", "-f", "clang",
+      environment: env
+    ).trimmingCharacters(in: .whitespacesAndNewlines)
+
+    return result.isEmpty ? nil : try AbsolutePath(validating: result)
+  }
+
+  internal func findXcodeClangLibPath(_ additionalPath: String) throws -> AbsolutePath? {
+    let path = try getToolPath(.swiftCompiler)
+      .parentDirectory // 'swift'
+      .parentDirectory // 'bin'
+      .appending(components: "lib", additionalPath)
+
+    if fileSystem.exists(path) { return path }
+
+    // If we don't have a 'lib/arc/' directory, find the "arclite" library
+    // relative to the Clang in the active Xcode.
+    if let clangPath = try? findXcodeClangPath() {
+      return clangPath
+        .parentDirectory // 'clang'
+        .parentDirectory // 'bin'
+        .appending(components: "lib", additionalPath)
+    }
+    return nil
+  }
+
+  internal func findARCLiteLibPath() throws -> AbsolutePath? {
+    return try findXcodeClangLibPath("arc")
+  }
+
   /// Adds the arguments necessary to link the files from the given set of
   /// options for a Darwin platform.
   public func addPlatformSpecificLinkerArgs(
@@ -185,6 +217,13 @@ extension DarwinToolchain {
     if let sdkPath = targetInfo.sdkPath?.path {
       commandLine.appendFlag("--sysroot")
       commandLine.appendPath(VirtualPath.lookup(sdkPath))
+    }
+
+    // -link-objc-runtime also implies -fobjc-link-runtime
+    if parsedOptions.hasFlag(positive: .linkObjcRuntime,
+                             negative: .noLinkObjcRuntime,
+                             default: false) {
+      commandLine.appendFlag("-fobjc-link-runtime")
     }
 
     let targetTriple = targetInfo.target.triple

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -188,6 +188,14 @@ public final class DarwinToolchain: Toolchain {
                            targetVariantTriple: Triple?,
                            compilerOutputType: FileType?,
                            diagnosticsEngine: DiagnosticsEngine) throws {
+    // On non-darwin hosts, libArcLite won't be found and a warning will be emitted
+    // Guard for the sake of tests running on all platforms
+    #if canImport(Darwin)
+    // Validating arclite library path when link-objc-runtime.
+    validateLinkObjcRuntimeARCLiteLib(&parsedOptions,
+                                      targetTriple: targetTriple,
+                                      diagnosticsEngine: diagnosticsEngine)
+    #endif
     // Validating apple platforms deployment targets.
     try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple, 
                                  compilerOutputType: compilerOutputType)
@@ -237,6 +245,22 @@ public final class DarwinToolchain: Toolchain {
       if let (platform, minVersion) = minVersions[os], targetTriple.version(for: platform) >= minVersion {
         throw ToolchainValidationError.invalidDeploymentTargetForIR(platform: platform, version: minVersion, archName: targetTriple.archName)
       }
+    }
+  }
+    
+  func validateLinkObjcRuntimeARCLiteLib(_ parsedOptions: inout ParsedOptions,
+                                           targetTriple: Triple,
+                                           diagnosticsEngine: DiagnosticsEngine) {
+    guard parsedOptions.hasFlag(positive: .linkObjcRuntime,
+                                negative: .noLinkObjcRuntime,
+                                default: !targetTriple.supports(.nativeARC))
+    else {
+      return
+    }
+
+    guard let _ = try? findARCLiteLibPath() else {
+        diagnosticsEngine.emit(.warn_arclite_not_found_when_link_objc_runtime)
+        return
     }
   }
 
@@ -378,6 +402,15 @@ public final class DarwinToolchain: Toolchain {
         .appending(component: sdkInfo.versionString))
     }
   }
+}
+
+extension Diagnostic.Message {
+    static var warn_arclite_not_found_when_link_objc_runtime: Diagnostic.Message {
+      .warning(
+        "unable to find Objective-C runtime support library 'arclite'; " +
+        "pass '-no-link-objc-runtime' to silence this warning"
+      )
+    }
 }
 
 private extension Version {

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -51,10 +51,6 @@ extension Diagnostic.Message {
     .warning("inferring simulator environment for target '\(originalTriple.triple)'; use '-target \(inferredTriple.triple)' instead")
   }
 
-  static func warning_darwin_link_objc_deprecated() -> Diagnostic.Message {
-    .warning("-link-objc-runtime is no longer supported on Apple platforms")
-  }
-
   static func error_argument_not_allowed_with(arg: String, other: String) -> Diagnostic.Message {
     .error("argument '\(arg)' is not allowed with '\(other)'")
   }

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -398,3 +398,25 @@ extension Triple {
     }
   }
 }
+
+extension Triple.FeatureAvailability {
+  /// Linking `libarclite` is unnecessary for triples supporting this feature.
+  ///
+  /// This impacts the `-link-objc-runtime` flag in Swift, which is akin to the
+  /// `-fobjc-link-runtime` build setting in clang. When set, these flags
+  /// automatically link libobjc, and any compatibility libraries that don't
+  /// ship with the OS. The versions here are the first OSes that support
+  /// ARC natively in their respective copies of the Objective-C runtime,
+  /// and therefore do not require additional support libraries.
+  static let nativeARC = Self(
+    macOS: .available(since: Triple.Version(10, 11, 0)),
+    iOS: .available(since: Triple.Version(9, 0, 0)),
+    tvOS: .available(since: Triple.Version(9, 0, 0)),
+    watchOS: .availableInAllVersions
+  )
+  // When updating the versions listed here, please record the most recent
+  // feature being depended on and when it was introduced:
+  //
+  // - Make assigning 'nil' to an NSMutableDictionary subscript delete the
+  //   entry, like it does for Swift.Dictionary, rather than trap.
+}

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -601,15 +601,6 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
-  func testLinkObjCFlagWarning() throws {
-    try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-link-objc-runtime") {
-      $1.expect(.warning("-link-objc-runtime is no longer supported on Apple platforms"))
-    }
-    try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-no-link-objc-runtime") {
-      $1.expect(.warning("-link-objc-runtime is no longer supported on Apple platforms"))
-    }
-  }
-
   func testHermeticSealAtLink() throws {
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-experimental-hermetic-seal-at-link", "-lto=llvm-full") { driver in
       let jobs = try driver.planBuild()
@@ -1780,6 +1771,39 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
+    }
+
+    do {
+      // -fobjc-link-runtime default
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15"], env: env)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(3, plannedJobs.count)
+      let linkJob = plannedJobs[2]
+      XCTAssertEqual(linkJob.kind, .link)
+      let cmd = linkJob.commandLine
+      XCTAssertFalse(cmd.contains(.flag("-fobjc-link-runtime")))
+    }
+
+    do {
+      // -fobjc-link-runtime enable
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15", "-link-objc-runtime"], env: env)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(3, plannedJobs.count)
+      let linkJob = plannedJobs[2]
+      XCTAssertEqual(linkJob.kind, .link)
+      let cmd = linkJob.commandLine
+      XCTAssertTrue(cmd.contains(.flag("-fobjc-link-runtime")))
+    }
+
+    do {
+      // -fobjc-link-runtime disable override
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-apple-macosx10.15", "-link-objc-runtime", "-no-link-objc-runtime"], env: env)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(3, plannedJobs.count)
+      let linkJob = plannedJobs[2]
+      XCTAssertEqual(linkJob.kind, .link)
+      let cmd = linkJob.commandLine
+      XCTAssertFalse(cmd.contains(.flag("-fobjc-link-runtime")))
     }
 
     do {
@@ -3812,6 +3836,11 @@ final class SwiftDriverTests: XCTestCase {
 
     // Ensure arm64_32 is not restricted to back-deployment like other 32-bit archs (armv7k/i386).
     XCTAssertNoThrow(try Driver(args: ["swiftc", "-emit-module", "-c", "-target", "arm64_32-apple-watchos12.0", "foo.swift"]))
+
+    // On non-darwin hosts, libArcLite won't be found and a warning will be emitted
+    #if os(macOS)
+    try assertNoDriverDiagnostics(args: "swiftc", "-c", "-target", "x86_64-apple-macosx10.14", "-link-objc-runtime", "foo.swift")
+    #endif
   }
 
   func testProfileArgValidation() throws {


### PR DESCRIPTION
Reverts apple/swift-driver#1295
----------------------------------
It appears this flag was load-bearing for some LLDB tests and the original PR caused a regression. We need to fix these tests to pass the required linker flags. 