### PR TITLE
[Dependency Scanning] Unify path-escaping handling using TSC's spm_shellEscaped

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -415,12 +415,11 @@ public extension Driver {
 
   static func itemizedJobCommand(of job: Job, useResponseFiles: ResponseFileHandling,
                                  using resolver: ArgsResolver) throws -> [String] {
-    // FIXME: this is to walkaround rdar://108769167
-    let quotePaths = job.kind != .scanDependencies
-    let (args, _) = try resolver.resolveArgumentList(for: job,
-                                                     useResponseFiles: useResponseFiles,
-                                                     quotePaths: quotePaths)
-    return args
+    // Because the command-line passed to libSwiftScan does not go through the shell
+    // we must ensure that we generate a shell-escaped string for all arguments/flags that may
+    // potentially need it.
+    return try resolver.resolveArgumentList(for: job,
+                                            useResponseFiles: useResponseFiles).0.map { $0.spm_shellEscaped() }
   }
 
   static func getRootPath(of toolchain: Toolchain, env: [String: String])


### PR DESCRIPTION
Command lines generated for `libSwiftScan` (either for actual dependency scanning queries, or for target-info queries) do not go through the shell, and are instead tokenized at the entry-points (inside `libSwiftScan`). In order for them to be correctly tokenized, we must ensure that all the various file paths are escaped in case they contain whitespace characters, to ensure they get treated as a whole path, rather than multiple strings.

The driver previously relied on a separate mechanism to do this for libSwiftScan command lines, by getting the `ArgsResolver` to always escape `.path` arguments. This turned out to be insufficient, because it happens to miss a whole class of paths specified on the command-line that the driver cannot/doesn't recognize as paths: arguments forwarded to tools, such as `-Xcc` or `-Xfrontend` or `-Xclang-linker`. As a result, it is possible for such paths to end-up unescaped and fail to get tokenized correctly by `libSwiftScan`.

Instead, this change switches the formulation of these command-lines to use the existing `spm_shellEscaped` mechanism from TSC which is a robust way to achieve exactly the desired behavior: produce shell-escaped command-line arguments by detecting flags/arguments that contain characters that would prevent correct tokenization: whitespaces, etc, and only quote-escaping them, and doing so in a platform-appropriate manner (e.g. using `"` instead of `'` on Windows)

Resolves rdar://108971395