### PR TITLE
[5.9 🍒][Explicit Modules] Handle re-mapped platform versions when specifying SDK-aligned `-clang-target` on Darwin platforms

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -415,7 +415,9 @@ public final class DarwinToolchain: Toolchain {
       if let explicitClangTripleArg = driver.parsedOptions.getLastArgument(.clangTarget)?.asSingle {
         clangTargetTriple = explicitClangTripleArg
       } else {
-        clangTargetTriple = frontendTargetInfo.target.unversionedTriple.triple + sdkInfo.versionString
+        let currentTriple = frontendTargetInfo.target.triple
+        let sdkVersionedOSString = currentTriple.osNameUnversioned + sdkInfo.sdkVersion(for: currentTriple).sdkVersionString
+        clangTargetTriple = currentTriple.triple.replacingOccurrences(of: currentTriple.osName, with: sdkVersionedOSString)
       }
 
       commandLine.appendFlag(.clangTarget)

--- a/TestInputs/SDKChecks/MacOSX10.15.sdk/SDKSettings.json
+++ b/TestInputs/SDKChecks/MacOSX10.15.sdk/SDKSettings.json
@@ -1,8 +1,8 @@
 {
 	"Version": "10.15",
 	"VersionMap": {
-		"macOS_iOSMac": {},
-		"iOSMac_macOS": {}
+		"macOS_iOSMac": {"10.15":"13.3"},
+		"iOSMac_macOS": {"13.3":"10.15"}
 	},
 	"CanonicalName": "macosx10.15"
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3685,7 +3685,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testClangTargetForExplicitModule() throws {
     #if os(macOS)
-    let sdkRoot = testInputsPath.appending(component: "SDKChecks").appending(component: "iPhoneOS.sdk")
+    let sdkRoot = testInputsPath.appending(component: "SDKChecks").appending(component: "MacOSX10.15.sdk")
 
     // Check -clang-target is on by default when explicit module is on.
     try withTemporaryDirectory { path in
@@ -3694,7 +3694,7 @@ final class SwiftDriverTests: XCTestCase {
         $0 <<< "import Swift"
       }
       var driver = try Driver(args: ["swiftc", "-explicit-module-build",
-                                     "-target", "arm64-apple-ios14.0",
+                                     "-target", "arm64-apple-macos10.14",
                                      "-sdk", sdkRoot.pathString,
                                      main.pathString])
       guard driver.isFrontendArgSupported(.clangTarget) else {
@@ -3702,9 +3702,29 @@ final class SwiftDriverTests: XCTestCase {
       }
       let plannedJobs = try driver.planBuild()
       XCTAssertTrue(plannedJobs.contains { job in
-        job.commandLine.contains(subsequence: [.flag("-clang-target"), .flag("arm64-apple-ios13.0")])
+        job.commandLine.contains(subsequence: [.flag("-clang-target"), .flag("arm64-apple-macos10.15")])
       })
     }
+
+    // Check -clang-target is handled correctly with the MacCatalyst remap.
+    try withTemporaryDirectory { path in
+      let main = path.appending(component: "Foo.swift")
+      try localFileSystem.writeFileContents(main) {
+        $0 <<< "import Swift"
+      }
+      var driver = try Driver(args: ["swiftc", "-explicit-module-build",
+                                     "-target", "arm64e-apple-ios13.0-macabi",
+                                     "-sdk", sdkRoot.pathString,
+                                     main.pathString])
+      guard driver.isFrontendArgSupported(.clangTarget) else {
+        throw XCTSkip("Skipping: compiler does not support '-clang-target'")
+      }
+      let plannedJobs = try driver.planBuild()
+      XCTAssertTrue(plannedJobs.contains { job in
+        job.commandLine.contains(subsequence: [.flag("-clang-target"), .flag("arm64e-apple-ios13.3-macabi")])
+      })
+    }
+
     // Check -disable-clang-target works
     try withTemporaryDirectory { path in
       let main = path.appending(component: "Foo.swift")
@@ -3713,7 +3733,7 @@ final class SwiftDriverTests: XCTestCase {
       }
       var driver = try Driver(args: ["swiftc", "-disable-clang-target",
                                      "-explicit-module-build",
-                                     "-target", "arm64-apple-ios14.0",
+                                     "-target", "arm64-apple-macos10.14",
                                      "-sdk", sdkRoot.pathString,
                                      main.pathString])
       guard driver.isFrontendArgSupported(.clangTarget) else {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1394
--------------------------------------------
**• Release**: 5.9
**• Explanation**: https://github.com/apple/swift-driver/pull/1322 introduced functionality to the driver where `-clang-target` for all Clang module dependencies is set to the target SDK deployment target on Darwin platforms. The original implementation missed the case of targeting platforms with an SDK-specified OS version re-map, causing incorrect versions to be used in those cases, in Explicit Module Builds.
**• Reviewed by**: @xymus 
**• Scope of Issue**: Explicitly-built module dependencies of builds targeting platforms with a version remap (e.g. MacCatalyst) use incorrect/unexpected target OS versions for Clang module dependencies. 
**• Risk**: Low. This change modifies code that does not run on default (Implicit Modules) compilation code-path, and the change itself is straight-forward and small, for affected code-paths. 
**• Testing**: Automated tests added to the driver test suite.

Resolves rdar://108288193