### PR TITLE
[Dependency Scanning] Open `libSwiftScan` without `RTLD_FIRST` 

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -100,7 +100,7 @@ internal extension swiftscan_diagnostic_severity_t {
     #if os(Windows)
     self.dylib = try Loader.load(path.pathString, mode: [])
     #else
-    self.dylib = try Loader.load(path.pathString, mode: [.lazy, .local, .first])
+    self.dylib = try Loader.load(path.pathString, mode: [.lazy, .local])
     #endif
     self.api = try swiftscan_functions_t(self.dylib)
     guard let scanner = api.swiftscan_scanner_create() else {
@@ -111,8 +111,6 @@ internal extension swiftscan_diagnostic_severity_t {
 
   deinit {
     api.swiftscan_scanner_dispose(self.scanner)
-    // FIXME: is it safe to dlclose() swiftscan? If so, do that here.
-    // For now, let the handle leak.
     dylib.leak()
   }
 


### PR DESCRIPTION
`RTLD_FIRST` seems to be causing us to use the first-opened `,dylib` in a given process, ignoring hte fact that subsequent calls to `dlopen` may be opening a different library.