### PR TITLE
[5.9 🍒] Fixes to WMO invocations without `.swift` input files

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -572,7 +572,10 @@ extension Driver {
         // To match the legacy driver behavior, make sure we add the first input file
         // to the output file map if compiling without primary inputs (WMO), even
         // if there aren't any corresponding outputs.
-        entries[inputFiles[0].fileHandle] = [:]
+        guard let firstSourceInputHandle = inputFiles.first(where:{ $0.type == .swift })?.fileHandle  else {
+          fatalError("Formulating swift-frontend invocation without any input .swift files")
+        }
+        entries[firstSourceInputHandle] = [:]
       }
 
       for flaggedPair in flaggedInputOutputPairs {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -328,11 +328,11 @@ extension Driver {
     addJobOutputs: ([TypedVirtualPath]) -> Void,
     emitModuleTrace: Bool
   ) throws -> Job? {
-    guard case .singleCompile = compilerMode
+    guard case .singleCompile = compilerMode,
+          inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation })
     else { return nil }
 
-    if parsedOptions.hasArgument(.embedBitcode),
-       inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation }) {
+    if parsedOptions.hasArgument(.embedBitcode) {
       let compile = try compileJob(primaryInputs: [],
                                    outputType: .llvmBitcode,
                                    addJobOutputs: addJobOutputs,

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -329,10 +329,11 @@ extension Driver {
     emitModuleTrace: Bool
   ) throws -> Job? {
     guard case .singleCompile = compilerMode,
-          inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation })
+          inputFiles.contains(where: { $0.type.isPartOfSwiftCompilation })
     else { return nil }
 
-    if parsedOptions.hasArgument(.embedBitcode) {
+    if parsedOptions.hasArgument(.embedBitcode),
+       inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation }) {
       let compile = try compileJob(primaryInputs: [],
                                    outputType: .llvmBitcode,
                                    addJobOutputs: addJobOutputs,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2824,6 +2824,27 @@ final class SwiftDriverTests: XCTestCase {
     
   }
 
+  func testWMOWithNonSourceInput() throws {
+    var driver1 = try Driver(args: [
+      "swiftc", "-whole-module-optimization", "danger.o", "foo.swift", "bar.swift", "wibble.swift", "-module-name", "Test",
+      "-driver-filelist-threshold=0"
+    ])
+    let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
+    XCTAssertEqual(plannedJobs.count, 2)
+    let compileJob = plannedJobs[0]
+    XCTAssertEqual(compileJob.kind, .compile)
+    XCTAssert(compileJob.commandLine.contains(.flag("-supplementary-output-file-map")))
+    let argIdx = try XCTUnwrap(compileJob.commandLine.firstIndex(where: { $0 == .flag("-supplementary-output-file-map") }))
+    let supplOutputs = compileJob.commandLine[argIdx+1]
+    guard case let .path(path) = supplOutputs,
+          case let .fileList(_, fileList) = path,
+          case let .outputFileMap(outFileMap) = fileList else {
+      throw StringError("Unexpected argument for output file map")
+    }
+    let firstKey: String = try VirtualPath.lookup(XCTUnwrap(outFileMap.entries.keys.first)).description
+    XCTAssertEqual(firstKey, "foo.swift")
+  }
+
   func testDashDashPassingDownInput() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-module-name=ThisModule", "-wmo", "-num-threads", "4", "-emit-module", "-o", "test.swiftmodule", "--", "main.swift", "multi-threaded.swift"])

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2875,6 +2875,15 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testWMOWithJustObjectInputs() throws {
+    var driver = try Driver(args: [
+      "swiftc", "-wmo", "foo.o", "bar.o"
+    ])
+    let plannedJobs = try driver.planBuild()
+    XCTAssertEqual(plannedJobs.count, 1)
+    XCTAssertEqual(plannedJobs.first?.kind, .link)
+  }
+
   func testModuleAliasingWithImplicitBuild() throws {
     var driver = try Driver(args: [
       "swiftc", "foo.swift", "-module-name", "Foo", "-module-alias", "Car=Bar",


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-driver/pull/1347 and https://github.com/apple/swift-driver/pull/1350
---------------------------------------------------
• **Release**: Swift 5.9
• **Explanation**: Invoking the driver (`swiftc`) in WMO mode with a collection of object file inputs crashes the driver. The expectation is that, in the absence of `.swift` inputs, the driver will simply invoke the linker to produce a binary of a desired kind. Instead, the driver crashes. 
• **Scope of Issue**: Command-line `swiftc` users who wish to use it to link stuff, or `swiftc` command-line generators who might do the same, e.g. CMake.
• **Origination**: A long-standing driver bug (even affects the legacy C++ driver...)
• **Risk**: Risk of this change is very low. It ensures the driver carefully checks what kinds of inputs it is dealing with instead of indiscriminately assuming it is fed `.swift` files. And now instead of crashing, it does the right thing.
• **Reviewed By**: @etcwilde 
• **Automated Testing**: Tests added to the driver test suite
• **Dependencies**: Are there any submission dependencies this change needs?

Resolves rdar://108057797 