### PR TITLE
Compute and reuse bridging header pch explicitly in explicit module b…

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -323,7 +323,12 @@ extension Driver {
       commandLine.appendFlag(.importObjcHeader)
       if bridgingHeaderHandling == .precompiled,
           let pch = bridgingPrecompiledHeader {
-        if parsedOptions.contains(.pchOutputDir) {
+        // For explicit module build, we directly pass the compiled pch as
+        // `-import-objc-header`, rather than rely on swift-frontend to locate
+        // the pch in the pchOutputDir and can start an implicit build in case
+        // of a lookup failure.
+        if parsedOptions.contains(.pchOutputDir) &&
+           !parsedOptions.contains(.driverExplicitModuleBuild) {
           commandLine.appendPath(VirtualPath.lookup(importedObjCHeader))
           try commandLine.appendLast(.pchOutputDir, from: &parsedOptions)
           if !compilerMode.isSingleCompilation {

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -53,7 +53,8 @@ extension Driver {
 
     commandLine.appendFlag(.emitPch)
 
-    if parsedOptions.hasArgument(.pchOutputDir) {
+    if parsedOptions.hasArgument(.pchOutputDir) &&
+       !parsedOptions.contains(.driverExplicitModuleBuild) {
       try commandLine.appendLast(.pchOutputDir, from: &parsedOptions)
     } else {
       commandLine.appendFlag(.o)


### PR DESCRIPTION
…uild

When `-pch-output-dir` is used during explicit module build, compute the output pch path and explicitly reuse that to downstream job via `-import-objc-header output.pch`.

rdar://106430264