### PR TITLE
SwiftDriver: mark bitcode interfaces as `internal`

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitcode.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitcode.swift
@@ -12,14 +12,14 @@
 
 import struct TSCBasic.ByteString
 
-public struct Bitcode {
+internal struct Bitcode {
   public let signature: Bitcode.Signature
   public let elements: [BitcodeElement]
   public let blockInfo: [UInt64:BlockInfo]
 }
 
 extension Bitcode {
-  public struct Signature: Equatable {
+  internal struct Signature: Equatable {
     private var value: UInt32
 
     public init(value: UInt32) {
@@ -41,7 +41,7 @@ extension Bitcode {
 extension Bitcode {
   /// Traverse a bitstream using the specified `visitor`, which will receive
   /// callbacks when blocks and records are encountered.
-  public static func read<Visitor: BitstreamVisitor>(bytes: ByteString, using visitor: inout Visitor) throws {
+  internal static func read<Visitor: BitstreamVisitor>(bytes: ByteString, using visitor: inout Visitor) throws {
     precondition(bytes.count > 4)
     var reader = BitstreamReader(buffer: bytes)
     try visitor.validate(signature: reader.readSignature())

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitcodeElement.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitcodeElement.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum BitcodeElement {
-  public struct Block {
+internal enum BitcodeElement {
+  internal struct Block {
     public var id: UInt64
     public var elements: [BitcodeElement]
   }
@@ -21,8 +21,8 @@ public enum BitcodeElement {
   /// - Warning: A `Record` element's fields and payload only live as long as
   ///            the `visit` function that provides them is called. To persist
   ///            a record, always make a copy of it.
-  public struct Record {
-    public enum Payload {
+  internal struct Record {
+    internal enum Payload {
       case none
       case array([UInt64])
       case char6String(String)
@@ -39,7 +39,7 @@ public enum BitcodeElement {
 }
 
 extension BitcodeElement.Record.Payload: CustomStringConvertible {
-  public var description: String {
+  internal var description: String {
     switch self {
     case .none:
       return "none"

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bits.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bits.swift
@@ -12,7 +12,7 @@
 
 import struct TSCBasic.ByteString
 
-struct Bits: RandomAccessCollection {
+internal struct Bits: RandomAccessCollection {
   var buffer: ByteString
 
   var startIndex: Int { return 0 }
@@ -50,7 +50,7 @@ struct Bits: RandomAccessCollection {
 }
 
 extension Bits {
-  struct Cursor {
+  internal struct Cursor {
     enum Error: Swift.Error { case bufferOverflow }
 
     let buffer: Bits

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitstream.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/Bitstream.swift
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 /// A top-level namespace for all bitstream-related structures.
-public enum Bitstream {}
+internal enum Bitstream {}
 
 extension Bitstream {
   /// An `Abbreviation` represents the encoding definition for a user-defined
   /// record. An `Abbreviation` is the primary form of compression available in
   /// a bitstream file.
-  public struct Abbreviation {
-    public enum Operand {
+  internal struct Abbreviation {
+    internal enum Operand {
       /// A literal value (emitted as a VBR8 field).
       case literal(UInt64)
 
@@ -91,7 +91,7 @@ extension Bitstream {
   ///            abbreviation defined by `BitstreamWriter`. Always use
   ///            `BitstreamWriter.defineBlockInfoAbbreviation(_:_:)`
   ///            to register abbreviations.
-  public struct AbbreviationID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
+  internal struct AbbreviationID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
     public var rawValue: UInt64
 
     public init(rawValue: UInt64) {
@@ -136,7 +136,7 @@ extension Bitstream {
   ///     static let diagnostics  = Self.firstApplicationID + 1
   /// }
   /// ```
-  public struct BlockID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
+  internal struct BlockID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
     public var rawValue: UInt8
 
     public init(rawValue: UInt8) {
@@ -166,7 +166,7 @@ extension Bitstream {
     /// a name is given to a block or record with `blockName` or
     /// `setRecordName`, debugging tools like `llvm-bcanalyzer` can be used to
     /// introspect the structure of blocks and records in the bitstream file.
-    public enum BlockInfoCode: UInt8 {
+    internal enum BlockInfoCode: UInt8 {
         /// Indicates which block ID is being described.
         case setBID = 1
         /// An optional element that records which bytes of the record are the

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamVisitor.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BitstreamVisitor.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol BitstreamVisitor {
+internal protocol BitstreamVisitor {
   /// Customization point to validate a bitstream's signature or "magic number".
   func validate(signature: Bitcode.Signature) throws
   /// Called when a new block is encountered. Return `true` to enter the block

--- a/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BlockInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/Bitcode/BlockInfo.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct BlockInfo {
+internal struct BlockInfo {
   public var name: String = ""
   public var recordNames: [UInt64:String] = [:]
 }


### PR DESCRIPTION
We do not vend the bitcode reading as an API that others may use.  Mark this as `internal` as the interfaces are used strictly within the `IncrementalCompilation` module.  If we need, we can extend in the further to use `@package` visibility.