### PR TITLE
[ExplicitModule] Correctly sort modules using direct and overlay dependencies

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -57,7 +57,7 @@ extension InterModuleDependencyGraph {
   var topologicalSorting: [ModuleDependencyId] {
     get throws {
       try topologicalSort(Array(modules.keys),
-                          successors: { try moduleInfo(of: $0).directDependencies! })
+                          successors: { try moduleInfo(of: $0).allDependencies })
     }
   }
 

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -228,6 +228,16 @@ public struct ModuleInfo: Codable {
   /// Specific details of a particular kind of module.
   public var details: Details
 
+  /// The set of all dependencies of this module, include direct and overlay dependencies.
+  public var allDependencies: [ModuleDependencyId] {
+    var directDeps = Set(directDependencies ?? [])
+    if case .swift(let swiftModuleDetails) = self.details  {
+      let swiftOverlayDependencies = swiftModuleDetails.swiftOverlayDependencies ?? []
+      directDeps.formUnion(swiftOverlayDependencies)
+    }
+    return Array(directDeps)
+  }
+
   /// Specific details of a particular kind of module.
   public enum Details {
     /// Swift modules may be built from a module interface, and may have


### PR DESCRIPTION
When topological sort the modules to compute transitive dependencies, it needs to use both direct and overlay dependencies. Otherwise, any dependencies that can only be discovered through overlay dependencies of the main module can end up sorted after main module and not scheduled in the build graph.