### PR TITLE
Fix handling of the '--' argument followed by inputs for the immediate compilation mode ('swift')

### DIFF
--- a/Sources/SwiftOptions/OptionParsing.swift
+++ b/Sources/SwiftOptions/OptionParsing.swift
@@ -153,7 +153,7 @@ extension OptionTable {
           throw OptionParseError.unknownOption(
             index: index - 1, argument: argument)
         }
-        parsedOptions.addOption(.DASHDASH, argument: .single("--"))
+        parsedOptions.addOption(.DASHDASH, argument: .multiple(Array()))
         arguments[index...].map { String($0) }.forEach { parsedOptions.addInput($0) }
         index = arguments.endIndex
 

--- a/Sources/SwiftOptions/ParsedOptions.swift
+++ b/Sources/SwiftOptions/ParsedOptions.swift
@@ -75,7 +75,11 @@ extension ParsedOption: CustomStringConvertible {
       return option.spelling + " " + argument.asSingle.spm_shellEscaped()
 
     case .remaining:
-      return argument.asSingle
+      let args = argument.asMultiple
+      if args.isEmpty {
+        return option.spelling
+      }
+      return option.spelling + " " + argument.asMultiple.map { $0.spm_shellEscaped() }.joined(separator: " ")
     }
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2907,6 +2907,18 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testDashDashImmediateInput() throws {
+    do {
+      var driver = try Driver(args: ["swift", "--", "main.swift"])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .interpret)
+      XCTAssertEqual(plannedJobs[0].inputs.count, 1)
+      XCTAssertEqual(plannedJobs[0].inputs[0].file, VirtualPath.relative(RelativePath("main.swift")))
+    }
+  }
+
   func testWholeModuleOptimizationOutputFileMap() throws {
     let contents = """
     {


### PR DESCRIPTION
Resolves rdar://114191406