### PR TITLE
[5.9] Propagate sanitizer arguments to the clang-linker-driver invocations for dynamic libraries

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -199,7 +199,7 @@ extension DarwinToolchain {
     // Linking sanitizers will add rpaths, which might negatively interact when
     // other rpaths are involved, so we should make sure we add the rpaths after
     // all user-specified rpaths.
-    if linkerOutputType == .executable && !sanitizers.isEmpty {
+    if linkerOutputType != .staticLibrary && !sanitizers.isEmpty {
       let sanitizerNames = sanitizers
         .map { $0.rawValue }
         .sorted() // Sort so we get a stable, testable order

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2451,6 +2451,34 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
+      // address sanitizer on a dylib
+      var driver = try Driver(args: commonArgs + ["-sanitize=address", "-emit-library"])
+      let plannedJobs = try driver.planBuild()
+
+      XCTAssertEqual(plannedJobs.count, 3)
+
+      let compileJob = plannedJobs[0]
+      let compileCmd = compileJob.commandLine
+      XCTAssertTrue(compileCmd.contains(.flag("-sanitize=address")))
+
+      let linkJob = plannedJobs[2]
+      let linkCmd = linkJob.commandLine
+      XCTAssertTrue(linkCmd.contains(.flag("-fsanitize=address")))
+    }
+
+    do {
+      // *no* address sanitizer on a static lib
+      var driver = try Driver(args: commonArgs + ["-sanitize=address", "-emit-library", "-static"])
+      let plannedJobs = try driver.planBuild()
+
+      XCTAssertEqual(plannedJobs.count, 3)
+
+      let linkJob = plannedJobs[2]
+      let linkCmd = linkJob.commandLine
+      XCTAssertFalse(linkCmd.contains(.flag("-fsanitize=address")))
+    }
+
+    do {
       // thread sanitizer
       var driver = try Driver(args: commonArgs + ["-sanitize=thread"])
       let plannedJobs = try driver.planBuild()


### PR DESCRIPTION
Cherry-pick of: https://github.com/apple/swift-driver/pull/1325
------------------------------
Unless we are building a static library, we need to propagate `-fsanitizer=` flag to the clang linker driver, otherwise sanitizers libraries will not be found at link-time.

Resolves rdar://107733898