### PR TITLE
[Driver] For immediate mode prefer using the default SDK over the `SDKROOT` variable

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2609,11 +2609,15 @@ extension Driver {
 
     if let arg = parsedOptions.getLastArgument(.sdk) {
       sdkPath = arg.asSingle
-    } else if let SDKROOT = env["SDKROOT"] {
-      sdkPath = SDKROOT
     } else if compilerMode == .immediate || compilerMode == .repl {
       // In immediate modes, query the toolchain for a default SDK.
+      // We avoid using `SDKROOT` because that may be set to a compilation platform (like iOS)
+      // that is different than the host.
       sdkPath = try? toolchain.defaultSDKPath(targetTriple)?.pathString
+    }
+
+    if sdkPath == nil, let SDKROOT = env["SDKROOT"] {
+      sdkPath = SDKROOT
     }
 
     // An empty string explicitly clears the SDK.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3495,7 +3495,17 @@ final class SwiftDriverTests: XCTestCase {
 
   func testImmediateMode() throws {
     do {
-      var driver = try Driver(args: ["swift", "foo.swift"])
+      var env: [String: String] = ProcessEnv.vars
+#if os(macOS)
+      let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
+                                             processSet: ProcessSet(),
+                                             fileSystem: localFileSystem,
+                                             env: ProcessEnv.vars)
+      let iosSDKPath = try executor.checkNonZeroExit(
+        args: "xcrun", "-sdk", "iphoneos", "--show-sdk-path").spm_chomp()
+      env["SDKROOT"] = iosSDKPath
+#endif
+      var driver = try Driver(args: ["swift", "foo.swift"], env: env)
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
@@ -3509,7 +3519,13 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(job.commandLine.contains(.flag("foo")))
 
       if driver.targetTriple.isMacOSX {
-        XCTAssertTrue(job.commandLine.contains(.flag("-sdk")))
+        let sdkIdx = try XCTUnwrap(job.commandLine.firstIndex(of: .flag("-sdk")))
+        let sdkPathOpt: VirtualPath? = switch job.commandLine[sdkIdx + 1] {
+        case .path(let path): path
+        default: nil
+        }
+        let sdkPath = try XCTUnwrap(sdkPathOpt)
+        XCTAssertTrue(sdkPath.name.contains("MacOSX.platform"))
       }
 
       XCTAssertFalse(job.commandLine.contains(.flag("--")))


### PR DESCRIPTION
Avoid using `SDKROOT` because that may be set to a compilation platform (like iOS) that is different than the host. For immediate mode the host SDK is what needs to be used.