### PR TITLE
Update requirements in `Package.swift` to match SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 import class Foundation.ProcessInfo
@@ -7,14 +7,14 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS(.v10_15)
+    macOSPlatform = .macOS("12.0")
 }
 
 let package = Package(
   name: "swift-driver",
   platforms: [
     macOSPlatform,
-    .iOS(.v13),
+    .iOS("15.0"),
   ],
   products: [
     .executable(

--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,14 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS("12.0")
+    macOSPlatform = .macOS(.v12)
 }
 
 let package = Package(
   name: "swift-driver",
   platforms: [
     macOSPlatform,
-    .iOS("15.0"),
+    .iOS(.v15),
   ],
   products: [
     .executable(


### PR DESCRIPTION
We no longer support Swift 5.5 and older versions of macOS with SwiftPM, makes sense to bring Swift Driver requirements in line with that.