### PR TITLE
Remove unused runtime library path on non-Darwin platforms

### DIFF
--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -46,7 +46,8 @@ extension Toolchain {
       result.append(path)
     }
 
-    if let sdkPath = sdkPath.map(VirtualPath.lookup) {
+    // Only Darwin places libraries directly in /sdk/usr/lib/swift/.
+    if triple.isDarwin, let sdkPath = sdkPath.map(VirtualPath.lookup) {
       // If we added the secondary resource dir, we also need the iOSSupport directory.
       if secondaryResourceDir != nil {
         result.append(sdkPath.appending(components: "System", "iOSSupport", "usr", "lib", "swift"))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4767,6 +4767,9 @@ final class SwiftDriverTests: XCTestCase {
     var driver = try Driver(args: ["swiftc", "foo.swift", "-sdk", "/"])
     let plannedJobs = try driver.planBuild()
     XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/")))]))
+    if !driver.targetTriple.isDarwin {
+      XCTAssertFalse(plannedJobs[2].commandLine.contains(subsequence: ["-L", .path(.absolute(.init("/usr/lib/swift")))]))
+    }
   }
 
   func testDumpASTOverride() throws {


### PR DESCRIPTION
Fixes apple/swift#63416