### PR TITLE
Allow unicode chars in package-name in driver

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -698,11 +698,12 @@ public struct Driver {
     // Compute debug information output.
     self.debugInfo = Self.computeDebugInfo(&parsedOptions, diagnosticsEngine: diagnosticEngine)
 
-    // Validate package name; if package name is nil, it will be checked
-    // in the frontend during type check on `package` symbols
+    // Error if package-name is passed but the input is empty; if
+    // package-name is not passed but `package` decls exist, error
+    // will occur during the frontend type check.
     self.packageName = parsedOptions.getLastArgument(.packageName)?.asSingle
-    if let packageName = packageName, !packageName.sd_isSwiftIdentifier {
-      diagnosticsEngine.emit(.error_bad_package_name(packageName))
+    if let packageName = packageName, packageName.isEmpty {
+      diagnosticsEngine.emit(.error_empty_package_name)
     }
 
     // Determine the module we're building and whether/how the module file itself will be emitted.

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -123,11 +123,8 @@ extension Diagnostic.Message {
     return .error("bad module alias \"\(arg)\"")
   }
 
-  static func error_bad_package_name(_ packageName: String) -> Diagnostic.Message {
-    if packageName.isEmpty {
-      return .error("package name is empty; pass a non-empty string or remove \'-package-name\'")
-    }
-    return .error("package name \"\(packageName)\" is not a valid identifier")
+  static var error_empty_package_name: Diagnostic.Message {
+    return .error("package-name is empty")
   }
 
   static var error_hermetic_seal_cannot_have_library_evolution: Diagnostic.Message {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -690,25 +690,26 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testPackageNameFlag() throws {
-    // -package-name mypkg (valid string)
-    try assertNoDriverDiagnostics(args: "swiftc", "file.swift", "bar.swift", "-module-name", "MyModule", "-package-name", "mypkg", "-emit-module", "-emit-module-path", "../../path/to/MyModule.swiftmodule") { driver in
-      XCTAssertEqual(driver.packageName, "mypkg")
+    // -package-name com.perf.my-pkg (valid string)
+    try assertNoDriverDiagnostics(args: "swiftc", "file.swift", "bar.swift", "-module-name", "MyModule", "-package-name", "com.perf.my-pkg", "-emit-module", "-emit-module-path", "../../path/to/MyModule.swiftmodule") { driver in
+      XCTAssertEqual(driver.packageName, "com.perf.my-pkg")
       XCTAssertEqual(driver.moduleOutputInfo.output, .topLevel(try VirtualPath.intern(path: "../../path/to/MyModule.swiftmodule")))
     }
 
-    // -package-name is not passed
+    // -package-name is not passed and file doesn't contain `package` decls; should pass
     try assertNoDriverDiagnostics(args: "swiftc", "file.swift") { driver in
       XCTAssertNil(driver.packageName)
       XCTAssertEqual(driver.moduleOutputInfo.name, "file")
     }
-  }
 
-  func testPackageNameDiags() throws {
-    try assertDriverDiagnostics(args: ["swiftc", "file.swift", "-package-name", ""]) {
-      $1.expect(.error("package name is empty; pass a non-empty string or remove \'-package-name\'"))
+    // -package-name 123a!@#$ (valid string)
+    try assertNoDriverDiagnostics(args: "swiftc", "file.swift", "-module-name", "Foo", "-package-name", "123a!@#$") { driver in
+      XCTAssertEqual(driver.packageName, "123a!@#$")
     }
-    try assertDriverDiagnostics(args: ["swiftc", "file.swift", "-module-name", "Foo", "-package-name", "123a!@#$"]) {
-      $1.expect(.error("package name \"123a!@#$\" is not a valid identifier"))
+
+    // -package-name input is an empty string
+    try assertDriverDiagnostics(args: "swiftc", "file.swift", "-package-name", "") {
+      $1.expect(.error("package-name is empty"))
     }
   }
 


### PR DESCRIPTION
Frontend allows unicode chars in package-name. This PR follows the same rule in the driver for consistency.
Resolves rdar://110021211