### PR TITLE
Revert "In WMO, make sure the dummy "primary" compilation input is a Swift source file"

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -585,10 +585,7 @@ extension Driver {
         // To match the legacy driver behavior, make sure we add the first input file
         // to the output file map if compiling without primary inputs (WMO), even
         // if there aren't any corresponding outputs.
-        guard let firstSourceInputHandle = inputFiles.first(where:{ $0.type == .swift })?.fileHandle  else {
-          fatalError("Formulating swift-frontend invocation without any input .swift files")
-        }
-        entries[firstSourceInputHandle] = [:]
+        entries[inputFiles[0].fileHandle] = [:]
       }
 
       for flaggedPair in flaggedInputOutputPairs {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2824,27 +2824,6 @@ final class SwiftDriverTests: XCTestCase {
     
   }
 
-  func testWMOWithNonSourceInput() throws {
-    var driver1 = try Driver(args: [
-      "swiftc", "-whole-module-optimization", "danger.o", "foo.swift", "bar.swift", "wibble.swift", "-module-name", "Test",
-      "-driver-filelist-threshold=0"
-    ])
-    let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
-    XCTAssertEqual(plannedJobs.count, 2)
-    let compileJob = plannedJobs[0]
-    XCTAssertEqual(compileJob.kind, .compile)
-    XCTAssert(compileJob.commandLine.contains(.flag("-supplementary-output-file-map")))
-    let argIdx = try XCTUnwrap(compileJob.commandLine.firstIndex(where: { $0 == .flag("-supplementary-output-file-map") }))
-    let supplOutputs = compileJob.commandLine[argIdx+1]
-    guard case let .path(path) = supplOutputs,
-          case let .fileList(_, fileList) = path,
-          case let .outputFileMap(outFileMap) = fileList else {
-      throw StringError("Unexpected argument for output file map")
-    }
-    let firstKey: String = try VirtualPath.lookup(XCTUnwrap(outFileMap.entries.keys.first)).description
-    XCTAssertEqual(firstKey, "foo.swift")
-  }
-
   func testDashDashPassingDownInput() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-module-name=ThisModule", "-wmo", "-num-threads", "4", "-emit-module", "-o", "test.swiftmodule", "--", "main.swift", "multi-threaded.swift"])


### PR DESCRIPTION
Reverts apple/swift-driver#1346. It's causing failures in CI that are breaking PR testing on Swift `main`. See, e.g., https://ci.swift.org/job/oss-swift-incremental-RA-macos/2773/.