### PR TITLE
Formatting: remove trailing whitespaces

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -98,7 +98,7 @@ typedef struct {
   (*swiftscan_module_info_get_direct_dependencies)(swiftscan_dependency_info_t);
   swiftscan_module_details_t
   (*swiftscan_module_info_get_details)(swiftscan_dependency_info_t);
-  
+
   //=== Dependency Module Info Details Functions ----------------------------===//
   swiftscan_dependency_info_kind_t
   (*swiftscan_module_detail_get_kind)(swiftscan_module_details_t);
@@ -222,7 +222,7 @@ typedef struct {
   swiftscan_string_set_t *
   (*swiftscan_compiler_supported_features_query)(void);
 
-  //=== Scanner Functions ---------------------------------------------------===//  
+  //=== Scanner Functions ---------------------------------------------------===//
   swiftscan_scanner_t (*swiftscan_scanner_create)(void);
   void (*swiftscan_scanner_dispose)(swiftscan_scanner_t);
   swiftscan_dependency_graph_t
@@ -233,7 +233,7 @@ typedef struct {
                                         swiftscan_scan_invocation_t);
   swiftscan_import_set_t
   (*swiftscan_import_set_create)(swiftscan_scanner_t, swiftscan_scan_invocation_t);
-  
+
   //=== Scanner Diagnostics -------------------------------------------------===//
   swiftscan_diagnostic_set_t*
   (*swiftscan_scanner_diagnostics_query)(swiftscan_scanner_t);

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -259,10 +259,10 @@ public struct Driver {
   /// Only present when the driver will be writing the record.
   /// Only used for reading when compiling incrementally.
   @_spi(Testing) public let buildRecordInfo: BuildRecordInfo?
-  
+
   /// Whether to consider incremental compilation.
   let shouldAttemptIncrementalCompilation: Bool
-  
+
   /// Code & data for incremental compilation. Nil if not running in incremental mode.
   /// Set during planning because needs the jobs to look at outputs.
   @_spi(Testing) public private(set) var incrementalCompilationState: IncrementalCompilationState? = nil
@@ -292,7 +292,7 @@ public struct Driver {
 
   /// Path to the dependencies file.
   let dependenciesFilePath: VirtualPath.Handle?
-  
+
   /// Path to the references dependencies file.
   let referenceDependenciesPath: VirtualPath.Handle?
 
@@ -760,7 +760,7 @@ public struct Driver {
       targetInfo: frontendTargetInfo)
 
     Self.validateSanitizerAddressUseOdrIndicatorFlag(&parsedOptions, diagnosticEngine: diagnosticsEngine, addressSanitizerEnabled: enabledSanitizers.contains(.address))
-    
+
     Self.validateSanitizerRecoverArgValues(&parsedOptions, diagnosticEngine: diagnosticsEngine, enabledSanitizers: enabledSanitizers)
 
     Self.validateSanitizerCoverageArgs(&parsedOptions,
@@ -1595,7 +1595,7 @@ extension Driver {
       // Added for the sake of compatibility with the legacy driver.
       try? fileSystem.move(
         from: absPath, to: absPath.appending(component: absPath.basename + "~"))
-      
+
       guard let contents = buildRecord.encode(diagnosticEngine: diagnosticEngine) else {
         diagnosticEngine.emit(.warning_could_not_write_build_record(absPath))
         return
@@ -1952,7 +1952,7 @@ extension Driver {
       // FIXME: The object-file default is carried over from the existing
       // driver, but seems odd.
       let fileType = FileType(rawValue: fileExtension) ?? FileType.object
-      
+
       if fileType == .swift {
         let basename = inputFile.basename
         if let originalPath = swiftFiles[basename] {
@@ -1966,28 +1966,28 @@ extension Driver {
 
       return TypedVirtualPath(file: inputHandle, type: fileType)
     }
-    
+
     if parsedOptions.hasArgument(.e) {
       if let mainPath = swiftFiles["main.swift"] {
         diagnosticsEngine.emit(.error_two_files_same_name(basename: "main.swift", firstPath: mainPath, secondPath: "-e"))
         diagnosticsEngine.emit(.note_explain_two_files_same_name)
         throw ErrorDiagnostics.emitted
       }
-      
+
       try withTemporaryDirectory(dir: fileSystem.tempDirectory, removeTreeOnDeinit: false) { absPath in
         let filePath = VirtualPath.absolute(absPath.appending(component: "main.swift"))
-        
+
         try fileSystem.writeFileContents(filePath) { file in
           file <<< ###"#sourceLocation(file: "-e", line: 1)\###n"###
           for option in parsedOptions.arguments(for: .e) {
             file <<< option.argument.asSingle <<< "\n"
           }
         }
-        
+
         paths.append(TypedVirtualPath(file: filePath.intern(), type: .swift))
       }
     }
-    
+
     return paths
   }
 
@@ -2112,11 +2112,11 @@ extension Diagnostic.Message {
   static var warn_ignore_embed_bitcode_marker: Diagnostic.Message {
     .warning("ignoring -embed-bitcode-marker since no object file is being generated")
   }
-  
+
   static func error_two_files_same_name(basename: String, firstPath: String, secondPath: String) -> Diagnostic.Message {
     .error("filename \"\(basename)\" used twice: '\(firstPath)' and '\(secondPath)'")
   }
-  
+
   static var note_explain_two_files_same_name: Diagnostic.Message {
     .note("filenames are used to distinguish private declarations with the same name")
   }
@@ -2381,7 +2381,7 @@ extension Diagnostic.Message {
   static var verify_debug_info_requires_debug_option: Diagnostic.Message {
     .warning("ignoring '-verify-debug-info'; no debug info is being generated")
   }
-  
+
   static func warning_option_requires_sanitizer(currentOption: Option, currentOptionValue: String, sanitizerRequired: Sanitizer) -> Diagnostic.Message {
       .warning("option '\(currentOption.spelling)\(currentOptionValue)' has no effect when '\(sanitizerRequired)' sanitizer is disabled. Use \(Option.sanitizeEQ.spelling)\(sanitizerRequired) to enable the sanitizer")
   }
@@ -2562,7 +2562,7 @@ extension Driver {
       }
       return true
     }
-    
+
     var used = [""]
     for item in aliasArgs {
       let arg = item.argument.asSingle
@@ -2906,7 +2906,7 @@ extension Driver {
       }
     }
   }
-  
+
   private static func validateSanitizerAddressUseOdrIndicatorFlag(
     _ parsedOptions: inout ParsedOptions,
     diagnosticEngine: DiagnosticsEngine,
@@ -2917,7 +2917,7 @@ extension Driver {
         .warning_option_requires_sanitizer(currentOption: .sanitizeAddressUseOdrIndicator, currentOptionValue: "", sanitizerRequired: .address))
     }
   }
-  
+
   /// Validates the set of `-sanitize-recover={sanitizer}` arguments
   private static func validateSanitizerRecoverArgValues(
     _ parsedOptions: inout ParsedOptions,
@@ -2941,14 +2941,14 @@ extension Driver {
           .error_invalid_arg_value(arg: .sanitizeRecoverEQ, value: arg))
         continue
       }
-      
+
       // only -sanitize-recover=address is supported
       if sanitizer != .address {
         diagnosticEngine.emit(
           .error_unsupported_argument(argument: arg, option: .sanitizeRecoverEQ))
         continue
       }
-      
+
       if !enabledSanitizers.contains(sanitizer) {
         diagnosticEngine.emit(
           .warning_option_requires_sanitizer(currentOption: .sanitizeRecoverEQ, currentOptionValue: arg, sanitizerRequired: sanitizer))
@@ -3251,7 +3251,7 @@ extension Driver {
            outputType: type) {
       return singleOutputPath
     }
-    
+
     // Emit-module discovered dependencies are always specified as a single-output
     // file
     if type == .emitModuleDependencies,

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -198,7 +198,7 @@ public final class ArgsResolver {
     guard useResponseFiles != .disabled else {
       return false
     }
-    
+
     let forceResponseFiles = useResponseFiles == .forced
     if forceResponseFiles ||
       (job.supportsResponseFiles && !commandLineFitsWithinSystemLimits(path: resolvedArguments[0], args: resolvedArguments)) {

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -26,7 +26,7 @@ public protocol DriverExecutor {
   func execute(job: Job,
                forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath: TimePoint]) throws -> ProcessResult
-  
+
   /// Execute multiple jobs, tracking job status using the provided execution delegate.
   /// Pass in the `IncrementalCompilationState` to allow for incremental compilation.
   func execute(workload: DriverExecutorWorkload,
@@ -90,7 +90,7 @@ extension DriverExecutor {
     let result = try execute(job: job,
                              forceResponseFiles: forceResponseFiles,
                              recordedInputModificationDates: recordedInputModificationDates)
-    
+
     if (result.exitStatus != .terminated(code: EXIT_SUCCESS)) {
       let returnCode = Self.computeReturnCode(exitStatus: result.exitStatus)
       throw JobExecutionError.jobFailedWithNonzeroExitCode(returnCode, try result.utf8stderrOutput())
@@ -141,7 +141,7 @@ extension DriverExecutor {
 public protocol JobExecutionDelegate {
   /// Called when a job starts executing.
   func jobStarted(job: Job, arguments: [String], pid: Int)
-  
+
   /// Called when a job finished.
   func jobFinished(job: Job, result: ProcessResult, pid: Int)
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -306,7 +306,7 @@ internal extension InterModuleDependencyGraph {
 
 public struct InterModuleDependencyImports: Codable {
   public var imports: [String]
-  
+
   public init(imports: [String], moduleAliases: [String: String]? = nil) {
     var realImports = [String]()
     if let aliases = moduleAliases {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -129,14 +129,14 @@ public class InterModuleDependencyOracle {
     }
     return swiftScan.hasBinarySwiftModuleIsFramework
   }
-  
+
   @_spi(Testing) public func supportsScannerDiagnostics() throws -> Bool {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to reset scanner cache with no scanner instance.")
     }
     return swiftScan.supportsScannerDiagnostics()
   }
-  
+
   @_spi(Testing) public func getScannerDiagnostics() throws -> [ScannerDiagnosticPayload]? {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to reset scanner cache with no scanner instance.")

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -210,7 +210,7 @@ public extension Driver {
     let scannerJob = try dependencyScanningJob()
     let forceResponseFiles = parsedOptions.hasArgument(.driverForceResponseFiles)
     let dependencyGraph: InterModuleDependencyGraph
-    
+
     if parsedOptions.contains(.v) {
       let arguments: [String] = try executor.resolver.resolveArgumentList(for: scannerJob,
                                                                           useResponseFiles: .disabled)

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bits.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bits.swift
@@ -59,7 +59,7 @@ extension Bits {
     init(buffer: Bits) {
       self.buffer = buffer
     }
-    
+
     init(buffer: ByteString) {
       self.init(buffer: Bits(buffer: buffer))
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamWriter.swift
@@ -33,7 +33,7 @@
 ///
 /// Next, identify the kinds of records needed in the format and assign them
 /// unique, stable identifiers. For example:
-/// 
+///
 /// ```
 /// enum DiagnosticRecordID: UInt8 {
 ///     case version        = 1
@@ -525,7 +525,7 @@ extension BitstreamWriter {
             self.write(0 as UInt8, width: 8)
         }
     }
-    
+
 
     /// Writes the blockinfo block and allows emitting abbreviations
     /// and records in it.

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -29,7 +29,7 @@ public struct DependencyGraphDotFileWriter {
     let basename = file.file.basename
     write(sfdg, basename: basename, internedStringTable: internedStringTable)
   }
-  
+
   mutating func write(_ mdg: ModuleDependencyGraph) {
     write(mdg, basename: Self.moduleDependencyGraphBasename,
           internedStringTable: mdg.internedStringTable)

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -27,13 +27,13 @@ import Dispatch
       self.fileName = fileName
       self.fileNameString = fileName.lookup(in: t)
   }
-  
+
   static var dummy: Self {
     MockIncrementalCompilationSynchronizer.withInternedStringTable { t in
       return Self(fileName: ".".intern(in: t), t)
     }
   }
-  
+
   public static func ==(lhs: ExternalDependency, rhs: ExternalDependency) -> Bool {
     lhs.fileName == rhs.fileName
   }
@@ -381,16 +381,16 @@ public func isInIncreasingOrder(_ lhs: DependencyKey.Designator,
     let (.nominal(ln), .nominal(rn)),
     let (.potentialMember(ln), .potentialMember(rn)):
     return f(ln) < f(rn)
-    
+
   case let (.externalDepend(ld), .externalDepend(rd)):
     return ld < rd
-    
+
   case let (.member(lc, ln), .member(rc, rn)):
     return lc == rc ? f(ln) < f(rn) : f(lc) < f(rc)
-    
+
   default: break
   }
-  
+
   /// Preserves the ordering that obtained before interned strings were introduced.
   func kindOrdering(_ d: DependencyKey.Designator) -> Int {
     switch d {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationProtectedState.swift
@@ -23,7 +23,7 @@ extension IncrementalCompilationState {
     /// This state is modified during the incremental build. All accesses must
     /// be protected by the confinement queue.
     fileprivate var skippedCompileGroups: [TypedVirtualPath: CompileJobGroup]
-    
+
     /// Sadly, has to be `var` for formBatchedJobs
     ///
     /// After initialization, mutating accesses to the driver must be protected by
@@ -33,7 +33,7 @@ extension IncrementalCompilationState {
     /// The oracle for deciding what depends on what. Applies to this whole module.
     /// fileprivate in order to control concurrency.
     fileprivate let moduleDependencyGraph: ModuleDependencyGraph
-    
+
     fileprivate let reporter: Reporter?
 
     init(skippedCompileGroups: [TypedVirtualPath: CompileJobGroup],
@@ -46,7 +46,7 @@ extension IncrementalCompilationState {
     }
   }
 }
-  
+
 extension IncrementalCompilationState.ProtectedState: IncrementalCompilationSynchronizer {
   public var incrementalCompilationQueue: DispatchQueue {
     moduleDependencyGraph.incrementalCompilationQueue
@@ -63,7 +63,7 @@ extension IncrementalCompilationState.ProtectedState {
     return try collectUnbatchedJobsDiscoveredToBeNeededAfterFinishing(job: finishedJob)
       .map {try driver.formBatchedJobs($0, showJobLifecycle: driver.showJobLifecycle)}
   }
-  
+
   /// Remember a job (group) that is before a compile or a compile itself.
   /// `job` just finished. Update state, and return the skipped compile job (groups) that are now known to be needed.
   /// If no more compiles are needed, return nil.
@@ -75,7 +75,7 @@ extension IncrementalCompilationState.ProtectedState {
       let invalidatedInputs = collectInputsInvalidatedByRunning(finishedJob)
       assert(invalidatedInputs.isDisjoint(with: finishedJob.primarySwiftSourceFiles),
              "Primaries should not overlap secondaries.")
-      
+
       if let reporter = self.reporter {
         for input in invalidatedInputs {
           reporter.report(
@@ -84,7 +84,7 @@ extension IncrementalCompilationState.ProtectedState {
       }
       return try getUnbatchedJobs(for: invalidatedInputs)
     }
-  
+
   /// After `job` finished find out which inputs must compiled that were not known to need compilation before
   fileprivate mutating func collectInputsInvalidatedByRunning(_ job: Job)-> Set<SwiftSourceFile> {
     mutationSafetyPrecondition()
@@ -98,7 +98,7 @@ extension IncrementalCompilationState.ProtectedState {
     }
     .subtracting(job.primarySwiftSourceFiles) // have already compiled these
   }
-  
+
   // "Mutating" because it mutates the graph, which may be a struct someday
   fileprivate mutating func collectInputsInvalidated(
     byCompiling input: SwiftSourceFile
@@ -111,7 +111,7 @@ extension IncrementalCompilationState.ProtectedState {
       "Failed to read some dependencies source; compiling everything", input)
     return TransitivelyInvalidatedSwiftSourceFileSet(skippedCompileGroups.keys.swiftSourceFiles)
   }
-  
+
   /// Find the jobs that now must be run that were not originally known to be needed.
   fileprivate mutating func getUnbatchedJobs(
     for invalidatedInputs: Set<SwiftSourceFile>
@@ -132,7 +132,7 @@ extension IncrementalCompilationState.ProtectedState {
     }
   }
 }
-  
+
 
 // MARK: - After the build
 extension IncrementalCompilationState.ProtectedState {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -279,12 +279,12 @@ extension IncrementalCompilationState {
     public func report(_ message: String) {
       diagnosticEngine.emit(.remark_incremental_compilation(because: message))
     }
-    
+
     /// Entry point for ``ExternalIntegrand``
     func report(_ message: String, _ integrand: ModuleDependencyGraph.ExternalIntegrand) {
       report(message, integrand.externalDependency)
     }
-    
+
     func report(_ message: String, _ fed: FingerprintedExternalDependency) {
       report(message, fed.externalDependency)
     }
@@ -405,7 +405,7 @@ extension IncrementalCompilationState {
         buildRecord: buildRecord)
     }
   }
-  
+
   @_spi(Testing) public static func removeDependencyGraphFile(_ driver: Driver) {
     if let path = driver.buildRecordInfo?.dependencyGraphPath {
       try? driver.fileSystem.removeFileTree(path)

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -32,7 +32,7 @@ import SwiftOptions
 /// The public API surface of this class is thread safe, but not re-entrant.
 /// FIXME: This should be an actor.
 public final class IncrementalCompilationState {
-    
+
   /// State needed for incremental compilation that can change during a run and must be protected from
   /// concurrent mutation and access. Concurrent accesses are OK.
   private var protectedState: ProtectedState
@@ -43,7 +43,7 @@ public final class IncrementalCompilationState {
 
   /// Jobs to run *after* the last compile, for instance, link-editing.
   public let jobsAfterCompiles: [Job]
-  
+
   public let info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
 
   internal let upToDateInterModuleDependencyGraph: InterModuleDependencyGraph?
@@ -60,7 +60,7 @@ public final class IncrementalCompilationState {
       ? Reporter(diagnosticEngine: driver.diagnosticEngine,
                  outputFileMap: driver.outputFileMap)
       : nil
-    
+
     reporter?.reportOnIncrementalImports(
       initialState.incrementalOptions.contains(.enableCrossModuleIncrementalBuild))
 
@@ -80,14 +80,14 @@ public final class IncrementalCompilationState {
     self.mandatoryJobsInOrder = firstWave.mandatoryJobsInOrder
     self.jobsAfterCompiles = jobsInPhases.afterCompiles
   }
-  
+
   /// Allow concurrent access to while preventing mutation of ``IncrementalCompilationState/protectedState``
   public func blockingConcurrentMutationToProtectedState<R>(
     _ fn: (ProtectedState) throws -> R
   ) rethrows -> R {
     try blockingConcurrentMutation {try fn(protectedState)}
   }
-  
+
   /// Block any other threads from doing anything to  or observing `protectedState`.
   public func blockingConcurrentAccessOrMutationToProtectedState<R>(
     _ fn: (inout ProtectedState) throws -> R

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationSynchronizer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationSynchronizer.swift
@@ -25,7 +25,7 @@ extension IncrementalCompilationSynchronizer {
   func accessSafetyPrecondition() {
     incrementalCompilationQueue.accessSafetyPrecondition()
   }
-  
+
   @_spi(Testing) public func blockingConcurrentAccessOrMutation<T>( _ fn: () throws -> T ) rethrows -> T {
     try incrementalCompilationQueue.blockingConcurrentAccessOrMutation(fn)
   }
@@ -44,7 +44,7 @@ extension DispatchQueue {
   fileprivate func accessSafetyPrecondition() {
     dispatchPrecondition(condition: .onQueue(self))
   }
-  
+
   /// Block any concurrent access or muitation so that the argument may access or mutate the protected state.
   @_spi(Testing) public func blockingConcurrentAccessOrMutation<T>( _ fn: () throws -> T ) rethrows -> T {
     try sync(flags: .barrier, execute: fn)
@@ -58,17 +58,17 @@ extension DispatchQueue {
 /// A fixture for tests and dot file creation, etc., that require synchronization and  an ``InternedStringTable``
 public struct MockIncrementalCompilationSynchronizer: IncrementalCompilationSynchronizer {
   public let incrementalCompilationQueue: DispatchQueue
-  
+
   init() {
     self.incrementalCompilationQueue = DispatchQueue(label: "testing")
   }
-  
+
   func withInternedStringTable<R>(_ fn: (InternedStringTable) throws -> R) rethrows -> R {
     try blockingConcurrentAccessOrMutation {
       try fn(InternedStringTable(incrementalCompilationQueue))
     }
   }
-  
+
   public static func withInternedStringTable<R>(_ fn: (InternedStringTable) throws -> R) rethrows -> R {
     try Self().withInternedStringTable(fn)
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -228,7 +228,7 @@ extension IncrementalCompilationState {
     /// The state managing incremental compilation gets mutated every time a compilation job completes.
     /// This queue ensures that the access and mutation of that state is thread-safe.
     @_spi(Testing) public let incrementalCompilationQueue: DispatchQueue
-    
+
     @_spi(Testing) public let diagnosticEngine: DiagnosticsEngine
 
     /// Options, someday
@@ -302,7 +302,7 @@ extension IncrementalCompilationState {
         inputsInvalidatedByExternals: priors.fileSet,
         incrementalOptions: options)
     }
-    
+
     /// Is this source file part of this build?
     ///
     /// - Parameter sourceFile: the Swift source-code file in question

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -51,7 +51,7 @@ import struct Foundation.TimeInterval
   let creationPhase: Phase
 
   fileprivate var currencyCache: ExternalDependencyCurrencyCache
-  
+
   /// To speed all the node insertions and lookups, intern all the strings.
   /// Put them here because it matches the concurrency constraints; just as modifications to this graph
   /// are serialized, so must all the mods to this table be.
@@ -90,7 +90,7 @@ import struct Foundation.TimeInterval
               NodeFinder(),
               Set())
   }
-  
+
   public static func createFromPrior(
     _ buildRecord: BuildRecord,
     _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup,
@@ -105,7 +105,7 @@ import struct Foundation.TimeInterval
               nodeFinder,
               fingerprintedExternalDependencies)
   }
-  
+
   public static func createForBuildingFromSwiftDeps(
     _ buildRecord: BuildRecord,
     _ info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
@@ -263,7 +263,7 @@ extension ModuleDependencyGraph {
 
 // MARK: - Scheduling either wave
 extension ModuleDependencyGraph {
-  
+
   /// Given nodes that are invalidated, find all the affected inputs that must be recompiled.
   ///
   /// - Parameter nodes: A set of graph nodes for changed declarations.
@@ -450,13 +450,13 @@ extension ModuleDependencyGraph {
     return integrateIncrementalImport(of: integrand.externalDependency, whyIntegrate)
            ?? indiscriminatelyFindNodesInvalidated(by: integrand, .couldNotRead)
   }
-  
+
   /// In order to report what happened in a sensible order, reify the reason for indiscriminately invalidating.
   private enum WhyIndiscriminatelyInvalidate: CustomStringConvertible {
     case incrementalImportsIsDisabled
     case missingFingerprint
     case couldNotRead
-    
+
     var description: String {
       switch self {
       case .incrementalImportsIsDisabled: return "Incremental imports are disabled"
@@ -694,7 +694,7 @@ extension ModuleDependencyGraph {
     case bogusNameOrContext
     case unknownKind
     case unknownDependencySourceExtension
-    
+
     fileprivate init(forMalformed kind: RecordID) {
       switch kind {
       case .metadata:
@@ -765,9 +765,9 @@ extension ModuleDependencyGraph {
       /// `Array` supports the deserialization of the def-use links by mapping index to node.
       /// The optionality of the contents lets the ``ModuleDependencyGraph/isForRemovedInput`` check to be cached.
       public private(set) var potentiallyUsedNodes: [Node?] = []
-      
+
       private var nodeFinder = NodeFinder()
-      
+
       var incrementalCompilationQueue: DispatchQueue {
         info.incrementalCompilationQueue
       }
@@ -776,7 +776,7 @@ extension ModuleDependencyGraph {
         self.info = info
         self.internedStringTable = InternedStringTable(info.incrementalCompilationQueue)
       }
-      
+
       private var fileSystem: FileSystem {
         info.fileSystem
       }
@@ -831,7 +831,7 @@ extension ModuleDependencyGraph {
         assert(oldNode == nil,
                "Integrated the same node twice: \(oldNode!), \(newNode)")
       }
-      
+
       /// Determine whether (deserialized) node was for a definition in a source file that is no longer part of the build.
       ///
       /// If the priors were read from an invocation containing a subsequently removed input,
@@ -847,14 +847,14 @@ extension ModuleDependencyGraph {
         }
         return !info.isPartOfBuild(SwiftSourceFile(dependencySource.typedFile))
       }
-      
+
       mutating func visit(record: BitcodeElement.Record) throws {
         guard let kind = RecordID(rawValue: record.id) else {
           throw ReadError.unknownRecord
         }
-        
+
         var malformedError: ReadError {.init(forMalformed: kind)}
-        
+
         func stringIndex(field i: Int) throws -> Int {
           let u = record.fields[i]
           guard u < UInt64(internedStringTable.count) else {
@@ -1004,7 +1004,7 @@ extension ModuleDependencyGraph {
         }
       }
     }
-    
+
     var visitor = Visitor(info)
     try Bitcode.read(bytes: data, using: &visitor)
     guard let major = visitor.majorVersion,
@@ -1216,7 +1216,7 @@ extension ModuleDependencyGraph {
         // dependency name
         .vbr(chunkBitWidth: 13),
       ]
-      
+
       self.abbreviate(.metadata, [
         .literal(RecordID.metadata.rawValue),
         // Major version

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -20,20 +20,20 @@ public struct DependencySource: Hashable, CustomStringConvertible {
   public let typedFile: TypedVirtualPath
   /// Keep this for effiencient lookups into the ``ModuleDependencyGraph``
   public let internedFileName: InternedString
-  
+
   init(typedFile: TypedVirtualPath, internedFileName: InternedString) {
     assert( typedFile.type == .swift ||
             typedFile.type == .swiftModule)
     self.typedFile = typedFile
     self.internedFileName = internedFileName
   }
-  
+
   public init(_ swiftSourceFile: SwiftSourceFile, _ t: InternedStringTable) {
     let typedFile = swiftSourceFile.typedFile
     self.init(typedFile: typedFile,
               internedFileName: typedFile.file.name.intern(in: t))
   }
-  
+
   init?(ifAppropriateFor file: VirtualPath.Handle,
         internedString: InternedString) {
     let ext = VirtualPath.lookup(file).extension
@@ -53,7 +53,7 @@ public struct DependencySource: Hashable, CustomStringConvertible {
   public var description: String {
     typedFile.file.externalDependencyPathDescription
   }
-  
+
   public func hash(into hasher: inout Hasher) {
     hasher.combine(internedFileName)
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Integrator.swift
@@ -49,7 +49,7 @@ extension ModuleDependencyGraph {
       .findNodes(for: .known(dependencySource))
         ?? [:]
     }
-    
+
     var reporter: IncrementalCompilationState.Reporter? {
       destination.info.reporter
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InternedStrings.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/InternedStrings.swift
@@ -17,19 +17,19 @@ public protocol InternedStringTableHolder {
 }
 
 public struct InternedString: CustomStringConvertible, Equatable, Hashable {
-  
+
   let index: Int
-  
+
   fileprivate init(_ s: String, _ table: InternedStringTable) {
     self.init(index: s.isEmpty ? 0 : table.intern(s))
   }
-  
+
   private init(index: Int) {
     self.index = index
   }
-  
+
   public var isEmpty: Bool { index == 0 }
-    
+
   public static var empty: Self {
     let r = Self(index: 0)
     assert(r.isEmpty)
@@ -39,9 +39,9 @@ public struct InternedString: CustomStringConvertible, Equatable, Hashable {
   public func lookup(in holder: InternedStringTableHolder) -> String {
     holder.internedStringTable.strings[index]
   }
-  
+
   public var description: String { "<<\(index)>>" }
-  
+
   public func description(in holder: InternedStringTableHolder) -> String {
     "\(lookup(in: holder))\(description)"
   }
@@ -59,14 +59,14 @@ public func isInIncreasingOrder(
 public class InternedStringTable: IncrementalCompilationSynchronizer {
   /// Ensure accesses & mutations are thread-safe
   public let incrementalCompilationQueue: DispatchQueue
-  
+
   var strings = [""]
   fileprivate var indices = ["": 0]
-  
+
   public init(_ incrementalCompilationQueue: DispatchQueue) {
     self.incrementalCompilationQueue = incrementalCompilationQueue
   }
-  
+
   fileprivate func intern(_ s: String) -> Int {
     mutationSafetyPrecondition()
     if let i = indices[s] { return i }
@@ -75,12 +75,12 @@ public class InternedStringTable: IncrementalCompilationSynchronizer {
     indices[s] = i
     return i
   }
-  
+
   var count: Int {
     accessSafetyPrecondition()
     return strings.count
   }
-  
+
   func reserveCapacity(_ minimumCapacity: Int) {
     mutationSafetyPrecondition()
     strings.reserveCapacity(minimumCapacity)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -12,7 +12,7 @@
 
 // MARK: - ModuleDependencyGraph.Node
 extension ModuleDependencyGraph {
-  
+
   /// A node in the per-module (i.e. the driver) dependency graph
   /// Each node represents a `Decl` from the frontend.
   /// If a file references a `Decl` we haven't seen yet, the node's `dependencySource` will be nil,
@@ -44,7 +44,7 @@ extension ModuleDependencyGraph {
     /// will be set to `.unknown`.
     /// A node's definition location can move from file to file when the driver reads the result of a
     /// compilation.
- 
+
     @_spi(Testing) public let definitionLocation: DefinitionLocation
     /// When integrating a change, the driver finds untraced nodes so it can kick off jobs that have not been
     /// kicked off yet. (Within any one driver invocation, compiling a source file is idempotent.)
@@ -126,7 +126,7 @@ extension ModuleDependencyGraph.Node {
     verifyNodesithoutDefinitionLocationHasNoFingerprints()
     key.verify()
   }
-  
+
   public func verifyNodesithoutDefinitionLocationHasNoFingerprints() {
     if case .unknown = definitionLocation, fingerprint != nil {
       fatalError(#function)
@@ -142,7 +142,7 @@ extension ModuleDependencyGraph {
   /// always known. For example, it may be in a `swiftdeps` file yet to be read.
   public enum DefinitionLocation: Equatable, Hashable, Comparable {
     case unknown, known(DependencySource)
-    
+
     public static func <(lhs: Self, rhs: Self) -> Bool {
       switch (lhs, rhs) {
         case (.unknown, .unknown): return false
@@ -151,7 +151,7 @@ extension ModuleDependencyGraph {
         case let (.known(lh), .known(rh)): return lh < rh
       }
     }
-    
+
     /// A string explaining where the definition is.
     public var locationString: String {
       switch self {
@@ -159,7 +159,7 @@ extension ModuleDependencyGraph {
         case let .known(dependencySource): return "in \(dependencySource.description)"
       }
     }
-    
+
     /// The file holding the definition.
     public var internedFileNameIfAny: InternedString? {
       switch self {

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/NodeFinder.swift
@@ -18,11 +18,11 @@ extension ModuleDependencyGraph {
   /// Isolate in a sub-structure in order to facilitate invariant maintenance
   public struct NodeFinder {
     @_spi(Testing) public typealias Graph = ModuleDependencyGraph
-    
+
     /// Maps definition locations and DependencyKeys to Nodes
     fileprivate typealias NodeMap = TwoDMap<DefinitionLocation, DependencyKey, Node>
     fileprivate var nodeMap = NodeMap()
-    
+
     /// Since dependency keys use baseNames, they are coarser than individual
     /// decls. So two decls might map to the same key. Given a use, which is
     /// denoted by a node, the code needs to find the files to recompile. So, the
@@ -32,7 +32,7 @@ extension ModuleDependencyGraph {
     /// (In a given file, only one node exists with a given key, but in the future
     /// that would need to change if/when we can recompile a smaller unit than a
     /// source file.)
-    
+
     /// Tracks def-use relationships by DependencyKey.
     @_spi(Testing) public private(set) var usesByDef = Multidictionary<DependencyKey, Node>()
   }
@@ -41,7 +41,7 @@ extension ModuleDependencyGraph {
 
 extension ModuleDependencyGraph.NodeFinder {
   public typealias DefinitionLocation = ModuleDependencyGraph.DefinitionLocation
-  
+
   @_spi(Testing) public func findNode(_ mapKey: (DefinitionLocation, DependencyKey)) -> Graph.Node? {
     nodeMap[mapKey]
   }
@@ -49,7 +49,7 @@ extension ModuleDependencyGraph.NodeFinder {
     n.key.correspondingImplementation
       .flatMap {findNode((n.definitionLocation, $0))}
   }
-  
+
   @_spi(Testing) public func findNodes(for definitionLocation: DefinitionLocation)
   -> [DependencyKey: Graph.Node]? {
     nodeMap[definitionLocation]
@@ -97,7 +97,7 @@ extension ModuleDependencyGraph.NodeFinder {
       return k
     }
   }
-  
+
   func defsUsing(_ n: Graph.Node) -> Set<DependencyKey> {
     usesByDef.keysContainingValue(n)
   }
@@ -112,13 +112,13 @@ fileprivate extension ModuleDependencyGraph.Node {
 // MARK: - inserting
 
 extension ModuleDependencyGraph.NodeFinder {
-  
+
   /// Add `node` to the structure, return the old node if any at those coordinates.
   @discardableResult
   mutating func insert(_ n: Graph.Node) -> Graph.Node? {
     nodeMap.updateValue(n, forKey: n.mapKey)
   }
-  
+
   /// record def-use, return if is new use
   mutating func record(def: DependencyKey, use: Graph.Node) -> Bool {
     assert(verifyOKTODependUponSomeKey(use))
@@ -133,12 +133,12 @@ extension ModuleDependencyGraph.NodeFinder {
     removeUsings(of: nodeToErase)
     removeMapping(of: nodeToErase)
   }
-  
+
   private mutating func removeUsings(of nodeToNotUse: Graph.Node) {
     usesByDef.removeOccurrences(of: nodeToNotUse)
     assert(defsUsing(nodeToNotUse).isEmpty)
   }
-  
+
   private mutating func removeMapping(of nodeToNotMap: Graph.Node) {
     let old = nodeMap.removeValue(forKey: nodeToNotMap.mapKey)
     assert(old == nodeToNotMap, "Should have been there")
@@ -180,7 +180,7 @@ extension ModuleDependencyGraph.NodeFinder {
     verifyUsesByDef()
     return true
   }
-  
+
   private func verifyNodeMap() {
     var nodes = [Set<Graph.Node>(), Set<Graph.Node>()]
     nodeMap.verify {
@@ -191,7 +191,7 @@ extension ModuleDependencyGraph.NodeFinder {
       v.verify()
     }
   }
-  
+
   private func verifyUsesByDef() {
     usesByDef.forEach { someKey, nodesDependingUponKey in
       for nodeDependingUponKey in nodesDependingUponKey {
@@ -206,11 +206,11 @@ extension ModuleDependencyGraph.NodeFinder {
     verifyNodeCanBeFoundFromItsKey(n)
     return true
   }
-  
+
   private func verifyNodeCanBeFoundFromItsKey(_ n: Graph.Node) {
     precondition(findNode(n.mapKey) == n)
   }
-  
+
   @discardableResult
   private func verifyDependentNodeHasKnownDefinitionLocation(_ use: Graph.Node) -> Bool {
     guard case .unknown = use.definitionLocation else { return true }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Tracer.swift
@@ -63,27 +63,27 @@ extension ModuleDependencyGraph.Tracer {
     self.currentPathIfTracing = graph.info.reporter != nil ? [] : nil
     self.diagnosticEngine = diagnosticEngine
   }
-  
+
   private mutating func collectPreviouslyUntracedDependents() {
     for n in startingPoints {
       collectNextPreviouslyUntracedDependent(of: n)
     }
   }
-  
+
   private mutating func collectNextPreviouslyUntracedDependent(
     of definition: ModuleDependencyGraph.Node
   ) {
     guard definition.isUntraced else { return }
     definition.setTraced()
-    
+
     tracedUses.append(definition)
-    
+
     // If this node is merely used, but not defined anywhere, nothing else
     // can possibly depend upon it
     if case .unknown = definition.definitionLocation { return }
-    
+
     let pathLengthAfterArrival = traceArrival(at: definition);
-    
+
     // If this use also provides something, follow it
     for use in graph.nodeFinder.uses(of: definition) {
       collectNextPreviouslyUntracedDependent(of: use)
@@ -92,7 +92,7 @@ extension ModuleDependencyGraph.Tracer {
   }
 
 
-  
+
   private mutating func traceArrival(at visitedNode: ModuleDependencyGraph.Node
   ) -> Int {
     guard var currentPath = currentPathIfTracing else {

--- a/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Multidictionary.swift
@@ -16,7 +16,7 @@
 
   /// Reverse index used to make value removal more efficient.
   private var reverseIndex: Dictionary<Value, Set<Key>> = [:]
-  
+
   public typealias Element = (Key, Set<Value>)
   public typealias Index = Dictionary<Key, Set<Value>>.Index
 

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -16,7 +16,7 @@ import struct TSCBasic.ByteString
 /*@_spi(Testing)*/ public struct SourceFileDependencyGraph {
   public static let sourceFileProvidesInterfaceSequenceNumber: Int = 0
   public static let sourceFileProvidesImplementationSequenceNumber: Int = 1
-  
+
   public var majorVersion: UInt64
   public var minorVersion: UInt64
   public var compilerVersionString: String
@@ -27,17 +27,17 @@ import struct TSCBasic.ByteString
     (interface: allNodes[SourceFileDependencyGraph.sourceFileProvidesInterfaceSequenceNumber],
      implementation: allNodes[SourceFileDependencyGraph.sourceFileProvidesImplementationSequenceNumber])
   }
-  
+
   public func forEachNode(_ visit: (Node) -> Void) {
     allNodes.forEach(visit)
   }
-  
+
   public func forEachDefDependedUpon(by node: Node, _ doIt: (Node) -> Void) {
     for sequenceNumber in node.defsIDependUpon {
       doIt(allNodes[sequenceNumber])
     }
   }
-  
+
   public func forEachArc(_ doIt: (Node, Node) -> Void) {
     forEachNode { useNode in
       forEachDefDependedUpon(by: useNode) { defNode in
@@ -64,7 +64,7 @@ extension SourceFileDependencyGraph {
     public let sequenceNumber: Int
     public let defsIDependUpon: [Int]
     public let definitionVsUse: DefinitionVsUse
-    
+
     /*@_spi(Testing)*/ public init(
       key: DependencyKey,
       fingerprint: InternedString?,
@@ -77,10 +77,10 @@ extension SourceFileDependencyGraph {
       self.defsIDependUpon = defsIDependUpon
       self.definitionVsUse = definitionVsUse
     }
-    
+
     public func verify() {
       key.verify()
-      
+
       if case .sourceFileProvide = key.designator {
         switch key.aspect {
         case .interface:
@@ -113,7 +113,7 @@ extension SourceFileDependencyGraph {
     case dependsOnDefinitionNode
     case identifierNode
   }
-  
+
   fileprivate enum ReadError: Error {
     case badMagic
     case swiftModuleHasNoDependencies
@@ -142,7 +142,7 @@ extension SourceFileDependencyGraph {
   ) throws -> Self? {
     try self.init(contentsOf: typedFile, on: fileSystem, internedStringTable: internedStringTable)
   }
-  
+
   /*@_spi(Testing)*/ public init(nodesForTesting: [Node],
                                  internedStringTable: InternedStringTable) {
     majorVersion = 0
@@ -195,7 +195,7 @@ extension SourceFileDependencyGraph {
 
       private var nextSequenceNumber = 0
       private var identifiers: [InternedString] // The empty string is hardcoded as identifiers[0]
-      
+
       func validate(signature: Bitcode.Signature) throws {
         if extractFromSwiftModule {
           guard signature == .init(value: 0x0EA89CE2) else { throw ReadError.swiftModuleHasNoDependencies }
@@ -338,7 +338,7 @@ fileprivate extension DependencyKey.Designator {
                   name: name.intern(in: internedStringTable),
                   internedStringTable: internedStringTable)
   }
-    
+
   init(kindCode: UInt64,
        context: InternedString,
        name: InternedString,
@@ -378,7 +378,7 @@ fileprivate extension DependencyKey.Designator {
 /// The reports are either for definitions or uses. The old terminology (pre-fine-grained) was `provides` vs `depends`.
 public enum DefinitionVsUse {
   case definition, use
-  
+
   static func deserializing(_ field: UInt64) -> Self {
     field != 0 ? .definition : .use
   }

--- a/Sources/SwiftDriver/IncrementalCompilation/TwoLevelMap.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/TwoLevelMap.swift
@@ -22,10 +22,10 @@
 public struct TwoLevelMap<OuterKey: Hashable, InnerKey: Hashable, Value> {
   public typealias InnerDict = [InnerKey: Value]
   public typealias OuterDict = [OuterKey: InnerDict]
-  
+
   public typealias Key = (OuterKey, InnerKey)
   public typealias Element = (Key, Value)
-  
+
   private var outerDict = [OuterKey: [InnerKey: Value]]()
 }
 
@@ -42,7 +42,7 @@ extension TwoLevelMap: Collection {
   public enum Index: Comparable {
     case end
     case notEnd(OuterDict.Index, InnerDict.Index)
-    
+
     public static func < (lhs: Self, rhs: Self) -> Bool {
       switch (lhs, rhs) {
       case (.end, .end): return false

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -40,7 +40,7 @@ extension Driver {
     }
 
     addSupplementalOutput(path: emitModuleSerializedDiagnosticsFilePath, flag: "-serialize-diagnostics-path", type: .emitModuleDiagnostics)
-    
+
     addSupplementalOutput(path: emitModuleDependenciesFilePath, flag: "-emit-dependencies-path", type: .emitModuleDependencies)
 
     // Skip files created by other jobs when emitting a module and building at the same time
@@ -55,11 +55,11 @@ extension Driver {
     // are risking collisions in output filenames.
     //
     // In cases where other compile jobs exist, they will produce dependency outputs already.
-    // There are currently no cases where this is the only job because even an `-emit-module` 
+    // There are currently no cases where this is the only job because even an `-emit-module`
     // driver invocation currently still involves partial compilation jobs.
     // When partial compilation jobs are removed for the `compilerOutputType == .swiftModule`
     // case, this will need to be changed here.
-    // 
+    //
     if emitModuleSeparately {
       return
     }
@@ -161,7 +161,7 @@ extension Driver {
       return false
     }
   }
-  
+
   static func canDoCrossModuleOptimization(parsedOptions: inout ParsedOptions) -> Bool {
     if !parsedOptions.hasArgument(.enableLibraryEvolution),
        !parsedOptions.hasArgument(.disableCrossModuleOptimization),

--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -41,7 +41,7 @@ extension Toolchain {
                                                              "".data(using: .utf8)!)
     commandLine.appendPath(dummyInputPath)
     inputs.append(TypedVirtualPath(file: dummyInputPath.intern(), type: .swift))
-    
+
     return Job(
       moduleName: "",
       kind: .emitSupportedFeatures,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -30,7 +30,7 @@ extension Driver {
                                                       .list(inputsFromOutputs.map { $0.file }))
       commandLine.appendPath(fileList)
       inputs.append(contentsOf: inputsFromOutputs)
-      
+
       for input in providedInputs {
         assert(input.type == .swiftModule)
         commandLine.append(.path(input.file))

--- a/Sources/SwiftDriver/SwiftDriver.docc/IncrementalBuilds.md
+++ b/Sources/SwiftDriver/SwiftDriver.docc/IncrementalBuilds.md
@@ -9,11 +9,11 @@ An *incremental build* is a resource-saving compilation mode that attempts
 to detect and rebuild only those files that have changed between successive
 invocations of the driver. By communicating with the frontends it spawns to
 determine their dependencies, the driver is able to intelligently schedule
-minimal rebuilds of Swift modules. 
+minimal rebuilds of Swift modules.
 
 ## Introduction
 
-The finest unit of scheduling the Swift driver is concerned about is an 
+The finest unit of scheduling the Swift driver is concerned about is an
 individual file. When the driver is invoked, every file in the module is passed
 to it as an input. It is up to the incremental build to sort these inputs into
 jobs that should be run, and jobs that should be skipped.
@@ -29,7 +29,7 @@ it to complete.
 
 The Swift driver includes built-in facilities for reading incremental dependnecy
 information produced by the Swift frontend called `.swiftdeps` files. These
-files contain serialized dependency information on both a per-file and 
+files contain serialized dependency information on both a per-file and
 per-declaration basis. The format of swiftdeps files is an implementation detail
 of the driver and frontends, and version mismatches will cause the incremental
 build to be cancelled and a full rebuild to be performed in its place.
@@ -53,9 +53,9 @@ This file *provides* the types `Foo` and `Bar` as well as their members
 `Foo.bar` and `Bar.baz`. There are also dependencies between `Foo` and `Bar`
 because the type of `Foo.bar` depends upon `Bar`, and a dependency between
 `Bar` and Swift's `Int` type because of `Bar.baz`.
- 
-Notably, the provides of a file need not be limited to the declarations it 
-contains. Provides are often composed transitively from other provided 
+
+Notably, the provides of a file need not be limited to the declarations it
+contains. Provides are often composed transitively from other provided
 declarations used in the file. For example,
 
 ```
@@ -65,14 +65,14 @@ class B : A {} // This file provides both A and B
 This may seem odd at first blush as this file only declares the class type `B`,
 not the superclass `A`. But consider that any file that uses the subclass `B`
 also *implicitly uses the superclass A*. If `A` were to change in a way that
-required a rebuild, we would want those transitive dependencies to rebuild as 
+required a rebuild, we would want those transitive dependencies to rebuild as
 well!
 
 In general, after collecting all of the provides and depends for a file, the
 result is an enormous [multi-graph](https://en.wikipedia.org/wiki/Multigraph)
 of dependency edges between Swift files. The Swift driver integrates each
-`.swiftdeps` file that corresponds to a `.swift` file into a 
-``SwiftDriver/ModuleDependencyGraph`` that then forms the backbone of 
+`.swiftdeps` file that corresponds to a `.swift` file into a
+``SwiftDriver/ModuleDependencyGraph`` that then forms the backbone of
 the dependency analysis procedures that power the incremental build.
 
 ## Constructing the Incremental Build
@@ -96,15 +96,15 @@ diagram:
 ┗━━━━━━━━┛                │                            │                      ├──────────────┘┌──────┐                          │
                           │                            │                      │               │ Yes! │  ┏━━━━━━━━━━━━━━━━━━━━┓  │
                           │    ┌──────┐                ▼                      └────────────┬──┴──────┴─▶┃ Schedule Next Wave ┃──┘
-                          │    │ Nope │    ┏━━━━━━━━━━━━━━━━━━━━━━━┓                ┌──────┤            ┗━━━━━━━━━━━━━━━━━━━━┛   
-                          └────┴──────┴───▶┃ Schedule Full Rebuild ┃─────────┐      │ Nope │                                     
-                                           ┗━━━━━━━━━━━━━━━━━━━━━━━┛         │      └──────┤                                     
-                                                                             │             │                                     
-                                                                             │             │                                     
-                                                                             │             ▼                                     
-                                                                             │         ┏━━━━━━━┓                                 
-                                                                             └────────▶┃ Done! ┃                                 
-                                                                                       ┗━━━━━━━┛                                 
+                          │    │ Nope │    ┏━━━━━━━━━━━━━━━━━━━━━━━┓                ┌──────┤            ┗━━━━━━━━━━━━━━━━━━━━┛
+                          └────┴──────┴───▶┃ Schedule Full Rebuild ┃─────────┐      │ Nope │
+                                           ┗━━━━━━━━━━━━━━━━━━━━━━━┛         │      └──────┤
+                                                                             │             │
+                                                                             │             │
+                                                                             │             ▼
+                                                                             │         ┏━━━━━━━┓
+                                                                             └────────▶┃ Done! ┃
+                                                                                       ┗━━━━━━━┛
 ```
 
 The build begins by examining "priors" - data left behind by the last compilation
@@ -112,10 +112,10 @@ session. If no data is found, the Driver considers the incremental build to be
 a lost cause and schedules a full rebuild in order to gather `.swiftdeps` files
 it can use to reconstruct this prior data.
 
-Assuming priors are present, they are deserialized and any dependency 
+Assuming priors are present, they are deserialized and any dependency
 information they contain is integrated into the driver's dependency graph. Next,
 the modification time of any files is examined. If these modification times do
-not match the driver's last expected modification time, those files are 
+not match the driver's last expected modification time, those files are
 immediately scheduled for rebuilding. Using the information from the prior build,
 we can also determine the files that directly depend upon those modified files
 and pull them in for rebuilding. The set of modified files and their direct
@@ -123,8 +123,8 @@ dependents is colloquially referred to as the *first wave* of compilation jobs.
 
 As the name *first wave* implies, additional discovered dependencies in the
 modified files can cause the formation of further waves of compilation. As
-each frontend job finishes compiling a swift file, it lays down a new 
-`.swiftdeps` file that the driver picks up and integrates into the module 
+each frontend job finishes compiling a swift file, it lays down a new
+`.swiftdeps` file that the driver picks up and integrates into the module
 dependency graph. New edges are added, and old edges removed, thus keeping
 the module dependency graph up to date with the current state of the user's code
 at that moment in time.

--- a/Sources/SwiftDriver/SwiftDriver.docc/SwiftDriver.md
+++ b/Sources/SwiftDriver/SwiftDriver.docc/SwiftDriver.md
@@ -5,10 +5,10 @@ A native compiler driver for the Swift language.
 ## Overview
 
 The `SwiftDriver` framework coordinates the compilation of Swift source code
-into various compiled results: executables, libraries, object files, Swift 
+into various compiled results: executables, libraries, object files, Swift
 modules and interfaces, etc. It is the program one invokes from the command line
-to build Swift code (i.e., swift or swiftc) and is often invoked on the 
-developer's behalf by a build system such as the 
+to build Swift code (i.e., swift or swiftc) and is often invoked on the
+developer's behalf by a build system such as the
 [Swift Package Manager](https://github.com/apple/swift-package-manager)
 or Xcode's build system.
 

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -267,7 +267,7 @@ internal extension swiftscan_diagnostic_severity_t {
   @_spi(Testing) public func supportsSeparateSwiftOverlayDependencies() -> Bool {
     return api.swiftscan_swift_textual_detail_get_swift_overlay_dependencies != nil
   }
-  
+
   @_spi(Testing) public func supportsScannerDiagnostics() -> Bool {
     return api.swiftscan_scanner_diagnostics_query != nil &&
            api.swiftscan_scanner_diagnostics_reset != nil &&
@@ -279,7 +279,7 @@ internal extension swiftscan_diagnostic_severity_t {
   @_spi(Testing) public func supportsStringDispose() -> Bool {
     return api.swiftscan_string_dispose != nil
   }
-  
+
   @_spi(Testing) public func queryScannerDiagnostics() throws -> [ScannerDiagnosticPayload] {
     var result: [ScannerDiagnosticPayload] = []
     let diagnosticSetRefOrNull = api.swiftscan_scanner_diagnostics_query(scanner)
@@ -291,7 +291,7 @@ internal extension swiftscan_diagnostic_severity_t {
     defer { api.swiftscan_diagnostics_set_dispose(diagnosticSetRef) }
     let diagnosticRefArray = Array(UnsafeBufferPointer(start: diagnosticSetRef.pointee.diagnostics,
                                                        count: Int(diagnosticSetRef.pointee.count)))
-    
+
     for diagnosticRefOrNull in diagnosticRefArray {
       guard let diagnosticRef = diagnosticRefOrNull else {
         throw DependencyScanningError.dependencyScanFailed
@@ -302,7 +302,7 @@ internal extension swiftscan_diagnostic_severity_t {
     }
     return result
   }
-  
+
   @_spi(Testing) public func resetScannerDiagnostics() throws {
     api.swiftscan_scanner_diagnostics_reset(scanner)
   }
@@ -404,7 +404,7 @@ private extension swiftscan_functions_t {
     // Clang dependency captured PCM args
     self.swiftscan_clang_detail_get_captured_pcm_args =
       try loadOptional("swiftscan_clang_detail_get_captured_pcm_args")
-    
+
     // Scanner diagnostic emission query
     self.swiftscan_scanner_diagnostics_query =
       try loadOptional("swiftscan_scanner_diagnostics_query")

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -197,7 +197,7 @@ public final class DarwinToolchain: Toolchain {
                                       diagnosticsEngine: diagnosticsEngine)
     #endif
     // Validating apple platforms deployment targets.
-    try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple, 
+    try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple,
                                  compilerOutputType: compilerOutputType)
     if let targetVariantTriple = targetVariantTriple,
        !targetTriple.isValidForZipperingWithTriple(targetVariantTriple) {
@@ -247,7 +247,7 @@ public final class DarwinToolchain: Toolchain {
       }
     }
   }
-    
+
   func validateLinkObjcRuntimeARCLiteLib(_ parsedOptions: inout ParsedOptions,
                                            targetTriple: Triple,
                                            diagnosticsEngine: DiagnosticsEngine) {

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -126,7 +126,7 @@ extension WindowsToolchain.ToolchainValidationError {
   }
 
   public var globalDebugPathRemapping: String? { nil }
-    
+
   public func runtimeLibraryName(for sanitizer: Sanitizer, targetTriple: Triple,
                                  isShared: Bool) throws -> String {
     // TODO(compnerd) handle shared linking

--- a/Sources/SwiftDriver/ToolingInterface/SimpleExecutor.swift
+++ b/Sources/SwiftDriver/ToolingInterface/SimpleExecutor.swift
@@ -24,13 +24,13 @@ internal class SimpleExecutor: DriverExecutor {
   let resolver: ArgsResolver
   let fileSystem: FileSystem
   let env: [String: String]
-  
+
   init(resolver: ArgsResolver, fileSystem: FileSystem, env: [String: String]) {
     self.resolver = resolver
     self.fileSystem = fileSystem
     self.env = env
   }
-  
+
   func execute(job: Job,
                forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws -> ProcessResult {
@@ -41,17 +41,17 @@ internal class SimpleExecutor: DriverExecutor {
     let process = try Process.launchProcess(arguments: arguments, env: childEnv)
     return try process.waitUntilExit()
   }
-  
+
   func execute(workload: DriverExecutorWorkload, delegate: JobExecutionDelegate,
                numParallelJobs: Int, forceResponseFiles: Bool,
                recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws {
     fatalError("Unsupported operation on current executor")
   }
-  
+
   func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
     try Process.checkNonZeroExit(arguments: args, environment: environment)
   }
-  
+
   func description(of job: Job, forceResponseFiles: Bool) throws -> String {
     let useResponseFiles : ResponseFileHandling = forceResponseFiles ? .forced : .heuristic
     let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, useResponseFiles: useResponseFiles)

--- a/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
+++ b/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
@@ -37,16 +37,16 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
                                                            forceNoOutputs: Bool = false) -> Bool {
   var args: [String] = []
   args.append(contentsOf: argList)
-  
+
   // When creating a CompilerInvocation, ensure that the driver creates a single
   // frontend command.
   args.append("-whole-module-optimization")
-  
+
   // Explicitly disable batch mode to avoid a spurious warning when combining
   // -enable-batch-mode with -whole-module-optimization.  This is an
   // implementation detail.
   args.append("-disable-batch-mode");
-  
+
   // Prevent having a separate job for emit-module, we would like
   // to just have one job
   args.append("-no-emit-module-separately-wmo")
@@ -54,10 +54,10 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
   // Avoid using filelists
   args.append("-driver-filelist-threshold");
   args.append(String(Int.max));
-  
+
   let diagnosticsEngine = DiagnosticsEngine()
   defer { emittedDiagnostics = diagnosticsEngine.diagnostics }
-  
+
   do {
     args = try ["swiftc"] + Driver.expandResponseFiles(args,
                                                        fileSystem: localFileSystem,
@@ -71,7 +71,7 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
       parsedOptions.eraseSupplementaryOutputs()
       parsedOptions.addOption(.typecheck, argument: .none)
     }
-    
+
     // Instantiate the driver, setting up the toolchain in the process, etc.
     let resolver = try ArgsResolver(fileSystem: localFileSystem)
     let executor = SimpleExecutor(resolver: resolver,
@@ -83,8 +83,8 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
     if diagnosticsEngine.hasErrors {
       return true
     }
-    
-    
+
+
     let buildPlan = try driver.planBuild()
     if diagnosticsEngine.hasErrors {
       return true

--- a/Sources/SwiftDriver/Utilities/DOTModuleDependencyGraphSerializer.swift
+++ b/Sources/SwiftDriver/Utilities/DOTModuleDependencyGraphSerializer.swift
@@ -18,7 +18,7 @@ import TSCBasic
   public init(_ interModuleDependencyGraph: InterModuleDependencyGraph) {
     self.graph = interModuleDependencyGraph
   }
-  
+
   func label(for moduleId: ModuleDependencyId) -> String {
     let label: String
     switch moduleId {
@@ -37,12 +37,12 @@ import TSCBasic
   func quoteName(_ name: String) -> String {
     return "\"" + name.replacingOccurrences(of: "\"", with: "\\\"") + "\""
   }
-  
+
   func outputNode(for moduleId: ModuleDependencyId) -> String {
     let nodeName = quoteName(label(for: moduleId))
     let output: String
     let font = "fontname=\"Helvetica Bold\""
-    
+
     if moduleId == .swift(graph.mainModuleName) {
       output = "  \(nodeName) [shape=box, style=bold, color=navy, \(font)];\n"
     } else {

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -158,11 +158,11 @@ extension Diagnostic.Message {
   static func warning_option_overrides_another(overridingOption: Option, overridenOption: Option) -> Diagnostic.Message {
     .warning("ignoring '\(overridenOption.spelling)' because '\(overridingOption.spelling)' was also specified")
   }
-  
+
   static func error_expected_one_frontend_job() -> Diagnostic.Message {
     .error("unable to handle compilation, expected exactly one frontend job")
   }
-  
+
   static func error_expected_frontend_command() -> Diagnostic.Message {
     .error("expected a swift frontend command")
   }

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -80,7 +80,7 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
 
   /// Serialized diagnostics produced by module-generation
   case emitModuleDiagnostics = "emit-module.dia"
-  
+
   /// Serialized diagnostics produced by module-generation
   case emitModuleDependencies = "emit-module.d"
 

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -336,13 +336,13 @@ extension Triple {
   ///
   /// - SeeAlso: `Triple.supports(_:)`
   public struct FeatureAvailability {
-    
+
     public enum Availability {
       case unavailable
       case available(since: Version)
       case availableInAllVersions
     }
-    
+
     public let macOS: Availability
     public let iOS: Availability
     public let tvOS: Availability
@@ -389,7 +389,7 @@ extension Triple {
     guard let darwinPlatform = darwinPlatform else {
       return feature.nonDarwin
     }
-    
+
     switch feature[darwinPlatform] {
     case .unavailable:
       return false

--- a/Sources/SwiftDriver/Utilities/TypedVirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/TypedVirtualPath.swift
@@ -20,7 +20,7 @@ public struct TypedVirtualPath: Hashable, Codable {
   public var file: VirtualPath {
     return VirtualPath.lookup(self.fileHandle)
   }
-  
+
   public init(file: VirtualPath.Handle, type: FileType) {
     self.fileHandle = file
     self.type = type

--- a/Sources/SwiftDriver/Utilities/VirtualPath.swift
+++ b/Sources/SwiftDriver/Utilities/VirtualPath.swift
@@ -102,7 +102,7 @@ public enum VirtualPath: Hashable {
     guard case .relative(let relativePath) = self else { return nil }
     return relativePath
   }
-  
+
   /// If the path is some kind of temporary file, returns the `RelativePath`
   /// representing its name.
   public var temporaryFileName: RelativePath? {

--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -64,7 +64,7 @@ extension OptionTable {
           parsedOptions.addOption(.DASHDASH, argument: .multiple(Array(arguments[(index-1)...])))
           break
         }
-        
+
         parsedOptions.addInput(argument)
 
         // In interactive mode, synthesize a "--" argument for all args after the first input.
@@ -97,7 +97,7 @@ extension OptionTable {
             currentDriverKind: driverKind)
         }
       }
-      
+
       if option == .e {
         seenDashE = true
       }

--- a/Sources/SwiftOptions/ParsedOptions.swift
+++ b/Sources/SwiftOptions/ParsedOptions.swift
@@ -344,7 +344,7 @@ extension ParsedOptions {
       groupIndex[group]?.removeAll { $0.option == option }
     }
   }
-  
+
   /// Remove all arguments of a given group from parsed options.
   public mutating func eraseAllArguments(in group: Option.Group) {
     for parsedOption in parsedOptions {
@@ -353,7 +353,7 @@ extension ParsedOptions {
       }
     }
   }
-  
+
   /// Remove all arguments with a .supplementaryOutput attribute
   public mutating func eraseSupplementaryOutputs() {
     for parsedOption in parsedOptions {

--- a/Sources/makeOptions/makeOptions.cpp
+++ b/Sources/makeOptions/makeOptions.cpp
@@ -161,7 +161,7 @@ static std::string stringOrNilLeftTrimmed(const char *text) {
 
   while (*text == ' ' && *text)
     ++text;
-  
+
   return "\"" + std::string(text) + "\"";
 }
 
@@ -198,7 +198,7 @@ int makeOptions_main() {
     std::cerr << "error: swift/Options/Options.inc unavailable at compile time\n";
     return 1;
   }
-    
+
   // Form the groups & record the ID mappings.
   unsigned rawOptionIdx = 0;
   for (const auto &rawOption : rawOptions) {
@@ -209,7 +209,7 @@ int makeOptions_main() {
         idName.erase(idName.begin() + groupSuffixStart, idName.end());
         idName = swiftify(idName);
       }
-      
+
       groupIndexByID[rawOption.id] = groups.size();
       groups.push_back({idName, rawOption.spelling, rawOption.helpText});
       ++rawOptionIdx;

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -96,7 +96,7 @@ do {
                           diagnosticsOutput: .engine(diagnosticsEngine),
                           executor: executor,
                           integratedDriver: false)
-  
+
   // FIXME: The following check should be at the end of Driver.init, but current
   // usage of the DiagnosticVerifier in tests makes this difficult.
   guard !driver.diagnosticEngine.hasErrors else {

--- a/TestInputs/Incremental/hello.swiftdeps.yaml
+++ b/TestInputs/Incremental/hello.swiftdeps.yaml
@@ -17,7 +17,7 @@ allNodes:
       name:            '/Users/owenvoorhees/Desktop/hello.swiftdeps'
     fingerprint:     38b457b424090ac2e595be0e5f7e3b5b
     sequenceNumber:  1
-    defsIDependUpon: [ 2, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 
+    defsIDependUpon: [ 2, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
                        30, 31, 4, 32, 33, 34, 35, 36, 8, 6, 39, 40 ]
     isProvides:      true
   - key:

--- a/Tests/IncrementalImportTests/SpecificFuncAdditionInExtensionWithinModuleTest.swift
+++ b/Tests/IncrementalImportTests/SpecificFuncAdditionInExtensionWithinModuleTest.swift
@@ -19,7 +19,7 @@ import SwiftOptions
 /// Try adding a more specific function in an extension in the same module
 class SpecificFuncAdditionInExtensionWithinModuleTest: XCTestCase {
   func testSpecificFuncAdditionInExtensionWithinModule() throws {
-    
+
     // MARK: - Define the module
     let main = Source(named: "main", containing: """
       // Define a struct with a general method and call it

--- a/Tests/IncrementalTestFramework/Module.swift
+++ b/Tests/IncrementalTestFramework/Module.swift
@@ -170,7 +170,7 @@ extension Module {
         "-emit-module-path", context.swiftmodulePath(for: self).pathString,
       ] + searchPaths
     }
-    
+
     var importedObjs: [String] {
       self.imports.flatMap { `import` in
         `import`.sources.map { source in

--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -58,7 +58,7 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
           $0 + "-some_suffix"
         }
       }
-      
+
       let driverArgs = [
         "swiftc",
         "-incremental",

--- a/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
+++ b/Tests/SwiftDriverTests/DependencyGraphSerializationTests.swift
@@ -40,7 +40,7 @@ class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker
         buildRecord: graph.buildRecord,
         mockSerializedGraphVersion: alteredVersion)
     }
- 
+
     do {
       let outputFileMap = OutputFileMap.mock(maxIndex: Self.maxIndex)
       let info = IncrementalCompilationState.IncrementalDependencyAndInputSetup.mock(outputFileMap: outputFileMap, fileSystem: fs)
@@ -78,7 +78,7 @@ class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker
     let deserializedGraph = try info.blockingConcurrentAccessOrMutation {
       try XCTUnwrap(ModuleDependencyGraph.read(from: mockPath, info: info))
     }
- 
+
     let descsToCompare = [originalGraph, deserializedGraph].map {
       graph -> (nodes: Set<String>, uses: [String: Set<String>], feds: Set<String>) in
       var nodes = Set<String>()
@@ -108,7 +108,7 @@ class DependencyGraphSerializationTests: XCTestCase, ModuleDependencyGraphMocker
         case reload(index: Int, nodes: [MockDependencyKind: [String]], fingerprint: String? = nil)
       }
     }
-    
+
     let fixtures: [GraphFixture] = [
       GraphFixture(commands: []),
       GraphFixture(commands: [

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -612,7 +612,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
   }
 
-  
+
   func testModuleAliasingPrebuiltWithScanDeps() throws {
     try withTemporaryDirectory { path in
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
@@ -623,7 +623,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try localFileSystem.writeFileContents(srcBar) {
         $0 <<< "public class KlassBar {}"
       }
-      
+
       // Create Bar.swiftmodule
       var driver = try Driver(args: ["swiftc",
                                      "-explicit-module-build",
@@ -647,7 +647,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try driver.run(jobs: jobs)
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
       XCTAssertTrue(FileManager.default.fileExists(atPath: moduleBarPath))
-      
+
       // Foo imports Car which is mapped to the real module Bar via
       // `-module-alias Car=Bar`; it allows Car (alias) to be referenced
       // in source files, while its contents are compiled as Bar (real
@@ -657,7 +657,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         $0 <<< "import Car\n"
         $0 <<< "func run() -> Car.KlassBar? { return nil }"
       }
-      
+
       // Module alias with the fallback scanner (frontend scanner)
       var driverA = try Driver(args: ["swiftc",
                                       "-nonlib-dependency-scanner",
@@ -670,7 +670,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       "-I", stdLibPath.nativePathString(escaped: true),
                                       "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting)
-      
+
       // Resulting graph should contain the real module name Bar
       let dependencyGraphA = try driverA.gatherModuleDependencies()
       XCTAssertTrue(dependencyGraphA.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
@@ -697,7 +697,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       "-I", stdLibPath.nativePathString(escaped: true),
                                       "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting)
-      
+
       // Resulting graph should contain the real module name Bar
       let dependencyGraphB = try driverB.gatherModuleDependencies()
       XCTAssertTrue(dependencyGraphB.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
@@ -714,7 +714,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       })
     }
   }
-  
+
   func testModuleAliasingInterfaceWithScanDeps() throws {
     try withTemporaryDirectory { path in
       let swiftModuleInterfacesPath: AbsolutePath =
@@ -746,7 +746,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       guard driverA.isFrontendArgSupported(.moduleAlias) else {
         throw XCTSkip("Skipping: compiler does not support '-module-alias'")
       }
-      
+
       // Resulting graph should contain the real module name Bar
       let dependencyGraphA = try driverA.gatherModuleDependencies()
       XCTAssertTrue(dependencyGraphA.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
@@ -772,7 +772,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       "-I", stdLibPath.nativePathString(escaped: true),
                                       "-I", shimsPath.nativePathString(escaped: true),
                                      ] + sdkArgumentsForTesting)
-      
+
       // Resulting graph should contain the real module name Bar
       let dependencyGraphB = try driverB.gatherModuleDependencies()
       XCTAssertTrue(dependencyGraphB.modules.contains { (key: ModuleDependencyId, value: ModuleInfo) in
@@ -789,7 +789,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       })
     }
   }
-  
+
   func testModuleAliasingWithImportPrescan() throws {
     let (_, _, toolchain, _) = try getDriverArtifactsForScanning()
 
@@ -826,13 +826,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
         try! dependencyOracle.getImports(workingDirectory: path,
                                          moduleAliases: ["Car": "Bar"],
                                          commandLine: scannerCommand)
-      
+
       XCTAssertTrue(deps.imports.contains("Bar"))
       XCTAssertFalse(deps.imports.contains("Car"))
       XCTAssertTrue(deps.imports.contains("Jet"))
     }
   }
-  
+
   func testModuleAliasingWithExplicitBuild() throws {
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
@@ -843,7 +843,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try localFileSystem.writeFileContents(srcBar) {
         $0 <<< "public class KlassBar {}"
       }
-      
+
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let (stdLibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
 
@@ -869,7 +869,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try driver1.run(jobs: jobs1)
       XCTAssertFalse(driver1.diagnosticEngine.hasErrors)
       XCTAssertTrue(FileManager.default.fileExists(atPath: moduleBarPath))
-      
+
       let srcFoo = path.appending(component: "foo.swift")
       let moduleFooPath = path.appending(component: "Foo.swiftmodule").nativePathString(escaped: true)
 
@@ -904,7 +904,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertTrue(FileManager.default.fileExists(atPath: moduleFooPath))
     }
   }
-  
+
   func testExplicitModuleBuildEndToEnd() throws {
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
@@ -1156,10 +1156,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertFalse(args[0].hasSuffix(".resp"))
     }
   }
-  
+
   func testDependencyScanningFailure() throws {
     let (stdlibPath, shimsPath, toolchain, _) = try getDriverArtifactsForScanning()
-    
+
     // The dependency oracle wraps an instance of libSwiftScan and ensures thread safety across
     // queries.
     let dependencyOracle = InterModuleDependencyOracle()
@@ -1173,13 +1173,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
     guard try dependencyOracle.supportsScannerDiagnostics() else {
       throw XCTSkip("libSwiftScan does not support diagnostics query.")
     }
-    
+
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testDependencyScanning.swift")
       try localFileSystem.writeFileContents(main) {
         $0 <<< "import S;"
       }
-      
+
       let cHeadersPath: AbsolutePath =
       testInputsPath.appending(component: "ExplicitModuleBuilds")
         .appending(component: "CHeaders")
@@ -1240,7 +1240,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTFail("Dependency scanner library not found")
       return
     }
-    
+
     // Create a simple test case.
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testDependencyScanning.swift")
@@ -1386,7 +1386,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         XCTAssertEqual(diagnosticEngine.diagnostics.first?.message.data.description,
                        "unsupported argument \'watercolor\' to option \'-explicit-dependency-graph-format=\'")
       }
-      
+
       let _ = try withHijackedOutputStream {
         let diagnosticEngine = DiagnosticsEngine()
         var driver = try Driver(args: baseCommandLine + ["-explicit-module-build",
@@ -1472,7 +1472,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
           try dependencyOracle.getDependencies(workingDirectory: path,
                                                 commandLine: scannerCommand)
         let serializer = DOTModuleDependencyGraphSerializer(dependencyGraph)
-        
+
         let outputFile = path.appending(component: "dependency_graph.dot")
         var outputStream = try ThreadSafeOutputByteStream(LocalFileOutputByteStream(outputFile))
         serializer.writeDOT(to: &outputStream)

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -69,7 +69,7 @@ extension DependencySource {
   var interfaceHashForMockDependencySource: String {
     file.name
   }
-  
+
   fileprivate  var sourceFileProvidesNameForMocking: InternedString {
     // Only when mocking are these two guaranteed to be the same
     internedFileName

--- a/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
@@ -1,5 +1,5 @@
 // Created by David Ungar on 7/28/21.
-// 
+//
 
 import XCTest
 @_spi(Testing) import SwiftDriver
@@ -65,10 +65,10 @@ class IncrementalBuildPerformanceTests: XCTestCase {
   ///    - limit: the maximum number of swiftdeps files to process.
   func test(swiftDepsDirectory: String, atMost limit: Int = .max, _ whatToMeasure: WhatToMeasure) throws {
     let (outputFileMap, inputs) = try createOFMAndInputs(swiftDepsDirectory, atMost: limit)
-    
+
     let info = IncrementalCompilationState.IncrementalDependencyAndInputSetup
       .mock(options: [], outputFileMap: outputFileMap)
-    
+
     let g = ModuleDependencyGraph.createForSimulatingCleanBuild(info.buildRecordInfo.buildRecord([], []), info)
     g.blockingConcurrentAccessOrMutation {
       switch whatToMeasure {
@@ -138,7 +138,7 @@ class IncrementalBuildPerformanceTests: XCTestCase {
       invalidatedInputs.formUnion(g.collectInputsRequiringCompilation(byCompiling: primaryInput)!)
     }
     .subtracting(inputs) // have already compiled these
-    
+
     XCTAssertEqual(result.count, 0, "Should be no invalid inputs left")
   }
 }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -532,7 +532,7 @@ extension IncrementalCompilationTests {
       return priorsModTime
     }
     try setModTime(of: .absolute(priorsPath), to: priorsModTime)
-    
+
     try checkReactionToObsoletePriors()
     try checkNullBuild(checkDiagnostics: true)
 #endif
@@ -641,7 +641,7 @@ extension IncrementalCompilationTests {
     if removedFileDependsOnChangedFileAndMainWasChanged {
       replace(contentsOf: "main", with: "let foo = \"hello\"")
     }
-    
+
     try checkRestorationOfIncrementalityAfterRemoval(
       removedInput: newInput,
       defining: topLevelName,
@@ -1141,7 +1141,7 @@ extension IncrementalCompilationTests {
       }
     }
   }
-  
+
   @DiagsBuilder private func respondToChangedInputs(
     changedInputs: [String],
     unchangedInputs: [String],
@@ -1156,7 +1156,7 @@ extension IncrementalCompilationTests {
     findingBatchingCompiling(swiftDepsReadAfterFirstWave)
     reading(deps: swiftDepsReadAfterFirstWave)
   }
-  
+
   @DiagsBuilder private var addDefsWithoutGraph: [Diagnostic.Message] {
     for (input, name) in [("main", "foo"), ("other", "bar")] {
       newDefinitionOfSourceFile(.interface,      input)
@@ -1165,7 +1165,7 @@ extension IncrementalCompilationTests {
       newDefinitionOfTopLevelName(.implementation, name: name, input: input)
     }
   }
-  
+
   @DiagsBuilder private func integrateChangedMainWithPriors(
     removedInput: String,
     defining topLevelName: String,
@@ -1177,7 +1177,7 @@ extension IncrementalCompilationTests {
   {
     fingerprintsChanged("main")
     fingerprintsMissingOfTopLevelName(name: "foo", "main")
-    
+
     for input in affectedInputs {
       trace {
         TraceStep(.interface, sourceFileProvide: "main")
@@ -1190,7 +1190,7 @@ extension IncrementalCompilationTests {
     findingBatchingCompiling(affectedInputsInInvocationOrder)
     reading(deps: "other")
     fingerprintsMissingOfTopLevelName(name: "bar", "other")
-    
+
     let readingAnotherDeps = !removeInputFromInvocation // if removed, won't read it
     if readingAnotherDeps {
       reading(deps: removedInput)
@@ -1614,7 +1614,7 @@ extension DiagVerifiable {
   @DiagsBuilder func reading(deps inputs: String...) -> [Diagnostic.Message] {
     reading(deps: inputs)
   }
-  
+
   @DiagsBuilder func fingerprintChanged(_ aspect: DependencyKey.DeclAspect, _ input: String) -> [Diagnostic.Message] {
     "Incremental compilation: Fingerprint changed for existing \(aspect) of source file from \(input).swiftdeps in \(input).swift"
   }
@@ -1623,7 +1623,7 @@ extension DiagVerifiable {
       fingerprintChanged(aspect, input)
     }
   }
-  
+
    @DiagsBuilder func fingerprintsMissingOfTopLevelName(name: String, _ input: String) -> [Diagnostic.Message] {
     for aspect: DependencyKey.DeclAspect in [.interface, .implementation] {
       "Incremental compilation: Fingerprint missing for existing \(aspect) of top-level name '\(name)' in \(input).swift"

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -150,7 +150,7 @@ final class IntegrationTests: IntegrationTestCase {
     }
     try self.runLitTests(suite: "test", "stdlib")
   }
-  
+
   func testLitSymbolGraphFrontendTest() throws {
     try runLitTests(suite: "test", "SymbolGraph", "EmitWhileBuilding.swift")
   }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -963,12 +963,12 @@ extension ModuleDependencyGraph {
       interfaceHash,
       includePrivateDeps: includePrivateDeps,
       hadCompilationError: hadCompilationError)
-    
+
     return collectInputsUsingInvalidated(nodes: directlyInvalidatedNodes)
       .map { $0.mockID }
   }
 
-  
+
   func getInvalidatedNodesForSimulatedLoad(
     _ swiftDepsIndex: Int,
     _ dependencyDescriptions: [MockDependencyKind: [String]],
@@ -981,7 +981,7 @@ extension ModuleDependencyGraph {
       let dependencySource = DependencySource(input, internedStringTable)
       let interfaceHash =
       interfaceHashIfPresent ?? dependencySource.interfaceHashForMockDependencySource
-      
+
       let sfdg = SourceFileDependencyGraphMocker.mock(
         includePrivateDeps: includePrivateDeps,
         hadCompilationError: hadCompilationError,
@@ -989,7 +989,7 @@ extension ModuleDependencyGraph {
         interfaceHash: interfaceHash,
         dependencyDescriptions,
         in: internedStringTable)
-      
+
       return Integrator.integrate(from: sfdg,
                                   dependencySource: DependencySource(input, internedStringTable),
                                   into: self)
@@ -1301,7 +1301,7 @@ fileprivate struct SourceFileDependencyGraphMocker: InternedStringTableHolder {
     }()
     dh.add(def.sequenceNumber)
   }
-  
+
   private mutating func fixupDependencies() {
     for (useSequenceNumber, depHolder) in dependencyAccumulator.enumerated() {
       if let depHolder = depHolder {
@@ -1473,7 +1473,7 @@ fileprivate extension DependencyKey.Designator {
     }
     let context = contextAndName.context?.intern(in: t)
     let    name = contextAndName.name?   .intern(in: t)
-    
+
     switch kind {
     case .topLevel:
       mustBeAbsent(context)

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -106,7 +106,7 @@ final class NonincrementalCompilationTests: XCTestCase {
       XCTAssertEqual(graph.minorVersion, 0)
       XCTAssertEqual(graph.compilerVersionString, "Swift version 5.3-dev (LLVM 4510748e505acd4, Swift 9f07d884c97eaf4)")
       graph.verify()
-      
+
       // Check that a node chosen at random appears as expected.
       var foundNode = false
       graph.forEachNode { node in
@@ -123,7 +123,7 @@ final class NonincrementalCompilationTests: XCTestCase {
         }
       }
       XCTAssertTrue(foundNode)
-      
+
       // Check that an edge chosen at random appears as expected.
       var foundEdge = false
       graph.forEachArc { defNode, useNode in
@@ -133,13 +133,13 @@ final class NonincrementalCompilationTests: XCTestCase {
                     .potentialMember(context: useContext)):
             XCTAssertFalse(foundEdge)
             foundEdge = true
-            
+
             XCTAssertEqual(defName.lookup(in: internedStringTable), "/Users/owenvoorhees/Desktop/hello.swiftdeps")
             XCTAssertEqual(defNode.fingerprint?.lookup(in: internedStringTable), "38b457b424090ac2e595be0e5f7e3b5b")
-            
+
             XCTAssertEqual(useContext.lookup(in: internedStringTable), "5hello1AC")
             XCTAssertEqual(useNode.fingerprint?.lookup(in: internedStringTable), "b83bbc0b4b0432dbfabff6556a3a901f")
-            
+
           default:
             XCTFail()
           }
@@ -162,7 +162,7 @@ final class NonincrementalCompilationTests: XCTestCase {
       XCTAssertEqual(graph.minorVersion, 0)
       XCTAssertEqual(graph.compilerVersionString, "Apple Swift version 5.3-dev (LLVM 240312aa7333e90, Swift 15bf0478ad7c47c)")
       graph.verify()
-      
+
       // Check that a node chosen at random appears as expected.
       var foundNode = false
       graph.forEachNode { node in

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -163,7 +163,7 @@ final class ParsableMessageTests: XCTestCase {
         let workdir: AbsolutePath = localFileSystem.currentWorkingDirectory!.appending(components: "WorkDir")
         let errorOutput = try withHijackedErrorStream {
           let resolver = try ArgsResolver(fileSystem: localFileSystem)
-          
+
           var driver = try Driver(args: ["swiftc", "-o", "test.o",
                                          "main.swift", "test1.swift", "test2.swift",
                                          "-enable-batch-mode", "-driver-batch-count", "1",
@@ -176,19 +176,19 @@ final class ParsableMessageTests: XCTestCase {
                                                    showJobLifecycle: false,
                                                    argsResolver: resolver,
                                                    diagnosticEngine: DiagnosticsEngine())
-          
+
           // Emit the began messages and examine the output
           toolDelegate.jobStarted(job: compileJob, arguments: args, pid: 42)
         }
-        
-        
+
+
         // There were 3 messages emitted
         XCTAssertEqual(errorOutput.components(separatedBy:
           """
             "kind" : "began",
             "name" : "compile",
           """).count - 1, 3)
-        
+
 #if os(Windows)
         let mainPath: String = workdir.appending(component: "main.swift").nativePathString(escaped: true)
         let test1Path: String = workdir.appending(component: "test1.swift").nativePathString(escaped: true)
@@ -198,7 +198,7 @@ final class ParsableMessageTests: XCTestCase {
         let test1Path: String = workdir.appending(component: "test1.swift").pathString.replacingOccurrences(of: "/", with: "\\/")
         let test2Path: String = workdir.appending(component: "test2.swift").pathString.replacingOccurrences(of: "/", with: "\\/")
 #endif
-        
+
         /// One per primary
         XCTAssertTrue(errorOutput.contains(
           """
@@ -230,7 +230,7 @@ final class ParsableMessageTests: XCTestCase {
               \"\(test2Path)\"
             ],
           """))
-        
+
         /// Real PID appeared in every message
         XCTAssertEqual(errorOutput.components(separatedBy:
           """
@@ -267,7 +267,7 @@ final class ParsableMessageTests: XCTestCase {
           // First emit the began messages
           toolDelegate!.jobStarted(job: compileJob!, arguments: args!, pid: 42)
         }
-        
+
         // Now hijack the error stream and emit finished messages
         let errorOutput = try withHijackedErrorStream {
           let resultSuccess = ProcessResult(arguments: args!,
@@ -356,7 +356,7 @@ final class ParsableMessageTests: XCTestCase {
             \"signal\" : 9
           """
 #endif
-        
+
         // Now hijack the error stream and emit finished messages
         let errorOutput = try withHijackedErrorStream {
           let resultSignalled = ProcessResult(arguments: args!,
@@ -425,7 +425,7 @@ final class ParsableMessageTests: XCTestCase {
       }
     }
   }
-  
+
   func testFrontendMessages() throws {
     do {
       try withTemporaryDirectory { path in
@@ -465,7 +465,7 @@ final class ParsableMessageTests: XCTestCase {
           """))
       }
     }
-    
+
     do {
       try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-parseable-output",
                                          "-use-frontend-parseable-output"]) {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -298,22 +298,22 @@ final class SwiftDriverTests: XCTestCase {
     let driver4 = try Driver(args: ["swift", "-", "-working-directory" , "-wobble"])
     XCTAssertEqual(driver4.inputFiles, [ TypedVirtualPath(file: .standardInput, type: .swift )])
   }
-  
+
   func testDashE() throws {
     let fs = localFileSystem
-    
+
     var driver1 = try Driver(args: ["swift", "-e", "print(1)", "-e", "print(2)", "foo/bar.swift", "baz/quux.swift"], fileSystem: fs)
     XCTAssertEqual(driver1.inputFiles.count, 1)
     XCTAssertEqual(driver1.inputFiles[0].file.basename, "main.swift")
     let tempFileContentsForDriver1 = try fs.readFileContents(XCTUnwrap(driver1.inputFiles[0].file.absolutePath))
     XCTAssertTrue(tempFileContentsForDriver1.description.hasSuffix("\nprint(1)\nprint(2)\n"))
-    
+
     let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
     XCTAssertEqual(plannedJobs.count, 1)
     XCTAssertEqual(plannedJobs[0].kind, .interpret)
     XCTAssertEqual(plannedJobs[0].commandLine.drop(while: { $0 != .flag("--") }),
                    [.flag("--"), .flag("foo/bar.swift"), .flag("baz/quux.swift")])
-    
+
     XCTAssertThrowsError(try Driver(args: ["swiftc", "baz/main.swift", "-e", "print(1)"], fileSystem: fs))
   }
 
@@ -815,7 +815,7 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
   }
-  
+
   func testEmitModuleSeparatelyDependenciesPath() throws {
     try withTemporaryFile { fileMapFile in
       let outputMapContents = """
@@ -1260,7 +1260,7 @@ final class SwiftDriverTests: XCTestCase {
                                       "-serialize-diagnostics", "-experimental-emit-module-separately",
                                       "-output-file-map", outputFileMap.description])
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
-      
+
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertTrue(plannedJobs[0].kind == .emitModule)
       XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-serialize-diagnostics-path"), .path(.absolute(.init("/build/Foo-test.dia")))]))
@@ -2836,7 +2836,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[2].kind, .mergeModule)
       XCTAssertTrue(plannedJobs[2].commandLine.contains(.flag("-emit-abi-descriptor-path")))
     }
-    
+
   }
 
   func testWMOWithNonSourceInput() throws {
@@ -3223,7 +3223,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-emit-symbol-graph", "-emit-symbol-graph-dir", root.pathString, "-emit-library", "-target", "x86_64-apple-macosx10.15", "-wmo", "-emit-module-separately-wmo"],
                                env: envVars)
-      
+
       let abiFileCount = (driver.isFeatureSupported(.emit_abi_descriptor) && driver.targetTriple.isDarwin) ? 1 : 0
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 3)
@@ -3686,7 +3686,7 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssert(currentJob.commandLine.contains(.flag("-target")))
     XCTAssert(currentJob.commandLine.contains(.flag("armv7-apple-ios13.0")))
   }
-    
+
   func testValidDeprecatedTargetWatchOS() throws {
     var driver = try Driver(args: ["swiftc", "-emit-module", "-target", "armv7k-apple-watchos10.0", "foo.swift"])
     let plannedJobs = try driver.planBuild()
@@ -3849,7 +3849,7 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "-emit-module", "-c", "-target", 
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-emit-module", "-c", "-target",
                                            "armv7s-apple-ios12.0", "foo.swift"])) { error in
       guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR(platform: .iOS(.device), version: Triple.Version(11, 0, 0), archName: "armv7s") = error else {
         XCTFail("Unexpected error: \(error)")
@@ -6705,7 +6705,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(jobA.commandLine.contains("-unlikely-flag-for-testing"))
     }
   }
-  
+
   func testCleaningUpOldCompilationOutputs() throws {
 #if !os(macOS)
     throw XCTSkip("sdkArguments does not work on Linux")
@@ -6718,7 +6718,7 @@ final class SwiftDriverTests: XCTestCase {
                                  inputPaths: [main],
                                  derivedData: tmpDir,
                                  to: ofm)
-      
+
       try localFileSystem.writeFileContents(main) {
         $0 <<< "// no errors here"
         $0 <<< "func foo() {}"
@@ -6746,7 +6746,7 @@ final class SwiftDriverTests: XCTestCase {
         tmpDir.appending(component: "main.swiftdeps")
         ]
       XCTAssert(outputs.allSatisfy(localFileSystem.exists))
-      
+
       try localFileSystem.writeFileContents(main) {
         $0 <<< "#error(\"Yipes!\")"
         $0 <<< "func foo() {}"
@@ -6948,10 +6948,10 @@ final class SwiftDriverTests: XCTestCase {
       let customSwiftScan = toolsDirectory.appending(component: sharedLibraryName("lib_InternalSwiftScan"))
       try localFileSystem.createSymbolicLink(customSwiftFrontend, pointingAt: defaultSwiftFrontend, relative: false)
 
-      try withTemporaryDirectory { tempDirectory in 
+      try withTemporaryDirectory { tempDirectory in
         try localFileSystem.changeCurrentWorkingDirectory(to: tempDirectory)
         defer { try! localFileSystem.changeCurrentWorkingDirectory(to: originalWorkingDirectory) }
- 
+
         let anotherSwiftFrontend = localFileSystem.currentWorkingDirectory!.appending(component: executableName("swift-frontend"))
         try localFileSystem.createSymbolicLink(anotherSwiftFrontend, pointingAt: defaultSwiftFrontend, relative: false)
 
@@ -6984,7 +6984,7 @@ final class SwiftDriverTests: XCTestCase {
           XCTAssertEqual(jobs.first!.tool.name, anotherSwiftFrontend.pathString)
         }
       }
-    }  
+    }
   }
 
   func testWindowsOptions() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -19,7 +19,7 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
     try withTemporaryDirectory { path in
       let inputFile = path.appending(components: "test.swift")
       try localFileSystem.writeFileContents(inputFile) { $0 <<< "public func foo()" }
-      
+
       // Expected success scenarios:
       do {
         let testCommand = inputFile.description
@@ -67,7 +67,7 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
         XCTAssertFalse(resultingFrontendArgs.contains("-emit-module-path"))
         XCTAssertFalse(resultingFrontendArgs.contains("-emit-tbd-path"))
       }
-      
+
       // Expected failure scenarios:
       do {
         let testCommand = "-v" // No inputs

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -1292,11 +1292,11 @@ final class TripleTests: XCTestCase {
                                 watchOSVersion: .init(60, 0, 0),
                                 shouldHaveJetPacks: true)
   }
-  
+
   func testToolchainSelection() {
     let diagnostics = DiagnosticsEngine()
     struct None { }
-    
+
     func assertToolchain<T>(
       _ rawTriple: String,
       _ expectedToolchain: T.Type?,

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -380,7 +380,7 @@ def install_binary_swift_modules(args, build_dir, toolchain_lib_dir, targets):
   package_subpath = os.path.join(args.configuration, 'dependencies', 'swift-system',
                                  product_subpath)
   install_module(args, build_dir, package_subpath, toolchain_lib_dir, 'SystemPackage', targets)
-  
+
 
 # Install the modulemaps and headers of the driver's C module dependencies into the toolchain
 # include directory


### PR DESCRIPTION
Trailing whitespaces can trigger linter and formatting warnings and can also introduce formatting churn in unrelated PRs. Let's clean those up in a single commit.