### PR TITLE
Revert "[Macros] Set -external-plugin-path when the toolchain is not Xcode"

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -275,10 +275,6 @@ extension Driver {
       commandLine.appendPath(localPluginPath)
     }
 
-    if isFrontendArgSupported(.externalPluginPath) {
-      try commandLine.appendAll(.externalPluginPath, from: &parsedOptions)
-    }
-
     if isFrontendArgSupported(.blockListFile) {
       try Driver.findBlocklists(RelativeTo: try toolchain.executableDir).forEach {
         commandLine.appendFlag(.blockListFile)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -275,6 +275,10 @@ extension Driver {
       commandLine.appendPath(localPluginPath)
     }
 
+    if isFrontendArgSupported(.externalPluginPath) {
+      try commandLine.appendAll(.externalPluginPath, from: &parsedOptions)
+    }
+
     if isFrontendArgSupported(.blockListFile) {
       try Driver.findBlocklists(RelativeTo: try toolchain.executableDir).forEach {
         commandLine.appendFlag(.blockListFile)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -376,7 +376,6 @@ public final class DarwinToolchain: Toolchain {
     // Pass -external-plugin-path if the current toolchain is not a Xcode
     // default toolchain.
     if
-      !driver.integratedDriver,
       driver.isFrontendArgSupported(.externalPluginPath),
       let xcodeDir = try self.findCurrentSelectedXcodeDir(),
       try !self.executableDir.isDescendant(of: xcodeDir),

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -373,32 +373,6 @@ public final class DarwinToolchain: Toolchain {
     frontendTargetInfo: FrontendTargetInfo,
     driver: inout Driver
   ) throws {
-    // Pass -external-plugin-path if the current toolchain is not a Xcode
-    // default toolchain.
-    if
-      driver.isFrontendArgSupported(.externalPluginPath),
-      let xcodeDir = try self.findCurrentSelectedXcodeDir(),
-      try !self.executableDir.isDescendant(of: xcodeDir),
-      let xcodeExecutableDir = try self.findXcodeExecutableDir()
-    {
-      let xcodePluginServerPath = xcodeExecutableDir
-        .appending(component: "swift-plugin-server")
-
-      if fileSystem.isExecutableFile(xcodePluginServerPath) {
-        let xcodeToolchainUsrPath = xcodeExecutableDir.parentDirectory
-
-        let xcodePluginPath = xcodeToolchainUsrPath
-          .appending(components: "lib", "swift", "host", "plugins")
-        commandLine.appendFlag(.externalPluginPath)
-        commandLine.appendFlag(xcodePluginPath.pathString + "#" + xcodePluginServerPath.pathString)
-
-        let xcodeLocalPluginPath = xcodeToolchainUsrPath
-          .appending(components: "local", "lib", "swift", "host", "plugins")
-        commandLine.appendFlag(.externalPluginPath)
-        commandLine.appendFlag(xcodeLocalPluginPath.pathString + "#" + xcodePluginServerPath.pathString)
-      }
-    }
-
     guard let sdkPath = frontendTargetInfo.sdkPath?.path,
           let sdkInfo = getTargetSDKInfo(sdkPath: sdkPath) else { return }
 
@@ -465,40 +439,5 @@ private extension Version {
       return "\(major).\(minor)"
     }
     return self.description
-  }
-}
-
-extension DarwinToolchain {
-  func findXcodeExecutableDir() throws -> AbsolutePath? {
-#if os(macOS)
-    let result = try executor.checkNonZeroExit(
-      args: "xcrun", "-toolchain", "default", "-f", "swiftc",
-      environment: env
-    ).trimmingCharacters(in: .whitespacesAndNewlines)
-
-    guard !result.isEmpty else {
-      return nil
-    }
-    return try AbsolutePath(validating: result)
-      .parentDirectory // swiftc
-#else
-    return nil
-#endif
-  }
-
-  func findCurrentSelectedXcodeDir() throws -> AbsolutePath? {
-#if os(macOS)
-    let result = try executor.checkNonZeroExit(
-      args: "xcode-select", "-p",
-      environment: env
-    ).trimmingCharacters(in: .whitespacesAndNewlines)
-
-    guard !result.isEmpty else {
-      return nil
-    }
-    return try AbsolutePath(validating: result)
-#else
-    return nil
-#endif
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6769,55 +6769,6 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertTrue(job.commandLine.contains(.path(.absolute(try driver.toolchain.executableDir.parentDirectory.appending(components: "local", "lib", "swift", "host", "plugins")))))
   }
 
-  func testExternalPluginPaths() throws {
-#if !os(macOS)
-    throw XCTSkip("Supported only in macOS")
-#endif
-
-    try withTemporaryDirectory { tmpDir in
-      var driver = try Driver(args: ["swiftc", "-typecheck", "foo.swift"],
-                              compilerExecutableDir: tmpDir)
-      guard driver.isFrontendArgSupported(.externalPluginPath) else {
-        return
-      }
-
-      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
-      XCTAssertEqual(jobs.count, 1)
-      let job = jobs.first!
-
-      // This happens only Xcode toolchain has 'swift-plugin-server' which we
-      // don't know.
-      let idx1 = job.commandLine.firstIndex(of: .flag("-external-plugin-path"))
-      try XCTSkipIf(idx1 == nil)
-      switch job.commandLine[job.commandLine.index(after: idx1!)] {
-      case .flag(let value):
-        let components = value.split(separator: "#")
-        if components.count == 2 {
-          XCTAssertTrue(components[0].hasSuffix("/usr/lib/swift/host/plugins"))
-          XCTAssertTrue(components[1].hasSuffix("/usr/bin/swift-plugin-server"))
-        } else {
-          XCTFail("# separated count must 2")
-        }
-      default:
-        XCTFail("invalid arg type after '-external-plugin-path'")
-      }
-
-      let idx2 = job.commandLine[job.commandLine.index(after: idx1!)...].firstIndex(of: .flag("-external-plugin-path"))
-      switch job.commandLine[job.commandLine.index(after: try XCTUnwrap(idx2))] {
-      case .flag(let value):
-        let components = value.split(separator: "#")
-        if (components.count == 2) {
-          XCTAssertTrue(components[0].hasSuffix("/usr/local/lib/swift/host/plugins"))
-          XCTAssertTrue(components[1].hasSuffix("/usr/bin/swift-plugin-server"))
-        } else {
-          XCTFail("# separated count must 2")
-        }
-      default:
-        XCTFail("invalid arg type after '-external-plugin-path'")
-      }
-    }
-  }
-
   func testClangModuleValidateOnce() throws {
     let flagTest = try Driver(args: ["swiftc", "-typecheck", "foo.swift"])
     guard flagTest.isFrontendArgSupported(.clangBuildSessionFile),

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6776,7 +6776,6 @@ final class SwiftDriverTests: XCTestCase {
 
     try withTemporaryDirectory { tmpDir in
       var driver = try Driver(args: ["swiftc", "-typecheck", "foo.swift"],
-                              integratedDriver: false,
                               compilerExecutableDir: tmpDir)
       guard driver.isFrontendArgSupported(.externalPluginPath) else {
         return
@@ -6816,27 +6815,6 @@ final class SwiftDriverTests: XCTestCase {
       default:
         XCTFail("invalid arg type after '-external-plugin-path'")
       }
-    }
-  }
-
-  func testExternalPluginPathsDisabled() throws {
-#if !os(macOS)
-    throw XCTSkip("Supported only in macOS")
-#endif
-
-    try withTemporaryDirectory { tmpDir in
-      var driver = try Driver(args: ["swiftc", "-typecheck", "foo.swift"],
-                              integratedDriver: true,
-                              compilerExecutableDir: tmpDir)
-      guard driver.isFrontendArgSupported(.externalPluginPath) else {
-        return
-      }
-
-      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
-      XCTAssertEqual(jobs.count, 1)
-      let job = jobs.first!
-
-      XCTAssertFalse(job.commandLine.contains(.flag("-external-plugin-path")))
     }
   }
 

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -23,8 +23,7 @@ extension Driver {
     env: [String: String] = ProcessEnv.vars,
     diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
     fileSystem: FileSystem = localFileSystem,
-    integratedDriver: Bool = true,
-    compilerExecutableDir: AbsolutePath? = nil
+    integratedDriver: Bool = true
   ) throws {
     let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
                                        processSet: ProcessSet(),
@@ -35,8 +34,7 @@ extension Driver {
                   diagnosticsOutput: .engine(diagnosticsEngine),
                   fileSystem: fileSystem,
                   executor: executor,
-                  integratedDriver: integratedDriver,
-                  compilerExecutableDir: compilerExecutableDir)
+                  integratedDriver: integratedDriver)
   }
 
   /// For tests that need to set the sdk path.


### PR DESCRIPTION
Revert #1320 and #1356 . Doing this in Driver was not a good idea.