### PR TITLE
Driver: allow static executables when using Musl

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2008,7 +2008,7 @@ extension Driver {
     if let outputOption = parsedOptions.getLast(in: .modes) {
       switch outputOption.option {
       case .emitExecutable:
-        if parsedOptions.contains(.static) && targetTriple.environment != .musl {
+        if parsedOptions.contains(.static) && !targetTriple.supportsStaticExecutables {
           diagnosticsEngine.emit(.error_static_emit_executable_disallowed)
         }
         linkerOutputType = .executable

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -1705,3 +1705,14 @@ fileprivate extension Array {
     }
   }
 }
+
+// MARK: - Linker support
+
+extension Triple {
+    /// Returns `true` if a given triple supports producing fully statically linked executables by providing `-static`
+    /// flag to the linker. This implies statically linking platform's libc, and of those that Swift supports currently
+    /// only Musl allows that reliably.
+    var supportsStaticExecutables: Bool {
+        self.environment == .musl
+    }
+}


### PR DESCRIPTION
This error diagnostic doesn't make sense when linking on Linux with Musl, which allows fully statically linked executables.