### PR TITLE
[5.9🍒] Avoid quoting paths for dependencies scanning jobs.

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -415,9 +415,11 @@ public extension Driver {
 
   static func itemizedJobCommand(of job: Job, useResponseFiles: ResponseFileHandling,
                                  using resolver: ArgsResolver) throws -> [String] {
+    // FIXME: this is to walkaround rdar://108769167
+    let quotePaths = job.kind != .scanDependencies
     let (args, _) = try resolver.resolveArgumentList(for: job,
                                                      useResponseFiles: useResponseFiles,
-                                                     quotePaths: true)
+                                                     quotePaths: quotePaths)
     return args
   }
 


### PR DESCRIPTION
(Cherry-pick from PR: https://github.com/apple/swift-driver/pull/1351)

Explanation: We recently added a change to always add quotes for path arguments. For some reason, the dependency scanning invocation used by prebuilt module cache job doesn't like this change, leading to failures when querying module dependency information. This is a simple change to opt-out adding quotes for dependency scanning jobs.
Scope: Swift prebuilt module cache
Risk: Low.
Reviewer: @artemcm 