### PR TITLE
Don't try to link private CYaml in CMake

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -131,7 +131,6 @@ target_link_libraries(SwiftDriver PUBLIC
   TSCUtility
   SwiftOptions)
 target_link_libraries(SwiftDriver PRIVATE
-  CYaml
   Yams
   CSwiftScan)
 


### PR DESCRIPTION
As of https://github.com/jpsim/Yams/pull/343 and Yams 5.0.0, CYaml is now a private static lib, and we no longer have to link it.

I think we also have to fix this in `release/5.9` and `main`? Do we need separate PRs for those?