### PR TITLE
Add `repl` to swift-help topics

### DIFF
--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -47,7 +47,7 @@ enum HelpTopic: ExpressibleByArgument, CustomStringConvertible {
 }
 
 enum Subcommand: String, CaseIterable {
-  case build, package, run, test
+  case build, package, run, test, repl
 
   var description: String {
     switch self {
@@ -59,6 +59,8 @@ enum Subcommand: String, CaseIterable {
       return "Run a program from a package"
     case .test:
       return "Run package tests"
+    case .repl:
+      return "Experiment with Swift code interactively"
     }
   }
 }
@@ -111,12 +113,6 @@ struct SwiftHelp: ParsableCommand {
       print("  \(plainBold)swift \(command.rawValue)\(plain)\(padding)    \(command.description)")
     }
 
-    // `repl` not included in `Subcommand`, also print it here.
-    do {
-      let padding = String(repeating: " ", count: maxSubcommandNameLength - "repl".count)
-      print("  \(plainBold)swift repl\(plain)\(padding)    Experiment with Swift code interactively")
-    }
-
     print("\n  Use \(plainBold)`swift --version`\(plain) for Swift version information.")
     print("\n  Use \(plainBold)`swift --help`\(plain) for descriptions of available options and flags.")
     print("\n  Use \(plainBold)`swift help <subcommand>`\(plain) for more information about a subcommand.")
@@ -131,6 +127,16 @@ struct SwiftHelp: ParsableCommand {
       if kind == .interactive {
         printIntro()
       }
+    case .subcommand(.repl):
+        print("""
+        USAGE: swift repl <options>
+
+          The Swift REPL runs code interactively with LLDB.
+          For most purposes, you can just run `swift repl`.
+
+        OPTIONS:
+          This mode takes optional Swift Frontend arguments: see `swift --help`.
+        """)
     case .subcommand(let subcommand):
       // Try to find the subcommand adjacent to the help tool.
       // If we didn't find the tool there, let the OS search for it.


### PR DESCRIPTION
Most just run `swift repl` here, but also reference the possibility of passing Swift Frontend arguments.

rdar://109411493