### PR TITLE
Add support for compatibility shims that we don't want to -force-load

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -77,6 +77,7 @@ public struct FrontendTargetInfo: Codable {
 
     let libraryName: String
     let filter: Filter
+    let forceLoad: Bool?
   }
 
   struct Target: Codable {

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -100,11 +100,13 @@ extension DarwinToolchain {
 
     // Link compatibility libraries, if we're deploying back to OSes that
     // have an older Swift runtime.
-    func addArgsForBackDeployLib(_ libName: String) throws {
+    func addArgsForBackDeployLib(_ libName: String, forceLoad: Bool) throws {
       let backDeployLibPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
         .appending(components: targetTriple.platformName() ?? "", libName)
       if try fileSystem.exists(backDeployLibPath) {
-        commandLine.append(.flag("-force_load"))
+        if forceLoad {
+          commandLine.append(.flag("-force_load"))
+        }
         commandLine.appendPath(backDeployLibPath)
       }
     }
@@ -121,7 +123,9 @@ extension DarwinToolchain {
       }
 
       if shouldLink {
-        try addArgsForBackDeployLib("lib" + compatibilityLib.libraryName + ".a")
+        // Old frontends don't set forceLoad at all; assume it's true in that case
+        try addArgsForBackDeployLib("lib" + compatibilityLib.libraryName + ".a",
+                                    forceLoad: compatibilityLib.forceLoad ?? true)
       }
     }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2262,10 +2262,12 @@ final class SwiftDriverTests: XCTestCase {
       let path5_0iOS = path.appending(components: "iphoneos", "libswiftCompatibility50.a")
       let path5_1iOS = path.appending(components: "iphoneos", "libswiftCompatibility51.a")
       let pathDynamicReplacementsiOS = path.appending(components: "iphoneos", "libswiftCompatibilityDynamicReplacements.a")
+      let pathCompatibilityPacksMac = path.appending(components: "macosx", "libswiftCompatibilityPacks.a")
 
       for compatibilityLibPath in [path5_0Mac, path5_1Mac,
                                    pathDynamicReplacementsMac, path5_0iOS,
-                                   path5_1iOS, pathDynamicReplacementsiOS] {
+                                   path5_1iOS, pathDynamicReplacementsiOS,
+                                   pathCompatibilityPacksMac] {
         try localFileSystem.writeFileContents(compatibilityLibPath) { $0 <<< "Empty" }
       }
       let commonArgs = ["swiftc", "foo.swift", "bar.swift",  "-module-name", "Test", "-resource-dir", path.pathString]
@@ -2282,6 +2284,9 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_0Mac))]))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_1Mac))]))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathDynamicReplacementsMac))]))
+
+        XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathCompatibilityPacksMac))]))
+        XCTAssertTrue(cmd.contains(subsequence: [.path(.absolute(pathCompatibilityPacksMac))]))
       }
 
       do {
@@ -2296,6 +2301,9 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_0Mac))]))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_1Mac))]))
         XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathDynamicReplacementsMac))]))
+
+        XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathCompatibilityPacksMac))]))
+        XCTAssertTrue(cmd.contains(subsequence: [.path(.absolute(pathCompatibilityPacksMac))]))
       }
 
       do {
@@ -2310,6 +2318,9 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_0Mac))]))
         XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_1Mac))]))
         XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathDynamicReplacementsMac))]))
+
+        XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathCompatibilityPacksMac))]))
+        XCTAssertTrue(cmd.contains(subsequence: [.path(.absolute(pathCompatibilityPacksMac))]))
       }
 
       do {
@@ -2324,6 +2335,9 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_0Mac))]))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(path5_1Mac))]))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathDynamicReplacementsMac))]))
+
+        XCTAssertFalse(cmd.contains(subsequence: [.flag("-force_load"), .path(.absolute(pathCompatibilityPacksMac))]))
+        XCTAssertTrue(cmd.contains(subsequence: [.path(.absolute(pathCompatibilityPacksMac))]))
       }
 
       do {


### PR DESCRIPTION
The CompatibilityPacks shim doesn't install any override hooks; it just exports a pair of symbols. We don't want to link the shim if we're not using the symbols.

This is part of https://github.com/apple/swift/pull/65884.