### PR TITLE
[Caching] Fix caching tests on windows hosts

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -281,6 +281,10 @@ internal extension swiftscan_diagnostic_severity_t {
   }
 
   @_spi(Testing) public var supportsCaching : Bool {
+#if os(Windows)
+    // Caching is currently not supported on Windows hosts.
+    return false
+#else
     return api.swiftscan_cas_create != nil &&
            api.swiftscan_cas_dispose != nil &&
            api.swiftscan_compute_cache_key != nil &&
@@ -288,6 +292,7 @@ internal extension swiftscan_diagnostic_severity_t {
            api.swiftscan_swift_textual_detail_get_module_cache_key != nil &&
            api.swiftscan_swift_binary_detail_get_module_cache_key != nil &&
            api.swiftscan_clang_detail_get_module_cache_key != nil
+#endif
   }
 
   @_spi(Testing) public var supportsBridgingHeaderPCHCommand : Bool {


### PR DESCRIPTION
For Windows host, the on-disk CAS is not yet enabled in libSwiftScan yet (due to the lack of support for Windows path in cached file system abstraction), so report caching is not supported on windows hosts.