### PR TITLE
Android: look in lib/linux/ for the LLVM sanitizers instead

### DIFF
--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -26,9 +26,14 @@ extension Toolchain {
     for targetInfo: FrontendTargetInfo,
     parsedOptions: inout ParsedOptions
   ) throws -> VirtualPath {
+    var platform = targetInfo.target.triple.platformName(conflatingDarwin: true)!
+    // compiler-rt moved these Android sanitizers into `lib/linux/` a couple
+    // years ago, llvm/llvm-project@a68ccba, so look for them there instead.
+    if platform == "android" {
+      platform = "linux"
+    }
     return VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-      .appending(components: "clang", "lib",
-                 targetInfo.target.triple.platformName(conflatingDarwin: true)!)
+      .appending(components: "clang", "lib", platform)
   }
 
   func runtimeLibraryPaths(


### PR DESCRIPTION
This upstream change, llvm/llvm-project@a68ccba, broke looking for ASan on Android, so fix it up.

I didn't bother with a test here as [it won't run without the Android sanitizers being installed](https://github.com/apple/swift-driver/blob/f66dd67ce2d0a5950befb3234004277afa866d75/Tests/SwiftDriverTests/SwiftDriverTests.swift#L2528), and this gets the sanitizer tests from the compiler validation suite working on Android anyway.