### PR TITLE
[Explicit Modules] Handle re-mapped platform versions when specifying SDK-aligned `-clang-target` on Darwin platforms

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -415,7 +415,9 @@ public final class DarwinToolchain: Toolchain {
       if let explicitClangTripleArg = driver.parsedOptions.getLastArgument(.clangTarget)?.asSingle {
         clangTargetTriple = explicitClangTripleArg
       } else {
-        clangTargetTriple = frontendTargetInfo.target.unversionedTriple.triple + sdkInfo.versionString
+        let currentTriple = frontendTargetInfo.target.triple
+        let sdkVersionedOSString = currentTriple.osNameUnversioned + sdkInfo.sdkVersion(for: currentTriple).sdkVersionString
+        clangTargetTriple = currentTriple.triple.replacingOccurrences(of: currentTriple.osName, with: sdkVersionedOSString)
       }
 
       commandLine.appendFlag(.clangTarget)

--- a/TestInputs/SDKChecks/MacOSX10.15.sdk/SDKSettings.json
+++ b/TestInputs/SDKChecks/MacOSX10.15.sdk/SDKSettings.json
@@ -1,8 +1,8 @@
 {
 	"Version": "10.15",
 	"VersionMap": {
-		"macOS_iOSMac": {},
-		"iOSMac_macOS": {}
+		"macOS_iOSMac": {"10.15":"13.3"},
+		"iOSMac_macOS": {"13.3":"10.15"}
 	},
 	"CanonicalName": "macosx10.15"
 }


### PR DESCRIPTION
Resolves rdar://108288193