### PR TITLE
swift-help: use the executable suffix on Windows

### DIFF
--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -140,7 +140,11 @@ struct SwiftHelp: ParsableCommand {
     case .subcommand(let subcommand):
       // Try to find the subcommand adjacent to the help tool.
       // If we didn't find the tool there, let the OS search for it.
+#if os(Windows)
+      let execName = "swift-\(subcommand.rawValue).exe"
+#else
       let execName = "swift-\(subcommand.rawValue)"
+#endif
       let subcommandPath = Process.findExecutable(
         CommandLine.arguments[0])?
         .parentDirectory


### PR DESCRIPTION
Windows relies on the suffix for differentiating files.  The use of `.exe` as the executable suffix is nearly universal on Windows.  Ensure that we use that when targeting Windows, repairing the use of certain subcommands, e.g. `swift help build`.

Fixes: #1404