### PR TITLE
[5.9] Disable adding '-external-plugin-path' in integrated driver mode

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -376,6 +376,7 @@ public final class DarwinToolchain: Toolchain {
     // Pass -external-plugin-path if the current toolchain is not a Xcode
     // default toolchain.
     if
+      !driver.integratedDriver,
       driver.isFrontendArgSupported(.externalPluginPath),
       let xcodeDir = try self.findCurrentSelectedXcodeDir(),
       try !self.executableDir.isDescendant(of: xcodeDir),

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6734,6 +6734,7 @@ final class SwiftDriverTests: XCTestCase {
 
     try withTemporaryDirectory { tmpDir in
       var driver = try Driver(args: ["swiftc", "-typecheck", "foo.swift"],
+                              integratedDriver: false,
                               compilerExecutableDir: tmpDir)
       guard driver.isFrontendArgSupported(.externalPluginPath) else {
         return
@@ -6773,6 +6774,27 @@ final class SwiftDriverTests: XCTestCase {
       default:
         XCTFail("invalid arg type after '-external-plugin-path'")
       }
+    }
+  }
+
+  func testExternalPluginPathsDisabled() throws {
+#if !os(macOS)
+    throw XCTSkip("Supported only in macOS")
+#endif
+
+    try withTemporaryDirectory { tmpDir in
+      var driver = try Driver(args: ["swiftc", "-typecheck", "foo.swift"],
+                              integratedDriver: true,
+                              compilerExecutableDir: tmpDir)
+      guard driver.isFrontendArgSupported(.externalPluginPath) else {
+        return
+      }
+
+      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(jobs.count, 1)
+      let job = jobs.first!
+
+      XCTAssertFalse(job.commandLine.contains(.flag("-external-plugin-path")))
     }
   }
 


### PR DESCRIPTION
Cherry-pick #1356 into `release/5.9`

**Explanation**: Detecting if `-external-plugin-path` should be added or not is not reliable in "integrated driver" mode. In such cases the user should manually add them. This change just disable adding `-external-plugin-path` if `Driver.integratedDriver` is true.
**Scope**: Frontend arguments
**Risk**: Low. This just disabled a newly added functionality depending on the condition
**Testing**: Added a regression test case to verify `-external-plugin-path` is added automatically if the flag is on.
**Issue**: rdar://109060298
**Reviewer**: Artem Chikin (@artemcm )