### PR TITLE
[5.9 🍒] Always quote path arguments when resolving command-lines for libSwiftScan queries

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -416,7 +416,8 @@ public extension Driver {
   static func itemizedJobCommand(of job: Job, useResponseFiles: ResponseFileHandling,
                                  using resolver: ArgsResolver) throws -> [String] {
     let (args, _) = try resolver.resolveArgumentList(for: job,
-                                                     useResponseFiles: useResponseFiles)
+                                                     useResponseFiles: useResponseFiles,
+                                                     quotePaths: true)
     return args
   }
 

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -124,14 +124,14 @@ extension FrontendTargetInfo {
 }
 
 extension Toolchain {
-  func printTargetInfoJob(target: Triple?,
-                          targetVariant: Triple?,
-                          sdkPath: VirtualPath? = nil,
-                          resourceDirPath: VirtualPath? = nil,
-                          runtimeCompatibilityVersion: String? = nil,
-                          requiresInPlaceExecution: Bool = false,
-                          useStaticResourceDir: Bool = false,
-                          swiftCompilerPrefixArgs: [String]) throws -> Job {
+  @_spi(Testing) public func printTargetInfoJob(target: Triple?,
+                                                targetVariant: Triple?,
+                                                sdkPath: VirtualPath? = nil,
+                                                resourceDirPath: VirtualPath? = nil,
+                                                runtimeCompatibilityVersion: String? = nil,
+                                                requiresInPlaceExecution: Bool = false,
+                                                useStaticResourceDir: Bool = false,
+                                                swiftCompilerPrefixArgs: [String]) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     commandLine.append(contentsOf: [.flag("-frontend"),
                                     .flag("-print-target-info")])

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4861,17 +4861,42 @@ final class SwiftDriverTests: XCTestCase {
 
     // In-process query
     do {
-      let targetInfoArgs = ["-print-target-info", "-sdk", "bar", "-resource-dir", "baz"]
+      let targetInfoArgs = ["-print-target-info", "-sdk", "/bar", "-resource-dir", "baz"]
       let driver = try Driver(args: ["swift"] + targetInfoArgs)
+      let printTargetInfoJob = try driver.toolchain.printTargetInfoJob(target: nil, targetVariant: nil,
+                                                                       sdkPath: .absolute(driver.absoluteSDKPath!),
+                                                                       swiftCompilerPrefixArgs: [])
+      var printTargetInfoCommand = try Driver.itemizedJobCommand(of: printTargetInfoJob, useResponseFiles: .disabled, using: ArgsResolver(fileSystem: InMemoryFileSystem()))
+      Driver.sanitizeCommandForLibScanInvocation(&printTargetInfoCommand)
       let swiftScanLibPath = try XCTUnwrap(driver.toolchain.lookupSwiftScanLib())
       if localFileSystem.exists(swiftScanLibPath) {
         let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
         if libSwiftScanInstance.canQueryTargetInfo() {
           XCTAssertTrue(try driver.verifyBeingAbleToQueryTargetInfoInProcess(workingDirectory: localFileSystem.currentWorkingDirectory,
-                                                                             invocationCommand: targetInfoArgs))
+                                                                             invocationCommand: printTargetInfoCommand,
+                                                                             expectedSDKPath: "/bar"))
         }
       }
+    }
 
+    // Ensure that quoted paths are always escaped on the in-process query commands
+    do {
+      let targetInfoArgs = ["-print-target-info", "-sdk", "/tmp/foo bar", "-resource-dir", "baz"]
+      let driver = try Driver(args: ["swift"] + targetInfoArgs)
+      let printTargetInfoJob = try driver.toolchain.printTargetInfoJob(target: nil, targetVariant: nil,
+                                                                       sdkPath: .absolute(driver.absoluteSDKPath!),
+                                                                       swiftCompilerPrefixArgs: [])
+      var printTargetInfoCommand = try Driver.itemizedJobCommand(of: printTargetInfoJob, useResponseFiles: .disabled, using: ArgsResolver(fileSystem: InMemoryFileSystem()))
+      Driver.sanitizeCommandForLibScanInvocation(&printTargetInfoCommand)
+      let swiftScanLibPath = try XCTUnwrap(driver.toolchain.lookupSwiftScanLib())
+      if localFileSystem.exists(swiftScanLibPath) {
+        let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
+        if libSwiftScanInstance.canQueryTargetInfo() {
+          XCTAssertTrue(try driver.verifyBeingAbleToQueryTargetInfoInProcess(workingDirectory: localFileSystem.currentWorkingDirectory,
+                                                                             invocationCommand: printTargetInfoCommand,
+                                                                             expectedSDKPath: "/tmp/foo bar"))
+        }
+      }
     }
 
     do {

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -45,11 +45,20 @@ extension Driver {
 
 
   public func verifyBeingAbleToQueryTargetInfoInProcess(workingDirectory: AbsolutePath?,
-                                                                       invocationCommand: [String]) throws -> Bool {
-    guard try Self.queryTargetInfoInProcess(of: toolchain,
-                                            fileSystem: fileSystem,
-                                            workingDirectory: workingDirectory,
-                                            invocationCommand: invocationCommand) != nil else {
+                                                        invocationCommand: [String],
+                                                        expectedSDKPath: String) throws -> Bool {
+    guard let targetInfo = try Self.queryTargetInfoInProcess(of: toolchain,
+                                                             fileSystem: fileSystem,
+                                                             workingDirectory: workingDirectory,
+                                                             invocationCommand: invocationCommand) else {
+      return false
+    }
+
+    guard let sdkPath = targetInfo.sdkPath else {
+      return false
+    }
+
+    if sdkPath.path.description != expectedSDKPath {
       return false
     }
     return true


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1335
--------------------------------------
Otherwise, if unquoted paths contain spaces, such paths will become treated as separate strings when we formulate a C string array to pass down to libSwiftScan API entry-points.

Resolves rdar://106712169