### PR TITLE
Attempt to recover from in-process Target Info and Supported Features query failures.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2924,6 +2924,7 @@ extension Driver {
                                       swiftCompilerPrefixArgs: frontendOverride.prefixArgsForTargetInfo,
                                       toolchain: toolchain, fileSystem: fileSystem,
                                       workingDirectory: workingDirectory,
+                                      diagnosticsEngine: diagnosticsEngine,
                                       executor: executor).target.triple
   }
 
@@ -2988,6 +2989,7 @@ extension Driver {
                                    swiftCompilerPrefixArgs: frontendOverride.prefixArgsForTargetInfo,
                                    toolchain: toolchain, fileSystem: fileSystem,
                                    workingDirectory: workingDirectory,
+                                   diagnosticsEngine: diagnosticsEngine,
                                    executor: executor)
 
       // Parse the runtime compatibility version. If present, it will override

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -64,9 +64,13 @@ extension Driver {
                                            fileSystem: FileSystem,
                                            executor: DriverExecutor)
   throws -> Set<String> {
-    if let supportedArgs =
-        try querySupportedCompilerArgsInProcess(of: toolchain, fileSystem: fileSystem) {
-      return supportedArgs
+    do {
+      if let supportedArgs =
+          try querySupportedCompilerArgsInProcess(of: toolchain, fileSystem: fileSystem) {
+        return supportedArgs
+      }
+    } catch {
+      diagnosticsEngine.emit(.warning_inprocess_supported_features_query_failed(error.localizedDescription))
     }
 
     // Fallback: Invoke `swift-frontend -emit-supported-features` and decode the output

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -55,6 +55,10 @@ extension Diagnostic.Message {
     .warning("In-process target-info query failed (\(error)). Using fallback mechanism.")
   }
 
+  static func warning_inprocess_supported_features_query_failed(_ error: String) -> Diagnostic.Message {
+    .warning("In-process supported-compiler-features query failed (\(error)). Using fallback mechanism.")
+  }
+
   static func error_argument_not_allowed_with(arg: String, other: String) -> Diagnostic.Message {
     .error("argument '\(arg)' is not allowed with '\(other)'")
   }

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -51,6 +51,10 @@ extension Diagnostic.Message {
     .warning("inferring simulator environment for target '\(originalTriple.triple)'; use '-target \(inferredTriple.triple)' instead")
   }
 
+  static func warning_inprocess_target_info_query_failed(_ error: String) -> Diagnostic.Message {
+    .warning("In-process target-info query failed (\(error)). Using fallback mechanism.")
+  }
+
   static func error_argument_not_allowed_with(arg: String, other: String) -> Diagnostic.Message {
     .error("argument '\(arg)' is not allowed with '\(other)'")
   }


### PR DESCRIPTION
Catch thrown exceptions and fallback to the previous mechanism of shelling out a `swift-frontend -print-target-info` and `swift-frontend -emit-supported-features` tasks. We are seeing spurious failures here and this will help potential users while we investigate the root cause.

Workaround for rdar://105559904