### PR TITLE
Update scudo sanitizer runtime name

### DIFF
--- a/Sources/SwiftDriver/Utilities/Sanitizer.swift
+++ b/Sources/SwiftDriver/Utilities/Sanitizer.swift
@@ -37,7 +37,7 @@ public enum Sanitizer: String, Hashable {
     case .thread: return "tsan"
     case .undefinedBehavior: return "ubsan"
     case .fuzzer: return "fuzzer"
-    case .scudo: return "scudo"
+    case .scudo: return "scudo_standalone"
     }
   }
 }


### PR DESCRIPTION
The Scudo sanitizer runtime name was changed from `scudo-<arch>.{a,so}` to `scudo_standalone-<arch>.{a,so}` in https://reviews.llvm.org/D138157.

@artemcm; I'm not sure how to deal with the fact that the driver may need to span across multiple toolchain versions here as there won't be a consistent runtime name that works for older and newer toolchains.

This is part of the work for rebranch; rdar://114209408