### PR TITLE
Package.swift: fix deprecated dependency initializers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         "SwiftOptions",
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         "CSwiftScan",
-        .product(name: "Yams", package: "Yams"),
+        .product(name: "Yams", package: "yams"),
       ],
       exclude: ["CMakeLists.txt"]),
 
@@ -137,7 +137,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", .branch("main")),
+            .package(url: "https://github.com/apple/swift-llbuild.git", branch: "main"),
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "swift-llbuild"),
@@ -156,7 +156,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: "main"),
     .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "5.0.0")),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
@@ -166,7 +166,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
 } else {
     package.dependencies += [
         .package(path: "../swift-tools-support-core"),
-        .package(name: "Yams", path: "../yams"),
+        .package(path: "../yams"),
         .package(path: "../swift-argument-parser"),
     ]
 }


### PR DESCRIPTION
Package dependency initializer overload with a `name:` argument was deprecated in recent versions of SwiftPM. Let's replace it with a non-deprecated version to fix the dependency warning.