### PR TITLE
Improve swift-driver test cases to avoid fatal crash

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -932,9 +932,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             main.nativePathString(escaped: true)] + sdkArgumentsForTesting
 
       let deps =
-        try! dependencyOracle.getImports(workingDirectory: path,
-                                         moduleAliases: ["Car": "Bar"],
-                                         commandLine: scannerCommand)
+        try dependencyOracle.getImports(workingDirectory: path,
+                                        moduleAliases: ["Car": "Bar"],
+                                        commandLine: scannerCommand)
 
       XCTAssertTrue(deps.imports.contains("Bar"))
       XCTAssertFalse(deps.imports.contains("Car"))
@@ -1192,8 +1192,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
         scannerCommand.removeFirst()
       }
       let dependencyGraph =
-          try! dependencyOracle.getDependencies(workingDirectory: path,
-                                                commandLine: scannerCommand)
+          try dependencyOracle.getDependencies(workingDirectory: path,
+                                               commandLine: scannerCommand)
 
       let fooDependencyInfo = try XCTUnwrap(dependencyGraph.modules[.swiftPrebuiltExternal("Foo")])
       guard case .swiftPrebuiltExternal(let fooDetails) = fooDependencyInfo.details else {
@@ -1299,8 +1299,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             main.nativePathString(escaped: true)] + sdkArgumentsForTesting
 
       let imports =
-        try! dependencyOracle.getImports(workingDirectory: path,
-                                         commandLine: scannerCommand)
+        try dependencyOracle.getImports(workingDirectory: path,
+                                        commandLine: scannerCommand)
       let expectedImports = ["C", "E", "G", "Swift", "SwiftOnoneSupport"]
       // Dependnig on how recent the platform we are running on, the _Concurrency module may or may not be present.
       let expectedImports2 = ["C", "E", "G", "Swift", "SwiftOnoneSupport", "_Concurrency"]
@@ -1414,9 +1414,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
         scannerCommand.removeFirst()
       }
       let _ =
-          try! dependencyOracle.getDependencies(workingDirectory: path,
-                                                commandLine: scannerCommand)
-      let potentialDiags = try! dependencyOracle.getScannerDiagnostics()
+          try dependencyOracle.getDependencies(workingDirectory: path,
+                                               commandLine: scannerCommand)
+      let potentialDiags = try dependencyOracle.getScannerDiagnostics()
       XCTAssertEqual(potentialDiags?.count, 5)
       let diags = try XCTUnwrap(potentialDiags)
       let error = diags[0]
@@ -1748,7 +1748,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       }
 
       let firstScanGraph =
-        try! firstDependencyOracle.getDependencies(workingDirectory: path,
+        try firstDependencyOracle.getDependencies(workingDirectory: path,
                                               commandLine: scannerCommand)
       firstDependencyOracle.serializeScannerCache(to: cacheSavePath)
 
@@ -1762,8 +1762,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       }
       XCTAssertFalse(secondDependencyOracle.loadScannerCache(from: cacheSavePath))
       let secondScanGraph =
-        try! secondDependencyOracle.getDependencies(workingDirectory: path,
-                                                    commandLine: scannerCommand)
+        try secondDependencyOracle.getDependencies(workingDirectory: path,
+                                                   commandLine: scannerCommand)
 
       XCTAssertTrue(firstScanGraph.modules.count == secondScanGraph.modules.count)
     }

--- a/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalBuildPerformanceTests.swift
@@ -101,7 +101,7 @@ class IncrementalBuildPerformanceTests: XCTestCase {
   ) throws -> (OutputFileMap, [SwiftSourceFile]) {
     let workingDirectory = localFileSystem.currentWorkingDirectory!
     let swiftDepsDirPath = try VirtualPath.init(path: swiftDepsDirectory).resolvedRelativePath(base: workingDirectory).absolutePath!
-    let withoutExtensions: ArraySlice<Substring> = try! localFileSystem.getDirectoryContents(swiftDepsDirPath)
+    let withoutExtensions: ArraySlice<Substring> = try localFileSystem.getDirectoryContents(swiftDepsDirPath)
       .compactMap {
         fileName -> Substring? in
         guard let suffixRange = fileName.range(of: ".swiftdeps"),

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -151,12 +151,12 @@ extension IncrementalCompilationTests {
     env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
     env["SWIFT_DRIVER_DSYMUTIL_EXEC"] = "/garbage/dsymutil"
 
-    var driver = try! Driver(
+    var driver = try Driver(
       args: commonArgs
         + ["-emit-library", "-target", "x86_64-unknown-linux"],
       env: env)
-    let plannedJobs = try! driver.planBuild()
-    let autolinkExtractJob = try! XCTUnwrap(
+    let plannedJobs = try driver.planBuild()
+    let autolinkExtractJob = try XCTUnwrap(
       plannedJobs
         .filter { $0.kind == .autolinkExtract }
         .first)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1422,7 +1422,7 @@ final class SwiftDriverTests: XCTestCase {
       guard let preserveCwd = localFileSystem.currentWorkingDirectory else {
         fatalError()
       }
-      try! localFileSystem.changeCurrentWorkingDirectory(to: path)
+      try localFileSystem.changeCurrentWorkingDirectory(to: path)
       defer { try! localFileSystem.changeCurrentWorkingDirectory(to: preserveCwd) }
 
       let diags = DiagnosticsEngine()
@@ -1451,7 +1451,7 @@ final class SwiftDriverTests: XCTestCase {
       guard let preserveCwd = localFileSystem.currentWorkingDirectory else {
         fatalError()
       }
-      try! localFileSystem.changeCurrentWorkingDirectory(to: path)
+      try localFileSystem.changeCurrentWorkingDirectory(to: path)
       defer { try! localFileSystem.changeCurrentWorkingDirectory(to: preserveCwd) }
 
       try localFileSystem.createDirectory(path.appending(component: "subdir"))
@@ -5151,7 +5151,7 @@ final class SwiftDriverTests: XCTestCase {
       let root = localFileSystem.currentWorkingDirectory!.appending(components: "build")
 
       let errorOutputFile = path.appending(component: "dummy_error_stream")
-      TSCBasic.stderrStream = try! ThreadSafeOutputByteStream(LocalFileOutputByteStream(errorOutputFile))
+      TSCBasic.stderrStream = try ThreadSafeOutputByteStream(LocalFileOutputByteStream(errorOutputFile))
 
       let libObj: AbsolutePath = root.appending(component: "lib.o")
       let mainObj: AbsolutePath = root.appending(component: "main.o")

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -61,7 +61,7 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
-  deinit {
+  override func tearDown() {
     try? localFileSystem.removeFileTree(AbsolutePath(validating: self.ld.dirname))
   }
 


### PR DESCRIPTION
Step 1 to fix https://github.com/apple/swift-driver/issues/1431
* Remove unnecessary `try!`: if in the throwable context, just use `try`. There are two remaining in `concurrentPerform` that would be good to be removed in the future, the rest are in setup/generic tests, that are probably file.
* Fix a nil unwrap when using `--parallel`