### PR TITLE
Add support for Musl libc

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -17,6 +17,8 @@ import ucrt
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Missing libc or equivalent")
 #endif

--- a/Sources/SwiftDriver/SwiftScan/Loader.swift
+++ b/Sources/SwiftDriver/SwiftScan/Loader.swift
@@ -17,8 +17,10 @@ import var Foundation.NSLocalizedDescriptionKey
 import WinSDK
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 internal enum Loader {
@@ -130,7 +132,7 @@ extension Loader.Flags {
       Loader.Flags(rawValue: 0)
     }
 
-#if os(Linux)
+#if os(Linux) && canImport(Glibc)
     public static var deepBind: Loader.Flags {
       Loader.Flags(rawValue: RTLD_DEEPBIND)
     }

--- a/Sources/SwiftDriver/Utilities/DateAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/DateAdditions.swift
@@ -14,8 +14,10 @@
 import WinSDK
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /// Represents a time point value with nanosecond precision.

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -14,6 +14,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 func argumentNeedsQuoting(_ argument: String) -> Bool {

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -15,8 +15,10 @@ import SwiftDriver
 import CRT
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 import TSCBasic // <<<

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -15,8 +15,10 @@ import SwiftDriver
 import CRT
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 import Dispatch


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.