### PR TITLE
Jobs: support multiple lookup paths

### DIFF
--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -128,8 +128,10 @@ extension WindowsToolchain {
 
     // Since Windows has separate libraries per architecture, link against the
     // architecture specific version of the static library.
-    commandLine.appendFlag(.L)
-    commandLine.appendPath(VirtualPath.lookup(targetInfo.runtimeLibraryImportPaths.last!.path))
+    for libpath in targetInfo.runtimeLibraryImportPaths {
+      commandLine.appendFlag(.L)
+      commandLine.appendPath(VirtualPath.lookup(libpath.path))
+    }
 
     if !parsedOptions.hasArgument(.nostartfiles) {
       // Locate the Swift registration helper by honouring any explicit


### PR DESCRIPTION
Adjust the driver to include the additional library paths that the driver may want to use.  We would previously only add a single path which worked due to internal ordering assumptions that held up.  This makes the driver more resilient to changes to the target info.