### PR TITLE
Do not attempt to create compilation jobs when no Swift source files are specified as inputs

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -328,11 +328,11 @@ extension Driver {
     addJobOutputs: ([TypedVirtualPath]) -> Void,
     emitModuleTrace: Bool
   ) throws -> Job? {
-    guard case .singleCompile = compilerMode
+    guard case .singleCompile = compilerMode,
+          inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation })
     else { return nil }
 
-    if parsedOptions.hasArgument(.embedBitcode),
-       inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation }) {
+    if parsedOptions.hasArgument(.embedBitcode) {
       let compile = try compileJob(primaryInputs: [],
                                    outputType: .llvmBitcode,
                                    addJobOutputs: addJobOutputs,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2875,6 +2875,15 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testWMOWithJustObjectInputs() throws {
+    var driver = try Driver(args: [
+      "swiftc", "-wmo", "foo.o", "bar.o"
+    ])
+    let plannedJobs = try driver.planBuild()
+    XCTAssertEqual(plannedJobs.count, 1)
+    XCTAssertEqual(plannedJobs.first?.kind, .link)
+  }
+
   func testModuleAliasingWithImplicitBuild() throws {
     var driver = try Driver(args: [
       "swiftc", "foo.swift", "-module-name", "Foo", "-module-alias", "Car=Bar",


### PR DESCRIPTION
Doing so means downstream code is likely to error or crash, because it expects Swift source (or SIL) inputs. 

Resolves rdar://108057797