### PR TITLE
[5.9] Downgrade priors version mismatch warning

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -344,8 +344,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
       graphIfPresent = try ModuleDependencyGraph.read(from: dependencyGraphPath, info: self)
     }
     catch let ModuleDependencyGraph.ReadError.mismatchedSerializedGraphVersion(expected, read) {
-      diagnosticEngine.emit(.warning("Will not do cross-module incremental builds, wrong version of priors; expected \(expected) but read \(read) at '\(dependencyGraphPath)'"),
-                            location: nil)
+      reporter?.report("Will not do cross-module incremental builds, wrong version of priors; expected \(expected) but read \(read) at '\(dependencyGraphPath)'")
       graphIfPresent = nil
     }
     catch {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -1603,7 +1603,7 @@ extension DiagVerifiable {
     "Incremental compilation: Read dependency graph"
   }
   @DiagsBuilder var couldNotReadPriors: [Diagnostic.Message] {
-      .warning("Will not do cross-module incremental builds, wrong version of priors; expected")
+      .remark("Will not do cross-module incremental builds, wrong version of priors; expected")
   }
   // MARK: - dependencies
   @DiagsBuilder func reading(deps inputs: [String]) -> [Diagnostic.Message] {


### PR DESCRIPTION
As a user when you're changing between versions of these files there's
nothing you could do to avoid invalidation so this warning feel
superfluous

(cherry picked from commit e98ddbdab89730d039a461ca134f0e5ec20e55dc / https://github.com/apple/swift-driver/pull/1396)
