### PR TITLE
Pass -experimental-lazy-typecheck to -emit-module jobs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2092,8 +2092,8 @@ extension Driver {
       case .indexFile:
         compilerOutputType = .indexData
 
-      case .parse, .resolveImports, .typecheck, .dumpParse,
-           .printAst, .dumpTypeRefinementContexts, .dumpScopeMaps,
+      case .parse, .resolveImports, .typecheck, .experimentalLazyTypecheck,
+           .dumpParse, .printAst, .dumpTypeRefinementContexts, .dumpScopeMaps,
            .dumpInterfaceHash, .dumpTypeInfo, .verifyDebugInfo:
         compilerOutputType = nil
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -106,6 +106,9 @@ extension Driver {
     try commandLine.appendLast(.emitExtensionBlockSymbols, .omitExtensionBlockSymbols, from: &parsedOptions)
     try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
     try commandLine.appendLast(.checkApiAvailabilityOnly, from: &parsedOptions)
+    if isFrontendArgSupported(.experimentalLazyTypecheck) {
+      try commandLine.appendLast(.experimentalLazyTypecheck, from: &parsedOptions)
+    }
 
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
       commandLine.appendFlag(.parseAsLibrary)

--- a/Sources/SwiftOptions/Option.swift
+++ b/Sources/SwiftOptions/Option.swift
@@ -59,7 +59,7 @@ public struct Option {
   /// The spelling of the option, including any leading dashes.
   public let spelling: String
 
-  ///. The kind of option, which determines how it is parsed.
+  /// The kind of option, which determines how it is parsed.
   public let kind: Kind
 
   /// The option that this aliases, if any, as a closure that produces the

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -1239,6 +1239,7 @@ extension Option {
       Option.ExperimentalPerformanceAnnotations,
       Option.platformCCallingConventionEQ,
       Option.platformCCallingConvention,
+      Option.experimentalLazyTypecheck,
       Option.experimentalPrintFullConvention,
       Option.experimentalSkipAllFunctionBodies,
       Option.experimentalSkipNonInlinableFunctionBodiesWithoutTypes,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7227,6 +7227,18 @@ final class SwiftDriverTests: XCTestCase {
       ]))
     }
   }
+
+  func testEmitModuleExperimentalLazyTypecheck() throws {
+    var driver = try Driver(args: [
+      "swiftc", "test.swift", "-module-name", "Test", "-experimental-lazy-typecheck", "-emit-module-interface"
+    ])
+    guard driver.isFrontendArgSupported(.experimentalLazyTypecheck) else {
+      throw XCTSkip("Skipping: compiler does not support '-experimental-lazy-typecheck'")
+    }
+    let jobs = try driver.planBuild().removingAutolinkExtractJobs()
+    let emitModuleJob = try XCTUnwrap(jobs.first(where: {$0.kind == .emitModule}))
+    XCTAssertTrue(emitModuleJob.commandLine.contains(.flag("-experimental-lazy-typecheck")))
+  }
 }
 
 func assertString(


### PR DESCRIPTION
Follow up to https://github.com/apple/swift-driver/pull/1419.

Resolves rdar://114203755