### PR TITLE
Revert "Always quote path arguments when resolving command-lines for libSwiftScan queries"

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -416,8 +416,7 @@ public extension Driver {
   static func itemizedJobCommand(of job: Job, useResponseFiles: ResponseFileHandling,
                                  using resolver: ArgsResolver) throws -> [String] {
     let (args, _) = try resolver.resolveArgumentList(for: job,
-                                                     useResponseFiles: useResponseFiles,
-                                                     quotePaths: true)
+                                                     useResponseFiles: useResponseFiles)
     return args
   }
 

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -124,14 +124,14 @@ extension FrontendTargetInfo {
 }
 
 extension Toolchain {
-  @_spi(Testing) public func printTargetInfoJob(target: Triple?,
-                                                targetVariant: Triple?,
-                                                sdkPath: VirtualPath? = nil,
-                                                resourceDirPath: VirtualPath? = nil,
-                                                runtimeCompatibilityVersion: String? = nil,
-                                                requiresInPlaceExecution: Bool = false,
-                                                useStaticResourceDir: Bool = false,
-                                                swiftCompilerPrefixArgs: [String]) throws -> Job {
+  func printTargetInfoJob(target: Triple?,
+                          targetVariant: Triple?,
+                          sdkPath: VirtualPath? = nil,
+                          resourceDirPath: VirtualPath? = nil,
+                          runtimeCompatibilityVersion: String? = nil,
+                          requiresInPlaceExecution: Bool = false,
+                          useStaticResourceDir: Bool = false,
+                          swiftCompilerPrefixArgs: [String]) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     commandLine.append(contentsOf: [.flag("-frontend"),
                                     .flag("-print-target-info")])

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4861,42 +4861,17 @@ final class SwiftDriverTests: XCTestCase {
 
     // In-process query
     do {
-      let targetInfoArgs = ["-print-target-info", "-sdk", "/bar", "-resource-dir", "baz"]
+      let targetInfoArgs = ["-print-target-info", "-sdk", "bar", "-resource-dir", "baz"]
       let driver = try Driver(args: ["swift"] + targetInfoArgs)
-      let printTargetInfoJob = try driver.toolchain.printTargetInfoJob(target: nil, targetVariant: nil,
-                                                                       sdkPath: .absolute(driver.absoluteSDKPath!),
-                                                                       swiftCompilerPrefixArgs: [])
-      var printTargetInfoCommand = try Driver.itemizedJobCommand(of: printTargetInfoJob, useResponseFiles: .disabled, using: ArgsResolver(fileSystem: InMemoryFileSystem()))
-      Driver.sanitizeCommandForLibScanInvocation(&printTargetInfoCommand)
       let swiftScanLibPath = try XCTUnwrap(driver.toolchain.lookupSwiftScanLib())
       if localFileSystem.exists(swiftScanLibPath) {
         let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
         if libSwiftScanInstance.canQueryTargetInfo() {
           XCTAssertTrue(try driver.verifyBeingAbleToQueryTargetInfoInProcess(workingDirectory: localFileSystem.currentWorkingDirectory,
-                                                                             invocationCommand: printTargetInfoCommand,
-                                                                             expectedSDKPath: "/bar"))
+                                                                             invocationCommand: targetInfoArgs))
         }
       }
-    }
 
-    // Ensure that quoted paths are always escaped on the in-process query commands
-    do {
-      let targetInfoArgs = ["-print-target-info", "-sdk", "/tmp/foo bar", "-resource-dir", "baz"]
-      let driver = try Driver(args: ["swift"] + targetInfoArgs)
-      let printTargetInfoJob = try driver.toolchain.printTargetInfoJob(target: nil, targetVariant: nil,
-                                                                       sdkPath: .absolute(driver.absoluteSDKPath!),
-                                                                       swiftCompilerPrefixArgs: [])
-      var printTargetInfoCommand = try Driver.itemizedJobCommand(of: printTargetInfoJob, useResponseFiles: .disabled, using: ArgsResolver(fileSystem: InMemoryFileSystem()))
-      Driver.sanitizeCommandForLibScanInvocation(&printTargetInfoCommand)
-      let swiftScanLibPath = try XCTUnwrap(driver.toolchain.lookupSwiftScanLib())
-      if localFileSystem.exists(swiftScanLibPath) {
-        let libSwiftScanInstance = try SwiftScan(dylib: swiftScanLibPath)
-        if libSwiftScanInstance.canQueryTargetInfo() {
-          XCTAssertTrue(try driver.verifyBeingAbleToQueryTargetInfoInProcess(workingDirectory: localFileSystem.currentWorkingDirectory,
-                                                                             invocationCommand: printTargetInfoCommand,
-                                                                             expectedSDKPath: "/tmp/foo bar"))
-        }
-      }
     }
 
     do {

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -45,20 +45,11 @@ extension Driver {
 
 
   public func verifyBeingAbleToQueryTargetInfoInProcess(workingDirectory: AbsolutePath?,
-                                                        invocationCommand: [String],
-                                                        expectedSDKPath: String) throws -> Bool {
-    guard let targetInfo = try Self.queryTargetInfoInProcess(of: toolchain,
-                                                             fileSystem: fileSystem,
-                                                             workingDirectory: workingDirectory,
-                                                             invocationCommand: invocationCommand) else {
-      return false
-    }
-
-    guard let sdkPath = targetInfo.sdkPath else {
-      return false
-    }
-
-    if sdkPath.path.description != expectedSDKPath {
+                                                                       invocationCommand: [String]) throws -> Bool {
+    guard try Self.queryTargetInfoInProcess(of: toolchain,
+                                            fileSystem: fileSystem,
+                                            workingDirectory: workingDirectory,
+                                            invocationCommand: invocationCommand) != nil else {
       return false
     }
     return true


### PR DESCRIPTION
Reverts apple/swift-driver#1335

I believe that this is breaking SPM on Windows:

```
C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swift-frontend.exe -frontend -c -primary-file "C:\Users\WDAGUT~1\AppData\Local\Temp\TemporaryDirectory.odLA64\manifest.swift" -target x86_64-unknown-windows-msvc -disable-objc-interop -sdk "'C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk'" -I C:\Library\Developer\Platforms\Windows.platform\Developer\Library\XCTest-development\usr\lib\swift\windows -I C:\Library\Developer\Platforms\Windows.platform\Developer\Library\XCTest-development\usr\lib\swift\windows\x86_64 -I C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib\swift\pm\ManifestAPI -swift-version 5 -package-description-version 5.8.0 -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -empty-abi-descriptor -plugin-path C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib\swift\host\plugins -plugin-path C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\local\lib\swift\host\plugins -resource-dir C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib\swift -module-name main -o "C:\Users\WDAGUT~1\AppData\Local\Temp\TemporaryDirectory.FFxF6q\manifest-1.o"
```

Note the quoting on `SDKROOT`.  The quoting style is an issue.