### PR TITLE
[5.9 🍒][NFC] Tweak testWMOWithJustObjectInputs test to not count autolink-extract jobs

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2901,7 +2901,7 @@ final class SwiftDriverTests: XCTestCase {
     var driver = try Driver(args: [
       "swiftc", "-wmo", "foo.o", "bar.o"
     ])
-    let plannedJobs = try driver.planBuild()
+    let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
     XCTAssertEqual(plannedJobs.count, 1)
     XCTAssertEqual(plannedJobs.first?.kind, .link)
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1388
-------------------------------------
Test-only fix, non-functional.