### PR TITLE
[5.9][Explicit Modules] Have `-clang-target` on Darwin platforms set to the SDK version by-default

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -74,17 +74,6 @@ extension Driver {
       break
     }
 
-    // Pass down -clang-target.
-    // If not specified otherwise, we should use the same triple as -target
-    // TODO: enable -clang-target for implicit module build as well.
-    if !parsedOptions.hasArgument(.disableClangTarget) &&
-        isFrontendArgSupported(.clangTarget) &&
-        parsedOptions.contains(.driverExplicitModuleBuild) {
-      let clangTriple = parsedOptions.getLastArgument(.clangTarget)?.asSingle ?? targetTriple.triple
-      commandLine.appendFlag(.clangTarget)
-      commandLine.appendFlag(clangTriple)
-    }
-
     // If in ExplicitModuleBuild mode and the dependency graph has been computed, add module
     // dependencies.
     // May also be used for generation of the dependency graph itself in ExplicitModuleBuild mode.
@@ -387,7 +376,7 @@ extension Driver {
     try toolchain.addPlatformSpecificCommonFrontendOptions(commandLine: &commandLine,
                                                            inputs: &inputs,
                                                            frontendTargetInfo: frontendTargetInfo,
-                                                           driver: self)
+                                                           driver: &self)
   }
 
   mutating func addFrontendSupplementaryOutputArguments(commandLine: inout [Job.ArgTemplate],

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -151,7 +151,7 @@ public protocol Toolchain {
     commandLine: inout [Job.ArgTemplate],
     inputs: inout [TypedVirtualPath],
     frontendTargetInfo: FrontendTargetInfo,
-    driver: Driver
+    driver: inout Driver
   ) throws
 
   var dummyForTestingObjectFormat: Triple.ObjectFormat {get}
@@ -306,7 +306,7 @@ extension Toolchain {
     commandLine: inout [Job.ArgTemplate],
     inputs: inout [TypedVirtualPath],
     frontendTargetInfo: FrontendTargetInfo,
-    driver: Driver
+    driver: inout Driver
   ) throws {}
 
   /// Resolves the path to the given tool and whether or not it supports response files so that it


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1274
-------------------------