### PR TITLE
Add generated file note to Options.swift

### DIFF
--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -9,6 +9,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+// NOTE: Generated file, do not edit!
+//
+// This file is generated from 'apple/swift:include/swift/Option/Options.td'.
+// Please see README.md#rebuilding-optionsswift for details
+//
+//===----------------------------------------------------------------------===//
 
 extension Option {
   public static let INPUT: Option = Option("<input>", .input, attributes: [.argumentIsPath])

--- a/Sources/makeOptions/makeOptions.cpp
+++ b/Sources/makeOptions/makeOptions.cpp
@@ -232,6 +232,13 @@ int makeOptions_main() {
       "// See https://swift.org/LICENSE.txt for license information\n"
       "// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors\n"
       "//\n"
+      "//===----------------------------------------------------------------------===//\n"
+      "//\n"
+      "// NOTE: Generated file, do not edit!\n"
+      "//\n"
+      "// This file is generated from 'apple/swift:include/swift/Option/Options.td'.\n"
+      "// Please see README.md#rebuilding-optionsswift for details\n"
+      "//\n"
       "//===----------------------------------------------------------------------===//\n\n";
   out << "extension Option {\n";
   forEachOption([&](const RawOption &option) {


### PR DESCRIPTION
Updating makeOptions to include note that options.swift is generated so it should not be edited by hand.

Adding a note to the file so that folks are reminded not to edit it by hand.