### PR TITLE
[Dependency Scanning] Add support for Swift Overlay dependencies as a separate dependency details field

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -122,6 +122,8 @@ typedef struct {
   (*swiftscan_swift_textual_detail_get_context_hash)(swiftscan_module_details_t);
   bool
   (*swiftscan_swift_textual_detail_get_is_framework)(swiftscan_module_details_t);
+  swiftscan_string_set_t *
+  (*swiftscan_swift_textual_detail_get_swift_overlay_dependencies)(swiftscan_module_details_t);
 
   //=== Swift Binary Module Details query APIs ------------------------------===//
   swiftscan_string_ref_t

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -124,7 +124,6 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     }
     for moduleId in swiftDependencies {
       let moduleInfo = try dependencyGraph.moduleInfo(of: moduleId)
-      let pcmArgs = try dependencyGraph.swiftModulePCMArgs(of: moduleId)
       var inputs: [TypedVirtualPath] = []
       let outputs: [TypedVirtualPath] = [
         TypedVirtualPath(file: moduleInfo.modulePath.path, type: .swiftModule)

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -79,7 +79,9 @@ extension ModuleDependencyId: Codable {
 /// Bridging header
 public struct BridgingHeader: Codable {
   var path: TextualVirtualPath
+  /// The source files referenced by the bridging header.
   var sourceFiles: [TextualVirtualPath]
+  /// Modules that the bridging header specifically depends on
   var moduleDependencies: [String]
 }
 
@@ -92,13 +94,16 @@ public struct SwiftModuleDetails: Codable {
   public var compiledModuleCandidates: [TextualVirtualPath]?
 
   /// The bridging header, if any.
-  public var bridgingHeaderPath: TextualVirtualPath?
-
-  /// The source files referenced by the bridging header.
-  public var bridgingSourceFiles: [TextualVirtualPath]? = []
-
-  /// Modules that the bridging header specifically depends on
-  public var bridgingHeaderDependencies: [ModuleDependencyId]? = []
+  public var bridgingHeader: BridgingHeader?
+  public var bridgingHeaderPath: TextualVirtualPath? {
+    bridgingHeader?.path
+  }
+  public var bridgingSourceFiles: [TextualVirtualPath]? {
+    bridgingHeader?.sourceFiles
+  }
+  public var bridgingHeaderDependencies: [ModuleDependencyId]? {
+    bridgingHeader?.moduleDependencies.map { .clang($0) }
+  }
 
   /// Options to the compile command
   public var commandLine: [String]? = []
@@ -115,6 +120,9 @@ public struct SwiftModuleDetails: Codable {
 
   /// A flag to indicate whether or not this module is a framework.
   public var isFramework: Bool?
+
+  /// A set of Swift Overlays of Clang Module Dependencies
+  var swiftOverlayDependencies: [ModuleDependencyId]?
 }
 
 /// Details specific to Swift placeholder dependencies.

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -263,6 +263,10 @@ internal extension swiftscan_diagnostic_severity_t {
   func resetScannerCache() {
     api.swiftscan_scanner_cache_reset(scanner)
   }
+
+  @_spi(Testing) public func supportsSeparateSwiftOverlayDependencies() -> Bool {
+    return api.swiftscan_swift_textual_detail_get_swift_overlay_dependencies != nil
+  }
   
   @_spi(Testing) public func supportsScannerDiagnostics() -> Bool {
     return api.swiftscan_scanner_diagnostics_query != nil &&
@@ -418,6 +422,10 @@ private extension swiftscan_functions_t {
     // isFramework on binary module dependencies
     self.swiftscan_swift_binary_detail_get_is_framework =
       try loadOptional("swiftscan_swift_binary_detail_get_is_framework")
+
+    // Swift Overlay Dependencies
+    self.swiftscan_swift_textual_detail_get_swift_overlay_dependencies =
+      try loadOptional("swiftscan_swift_textual_detail_get_swift_overlay_dependencies")
 
     // MARK: Required Methods
     func loadRequired<T>(_ symbol: String) throws -> T {


### PR DESCRIPTION
Instead of assuming such dependencies are contained in the 'directDependencies' field of the module info, support querying them from a details of a textual module.

Adds support for dependency scanner changes added in:
https://github.com/apple/swift/pull/66031