### PR TITLE
Add `-gcc-toolchain` flag to swift-driver

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -13,6 +13,7 @@
 import class TSCBasic.LocalFileOutputByteStream
 import class TSCBasic.TerminalController
 import struct TSCBasic.RelativePath
+import struct TSCBasic.AbsolutePath
 import var TSCBasic.stderrStream
 
 /// Whether we should produce color diagnostics by default.
@@ -140,6 +141,11 @@ extension Driver {
     try commandLine.appendAll(.I, from: &parsedOptions)
     try commandLine.appendAll(.F, .Fsystem, from: &parsedOptions)
     try commandLine.appendAll(.vfsoverlay, from: &parsedOptions)
+
+    if let gccToolchain = parsedOptions.getLastArgument(.gccToolchain) {
+        commandLine.appendFlag(.Xcc)
+        commandLine.appendFlag("--gcc-toolchain=\(gccToolchain.asSingle)")
+    }
 
     try commandLine.appendLast(.AssertConfig, from: &parsedOptions)
     try commandLine.appendLast(.autolinkForceLoad, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -55,6 +55,11 @@ extension Driver {
       outputFile = try outputFileForImage
     }
 
+    if let gccToolchain = parsedOptions.getLastArgument(.gccToolchain) {
+        commandLine.appendFlag(.XclangLinker)
+        commandLine.appendFlag("--gcc-toolchain=\(gccToolchain.asSingle)")
+    }
+
     // Defer to the toolchain for platform-specific linking
     let linkTool = try toolchain.addPlatformSpecificLinkerArgs(
       to: &commandLine,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -435,6 +435,7 @@ extension Option {
   public static let Fsystem: Option = Option("-Fsystem", .separate, attributes: [.frontend, .argumentIsPath], helpText: "Add directory to system framework search path")
   public static let functionSections: Option = Option("-function-sections", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Emit functions to separate sections.")
   public static let F: Option = Option("-F", .joinedOrSeparate, attributes: [.frontend, .argumentIsPath], helpText: "Add directory to framework search path")
+  public static let gccToolchain: Option = Option("-gcc-toolchain", .separate, attributes: [.helpHidden, .argumentIsPath], metaVar: "<path>", helpText: "Specify a directory where the clang importer and clang linker can find headers and libraries")
   public static let gdwarfTypes: Option = Option("-gdwarf-types", .flag, attributes: [.frontend], helpText: "Emit full DWARF type info.", group: .g)
   public static let generateEmptyBaseline: Option = Option("-generate-empty-baseline", .flag, attributes: [.noDriver], helpText: "Generate an empty baseline")
   public static let generateEmptyBaseline_: Option = Option("--generate-empty-baseline", .flag, alias: Option.generateEmptyBaseline, attributes: [.noDriver], helpText: "Generate an empty baseline")
@@ -1188,6 +1189,7 @@ extension Option {
       Option.Fsystem,
       Option.functionSections,
       Option.F,
+      Option.gccToolchain,
       Option.gdwarfTypes,
       Option.generateEmptyBaseline,
       Option.generateEmptyBaseline_,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6650,6 +6650,18 @@ final class SwiftDriverTests: XCTestCase {
 #endif
   }
 
+  func testGccToolchainFlags() throws {
+      VirtualPath.resetTemporaryFileStore()
+      var driver = try Driver(args: [
+        "swiftc", "-gcc-toolchain", "foo/as/blarpy", "test.swift"
+      ])
+      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(jobs.count, 2)
+      let (compileJob, linkJob) = (jobs[0], jobs[1])
+      compileJob.commandLine.contains(.flag("--gcc-toolchain=foo/as/blarpy"))
+      linkJob.commandLine.contains(.flag("--gcc-toolchain=foo/as/blarpy"))
+  }
+
   func testPluginPaths() throws {
     var driver = try Driver(args: ["swiftc", "-typecheck", "foo.swift"])
     guard driver.isFrontendArgSupported(.pluginPath) else {


### PR DESCRIPTION
GCC toolchains are useful when cross-compiling to Linux with a given gcc toolchain. The gcc toolchain contains tools for linking, libraries for linking against, and the headers that map to those libraries.

This patch adds a `-gcc-toolchain` flag to the driver so that Swift can pass that information down to both the clang importer and clang linker appropriately.

I went with the double-dash, equals format passed to clang because maskray keeps poking at the clang flags and that format is the only one that goes all of the way back (to 2013). I'm also passing the path down directly instead of reinterpreting them as an absolute path. The driver seems to use the `-working-directory` path to resolve most of these instead of the current working directory path, which I believe is inconsistent with Clang. Letting clang deal with the paths will, by definition, be consistent with clang. Yes, little Bobby Tables is waiting to make a mess of things.