### PR TITLE
NFC: Fix comment header in SwiftDriverExecutor.swift

### DIFF
--- a/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
+++ b/Sources/SwiftDriverExecution/SwiftDriverExecutor.swift
@@ -1,4 +1,4 @@
-//===--- MultiJobExecutor.swift - Builtin DriverExecutor implementation ---===//
+//===- SwiftDriverExecutor.swift - Builtin DriverExecutor implementation --===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
This header contained outdated file name.