### PR TITLE
[Caching] Support pluginCAS in swiftDriver

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 
 #define SWIFTSCAN_VERSION_MAJOR 0
-#define SWIFTSCAN_VERSION_MINOR 4
+#define SWIFTSCAN_VERSION_MINOR 5
 
 //=== Public Scanner Data Types -------------------------------------------===//
 
@@ -79,6 +79,7 @@ typedef void *swiftscan_scanner_t;
 
 //=== CAS/Caching Specification -------------------------------------------===//
 typedef struct swiftscan_cas_s *swiftscan_cas_t;
+typedef struct swiftscan_cas_options_s *swiftscan_cas_options_t;
 
 typedef enum {
   SWIFTSCAN_OUTPUT_TYPE_OBJECT = 0,
@@ -274,15 +275,24 @@ typedef struct {
   void (*swiftscan_scanner_cache_reset)(swiftscan_scanner_t scanner);
 
   //=== Scanner CAS Operations ----------------------------------------------===//
-  swiftscan_cas_t (*swiftscan_cas_create)(const char *path);
+  swiftscan_cas_options_t (*swiftscan_cas_options_create)(void);
+  void (*swiftscan_cas_options_dispose)(swiftscan_cas_options_t options);
+  void (*swiftscan_cas_options_set_ondisk_path)(swiftscan_cas_options_t options,
+                                                const char *path);
+  void (*swiftscan_cas_options_set_plugin_path)(swiftscan_cas_options_t options,
+                                                const char *path);
+  bool (*swiftscan_cas_options_set_option)(swiftscan_cas_options_t options,
+                                           const char *name, const char *value,
+                                           swiftscan_string_ref_t *error);
+  swiftscan_cas_t (*swiftscan_cas_create_from_options)(
+      swiftscan_cas_options_t options, swiftscan_string_ref_t *error);
   void (*swiftscan_cas_dispose)(swiftscan_cas_t cas);
   swiftscan_string_ref_t (*swiftscan_cas_store)(swiftscan_cas_t cas,
-                                                uint8_t *data, unsigned size);
-  swiftscan_string_ref_t (*swiftscan_compute_cache_key)(swiftscan_cas_t cas,
-                                                        int argc,
-                                                        const char *argv,
-                                                        const char *input,
-                                                        swiftscan_output_kind_t);
+                                                uint8_t *data, unsigned size,
+                                                swiftscan_string_ref_t *error);
+  swiftscan_string_ref_t (*swiftscan_compute_cache_key)(
+      swiftscan_cas_t cas, int argc, const char *argv, const char *input,
+      swiftscan_output_kind_t, swiftscan_string_ref_t *error);
 
 } swiftscan_functions_t;
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -171,11 +171,11 @@ public class InterModuleDependencyOracle {
     return diags.isEmpty ? nil : diags
   }
 
-  public func createCAS(path: String) throws {
+  public func createCAS(pluginPath: AbsolutePath?, onDiskPath: AbsolutePath?, pluginOptions: [(String, String)]) throws {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to reset scanner cache with no scanner instance.")
     }
-    try swiftScan.createCAS(casPath: path)
+    try swiftScan.createCAS(pluginPath: pluginPath?.pathString, onDiskPath: onDiskPath?.pathString, pluginOptions: pluginOptions)
   }
 
   public func store(data: Data) throws -> String {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -167,7 +167,9 @@ public extension Driver {
       }
     }
     if !fallbackToFrontend && enableCaching {
-      try interModuleDependencyOracle.createCAS(path: casPath)
+      try interModuleDependencyOracle.createCAS(pluginPath: try getCASPluginPath(),
+                                                onDiskPath: try getOnDiskCASPath(),
+                                                pluginOptions: try getCASPluginOptions())
     }
     return fallbackToFrontend
   }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -336,13 +336,16 @@ extension Driver {
     // CAS related options.
     if enableCaching {
       commandLine.appendFlag(.cacheCompileJob)
-      if !casPath.isEmpty {
+      if let casPath = try getOnDiskCASPath() {
         commandLine.appendFlag(.casPath)
-        commandLine.appendFlag(casPath)
+        commandLine.appendFlag(casPath.pathString)
       }
-      try commandLine.appendLast(.cacheRemarks, from: &parsedOptions)
-      try commandLine.appendLast(.casPluginPath, from: &parsedOptions)
+      if let pluginPath = try getCASPluginPath() {
+        commandLine.appendFlag(.casPluginPath)
+        commandLine.appendFlag(pluginPath.pathString)
+      }
       try commandLine.appendAll(.casPluginOption, from: &parsedOptions)
+      try commandLine.appendLast(.cacheRemarks, from: &parsedOptions)
     }
     if useClangIncludeTree {
       commandLine.appendFlag(.clangIncludeTree)


### PR DESCRIPTION
Add support for pluginCAS by adopting the new SwiftScan CAS creation APIs. The old CAS creation API is deprecated, and will be removed once all users are updated.