### PR TITLE
build-script-helper.py: remove unused `distutils` import

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-from distutils import file_util
 import os
 import json
 import platform


### PR DESCRIPTION
`distutils` was deprecated in Python 3.10 and will be removed in Python 3.12. We should not depend on it and this import looks unused anyway.