### PR TITLE
Update dependencies to track `release/5.10`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/apple/swift-llbuild.git", branch: "main"),
+            .package(url: "https://github.com/apple/swift-llbuild.git", branch: "release/5.10"),
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "swift-llbuild"),
@@ -158,7 +158,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: "main"),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: "release/5.10"),
     .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "5.0.0")),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate


### PR DESCRIPTION
We cut `release/5.10`.