### PR TITLE
SwiftDriver: speculative changes to support Windows macros

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -482,13 +482,21 @@ extension VirtualPath {
   // Given a virtual path pointing into a toolchain/SDK/platform, produce the
   // path to `swift-plugin-server`.
   fileprivate var pluginServerPath: VirtualPath {
+#if os(Windows)
+    self.appending(components: "bin", "swift-plugin-server.exe")
+#else
     self.appending(components: "bin", "swift-plugin-server")
+#endif
   }
 
   // Given a virtual path pointing into a toolchain/SDK/platform, produce the
   // path to the plugins.
   var pluginPath: VirtualPath {
+#if os(Windows)
+    self.appending(components: "bin")
+#else
     self.appending(components: "lib", "swift", "host", "plugins")
+#endif
   }
 
   // Given a virtual path pointing into a toolchain/SDK/platform, produce the

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6849,8 +6849,12 @@ final class SwiftDriverTests: XCTestCase {
     #endif
 
     XCTAssertTrue(job.commandLine.contains(.flag("-plugin-path")))
+#if os(Windows)
+    XCTAssertTrue(job.commandLine.contains(.path(.absolute(try driver.toolchain.executableDir.parentDirectory.appending(components: "bin")))))
+#else
     XCTAssertTrue(job.commandLine.contains(.path(.absolute(try driver.toolchain.executableDir.parentDirectory.appending(components: "lib", "swift", "host", "plugins")))))
     XCTAssertTrue(job.commandLine.contains(.path(.absolute(try driver.toolchain.executableDir.parentDirectory.appending(components: "local", "lib", "swift", "host", "plugins")))))
+#endif
   }
 
   func testClangModuleValidateOnce() throws {


### PR DESCRIPTION
The test suite is currently entirely broken on Windows (awaiting @cachemeifyoucan to fix apple/swift-driver#1431).  This speculatively changes the driver to alter the search paths to match apple/swift#68322).