### PR TITLE
driver: honour new Windows options

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftOptions
+
 import class TSCBasic.LocalFileOutputByteStream
 import class TSCBasic.TerminalController
 import struct TSCBasic.RelativePath
@@ -136,6 +138,23 @@ extension Driver {
     if let sdkPath = frontendTargetInfo.sdkPath?.path {
       commandLine.appendFlag(.sdk)
       commandLine.append(.path(VirtualPath.lookup(sdkPath)))
+    }
+
+    for args: (Option, Option) in [
+          (.visualcToolsRoot, .visualcToolsVersion),
+          (.windowsSdkRoot, .windowsSdkVersion)
+        ] {
+      let (rootArg, versionArg) = args
+      if let value = parsedOptions.getLastArgument(rootArg)?.asSingle,
+          isFrontendArgSupported(rootArg) {
+        commandLine.appendFlag(rootArg.spelling)
+        commandLine.appendPath(.init(value))
+      }
+
+      if let value = parsedOptions.getLastArgument(versionArg)?.asSingle,
+          isFrontendArgSupported(versionArg) {
+        commandLine.appendFlags(versionArg.spelling, value)
+      }
     }
 
     try commandLine.appendAll(.I, from: &parsedOptions)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6844,6 +6844,99 @@ final class SwiftDriverTests: XCTestCase {
       }
     }  
   }
+
+  func testWindowsOptions() throws {
+    let driver =
+        try Driver(args: ["swiftc", "-windows-sdk-version", "10.0.17763.0", #file])
+    guard [
+            .visualcToolsRoot,
+            .visualcToolsVersion,
+            .windowsSdkRoot,
+            .windowsSdkVersion
+          ].map(driver.isFrontendArgSupported).reduce(true, { $0 && $1 }) else {
+      return
+    }
+
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-unknown-windows-msvc", "-windows-sdk-root", "/SDK", #file
+      ])
+      let frontend = try driver.planBuild().first!
+
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-windows-sdk-root"),
+        .path(.absolute(.init("/SDK")))
+      ]))
+    }
+
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-unknown-windows-msvc", "-windows-sdk-version", "10.0.17763.0", #file
+      ])
+      let frontend = try driver.planBuild().first!
+
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-windows-sdk-version"),
+        .flag("10.0.17763.0")
+      ]))
+    }
+
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-unknown-windows-msvc", "-windows-sdk-version", "10.0.17763.0", "-windows-sdk-root", "/SDK", #file
+      ])
+      let frontend = try driver.planBuild().first!
+
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-windows-sdk-root"),
+        .path(.absolute(.init("/SDK")))
+      ]))
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-windows-sdk-version"),
+        .flag("10.0.17763.0")
+      ]))
+    }
+
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-unknown-windows-msvc", "-visualc-tools-root", "/MSVC/14.34.31933", #file
+      ])
+      let frontend = try driver.planBuild().first!
+
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-visualc-tools-root"),
+        .path(.absolute(.init("/MSVC/14.34.31933"))),
+      ]))
+    }
+
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-unknown-windows-msvc", "-visualc-tools-version", "14.34.31933", #file
+      ])
+      let frontend = try driver.planBuild().first!
+
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-visualc-tools-version"),
+        .flag("14.34.31933")
+      ]))
+    }
+
+    do {
+      var driver = try Driver(args: [
+        "swiftc", "-target", "x86_64-unknown-windows-msvc", "-visualc-tools-root", "/MSVC", "-visualc-tools-version", "14.34.31933", #file
+      ])
+      let frontend = try driver.planBuild().first!
+
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-visualc-tools-version"),
+        .flag("14.34.31933")
+      ]))
+      XCTAssertTrue(frontend.commandLine.contains(subsequence: [
+        .flag("-visualc-tools-root"),
+        .path(.absolute(.init("/MSVC"))),
+      ]))
+    }
+  }
 }
 
 func assertString(


### PR DESCRIPTION
Add handling for the newly minted Windows options:
  - `-windows-sdk-root`
  - `-windows-sdk-version`
  - `-visualc-tools-root`
  - `-visualc-tools-version`

Add some tests to ensure that we handle the flags properly.