### PR TITLE
NFC: Consolidate the code for adding symbol graph related options to a job

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -372,13 +372,8 @@ extension Driver {
     try commandLine.appendLast(.disableAutolinkingRuntimeCompatibilityConcurrency, from: &parsedOptions)
     try commandLine.appendLast(.checkApiAvailabilityOnly, from: &parsedOptions)
 
-    if compilerMode.isSingleCompilation {
-      try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
-      try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
-    }
-    try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
-    try commandLine.appendLast(.emitExtensionBlockSymbols, .omitExtensionBlockSymbols, from: &parsedOptions)
-    try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
+    try addCommonSymbolGraphOptions(commandLine: &commandLine,
+                                    includeGraph: compilerMode.isSingleCompilation)
 
     addJobOutputs(outputs)
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -99,12 +99,8 @@ extension Driver {
     // FIXME: Add MSVC runtime library flags
 
     try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: false)
+    try addCommonSymbolGraphOptions(commandLine: &commandLine)
 
-    try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
-    try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
-    try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
-    try commandLine.appendLast(.emitExtensionBlockSymbols, .omitExtensionBlockSymbols, from: &parsedOptions)
-    try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
     try commandLine.appendLast(.checkApiAvailabilityOnly, from: &parsedOptions)
     if isFrontendArgSupported(.experimentalLazyTypecheck) {
       try commandLine.appendLast(.experimentalLazyTypecheck, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -648,6 +648,17 @@ extension Driver {
     return flaggedInputOutputPairs.map { $0.output }
   }
 
+  mutating func addCommonSymbolGraphOptions(commandLine: inout [Job.ArgTemplate],
+                                            includeGraph: Bool = true) throws {
+    if includeGraph {
+      try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
+      try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
+    }
+    try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
+    try commandLine.appendLast(.emitExtensionBlockSymbols, .omitExtensionBlockSymbols, from: &parsedOptions)
+    try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
+  }
+
   func addEntry(_ entries: inout [VirtualPath.Handle: [FileType: VirtualPath.Handle]], input: TypedVirtualPath?, output: TypedVirtualPath) {
     let entryInput: VirtualPath.Handle
     if let input = input?.fileHandle, input != OutputFileMap.singleInputKey {

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -59,11 +59,7 @@ extension Driver {
 
     try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: true)
 
-    try commandLine.appendLast(.emitSymbolGraph, from: &parsedOptions)
-    try commandLine.appendLast(.emitSymbolGraphDir, from: &parsedOptions)
-    try commandLine.appendLast(.includeSpiSymbols, from: &parsedOptions)
-    try commandLine.appendLast(.emitExtensionBlockSymbols, .omitExtensionBlockSymbols, from: &parsedOptions)
-    try commandLine.appendLast(.symbolGraphMinimumAccessLevel, from: &parsedOptions)
+    try addCommonSymbolGraphOptions(commandLine: &commandLine)
 
     // Propagate the disable flag for cross-module incremental builds
     // if necessary. Note because we're interested in *disabling* this feature,


### PR DESCRIPTION
The code for doing so was duplicated in three separate job implementations.