### PR TITLE
[Dependency Scanning] Remove coarse-grained synchronization on all dependency scan queries

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -47,11 +47,9 @@ public class InterModuleDependencyOracle {
                                              commandLine: [String])
   throws -> InterModuleDependencyGraph {
     precondition(hasScannerInstance)
-    return try queue.sync {
-      return try swiftScanLibInstance!.scanDependencies(workingDirectory: workingDirectory,
-                                                        moduleAliases: moduleAliases,
-                                                       invocationCommand: commandLine)
-    }
+    return try swiftScanLibInstance!.scanDependencies(workingDirectory: workingDirectory,
+                                                      moduleAliases: moduleAliases,
+                                                      invocationCommand: commandLine)
   }
 
   @_spi(Testing) public func getBatchDependencies(workingDirectory: AbsolutePath,
@@ -60,12 +58,10 @@ public class InterModuleDependencyOracle {
                                                   batchInfos: [BatchScanModuleInfo])
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     precondition(hasScannerInstance)
-    return try queue.sync {
-      return try swiftScanLibInstance!.batchScanDependencies(workingDirectory: workingDirectory,
-                                                             moduleAliases: moduleAliases,
-                                                            invocationCommand: commandLine,
-                                                            batchInfos: batchInfos)
-    }
+    return try swiftScanLibInstance!.batchScanDependencies(workingDirectory: workingDirectory,
+                                                           moduleAliases: moduleAliases,
+                                                           invocationCommand: commandLine,
+                                                           batchInfos: batchInfos)
   }
 
   @_spi(Testing) public func getImports(workingDirectory: AbsolutePath,
@@ -73,11 +69,9 @@ public class InterModuleDependencyOracle {
                                              commandLine: [String])
   throws -> InterModuleDependencyImports {
     precondition(hasScannerInstance)
-    return try queue.sync {
-      return try swiftScanLibInstance!.preScanImports(workingDirectory: workingDirectory,
-                                                      moduleAliases: moduleAliases,
-                                                      invocationCommand: commandLine)
-    }
+    return try swiftScanLibInstance!.preScanImports(workingDirectory: workingDirectory,
+                                                    moduleAliases: moduleAliases,
+                                                    invocationCommand: commandLine)
   }
 
   /// Given a specified toolchain path, locate and instantiate an instance of the SwiftScan library

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -996,7 +996,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", stdLibPath.nativePathString(escaped: true),
                                      "-I", shimsPath.nativePathString(escaped: true),
                                      "-F", frameworksPath.nativePathString(escaped: true),
-                                     "-import-objc-header",
                                      "-explicit-module-build",
                                      "-module-name", "main",
                                      "-working-directory", path.nativePathString(escaped: true),
@@ -1193,7 +1192,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-I", stdlibPath.nativePathString(escaped: true),
                                      "-I", shimsPath.nativePathString(escaped: true),
-                                     "-import-objc-header",
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
@@ -1265,7 +1263,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-I", stdlibPath.nativePathString(escaped: true),
                                      "-I", shimsPath.nativePathString(escaped: true),
                                      "/tmp/Foo.o",
-                                     "-import-objc-header",
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
@@ -1303,7 +1300,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
       DispatchQueue.concurrentPerform(iterations: 20) { index in
         // Give the main modules different names
         let iterationCommand = scannerCommand + ["-module-name",
-                                                 "testDependencyScanning\(index)"]
+                                                 "testDependencyScanning\(index)",
+                                                 // FIXME: We need to differentiate the scanning action hash,
+                                                 // though the module-name above should be sufficient.
+                                                 "-I/tmp/foo/bar/\(index)"]
         let dependencyGraph =
           try! dependencyOracle.getDependencies(workingDirectory: path,
                                                 commandLine: iterationCommand)
@@ -1458,7 +1458,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                        "-I", stdlibPath.nativePathString(escaped: true),
                                        "-I", shimsPath.nativePathString(escaped: true),
-                                       "-import-objc-header",
                                        "-explicit-module-build",
                                        "-working-directory", path.nativePathString(escaped: true),
                                        "-disable-clang-target",


### PR DESCRIPTION
In the `InterModuleDependencyOracle`, which may be shared across different instances of the `Driver`, all dependency scanning queries are executed synchronously on a shared dispatch queue. This is no longer necessary with the scanner guarding its own shared state as of https://github.com/apple/swift/pull/64615.