### PR TITLE
Fix a non-deterministic failure in testPrintingExplicitDependencyGraph

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1480,7 +1480,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                 diagnosticsEngine: diagnosticEngine)
         let _ = try driver.planBuild()
       }
-      XCTAssertTrue(output.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\","))
+      XCTAssertTrue(output.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\""))
 
       let output2 = try withHijackedOutputStream {
         let diagnosticEngine = DiagnosticsEngine()
@@ -1499,7 +1499,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                 diagnosticsEngine: diagnosticEngine)
         let _ = try driver.planBuild()
       }
-      XCTAssertTrue(output3.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\","))
+      XCTAssertTrue(output3.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\""))
     }
   }
 


### PR DESCRIPTION
When JSONEncoder puts `mainModuleName` in the end of the JSON dictionary, it does not have `,` in the end. Remove the trailing `,` to avoid such failures.