### PR TITLE
[Dependency Scanning] Add option to specify a separate Clang Dependency scanner module cache.

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -121,6 +121,7 @@ public extension Driver {
     }
 
     try commandLine.appendLast(.clangIncludeTree, from: &parsedOptions)
+    try commandLine.appendLast(.clangScannerModuleCachePath, from: &parsedOptions)
 
     // Pass on the input files
     commandLine.append(contentsOf: inputFiles.filter { $0.type == .swift }.map { .path($0.file) })

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -121,7 +121,9 @@ public extension Driver {
     }
 
     try commandLine.appendLast(.clangIncludeTree, from: &parsedOptions)
-    try commandLine.appendLast(.clangScannerModuleCachePath, from: &parsedOptions)
+    if isFrontendArgSupported(.clangScannerModuleCachePath) {
+      try commandLine.appendLast(.clangScannerModuleCachePath, from: &parsedOptions)
+    }
 
     // Pass on the input files
     commandLine.append(contentsOf: inputFiles.filter { $0.type == .swift }.map { .path($0.file) })

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -74,6 +74,7 @@ extension Option {
   public static let clangHeaderExposeModule: Option = Option("-clang-header-expose-module", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<imported-module-name>=<generated-header-name>", helpText: "Allow the compiler to assume that APIs from the specified module are exposed to C/C++/Objective-C in another generated header, so that APIs in the current module that depend on declarations from the specified module can be exposed in the generated header.")
   public static let clangIncludeTreeRoot: Option = Option("-clang-include-tree-root", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<cas-id>", helpText: "Clang Include Tree CASID")
   public static let clangIncludeTree: Option = Option("-clang-include-tree", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Use clang include tree")
+  public static let clangScannerModuleCachePath: Option = Option("-clang-scanner-module-cache-path", .separate, attributes: [.frontend, .doesNotAffectIncrementalBuild, .argumentIsPath], helpText: "Specifies the Clang dependency scanner module cache path")
   public static let clangTarget: Option = Option("-clang-target", .separate, attributes: [.frontend], helpText: "Separately set the target we should use for internal Clang instance")
   public static let codeCompleteCallPatternHeuristics: Option = Option("-code-complete-call-pattern-heuristics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Use heuristics to guess whether we want call pattern completions")
   public static let codeCompleteInitsInPostfixExpr: Option = Option("-code-complete-inits-in-postfix-expr", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Include initializers when completing a postfix expression")
@@ -867,6 +868,7 @@ extension Option {
       Option.clangHeaderExposeModule,
       Option.clangIncludeTreeRoot,
       Option.clangIncludeTree,
+      Option.clangScannerModuleCachePath,
       Option.clangTarget,
       Option.codeCompleteCallPatternHeuristics,
       Option.codeCompleteInitsInPostfixExpr,

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1365,7 +1365,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
   }
 
-  /// Test that the scanner invocation does not rely in response files
+  /// Test that the scanner invocation does not rely on response files
   func testDependencyScanningSeparateClangScanCache() throws {
     try withTemporaryDirectory { path in
       let scannerCachePath: AbsolutePath = path.appending(component: "ClangScannerCache")
@@ -1381,6 +1381,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-working-directory", path.nativePathString(escaped: true),
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
+      guard driver.isFrontendArgSupported(.clangScannerModuleCachePath) else {
+        throw XCTSkip("Skipping: compiler does not support '-clang-scanner-module-cache-path'")
+      }
+
       let scannerJob = try driver.dependencyScanningJob()
       XCTAssertTrue(scannerJob.commandLine.contains(subsequence: [.flag("-clang-scanner-module-cache-path"),
                                                                   .path(.absolute(scannerCachePath))]))


### PR DESCRIPTION
Clang dependency scanning produces scanner PCMs which we may want to live in a different filesystem location than the main build module cache.

Resolves rdar://113222853