### PR TITLE
Tests: Replace uses of deprecated AbsolutePath initializers with throwing variant

### DIFF
--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -112,7 +112,7 @@ class APIDigesterTests: XCTestCase {
                                        "-output-file-map", ofmPath.pathString,
                                       ])
         let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
-        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/path/to/baseline.abi.json")))]))
+        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/path/to/baseline.abi.json")))]))
       }
     }
     do {
@@ -136,7 +136,7 @@ class APIDigesterTests: XCTestCase {
                                        "-output-file-map", ofmPath.pathString,
                                       ])
         let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .generateABIBaseline })
-        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/path/to/sourceinfo.abi.json")))]))
+        XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/path/to/sourceinfo.abi.json")))]))
       }
     }
   }
@@ -149,8 +149,8 @@ class APIDigesterTests: XCTestCase {
       XCTAssertTrue(digesterJob.commandLine.contains("-dump-sdk"))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(try .init(validating: "/path/to/sdk")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(try .init(validating: "/some/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.api.json")))]))
 
@@ -165,8 +165,8 @@ class APIDigesterTests: XCTestCase {
       XCTAssertTrue(digesterJob.commandLine.contains("-dump-sdk"))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(try .init(validating: "/path/to/sdk")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(try .init(validating: "/some/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-o", .path(.relative(.init("foo.abi.json")))]))
 
@@ -238,10 +238,10 @@ class APIDigesterTests: XCTestCase {
       let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareAPIBaseline })
       XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-module", "foo"]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(.init("/baseline/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-baseline-path", .path(.absolute(try .init(validating: "/baseline/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.relative(.init(".")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/path/to/sdk")))]))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(.init("/some/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-sdk", .path(.absolute(try .init(validating: "/path/to/sdk")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-I", .path(.absolute(try .init(validating: "/some/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-F", .path(.relative(.init("framework/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
                                                                    .path(.relative(.init("allowlist/path")))]))
@@ -257,7 +257,7 @@ class APIDigesterTests: XCTestCase {
                                      "-digester-breakage-allowlist-path", "allowlist/path"])
       let digesterJob = try XCTUnwrap(driver.planBuild().first { $0.kind == .compareABIBaseline })
       XCTAssertTrue(digesterJob.commandLine.contains("-diagnose-sdk"))
-      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-input-paths", .path(.absolute(.init("/baseline/path")))]))
+      XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-input-paths", .path(.absolute(try .init(validating: "/baseline/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains(subsequence: ["-breakage-allowlist-path",
                                                                    .path(.relative(.init("allowlist/path")))]))
       XCTAssertTrue(digesterJob.commandLine.contains("-abi"))

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import TestUtilities
 
 private var testInputsPath: AbsolutePath = {
-  var root: AbsolutePath = AbsolutePath(#file)
+  var root: AbsolutePath = try! AbsolutePath(validating: #file)
   while root.basename != "Tests" {
     root = root.parentDirectory
   }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import TestUtilities
 
 private var testInputsPath: AbsolutePath = {
-  var root: AbsolutePath = AbsolutePath(#file)
+  var root: AbsolutePath = try! AbsolutePath(validating: #file)
   while root.basename != "Tests" {
     root = root.parentDirectory
   }
@@ -199,13 +199,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
   func testModuleDependencyBuildCommandGenerationWithExternalFramework() throws {
     do {
-      let externalDetails: ExternalTargetModuleDetailsMap =
-            [.swiftPrebuiltExternal("A"): ExternalTargetModuleDetails(path: AbsolutePath("/tmp/A.swiftmodule"),
-                                                                      isFramework: true),
-             .swiftPrebuiltExternal("K"): ExternalTargetModuleDetails(path: AbsolutePath("/tmp/K.swiftmodule"),
-                                                                       isFramework: true),
-             .swiftPrebuiltExternal("simpleTestModule"): ExternalTargetModuleDetails(path: AbsolutePath("/tmp/simpleTestModule.swiftmodule"),
-                                                                                     isFramework: true)]
+      let externalDetails: ExternalTargetModuleDetailsMap = [
+        .swiftPrebuiltExternal("A"): ExternalTargetModuleDetails(path: try AbsolutePath(validating: "/tmp/A.swiftmodule"),
+                                                                 isFramework: true),
+        .swiftPrebuiltExternal("K"): ExternalTargetModuleDetails(path: try AbsolutePath(validating: "/tmp/K.swiftmodule"),
+                                                                 isFramework: true),
+        .swiftPrebuiltExternal("simpleTestModule"): ExternalTargetModuleDetails(path: try AbsolutePath(validating: "/tmp/simpleTestModule.swiftmodule"),
+                                                                                isFramework: true)
+      ]
       var driver = try Driver(args: ["swiftc", "-explicit-module-build",
                                      "-module-name", "simpleTestModule",
                                      "test.swift"])
@@ -1240,7 +1241,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                              env: ProcessEnv.vars)
       let sdkPath = try executor.checkNonZeroExit(
         args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
-      let stdLibPath = AbsolutePath(sdkPath).appending(component: "usr")
+      let stdLibPath = try AbsolutePath(validating: sdkPath)
+        .appending(component: "usr")
         .appending(component: "lib")
         .appending(component: "swift")
       return (stdLibPath, stdLibPath.appending(component: "shims"))

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -20,8 +20,8 @@ import TestUtilities
 // MARK: - Instance variables and initialization
 final class IncrementalCompilationTests: XCTestCase {
 
-  var tempDir: AbsolutePath = AbsolutePath("/tmp")
-  var explicitModuleCacheDir: AbsolutePath = AbsolutePath("/tmp/ModuleCache")
+  var tempDir: AbsolutePath = { try! AbsolutePath(validating: "/tmp") }()
+  var explicitModuleCacheDir: AbsolutePath = { try! AbsolutePath(validating: "/tmp/ModuleCache") }()
 
   var derivedDataDir: AbsolutePath {
     tempDir.appending(component: "derivedData")

--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -16,12 +16,14 @@ import TSCBasic
 #if os(macOS)
 internal func bundleRoot() -> AbsolutePath {
     for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-        return AbsolutePath(bundle.bundlePath).parentDirectory
+      return try! AbsolutePath(validating: bundle.bundlePath).parentDirectory
     }
     fatalError()
 }
 
-private let packageDirectory = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+private let packageDirectory = {
+  try! AbsolutePath(validating: #file).parentDirectory.parentDirectory.parentDirectory
+}()
 
 // The "default" here means lit.py will be invoked as an executable, while otherwise let's use
 // python 3 explicitly.
@@ -95,7 +97,7 @@ final class IntegrationTests: IntegrationTestCase {
         environment: ProcessEnv.vars.merging(extraEnv) { $1 }
       )
 
-      XCTAssertTrue(localFileSystem.isExecutableFile(AbsolutePath("debug/swift-driver", relativeTo: buildPath)), result)
+      XCTAssertTrue(localFileSystem.isExecutableFile(try AbsolutePath(validating: "debug/swift-driver", relativeTo: buildPath)), result)
     }
   #endif
   }
@@ -173,8 +175,8 @@ final class IntegrationTests: IntegrationTestCase {
       // you've cloned this package into a Swift compiler working directory,
       // that means it'll be the directory with build/, llvm/, swift/, and
       // swift-driver/ in it.
-      let litConfigDir = AbsolutePath(
-        litConfigPathString,
+      let litConfigDir = try AbsolutePath(
+        validating: litConfigPathString,
         relativeTo: swiftRootDir
       )
 

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -68,19 +68,19 @@ extension DarwinToolchain {
         args: "xcrun", "-sdk", "macosx", "--show-sdk-path",
         environment: env
       ).spm_chomp()
-      return AbsolutePath(result)
+      return try AbsolutePath(validating: result)
     }
   }
 
   /// macOS resource directory, for testing only.
   var resourcesDirectory: Result<AbsolutePath, Swift.Error> {
     return Result {
-      try AbsolutePath("../../lib/swift/macosx", relativeTo: getToolPath(.swiftCompiler))
+      try AbsolutePath(validating: "../../lib/swift/macosx", relativeTo: getToolPath(.swiftCompiler))
     }
   }
 
   var clangRT: Result<AbsolutePath, Error> {
-    resourcesDirectory.map { AbsolutePath("../clang/lib/darwin/libclang_rt.osx.a", relativeTo: $0) }
+    resourcesDirectory.map { try! AbsolutePath(validating: "../clang/lib/darwin/libclang_rt.osx.a", relativeTo: $0) }
   }
 
   var compatibility50: Result<AbsolutePath, Error> {
@@ -202,9 +202,9 @@ final class JobExecutorTests: XCTestCase {
       XCTAssertEqual(delegate.started.count, 3)
 
       let fooObject = try resolver.resolve(.path(.temporary(RelativePath("foo.o"))))
-      XCTAssertTrue(localFileSystem.exists(AbsolutePath(fooObject)), "expected foo.o to be present in the temporary directory")
+      XCTAssertTrue(localFileSystem.exists(try AbsolutePath(validating: fooObject)), "expected foo.o to be present in the temporary directory")
       try resolver.removeTemporaryDirectory()
-      XCTAssertFalse(localFileSystem.exists(AbsolutePath(fooObject)), "expected foo.o to be removed from the temporary directory")
+      XCTAssertFalse(localFileSystem.exists(try AbsolutePath(validating: fooObject)), "expected foo.o to be removed from the temporary directory")
     }
 #endif
   }
@@ -291,7 +291,7 @@ final class JobExecutorTests: XCTestCase {
     let job = Job(
       moduleName: "main",
       kind: .compile,
-      tool: ResolvedTool(path: AbsolutePath("/usr/bin/swift"), supportsResponseFiles: false),
+      tool: ResolvedTool(path: try AbsolutePath(validating: "/usr/bin/swift"), supportsResponseFiles: false),
       commandLine: [.flag("something")],
       inputs: [],
       primaryInputs: [],
@@ -329,7 +329,7 @@ final class JobExecutorTests: XCTestCase {
 
     env[envVarName] = dummyPath
     let overriddenSwiftPath = try DarwinToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
-    XCTAssertEqual(overriddenSwiftPath, AbsolutePath(dummyPath))
+    XCTAssertEqual(overriddenSwiftPath, try AbsolutePath(validating: dummyPath))
 
     // GenericUnixToolchain
     env.removeValue(forKey: envVarName)
@@ -339,7 +339,7 @@ final class JobExecutorTests: XCTestCase {
 
     env[envVarName] = dummyPath
     let unixOverriddenSwiftPath = try GenericUnixToolchain(env: env, executor: executor).getToolPath(.swiftCompiler)
-    XCTAssertEqual(unixOverriddenSwiftPath, AbsolutePath(dummyPath))
+    XCTAssertEqual(unixOverriddenSwiftPath, try AbsolutePath(validating: dummyPath))
   }
 
   func testInputModifiedDuringSingleJobBuild() throws {
@@ -378,10 +378,10 @@ final class JobExecutorTests: XCTestCase {
     let job = Job(moduleName: "Module",
                   kind: .compile,
                   tool: ResolvedTool(
-                    path: AbsolutePath("/path/to/the tool"),
+                    path: try AbsolutePath(validating: "/path/to/the tool"),
                     supportsResponseFiles: false),
-                  commandLine: [.path(.absolute(.init("/with space"))),
-                                .path(.absolute(.init("/withoutspace")))],
+                  commandLine: [.path(.absolute(try .init(validating: "/with space"))),
+                                .path(.absolute(try .init(validating: "/withoutspace")))],
                   inputs: [], primaryInputs: [], outputs: [])
 #if os(Windows)
     XCTAssertEqual(try executor.description(of: job, forceResponseFiles: false),
@@ -509,9 +509,9 @@ final class JobExecutorTests: XCTestCase {
         XCTAssertTrue(localFileSystem.exists(outputPath))
         // -save-temps wasn't passed, so ensure the temporary file was removed.
         XCTAssertFalse(
-          localFileSystem.exists(.init(try executor.resolver.resolve(.path(driver.allSourcesFileList!))))
+          localFileSystem.exists(try .init(validating: executor.resolver.resolve(.path(driver.allSourcesFileList!))))
         )
-        XCTAssertFalse(localFileSystem.exists(.init(try executor.resolver.resolve(.path(compileOutput)))))
+        XCTAssertFalse(localFileSystem.exists(try .init(validating: executor.resolver.resolve(.path(compileOutput)))))
       }
     }
 
@@ -547,9 +547,9 @@ final class JobExecutorTests: XCTestCase {
         XCTAssertTrue(localFileSystem.exists(outputPath))
         // -save-temps was passed, so ensure the temporary file was not removed.
         XCTAssertTrue(
-          localFileSystem.exists(.init(try executor.resolver.resolve(.path(driver.allSourcesFileList!))))
+          localFileSystem.exists(try .init(validating: executor.resolver.resolve(.path(driver.allSourcesFileList!))))
         )
-        XCTAssertTrue(localFileSystem.exists(.init(try executor.resolver.resolve(.path(compileOutput)))))
+        XCTAssertTrue(localFileSystem.exists(try .init(validating: executor.resolver.resolve(.path(compileOutput)))))
       }
     }
 
@@ -584,7 +584,7 @@ final class JobExecutorTests: XCTestCase {
         try? driver.run(jobs: jobs)
         // A job crashed, so ensure any temporary files written so far are preserved.
         XCTAssertTrue(
-          localFileSystem.exists(.init(try executor.resolver.resolve(.path(driver.allSourcesFileList!))))
+          localFileSystem.exists(try .init(validating: executor.resolver.resolve(.path(driver.allSourcesFileList!))))
         )
       }
     }

--- a/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
+++ b/Tests/SwiftDriverTests/ModuleDependencyGraphTests.swift
@@ -1451,7 +1451,7 @@ extension Job {
                                       type: .swift)
     try! self.init(moduleName: "nothing",
                    kind: .compile,
-                   tool: ResolvedTool(path: AbsolutePath("/dummy"), supportsResponseFiles: false),
+                   tool: ResolvedTool(path: AbsolutePath(validating: "/dummy"), supportsResponseFiles: false),
                    commandLine: [],
                    inputs:  [input],
                    primaryInputs: [input],

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -36,7 +36,7 @@ private func rebase(_ arcs: String..., at base: AbsolutePath) -> String {
 }
 
 private var testInputsPath: AbsolutePath = {
-  var root: AbsolutePath = AbsolutePath(#file)
+  var root = try! AbsolutePath(validating: #file)
   while root.basename != "Tests" {
     root = root.parentDirectory
   }
@@ -52,7 +52,7 @@ final class SwiftDriverTests: XCTestCase {
         let ld = $0.appending(component: executableName("ld64.lld"))
 
         try localFileSystem.writeFileContents(ld) { $0 <<< "" }
-        try localFileSystem.chmod(.executable, path: AbsolutePath(ld.nativePathString(escaped: false)))
+        try localFileSystem.chmod(.executable, path: AbsolutePath(validating: ld.nativePathString(escaped: false)))
 
         return ld
       }
@@ -201,7 +201,7 @@ final class SwiftDriverTests: XCTestCase {
   func testJoinedPathOptions() throws {
     var driver = try Driver(args: ["swiftc", "-c", "-I=/some/dir", "-F=other/relative/dir", "foo.swift"])
     let jobs = try driver.planBuild()
-    XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-I=", .absolute(.init("/some/dir")))))
+    XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-I=", .absolute(try .init(validating: "/some/dir")))))
     XCTAssertTrue(jobs[0].commandLine.contains(.joinedOptionAndPath("-F=", .relative(.init("other/relative/dir")))))
   }
 
@@ -213,9 +213,9 @@ final class SwiftDriverTests: XCTestCase {
     let jobs = try driver.planBuild()
     XCTAssertEqual(jobs[0].kind, .compile)
     // The relative ordering of -F and -Fsystem options should be preserved.
-    XCTAssertTrue(jobs[0].commandLine.contains(subsequence: [.flag("-F"), .path(.absolute(.init("/path/to/frameworks"))),
-                                                             .flag("-Fsystem"), .path(.absolute(.init("/path/to/systemframeworks"))),
-                                                             .flag("-F"), .path(.absolute(.init("/path/to/more/frameworks")))]))
+    XCTAssertTrue(jobs[0].commandLine.contains(subsequence: [.flag("-F"), .path(.absolute(try .init(validating: "/path/to/frameworks"))),
+                                                             .flag("-Fsystem"), .path(.absolute(try .init(validating: "/path/to/systemframeworks"))),
+                                                             .flag("-F"), .path(.absolute(try .init(validating: "/path/to/more/frameworks")))]))
   }
 
   func testBatchModeDiagnostics() throws {
@@ -282,15 +282,15 @@ final class SwiftDriverTests: XCTestCase {
     let driver1 = try Driver(args: ["swiftc", "a.swift", "/tmp/b.swift"])
     XCTAssertEqual(driver1.inputFiles,
                    [ TypedVirtualPath(file: VirtualPath.relative(RelativePath("a.swift")).intern(), type: .swift),
-                     TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath("/tmp/b.swift")).intern(), type: .swift) ])
+                     TypedVirtualPath(file: VirtualPath.absolute(try AbsolutePath(validating: "/tmp/b.swift")).intern(), type: .swift) ])
 
     let workingDirectory = localFileSystem.currentWorkingDirectory!.appending(components: "wobble")
     let tempDirectory = localFileSystem.currentWorkingDirectory!.appending(components: "tmp")
 
     let driver2 = try Driver(args: ["swiftc", "a.swift", "-working-directory", workingDirectory.pathString, rebase("b.swift", at: tempDirectory)])
     XCTAssertEqual(driver2.inputFiles,
-                   [ TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath(rebase("a.swift", at: workingDirectory))).intern(), type: .swift),
-                     TypedVirtualPath(file: VirtualPath.absolute(AbsolutePath(rebase("b.swift", at: tempDirectory))).intern(), type: .swift) ])
+                   [ TypedVirtualPath(file: VirtualPath.absolute(try AbsolutePath(validating: rebase("a.swift", at: workingDirectory))).intern(), type: .swift),
+                     TypedVirtualPath(file: VirtualPath.absolute(try AbsolutePath(validating: rebase("b.swift", at: tempDirectory))).intern(), type: .swift) ])
 
     let driver3 = try Driver(args: ["swift", "-"])
     XCTAssertEqual(driver3.inputFiles, [ TypedVirtualPath(file: .standardInput, type: .swift )])
@@ -796,8 +796,8 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .emitModule)
         XCTAssertTrue(plannedJobs[1].kind == .compile)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.dia")))]))
+        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
+        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.dia")))]))
       }
 
       // WMO
@@ -810,8 +810,8 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .compile)
         XCTAssertTrue(plannedJobs[1].kind == .emitModule)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
+        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia")))]))
+        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-serialize-diagnostics-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia")))]))
       }
     }
   }
@@ -840,8 +840,8 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .emitModule)
         XCTAssertTrue(plannedJobs[1].kind == .compile)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.d")))]))
+        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
+        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.d")))]))
       }
 
       // WMO
@@ -854,15 +854,14 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(plannedJobs[0].kind == .compile)
         XCTAssertTrue(plannedJobs[1].kind == .emitModule)
         XCTAssertTrue(plannedJobs[2].kind == .link)
-        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.d")))]))
-        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
+        XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.d")))]))
+        XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: ["-emit-dependencies-path", .path(.absolute(try .init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.d")))]))
       }
     }
   }
 
   func testOutputFileMapLoading() throws {
-    let objroot: AbsolutePath =
-        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+    let objroot = try AbsolutePath(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
 
     let contents = """
     {
@@ -893,8 +892,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testFindingObjectPathFromllvmBCPath() throws {
-    let objroot: AbsolutePath =
-        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+    let objroot = try AbsolutePath(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
 
     let contents = """
     {
@@ -922,8 +920,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testOutputFileMapLoadingDocAndSourceinfo() throws {
-    let objroot: AbsolutePath =
-        AbsolutePath("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
+    let objroot = try AbsolutePath(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build")
 
     let contents = """
     {
@@ -993,10 +990,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         var jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/main.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
-        XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/main.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/tmp/build1/second.o")))]))
+        XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/tmp/build1/main.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(try .init(validating: "/tmp/build2/second.o")))]))
+        XCTAssertTrue(jobs[1].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(try .init(validating: "/tmp/build2/main.o")))]))
 
         // b) with filelists
         driver = try Driver(args: [
@@ -1006,13 +1003,13 @@ final class SwiftDriverTests: XCTestCase {
         ])
         jobs = try driver.planBuild()
         XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build1/second.o"))])
+                       [.absolute(try .init(validating: "/tmp/build1/second.o"))])
         XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build2/second.o"))])
+                       [.absolute(try .init(validating: "/tmp/build2/second.o"))])
         XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[1]),
-                       [.absolute(.init("/tmp/build1/main.o"))])
+                       [.absolute(try .init(validating: "/tmp/build1/main.o"))])
         XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[1]),
-                       [.absolute(.init("/tmp/build2/main.o"))])
+                       [.absolute(try .init(validating: "/tmp/build2/main.o"))])
 
 
         // 2. Batch mode (two primary files)
@@ -1023,10 +1020,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/main.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/main.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/tmp/build1/second.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/tmp/build1/main.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(try .init(validating: "/tmp/build2/second.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(try .init(validating: "/tmp/build2/main.o")))]))
 
         // b) with filelists
         driver = try Driver(args: [
@@ -1037,9 +1034,9 @@ final class SwiftDriverTests: XCTestCase {
         ])
         jobs = try driver.planBuild()
         XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build1/second.o")), .absolute(.init("/tmp/build1/main.o"))])
+                       [.absolute(try .init(validating: "/tmp/build1/second.o")), .absolute(try .init(validating: "/tmp/build1/main.o"))])
         XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build2/second.o")), .absolute(.init("/tmp/build2/main.o"))])
+                       [.absolute(try .init(validating: "/tmp/build2/second.o")), .absolute(try .init(validating: "/tmp/build2/main.o"))])
 
         // 3. Multi-threaded WMO
         // a) without filelists
@@ -1049,10 +1046,10 @@ final class SwiftDriverTests: XCTestCase {
           "-module-name", "test", "/tmp/second.swift", "/tmp/main.swift"
         ])
         jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/main.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/main.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/tmp/build1/second.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(try .init(validating: "/tmp/build2/second.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/tmp/build1/main.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(try .init(validating: "/tmp/build2/main.o")))]))
 
         // b) with filelists
         driver = try Driver(args: [
@@ -1063,9 +1060,9 @@ final class SwiftDriverTests: XCTestCase {
         ])
         jobs = try driver.planBuild()
         XCTAssertEqual(getFileListElements(for: "-output-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build1/second.o")), .absolute(.init("/tmp/build1/main.o"))])
+                       [.absolute(try .init(validating: "/tmp/build1/second.o")), .absolute(try .init(validating: "/tmp/build1/main.o"))])
         XCTAssertEqual(getFileListElements(for: "-index-unit-output-path-filelist", job: jobs[0]),
-                       [.absolute(.init("/tmp/build2/second.o")), .absolute(.init("/tmp/build2/main.o"))])
+                       [.absolute(try .init(validating: "/tmp/build2/second.o")), .absolute(try .init(validating: "/tmp/build2/main.o"))])
 
         // 4. Index-file (single primary)
         driver = try Driver(args: [
@@ -1076,8 +1073,8 @@ final class SwiftDriverTests: XCTestCase {
           "-index-unit-output-path", "/tmp/build2/second.o"
         ])
         jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(.init("/tmp/build1/second.o")))]))
-        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(.init("/tmp/build2/second.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-o", .path(.absolute(try .init(validating: "/tmp/build1/second.o")))]))
+        XCTAssertTrue(jobs[0].commandLine.contains(subsequence: ["-index-unit-output-path", .path(.absolute(try .init(validating: "/tmp/build2/second.o")))]))
       }
     }
   }
@@ -1188,14 +1185,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[0].kind, .compile)
       XCTAssertTrue(plannedJobs[0].primaryInputs.map{ $0.file.description }.elementsEqual(["foo.swift",
                                                                                            "bar.swift"]))
-      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init("/tmp/foo.build/foo.swiftconstvalues")))]))
-      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init("/tmp/foo.build/bar.swiftconstvalues")))]))
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(try .init(validating: "/tmp/foo.build/foo.swiftconstvalues")))]))
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(try .init(validating: "/tmp/foo.build/bar.swiftconstvalues")))]))
       XCTAssertEqual(plannedJobs[0].outputs.filter({ $0.type == .swiftConstValues }).count, 2)
       XCTAssertEqual(plannedJobs[1].kind, .compile)
       XCTAssertTrue(plannedJobs[1].primaryInputs.map{ $0.file.description }.elementsEqual(["baz.swift"]))
       XCTAssertTrue(plannedJobs[1].commandLine.contains("-emit-const-values-path"))
       XCTAssertEqual(plannedJobs[1].outputs.filter({ $0.type == .swiftConstValues }).count, 1)
-      XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(.init("/tmp/foo.build/baz.swiftconstvalues")))]))
+      XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(try .init(validating: "/tmp/foo.build/baz.swiftconstvalues")))]))
       XCTAssertEqual(plannedJobs[2].kind, .link)
     }
 
@@ -1239,7 +1236,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
       XCTAssertEqual(plannedJobs[0].outputs.first(where: { $0.type == .swiftConstValues })?.file,
-                     .absolute(.init("/tmp/foo.build/foo.master.swiftconstvalues")))
+                     .absolute(try .init(validating: "/tmp/foo.build/foo.master.swiftconstvalues")))
       XCTAssertEqual(plannedJobs[1].kind, .link)
     }
   }
@@ -1263,7 +1260,7 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertTrue(plannedJobs[0].kind == .emitModule)
-      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-serialize-diagnostics-path"), .path(.absolute(.init("/build/Foo-test.dia")))]))
+      XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-serialize-diagnostics-path"), .path(.absolute(try .init(validating: "/build/Foo-test.dia")))]))
     }
   }
 
@@ -1767,7 +1764,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-dynamiclib")))
       XCTAssertTrue(cmd.contains(.flag("-w")))
       XCTAssertTrue(cmd.contains(.flag("-L")))
-      XCTAssertTrue(cmd.contains(.path(.absolute(AbsolutePath("/tmp")))))
+      XCTAssertTrue(cmd.contains(.path(.absolute(try .init(validating: "/tmp")))))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 
       XCTAssertFalse(cmd.contains(.flag("-static")))
@@ -1863,10 +1860,10 @@ final class SwiftDriverTests: XCTestCase {
       let cmd = linkJob.commandLine
       XCTAssertTrue(linkJob.inputs.contains { matchTemporary($0.file, "foo.o") && $0.type == .object })
       XCTAssertTrue(linkJob.inputs.contains { matchTemporary($0.file, "bar.o") && $0.type == .object })
-      XCTAssertTrue(linkJob.inputs.contains(.init(file: VirtualPath.relative(.init("baz.o")).intern(), type: .object)))
+      XCTAssertTrue(linkJob.inputs.contains(.init(file: VirtualPath.relative(try .init(validating: "baz.o")).intern(), type: .object)))
       XCTAssertTrue(commandContainsTemporaryPath(cmd, "foo.o"))
       XCTAssertTrue(commandContainsTemporaryPath(cmd, "bar.o"))
-      XCTAssertTrue(cmd.contains(.path(.relative(.init("baz.o")))))
+      XCTAssertTrue(cmd.contains(.path(.relative(try .init(validating: "baz.o")))))
     }
 
     do {
@@ -1891,7 +1888,7 @@ final class SwiftDriverTests: XCTestCase {
       // linker, so be consistent with this
       XCTAssertFalse(cmd.contains(.flag("-w")))
       XCTAssertFalse(cmd.contains(.flag("-L")))
-      XCTAssertFalse(cmd.contains(.path(.absolute(AbsolutePath("/tmp")))))
+      XCTAssertFalse(cmd.contains(.path(.absolute(try .init(validating: "/tmp")))))
 
       XCTAssertFalse(cmd.contains(.flag("-dylib")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
@@ -1921,7 +1918,7 @@ final class SwiftDriverTests: XCTestCase {
       // linker, so be consistent with this
       XCTAssertFalse(cmd.contains(.flag("-w")))
       XCTAssertFalse(cmd.contains(.flag("-L")))
-      XCTAssertFalse(cmd.contains(.path(.absolute(AbsolutePath("/tmp")))))
+      XCTAssertFalse(cmd.contains(.path(.absolute(try .init(validating: "/tmp")))))
 
       XCTAssertFalse(cmd.contains(.flag("-dylib")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
@@ -1999,7 +1996,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-o")))
       XCTAssertTrue(commandContainsTemporaryPath(cmd, "foo.o"))
       XCTAssertTrue(commandContainsTemporaryPath(cmd, "bar.o"))
-      XCTAssertTrue(cmd.contains(.joinedOptionAndPath("-Wl,-add_ast_path,", .relative(.init("Test.swiftmodule")))))
+      XCTAssertTrue(cmd.contains(.joinedOptionAndPath("-Wl,-add_ast_path,", .relative(try .init(validating: "Test.swiftmodule")))))
       XCTAssertTrue(cmd.contains(.flag("-O0")))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "Test"))
 
@@ -2187,7 +2184,7 @@ final class SwiftDriverTests: XCTestCase {
         let linkJob = plannedJobs[3]
         let cmd = linkJob.commandLine
         XCTAssertTrue(cmd.contains(subsequence: ["-target", "wasm32-unknown-wasi"]))
-        XCTAssertTrue(cmd.contains(subsequence: ["--sysroot", .path(.absolute(.init("/sdk/path")))]))
+        XCTAssertTrue(cmd.contains(subsequence: ["--sysroot", .path(.absolute(try .init(validating: "/sdk/path")))]))
         XCTAssertTrue(cmd.contains(.path(.absolute(path.appending(components: "wasi", "wasm32", "swiftrt.o")))))
         XCTAssertTrue(commandContainsTemporaryPath(cmd, "foo.o"))
         XCTAssertTrue(commandContainsTemporaryPath(cmd, "bar.o"))
@@ -2281,7 +2278,7 @@ final class SwiftDriverTests: XCTestCase {
     let result = try process.waitUntilExit()
     guard result.exitStatus == .terminated(code: EXIT_SUCCESS) else { return nil }
     guard let path = String(bytes: try result.output.get(), encoding: .utf8) else { return nil }
-    return path.isEmpty ? nil : AbsolutePath(path.spm_chomp())
+    return path.isEmpty ? nil : try AbsolutePath(validating: path.spm_chomp())
 #endif
   }
 
@@ -2799,7 +2796,7 @@ final class SwiftDriverTests: XCTestCase {
         // Make sure the supplementary output map has an entry for the Swift file
         // under indexing and its indexData entry is the primary output file
         let entry = map.entries[VirtualPath.relative(RelativePath("foo5.swift")).intern()]!
-        XCTAssert(VirtualPath.lookup(entry[.indexData]!) == .absolute(AbsolutePath("/tmp/t.o")))
+        XCTAssert(VirtualPath.lookup(entry[.indexData]!) == .absolute(try .init(validating: "/tmp/t.o")))
         return
       default:
         break
@@ -2935,7 +2932,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssert(!plannedJobs[0].commandLine.contains(.flag("-primary-file")))
 
         let emitModuleJob = plannedJobs.first(where: {$0.kind == .emitModule})!
-        XCTAssertEqual(emitModuleJob.outputs[3].file, VirtualPath.absolute(AbsolutePath("/tmp/salty/Test.swiftinterface")))
+        XCTAssertEqual(emitModuleJob.outputs[3].file, VirtualPath.absolute(try .init(validating: "/tmp/salty/Test.swiftinterface")))
         XCTAssert(!emitModuleJob.commandLine.contains(.flag("-primary-file")))
 
         XCTAssertEqual(plannedJobs[2].kind, .link)
@@ -2963,7 +2960,7 @@ final class SwiftDriverTests: XCTestCase {
     let moduleJob = plannedJobs.first(where: { $0.kind == .emitModule })!
     XCTAssertTrue(moduleJob.commandLine.contains("-module-alias"))
     XCTAssertTrue(moduleJob.commandLine.contains("Car=Bar"))
-    XCTAssertEqual(moduleJob.outputs[0].file, .absolute(AbsolutePath("/tmp/dir/Foo.swiftmodule")))
+    XCTAssertEqual(moduleJob.outputs[0].file, .absolute(try .init(validating: "/tmp/dir/Foo.swiftmodule")))
 
     XCTAssertEqual(driver.moduleOutputInfo.name, "Foo")
     XCTAssertNotNil(driver.moduleOutputInfo.aliases)
@@ -3108,7 +3105,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[2].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
       XCTAssertEqual(plannedJobs[2].outputs[0].file, .relative(RelativePath("Test.swiftmodule")))
       XCTAssertEqual(plannedJobs[2].outputs[1].file, .relative(RelativePath("Test.swiftdoc")))
-      XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(AbsolutePath("/foo/bar/Test.swiftsourceinfo")))
+      XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(try .init(validating: "/foo/bar/Test.swiftsourceinfo")))
       if driver.targetTriple.isDarwin {
         XCTAssertEqual(plannedJobs[2].outputs[3].file, .relative(RelativePath("Test.abi.json")))
       }
@@ -3123,11 +3120,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertTrue(plannedJobs[2].tool.name.contains("swift"))
       XCTAssertEqual(plannedJobs[2].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
-      XCTAssertEqual(plannedJobs[2].outputs[0].file, .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root))))
-      XCTAssertEqual(plannedJobs[2].outputs[1].file, .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root))))
-      XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root))))
+      XCTAssertEqual(plannedJobs[2].outputs[0].file, .absolute(try .init(validating: rebase("Test.swiftmodule", at: root))))
+      XCTAssertEqual(plannedJobs[2].outputs[1].file, .absolute(try .init(validating: rebase("Test.swiftdoc", at: root))))
+      XCTAssertEqual(plannedJobs[2].outputs[2].file, .absolute(try .init(validating: rebase("Test.swiftsourceinfo", at: root))))
       if driver.targetTriple.isDarwin {
-        XCTAssertEqual(plannedJobs[2].outputs[3].file, .absolute(AbsolutePath(rebase("Test.abi.json", at: root))))
+        XCTAssertEqual(plannedJobs[2].outputs[3].file, .absolute(try .init(validating: rebase("Test.abi.json", at: root))))
       }
     }
 
@@ -3171,7 +3168,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(matchTemporary(plannedJobs[0].outputs[0].file, "input.swiftmodule"))
       XCTAssertEqual(plannedJobs[1].kind, .mergeModule)
       XCTAssertTrue(matchTemporary(plannedJobs[1].inputs[0].file, "input.swiftmodule"))
-      XCTAssertEqual(plannedJobs[1].outputs[0].file, .absolute(AbsolutePath("/tmp/test.swiftmodule")))
+      XCTAssertEqual(plannedJobs[1].outputs[0].file, .absolute(try .init(validating: "/tmp/test.swiftmodule")))
     }
   }
 
@@ -3190,11 +3187,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
       XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-parse-as-library")))
       XCTAssertEqual(plannedJobs[0].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
-      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root))))
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(try .init(validating: rebase("Test.swiftmodule", at: root))))
+      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(try .init(validating: rebase("Test.swiftdoc", at: root))))
+      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(try .init(validating: rebase("Test.swiftsourceinfo", at: root))))
       if driver.targetTriple.isDarwin {
-        XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(AbsolutePath(rebase("Test.abi.json", at: root))))
+        XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(try .init(validating: rebase("Test.abi.json", at: root))))
       }
 
       // We don't know the output file of the symbol graph, just make sure the flag is passed along.
@@ -3212,11 +3209,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.emitModule, .compile]))
       XCTAssertTrue(plannedJobs[0].tool.name.contains("swift"))
       XCTAssertEqual(plannedJobs[0].outputs.count, driver.targetTriple.isDarwin ? 4 : 3)
-      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root))))
-      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root))))
+      XCTAssertEqual(plannedJobs[0].outputs[0].file, .absolute(try .init(validating: rebase("Test.swiftmodule", at: root))))
+      XCTAssertEqual(plannedJobs[0].outputs[1].file, .absolute(try .init(validating: rebase("Test.swiftdoc", at: root))))
+      XCTAssertEqual(plannedJobs[0].outputs[2].file, .absolute(try .init(validating: rebase("Test.swiftsourceinfo", at: root))))
       if driver.targetTriple.isDarwin {
-        XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(AbsolutePath(rebase("Test.abi.json", at: root))))
+        XCTAssertEqual(plannedJobs[0].outputs[3].file, .absolute(try .init(validating: rebase("Test.abi.json", at: root))))
       }
     }
 
@@ -3251,6 +3248,10 @@ final class SwiftDriverTests: XCTestCase {
     var envVars = ProcessEnv.vars
     envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)
     let root = localFileSystem.currentWorkingDirectory!.appending(components: "foo", "bar")
+    let swiftmodulePath = try AbsolutePath(validating: rebase("Test.swiftmodule", at: root))
+    let swiftdocPath = try AbsolutePath(validating: rebase("Test.swiftdoc", at: root))
+    let swiftsourceinfoPath = try AbsolutePath(validating: rebase("Test.swiftsourceinfo", at: root))
+    let abiJsonPath = try AbsolutePath(validating: rebase("Test.abi.json", at: root))
 
     do {
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-emit-symbol-graph", "-emit-symbol-graph-dir", root.pathString, "-emit-library", "-target", "x86_64-apple-macosx10.15", "-wmo", "-emit-module-separately-wmo"],
@@ -3272,11 +3273,11 @@ final class SwiftDriverTests: XCTestCase {
       let emitModuleJob = plannedJobs.first(where: {$0.kind == .emitModule})!
       XCTAssertTrue(emitModuleJob.tool.name.contains("swift"))
       XCTAssertEqual(emitModuleJob.outputs.count, 3 + abiFileCount)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root)))}).count)
+      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(swiftmodulePath)}).count)
+      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(swiftdocPath)}).count)
+      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(swiftsourceinfoPath)}).count)
       if abiFileCount == 1 {
-        XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.abi.json", at: root)))}).count)
+        XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({$0.file == .absolute(abiJsonPath)}).count)
       }
 
       // We don't know the output file of the symbol graph, just make sure the flag is passed along.
@@ -3295,11 +3296,11 @@ final class SwiftDriverTests: XCTestCase {
       let emitModuleJob = plannedJobs[0]
       XCTAssertTrue(emitModuleJob.tool.name.contains("swift"))
       XCTAssertEqual(emitModuleJob.outputs.count, 3 + abiFileCount)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root)))}).count)
-      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root)))}).count)
+      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(swiftmodulePath)}).count)
+      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(swiftdocPath)}).count)
+      XCTAssertEqual(1, emitModuleJob.outputs.filter({$0.file == .absolute(swiftsourceinfoPath)}).count)
       if abiFileCount == 1 {
-        XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.abi.json", at: root)))}).count)
+        XCTAssertEqual(abiFileCount, emitModuleJob.outputs.filter({$0.file == .absolute(abiJsonPath)}).count)
       }
     }
 
@@ -3320,11 +3321,11 @@ final class SwiftDriverTests: XCTestCase {
       let compileJob = plannedJobs.first(where: {$0.kind == .compile})!
       XCTAssertEqual(compileJob.outputs.count, 4 + abiFileCount)
       XCTAssertEqual(1, compileJob.outputs.filter({$0.type == .object}).count)
-      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftmodule", at: root)))}).count)
-      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftdoc", at: root)))}).count)
-      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.swiftsourceinfo", at: root)))}).count)
+      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(swiftmodulePath)}).count)
+      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(swiftdocPath)}).count)
+      XCTAssertEqual(1, compileJob.outputs.filter({$0.file == .absolute(swiftsourceinfoPath)}).count)
       if abiFileCount == 1 {
-        XCTAssertEqual(abiFileCount, compileJob.outputs.filter({$0.file == .absolute(AbsolutePath(rebase("Test.abi.json", at: root)))}).count)
+        XCTAssertEqual(abiFileCount, compileJob.outputs.filter({$0.file == .absolute(abiJsonPath)}).count)
       }
     }
 
@@ -4180,7 +4181,7 @@ final class SwiftDriverTests: XCTestCase {
           0x02
       ]
       try localFileSystem.writeFileContents(ld) { $0 <<< contents }
-      try localFileSystem.chmod(.executable, path: AbsolutePath(ld.pathString))
+      try localFileSystem.chmod(.executable, path: AbsolutePath(validating: ld.pathString))
 
       // Drop SWIFT_DRIVER_CLANG_EXEC from the environment so it doesn't
       // interfere with tool lookup.
@@ -4602,7 +4603,7 @@ final class SwiftDriverTests: XCTestCase {
       let job = plannedJobs[0]
       XCTAssertTrue(
         job.commandLine.contains(subsequence: ["-emit-loaded-module-trace-path",
-                                               .path(.relative(.init("foo.trace.json")))])
+                                               .path(.relative(try .init(validating: "foo.trace.json")))])
       )
     }
     do {
@@ -4610,9 +4611,9 @@ final class SwiftDriverTests: XCTestCase {
                                      "-emit-loaded-module-trace",
                                      "foo.swift", "bar.swift", "baz.swift"])
       let plannedJobs = try driver.planBuild()
-      let tracedJobs = plannedJobs.filter {
+      let tracedJobs = try plannedJobs.filter {
         $0.commandLine.contains(subsequence: ["-emit-loaded-module-trace-path",
-                                              .path(.relative(.init("main.trace.json")))])
+                                              .path(.relative(try .init(validating: "main.trace.json")))])
       }
       XCTAssertEqual(tracedJobs.count, 1)
     }
@@ -4622,12 +4623,12 @@ final class SwiftDriverTests: XCTestCase {
       var driver = try Driver(args: ["swiftc", "-emit-loaded-module-trace",
                                      "foo.o", "bar.swift", "baz.o"])
       let plannedJobs = try driver.planBuild()
-      let tracedJobs = plannedJobs.filter {
+      let tracedJobs = try plannedJobs.filter {
         $0.commandLine.contains(subsequence: ["-emit-loaded-module-trace-path",
-                                              .path(.relative(.init("main.trace.json")))])
+                                              .path(.relative(try .init(validating: "main.trace.json")))])
       }
       XCTAssertEqual(tracedJobs.count, 1)
-      XCTAssertTrue(tracedJobs[0].inputs.contains(.init(file: VirtualPath.relative(.init("bar.swift")).intern(), type: .swift)))
+      XCTAssertTrue(tracedJobs[0].inputs.contains(.init(file: VirtualPath.relative(try .init(validating: "bar.swift")).intern(), type: .swift)))
     }
     do {
       var env = ProcessEnv.vars
@@ -4640,7 +4641,7 @@ final class SwiftDriverTests: XCTestCase {
       let job = plannedJobs[0]
       XCTAssertTrue(
         job.commandLine.contains(subsequence: ["-emit-loaded-module-trace-path",
-                                               .path(.absolute(.init("/some/path/to/the.trace.json")))])
+                                               .path(.absolute(try .init(validating: "/some/path/to/the.trace.json")))])
       )
     }
   }
@@ -4833,9 +4834,9 @@ final class SwiftDriverTests: XCTestCase {
 
     var driver = try Driver(args: ["swiftc", "foo.swift", "-sdk", "/"])
     let plannedJobs = try driver.planBuild()
-    XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-sdk", .path(.absolute(.init("/")))]))
+    XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: ["-sdk", .path(.absolute(try .init(validating: "/")))]))
     if !driver.targetTriple.isDarwin {
-      XCTAssertFalse(plannedJobs[2].commandLine.contains(subsequence: ["-L", .path(.absolute(.init("/usr/lib/swift")))]))
+      XCTAssertFalse(plannedJobs[2].commandLine.contains(subsequence: ["-L", .path(.absolute(try .init(validating: "/usr/lib/swift")))]))
     }
   }
 
@@ -6269,7 +6270,7 @@ final class SwiftDriverTests: XCTestCase {
     // FIXME: On Linux, we might not have any Clang in the path. We need a
     // better override.
     var env = ProcessEnv.vars
-    let swiftHelp: AbsolutePath = AbsolutePath("/usr/bin/nonexistent-swift-help")
+    let swiftHelp = try AbsolutePath(validating: "/usr/bin/nonexistent-swift-help")
     env["SWIFT_DRIVER_SWIFT_HELP_EXEC"] = swiftHelp.pathString
     env["SWIFT_DRIVER_CLANG_EXEC"] = "/usr/bin/clang"
     var driver = try Driver(
@@ -6499,7 +6500,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(configs.count, 0)
     }
     do {
-      let configs = Driver.parseAdopterConfigs(AbsolutePath("/abc/c/a.json"))
+      let configs = Driver.parseAdopterConfigs(try AbsolutePath(validating: "/abc/c/a.json"))
       XCTAssertEqual(configs.count, 0)
     }
   }
@@ -7155,7 +7156,7 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertTrue(frontend.commandLine.contains(subsequence: [
         .flag("-windows-sdk-root"),
-        .path(.absolute(.init("/SDK")))
+        .path(.absolute(try .init(validating: "/SDK")))
       ]))
     }
 
@@ -7179,7 +7180,7 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertTrue(frontend.commandLine.contains(subsequence: [
         .flag("-windows-sdk-root"),
-        .path(.absolute(.init("/SDK")))
+        .path(.absolute(try .init(validating: "/SDK")))
       ]))
       XCTAssertTrue(frontend.commandLine.contains(subsequence: [
         .flag("-windows-sdk-version"),
@@ -7195,7 +7196,7 @@ final class SwiftDriverTests: XCTestCase {
 
       XCTAssertTrue(frontend.commandLine.contains(subsequence: [
         .flag("-visualc-tools-root"),
-        .path(.absolute(.init("/MSVC/14.34.31933"))),
+        .path(.absolute(try .init(validating: "/MSVC/14.34.31933"))),
       ]))
     }
 
@@ -7223,7 +7224,7 @@ final class SwiftDriverTests: XCTestCase {
       ]))
       XCTAssertTrue(frontend.commandLine.contains(subsequence: [
         .flag("-visualc-tools-root"),
-        .path(.absolute(.init("/MSVC"))),
+        .path(.absolute(try .init(validating: "/MSVC"))),
       ]))
     }
   }

--- a/Tests/TestUtilities/Fixture.swift
+++ b/Tests/TestUtilities/Fixture.swift
@@ -30,10 +30,10 @@ public enum Fixture {
     on fileSystem: FileSystem = localFileSystem
   ) -> AbsolutePath? {
     let packageRootPath: AbsolutePath =
-        AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
+        try! AbsolutePath(validating: #file).parentDirectory.parentDirectory.parentDirectory
     let fixturePath =
-        AbsolutePath(relativePath.pathString,
-                     relativeTo: packageRootPath.appending(component: "TestInputs"))
+        try! AbsolutePath(validating: relativePath.pathString,
+                          relativeTo: packageRootPath.appending(component: "TestInputs"))
             .appending(component: file)
 
     // Check that the fixture is really there.


### PR DESCRIPTION
`AbsolutePath(_:)` has been replaced by a throwing alternative `AbsolutePath(validating:)`. There were dozens of warnings about this emitted when building the driver making it difficult to notice newly introduced warnings.