### PR TITLE
Allow clients of `Driver` to pass `DiagnosticsHandler`

### DIFF
--- a/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
+++ b/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
@@ -78,7 +78,7 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
                                   fileSystem: localFileSystem,
                                   env: ProcessEnv.vars)
     var driver = try Driver(args: parsedOptions.commandLine,
-                            diagnosticsEngine: diagnosticsEngine,
+                            diagnosticsOutput: .engine(diagnosticsEngine),
                             executor: executor)
     if diagnosticsEngine.hasErrors {
       return true

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -156,7 +156,7 @@ do {
     }
     let baselineABIDir = try getArgumentAsPath("-baseline-abi-dir")
     var driver = try Driver(args: args,
-                            diagnosticsEngine: diagnosticsEngine,
+                            diagnosticsOutput: .engine(diagnosticsEngine),
                             executor: executor,
                             compilerExecutableDir: swiftcPath.parentDirectory)
     let (jobs, danglingJobs) = try driver.generatePrebuiltModuleGenerationJobs(with: inputMap,

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -93,7 +93,7 @@ do {
                                          fileSystem: localFileSystem,
                                          env: ProcessEnv.vars)
   var driver = try Driver(args: arguments,
-                          diagnosticsEngine: diagnosticsEngine,
+                          diagnosticsOutput: .engine(diagnosticsEngine),
                           executor: executor,
                           integratedDriver: false)
   

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -494,7 +494,7 @@ final class JobExecutorTests: XCTestCase {
                                        "-driver-filelist-threshold", "0",
                                        "-o", outputPath.pathString] + getHostToolchainSdkArg(executor),
                                 env: ProcessEnv.vars,
-                                diagnosticsEngine: diags,
+                                diagnosticsOutput: .engine(diags),
                                 fileSystem: localFileSystem,
                                 executor: executor)
         let jobs = try driver.planBuild()
@@ -532,7 +532,7 @@ final class JobExecutorTests: XCTestCase {
                                        "-driver-filelist-threshold", "0",
                                        "-o", outputPath.pathString] + getHostToolchainSdkArg(executor),
                                 env: ProcessEnv.vars,
-                                diagnosticsEngine: diags,
+                                diagnosticsOutput: .engine(diags),
                                 fileSystem: localFileSystem,
                                 executor: executor)
         let jobs = try driver.planBuild()
@@ -570,7 +570,7 @@ final class JobExecutorTests: XCTestCase {
                                        "-Xfrontend", "-debug-crash-immediately",
                                        "-o", outputPath.pathString] + getHostToolchainSdkArg(executor),
                                 env: ProcessEnv.vars,
-                                diagnosticsEngine: diags,
+                                diagnosticsOutput: .engine(diags),
                                 fileSystem: localFileSystem,
                                 executor: executor)
         let jobs = try driver.planBuild()

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -31,7 +31,7 @@ extension Driver {
                                        env: env)
     try self.init(args: args,
                   env: env,
-                  diagnosticsEngine: diagnosticsEngine,
+                  diagnosticsOutput: .engine(diagnosticsEngine),
                   fileSystem: fileSystem,
                   executor: executor,
                   integratedDriver: integratedDriver)


### PR DESCRIPTION
Uses of `DiagnosticsEngine` are [deprecated in SwiftPM](https://github.com/apple/swift-package-manager/blob/2c9fa974bc6ed9662e9399b734a0567952fb3e1d/Sources/Basics/Observability.swift#L530), since it uses a different logging infrastructure based on its own `ObservabilityScope` type. Resolving that deprecation warning is possible if `Driver.init` is able to take a diagnostics handler directly.