### PR TITLE
Replace deprecated uses of `<<<` with `send`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": "main",
-          "revision": "7c8bcf3eab7286855a2eb0cd0df103ea2761e259",
+          "revision": "ee4cb5e1c2ba6b033a964c77c96bc057be2e2e2a",
           "version": null
         }
       },

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1508,9 +1508,9 @@ extension Driver {
       // Print the driver source version first before we print the compiler
       // versions.
       if inPlaceJob.kind == .versionRequest && !Driver.driverSourceVersion.isEmpty {
-        stderrStream <<< "swift-driver version: " <<< Driver.driverSourceVersion <<< " "
+          stderrStream.send("swift-driver version: \(Driver.driverSourceVersion) ")
         if let blocklistVersion = try Driver.findCompilerClientsConfigVersion(RelativeTo: try toolchain.executableDir) {
-          stderrStream <<< blocklistVersion <<< " "
+          stderrStream.send("\(blocklistVersion) ")
         }
         stderrStream.flush()
       }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -1508,7 +1508,7 @@ extension Driver {
       // Print the driver source version first before we print the compiler
       // versions.
       if inPlaceJob.kind == .versionRequest && !Driver.driverSourceVersion.isEmpty {
-          stderrStream.send("swift-driver version: \(Driver.driverSourceVersion) ")
+        stderrStream.send("swift-driver version: \(Driver.driverSourceVersion) ")
         if let blocklistVersion = try Driver.findCompilerClientsConfigVersion(RelativeTo: try toolchain.executableDir) {
           stderrStream.send("\(blocklistVersion) ")
         }

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -12,13 +12,15 @@
 import SwiftOptions
 
 import class Dispatch.DispatchQueue
-
 import class TSCBasic.DiagnosticsEngine
+import class TSCBasic.UnknownLocation
 import enum TSCBasic.ProcessEnv
+import func TSCBasic.withTemporaryDirectory
 import protocol TSCBasic.DiagnosticData
 import protocol TSCBasic.FileSystem
 import protocol TSCBasic.OutputByteStream
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
 import struct TSCBasic.Diagnostic
 import struct TSCBasic.FileInfo
 import struct TSCBasic.RelativePath
@@ -490,7 +492,7 @@ public struct Driver {
           break
       }
 
-      stream("\(diagnostic.localizedDescription)\n")
+      stream.send("\(diagnostic.localizedDescription)\n")
       stream.flush()
     }
   }
@@ -1516,7 +1518,7 @@ extension Driver {
       if parsedOptions.contains(.v) {
         let arguments: [String] = try executor.resolver.resolveArgumentList(for: inPlaceJob,
                                                                             useResponseFiles: forceResponseFiles ? .forced : .heuristic)
-        stdoutStream("\(arguments.map { $0.spm_shellEscaped() }.joined(separator: " "))\n")
+        stdoutStream.send("\(arguments.map { $0.spm_shellEscaped() }.joined(separator: " "))\n")
         stdoutStream.flush()
       }
       try executor.execute(job: inPlaceJob,
@@ -1639,9 +1641,9 @@ extension Driver {
   }
 
   private func printBindings(_ job: Job) {
-    stdoutStream <<< #"# ""# <<< targetTriple.triple
-    stdoutStream <<< #"" - ""# <<< job.tool.basename
-    stdoutStream <<< #"", inputs: ["#
+    stdoutStream.send(#"# ""#).send(targetTriple.triple)
+    stdoutStream.send(#"" - ""#).send(job.tool.basename)
+    stdoutStream.send(#"", inputs: ["#)
     stdoutStream.send(job.displayInputs.map { "\"" + $0.file.name + "\"" }.joined(separator: ", "))
 
     stdoutStream.send("], output: {")
@@ -1719,19 +1721,19 @@ extension Driver {
       }
 
       // Print current Job
-      stdoutStream <<< nextId <<< ": " <<< job.kind.rawValue <<< ", {"
+      stdoutStream.send("\(nextId): ").send(job.kind.rawValue).send(", {")
       switch job.kind {
       // Don't sort for compile jobs. Puts pch last
       case .compile:
-        stdoutStream <<< inputIds.map(\.description).joined(separator: ", ")
+        stdoutStream.send(inputIds.map(\.description).joined(separator: ", "))
       default:
-        stdoutStream <<< inputIds.sorted().map(\.description).joined(separator: ", ")
+        stdoutStream.send(inputIds.sorted().map(\.description).joined(separator: ", "))
       }
       var typeName = job.outputs.first?.type.name
       if typeName == nil {
         typeName = "none"
       }
-      stdoutStream <<< "}, " <<< typeName! <<< "\n"
+      stdoutStream.send("}, \(typeName!)\n")
       jobIdMap[job] = nextId
       nextId += 1
     }
@@ -1739,16 +1741,16 @@ extension Driver {
 
   private static func printInputIfNew(_ input: TypedVirtualPath, inputIdMap: inout [TypedVirtualPath: UInt], nextId: inout UInt) {
     if inputIdMap[input] == nil {
-      stdoutStream <<< nextId <<< ": " <<< "input, "
-      stdoutStream <<< "\"" <<< input.file <<< "\", " <<< input.type <<< "\n"
+      stdoutStream.send("\(nextId): input, ")
+      stdoutStream.send("\"\(input.file)\", \(input.type)\n")
       inputIdMap[input] = nextId
       nextId += 1
     }
   }
 
   private func printVersion<S: OutputByteStream>(outputStream: inout S) throws {
-    outputStream <<< frontendTargetInfo.compilerVersion <<< "\n"
-    outputStream <<< "Target: \(frontendTargetInfo.target.triple.triple)\n"
+    outputStream.send("\(frontendTargetInfo.compilerVersion)\n")
+    outputStream.send("Target: \(frontendTargetInfo.target.triple.triple)\n")
     outputStream.flush()
   }
 }
@@ -2005,9 +2007,9 @@ extension Driver {
         let filePath = VirtualPath.absolute(absPath.appending(component: "main.swift"))
 
         try fileSystem.writeFileContents(filePath) { file in
-          file <<< ###"#sourceLocation(file: "-e", line: 1)\###n"###
+          file.send(###"#sourceLocation(file: "-e", line: 1)\###n"###)
           for option in parsedOptions.arguments(for: .e) {
-            file <<< option.argument.asSingle <<< "\n"
+            file.send("\(option.argument.asSingle)\n")
           }
         }
 

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -23,7 +23,6 @@ import Musl
 #error("Missing libc or equivalent")
 #endif
 
-import TSCBasic // <<<
 import class TSCBasic.DiagnosticsEngine
 import struct TSCBasic.Diagnostic
 import struct TSCBasic.ProcessResult
@@ -79,7 +78,7 @@ import var TSCBasic.stdoutStream
     case .regular, .silent:
       break
     case .verbose:
-      stdoutStream <<< arguments.map { $0.spm_shellEscaped() }.joined(separator: " ") <<< "\n"
+      stdoutStream.send("\(arguments.map { $0.spm_shellEscaped() }.joined(separator: " "))\n")
       stdoutStream.flush()
     case .parsableOutput:
       let messages = constructJobBeganMessages(job: job, arguments: arguments, pid: pid)
@@ -114,7 +113,7 @@ import var TSCBasic.stdoutStream
       let output = (try? result.utf8Output() + result.utf8stderrOutput()) ?? ""
       if !output.isEmpty {
         Driver.stdErrQueue.sync {
-          stderrStream <<< output
+          stderrStream.send(output)
           stderrStream.flush()
         }
       }
@@ -169,8 +168,13 @@ import var TSCBasic.stdoutStream
     // FIXME: Do we need to do error handling here? Can this even fail?
     guard let json = try? message.toJSON() else { return }
     Driver.stdErrQueue.sync {
-      stderrStream <<< json.count <<< "\n"
-      stderrStream <<< String(data: json, encoding: .utf8)! <<< "\n"
+      stderrStream.send(
+        """
+        \(json.count)
+        \(String(data: json, encoding: .utf8)!)
+
+        """
+      )
       stderrStream.flush()
     }
   }

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -12,7 +12,6 @@
 
 import class Foundation.NSLock
 
-import TSCBasic // <<<
 import func TSCBasic.withTemporaryDirectory
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
@@ -152,7 +151,7 @@ public final class ArgsResolver {
     if let absPath = path.absolutePath {
       try fileSystem.writeFileContents(absPath) { out in
         for path in contents {
-          try! out <<< unsafeResolve(path: path) <<< "\n"
+          try! out.send("\(unsafeResolve(path: path))\n")
         }
       }
     }

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -50,7 +50,7 @@ public final class ArgsResolver {
       // FIXME: withTemporaryDirectory uses FileManager.default, need to create a FileSystem.temporaryDirectory api.
       let tmpDir: AbsolutePath = try withTemporaryDirectory(removeTreeOnDeinit: false) { path in
         // FIXME: TSC removes empty directories even when removeTreeOnDeinit is false. This seems like a bug.
-        try fileSystem.writeFileContents(path.appending(component: ".keep-directory")) { $0 <<< "" }
+        try fileSystem.writeFileContents(path.appending(component: ".keep-directory")) { $0.send("") }
         return path
       }
       self.temporaryDirectory = .absolute(tmpDir)
@@ -167,13 +167,13 @@ public final class ArgsResolver {
       // and the frontend (llvm) only seems to support implicit block format.
       try fileSystem.writeFileContents(absPath) { out in
         for (input, map) in outputFileMap.entries {
-          out <<< quoteAndEscape(path: VirtualPath.lookup(input)) <<< ":"
+          out.send("\(quoteAndEscape(path: VirtualPath.lookup(input))):")
           if map.isEmpty {
-            out <<< " {}\n"
+            out.send(" {}\n")
           } else {
-            out <<< "\n"
+            out.send("\n")
             for (type, output) in map {
-              out <<< "  " <<< type.name <<< ": " <<< quoteAndEscape(path: VirtualPath.lookup(output)) <<< "\n"
+              out.send("  \(type.name): \(quoteAndEscape(path: VirtualPath.lookup(output)))\n")
             }
           }
         }
@@ -213,7 +213,7 @@ public final class ArgsResolver {
         //   Wrap all arguments in double quotes to ensure that both Unix and
         //   Windows tools understand the response file.
         try fileSystem.writeFileContents(absPath) {
-          $0 <<< resolvedArguments[1...].map { quote($0) }.joined(separator: "\n")
+          $0.send(resolvedArguments[1...].map { quote($0) }.joined(separator: "\n"))
         }
         resolvedArguments = [resolvedArguments[0], "@\(absPath.pathString)"]
       }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic // <<<
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.Diagnostic
@@ -49,7 +48,7 @@ extension Diagnostic.Message {
     var dependencyGraph = try performDependencyScan()
 
     if parsedOptions.hasArgument(.printPreprocessedExplicitDependencyGraph) {
-      try stdoutStream <<< dependencyGraph.toJSONString()
+      try stdoutStream.send(dependencyGraph.toJSONString())
       stdoutStream.flush()
     }
 
@@ -68,7 +67,7 @@ extension Diagnostic.Message {
     if parsedOptions.hasArgument(.printExplicitDependencyGraph) {
       let outputFormat = parsedOptions.getLastArgument(.explicitDependencyGraphFormat)?.asSingle
       if outputFormat == nil || outputFormat == "json" {
-        try stdoutStream <<< dependencyGraph.toJSONString()
+        try stdoutStream.send(dependencyGraph.toJSONString())
       } else if outputFormat == "dot" {
         DOTModuleDependencyGraphSerializer(dependencyGraph).writeDOT(to: &stdoutStream)
       }
@@ -224,7 +223,7 @@ public extension Driver {
     if parsedOptions.contains(.v) {
       let arguments: [String] = try executor.resolver.resolveArgumentList(for: scannerJob,
                                                                           useResponseFiles: .disabled)
-      stdoutStream <<< arguments.map { $0.spm_shellEscaped() }.joined(separator: " ") <<< "\n"
+      stdoutStream.send("\(arguments.map { $0.spm_shellEscaped() }.joined(separator: " "))\n")
       stdoutStream.flush()
     }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyGraphDotFileWriter.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import TSCBasic // <<<
 import protocol TSCBasic.WritableByteStream
 
 // MARK: - Asking to write dot files / interface
@@ -126,7 +125,7 @@ extension ModuleDependencyGraph.Node: ExportableNode {
 
 extension ExportableNode {
   fileprivate func emit(id: Int, to out: inout WritableByteStream, _ t: InternedStringTable) {
-    out <<< DotFileNode(id: id, node: self, in: t).description <<< "\n"
+    out.send("\(DotFileNode(id: id, node: self, in: t).description)\n")
   }
 
   fileprivate func label(in t: InternedStringTable) -> String {
@@ -225,11 +224,11 @@ fileprivate struct DOTDependencyGraphSerializer<Graph: ExportableGraph>: Interne
   }
 
   private func emitPrelude() {
-    out <<< "digraph " <<< graphID.quoted <<< " {\n"
+    out.send("digraph \(graphID.quoted) {\n")
   }
   private mutating func emitLegend() {
     for dummy in DependencyKey.Designator.oneOfEachKind {
-      out <<< DotFileNode(forLegend: dummy).description <<< "\n"
+      out.send("\(DotFileNode(forLegend: dummy).description)\n")
     }
   }
   private mutating func emitNodes() {
@@ -250,12 +249,12 @@ fileprivate struct DOTDependencyGraphSerializer<Graph: ExportableGraph>: Interne
   private func emitArcs() {
     graph.forEachExportableArc { (def: Graph.Node, use: Graph.Node) in
       if include(def: def, use: use) {
-        out <<< DotFileArc(defID: nodeIDs[def]!, useID: nodeIDs[use]!).description <<< "\n"
+        out.send("\(DotFileArc(defID: nodeIDs[def]!, useID: nodeIDs[use]!).description)\n")
       }
     }
   }
   private func emitPostlude() {
-    out <<< "\n}\n"
+    out.send("\n}\n")
   }
 
   func include(_ n: Graph.Node) -> Bool {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -13,7 +13,6 @@
 import SwiftOptions
 import class Foundation.JSONDecoder
 
-import TSCBasic // <<<
 import protocol TSCBasic.DiagnosticData
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.Diagnostic

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -72,7 +72,7 @@ public final class WebAssemblyToolchain: Toolchain {
     case .executable:
       return moduleName
     case .dynamicLibrary:
-      // WASM doesn't support dynamic libraries yet, but we'll report the error later.
+      // Wasm doesn't support dynamic libraries yet, but we'll report the error later.
       return ""
     case .staticLibrary:
       return "lib\(moduleName).a"

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -21,7 +21,6 @@ import Glibc
 import Musl
 #endif
 
-import TSCBasic // <<<
 import class TSCBasic.DiagnosticsEngine
 import class TSCBasic.ProcessSet
 import enum TSCBasic.ProcessEnv

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -132,11 +132,10 @@ do {
   let allModules = coreMode ? ["Foundation"] : Array(inputMap.keys)
   try withTemporaryFile(suffix: ".swift") {
     let tempPath = $0.path
-    try localFileSystem.writeFileContents(tempPath, body: {
-      for module in allModules {
-        $0 <<< "import " <<< module <<< "\n"
-      }
-    })
+    let importString = allModules.map { "import \($0)" }.joined(separator: "\n")
+    try localFileSystem
+      .writeFileContents(tempPath,
+                         bytes: .init(importString.utf8))
     let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
                                            processSet: processSet,
                                            fileSystem: localFileSystem,
@@ -166,7 +165,7 @@ do {
       currentABIDir: currentABIDir, baselineABIDir: baselineABIDir)
     if verbose {
       Driver.stdErrQueue.sync {
-        stderrStream <<< "job count: \(jobs.count + danglingJobs.count)\n"
+        stderrStream.send("job count: \(jobs.count + danglingJobs.count)\n")
         stderrStream.flush()
       }
     }

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -131,10 +131,11 @@ do {
   let allModules = coreMode ? ["Foundation"] : Array(inputMap.keys)
   try withTemporaryFile(suffix: ".swift") {
     let tempPath = $0.path
-    let importString = allModules.map { "import \($0)" }.joined(separator: "\n")
-    try localFileSystem
-      .writeFileContents(tempPath,
-                         bytes: .init(importString.utf8))
+    try localFileSystem.writeFileContents(tempPath, body: {
+      for module in allModules {
+        $0.send("import \(module)\n")
+      }
+    })
     let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
                                            processSet: processSet,
                                            fileSystem: localFileSystem,

--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -95,13 +95,13 @@ class APIDigesterTests: XCTestCase {
       try withTemporaryDirectory { path in
         let ofmPath = path.appending(component: "ofm.json")
         try localFileSystem.writeFileContents(ofmPath) {
-          $0 <<< """
+          $0.send("""
           {
             "": {
               "abi-baseline-json": "/path/to/baseline.abi.json"
             }
           }
-          """
+          """)
         }
         var driver = try Driver(args: ["swiftc", "-wmo", "-emit-module",
                                        "-emit-module-interface", "-enable-library-evolution",
@@ -119,13 +119,13 @@ class APIDigesterTests: XCTestCase {
       try withTemporaryDirectory { path in
         let ofmPath = path.appending(component: "ofm.json")
         try localFileSystem.writeFileContents(ofmPath) {
-          $0 <<< """
+          $0.send("""
           {
             "": {
               "swiftsourceinfo": "/path/to/sourceinfo"
             }
           }
-          """
+          """)
         }
         var driver = try Driver(args: ["swiftc", "-wmo", "-emit-module",
                                        "-emit-module-interface", "-enable-library-evolution",
@@ -183,13 +183,13 @@ class APIDigesterTests: XCTestCase {
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let source = path.appending(component: "foo.swift")
       try localFileSystem.writeFileContents(source) {
-        $0 <<< """
+        $0.send("""
         import C
         import E
         import G
 
         public struct MyStruct {}
-        """
+        """)
       }
 
       let packageRootPath = URL(fileURLWithPath: #file).pathComponents
@@ -274,11 +274,11 @@ class APIDigesterTests: XCTestCase {
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let source = path.appending(component: "foo.swift")
       try localFileSystem.writeFileContents(source) {
-        $0 <<< """
+        $0.send("""
         public struct MyStruct {
           public var a: Int
         }
-        """
+        """)
       }
       var driver = try Driver(args: ["swiftc",
                                      "-working-directory", path.pathString,
@@ -295,11 +295,11 @@ class APIDigesterTests: XCTestCase {
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
 
       try localFileSystem.writeFileContents(source) {
-        $0 <<< """
+        $0.send("""
         public struct MyStruct {
           public var a: Bool
         }
-        """
+        """)
       }
       var driver2 = try Driver(args: ["swiftc",
                                       "-working-directory", path.pathString,
@@ -335,16 +335,16 @@ class APIDigesterTests: XCTestCase {
       let source = path.appending(component: "foo.swift")
       let allowlist = path.appending(component: "allowlist.txt")
       try localFileSystem.writeFileContents(source) {
-        $0 <<< """
+        $0.send("""
         @frozen public struct MyStruct {
           var a: Int
           var b: String
           var c: Int
         }
-        """
+        """)
       }
       try localFileSystem.writeFileContents(allowlist) {
-        $0 <<< "ABI breakage: var MyStruct.c has declared type change from Swift.Int to Swift.String"
+        $0.send("ABI breakage: var MyStruct.c has declared type change from Swift.Int to Swift.String")
       }
       var driver = try Driver(args: ["swiftc",
                                      "-working-directory", path.pathString,
@@ -364,13 +364,13 @@ class APIDigesterTests: XCTestCase {
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
 
       try localFileSystem.writeFileContents(source) {
-        $0 <<< """
+        $0.send("""
         @frozen public struct MyStruct {
           var b: String
           var a: Int
           var c: String
         }
-        """
+        """)
       }
       var driver2 = try Driver(args: ["swiftc",
                                       "-working-directory", path.pathString,

--- a/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
+++ b/Tests/SwiftDriverTests/CrossModuleIncrementalBuildTests.swift
@@ -49,14 +49,14 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let magic = path.appending(component: "magic.swift")
       try localFileSystem.writeFileContents(magic) {
-        $0 <<< "public func castASpell() {}"
+        $0.send("public func castASpell() {}")
       }
 
       let ofm = path.appending(component: "ofm.json")
       try localFileSystem.writeFileContents(ofm) {
-        $0 <<< self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ]) {
+        $0.send(self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ]) {
           $0 + "-some_suffix"
-        }
+        })
       }
 
       let driverArgs = [
@@ -76,9 +76,9 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       }
 
       try localFileSystem.writeFileContents(ofm) {
-        $0 <<< self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ]) {
+        $0.send(self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ]) {
           $0 + "-some_other_suffix"
-        }
+        })
       }
 
       do {
@@ -98,12 +98,12 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
       do {
         let magic = path.appending(component: "magic.swift")
         try localFileSystem.writeFileContents(magic) {
-          $0 <<< "public func castASpell() {}"
+          $0.send("public func castASpell() {}")
         }
 
         let ofm = path.appending(component: "ofm.json")
         try localFileSystem.writeFileContents(ofm) {
-          $0 <<< self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ])
+          $0.send(self.makeOutputFileMap(in: path, module: "MagicKit", for: [ magic ]))
         }
 
         var driver = try Driver(args: [
@@ -122,13 +122,13 @@ class CrossModuleIncrementalBuildTests: XCTestCase {
 
       let main = path.appending(component: "main.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import MagicKit\n"
-        $0 <<< "castASpell()"
+        $0.send("import MagicKit\n")
+        $0.send("castASpell()")
       }
 
       let ofm = path.appending(component: "ofm2.json")
       try localFileSystem.writeFileContents(ofm) {
-        $0 <<< self.makeOutputFileMap(in: path, module: "theModule", for: [ main ])
+        $0.send(self.makeOutputFileMap(in: path, module: "theModule", for: [ main ]))
       }
 
       var driver = try Driver(args: [

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -238,11 +238,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
   func testExplicitModuleBuildJobs() throws {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleBuildJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;\
+        import E;\
+        import G;
+        """
+      )
 
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -488,11 +490,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
   func testExplicitModuleBuildPCHOutputJobs() throws {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleBuildPCHOutputJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;\
+        import E;\
+        import G;
+        """
+      )
 
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -618,9 +622,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
   func testImmediateModeExplicitModuleBuild() throws {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleBuildJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import C\n")
 
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -729,9 +731,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let srcBar = path.appending(component: "bar.swift")
       let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: true)
-      try localFileSystem.writeFileContents(srcBar) {
-        $0 <<< "public class KlassBar {}"
-      }
+      try localFileSystem.writeFileContents(srcBar, bytes: "public class KlassBar {}")
 
       // Create Bar.swiftmodule
       var driver = try Driver(args: ["swiftc",
@@ -762,10 +762,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // in source files, while its contents are compiled as Bar (real
       // name on disk).
       let srcFoo = path.appending(component: "Foo.swift")
-      try localFileSystem.writeFileContents(srcFoo) {
-        $0 <<< "import Car\n"
-        $0 <<< "func run() -> Car.KlassBar? { return nil }"
-      }
+      try localFileSystem.writeFileContents(srcFoo, bytes:
+        """
+        import Car
+        func run() -> Car.KlassBar? { return nil }
+        """
+      )
 
       // Module alias with the fallback scanner (frontend scanner)
       var driverA = try Driver(args: ["swiftc",
@@ -838,9 +840,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // in source files, while its contents are compiled as E (real
       // name on disk).
       let srcFoo = path.appending(component: "Foo.swift")
-      try localFileSystem.writeFileContents(srcFoo) {
-        $0 <<< "import Car\n"
-      }
+      try localFileSystem.writeFileContents(srcFoo, bytes: "import Car\n")
 
       // Module alias with the fallback scanner (frontend scanner)
       var driverA = try Driver(args: ["swiftc",
@@ -920,10 +920,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
     try withTemporaryDirectory { path in
       let main = path.appending(component: "foo.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import Car;"
-        $0 <<< "import Jet;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import Car;\
+        import Jet;
+        """
+      )
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let scannerCommand = ["-scan-dependencies",
                             "-import-prescan",
@@ -949,9 +951,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try localFileSystem.createDirectory(moduleCachePath)
       let srcBar = path.appending(component: "bar.swift")
       let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: true)
-      try localFileSystem.writeFileContents(srcBar) {
-        $0 <<< "public class KlassBar {}"
-      }
+      try localFileSystem.writeFileContents(srcBar, bytes: "public class KlassBar {}")
 
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let (stdLibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
@@ -986,10 +986,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // `-module-alias Car=Bar` allows Car (alias) to be referenced
       // in source files in Foo, but its contents will be compiled
       // as Bar (real name on-disk).
-      try localFileSystem.writeFileContents(srcFoo) {
-        $0 <<< "import Car\n"
-        $0 <<< "func run() -> Car.KlassBar? { return nil }"
-      }
+      try localFileSystem.writeFileContents(srcFoo, bytes:
+        """
+        import Car
+        func run() -> Car.KlassBar? { return nil }
+        """
+      )
       var driver2 = try Driver(args: ["swiftc",
                                       "-I", path.nativePathString(escaped: true),
                                       "-explicit-module-build",
@@ -1096,11 +1098,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let moduleCachePath = path.appending(component: "ModuleCache")
       try localFileSystem.createDirectory(moduleCachePath)
       let main = path.appending(component: "testExplicitModuleBuildEndToEnd.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;
+        import E;
+        import G;
+        """
+      )
 
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -1138,15 +1142,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
           frameworkModuleDir.appending(component: hostTriple.archName + ".swiftmodule")
       try localFileSystem.createDirectory(frameworkModuleDir, recursive: true)
       let fooSourcePath = path.appending(component: "Foo.swift")
-      try localFileSystem.writeFileContents(fooSourcePath) {
-        $0 <<< "public func foo() {}"
-      }
+      try localFileSystem.writeFileContents(fooSourcePath, bytes: "public func foo() {}")
 
       // Setup our main test module
       let mainSourcePath = path.appending(component: "Foo.swift")
-      try localFileSystem.writeFileContents(mainSourcePath) {
-        $0 <<< "import Foo"
-      }
+      try localFileSystem.writeFileContents(mainSourcePath, bytes: "import Foo")
 
       // 1. Build Foo module
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
@@ -1278,11 +1278,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
     // Create a simple test case.
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testDependencyScanning.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;\
+        import E;\
+        import G;"
+        """
+      )
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
                         .appending(component: "CHeaders")
@@ -1387,9 +1389,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testDependencyScanning.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import S;"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import S;")
 
       let cHeadersPath: AbsolutePath =
       testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -1455,11 +1455,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
     // Create a simple test case.
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testDependencyScanning.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;\
+        import E;\
+        import G;
+        """
+      )
 
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -1554,11 +1556,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
   func testPrintingExplicitDependencyGraph() throws {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrintingExplicitDependencyGraph.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;\
+        import E;\
+        import G;
+        """
+      )
       let cHeadersPath: AbsolutePath = testInputsPath.appending(component: "ExplicitModuleBuilds").appending(component: "CHeaders")
       let swiftModuleInterfacesPath: AbsolutePath = testInputsPath.appending(component: "ExplicitModuleBuilds").appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
@@ -1651,11 +1655,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // Create a simple test case.
       try withTemporaryDirectory { path in
         let main = path.appending(component: "testDependencyScanning.swift")
-        try localFileSystem.writeFileContents(main) {
-          $0 <<< "import C;"
-          $0 <<< "import E;"
-          $0 <<< "import G;"
-        }
+        try localFileSystem.writeFileContents(main, bytes:
+          """
+          import C;\
+          import E;\
+          import G;
+          """
+        )
 
         let cHeadersPath: AbsolutePath =
             testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -1705,11 +1711,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
     try withTemporaryDirectory { path in
       let cacheSavePath = path.appending(component: "saved.moddepcache")
       let main = path.appending(component: "testDependencyScanning.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;\
+        import E;\
+        import G;
+        """
+      )
 
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -1837,18 +1845,19 @@ final class ExplicitModuleBuildTests: XCTestCase {
     XCTAssertEqual(moduleMap[1].isFramework, false)
   }
 
-
   func testTraceDependency() throws {
     try withTemporaryDirectory { path in
       try localFileSystem.changeCurrentWorkingDirectory(to: path)
       let moduleCachePath = path.appending(component: "ModuleCache")
       try localFileSystem.createDirectory(moduleCachePath)
       let main = path.appending(component: "testTraceDependency.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
-      }
+      try localFileSystem.writeFileContents(main, bytes: 
+        """
+        import C;\
+        import E;\
+        import G;
+        """
+      )
 
       let cHeadersPath: AbsolutePath =
           testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -1937,14 +1946,17 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import A\n"
-        $0 <<< "import E\n"
-        $0 <<< "import F\n"
-        $0 <<< "import G\n"
-        $0 <<< "import H\n"
-        $0 <<< "import Swift\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import A
+        import E
+        import F
+        import G
+        import H
+        import Swift
+
+        """
+      )
       let moduleCachePath = "/tmp/module-cache"
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
@@ -1990,9 +2002,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import H\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import H\n")
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
@@ -2028,9 +2038,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import Swift\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import Swift\n")
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
@@ -2044,9 +2052,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import F\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import F\n")
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
@@ -2064,9 +2070,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import H\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import H\n")
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
                                     ])
@@ -2104,9 +2108,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     let interfaceMap = try collector.collectSwiftInterfaceMap().inputMap
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import A\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import A\n")
       let moduleCachePath = "/tmp/module-cache"
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPath,
@@ -2132,9 +2134,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     let interfaceMap = try collector.collectSwiftInterfaceMap().inputMap
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "import A\n"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "import A\n")
       let moduleCachePath = "/tmp/module-cache"
       var driver = try Driver(args: ["swiftc", main.pathString,
                                      "-sdk", mockSDKPathStr,

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -1313,7 +1313,7 @@ extension IncrementalCompilationTests {
 
     for (file, contents) in self.inputPathsAndContents {
       let linkTarget = tempDir.appending(component: "links").appending(component: file.basename)
-      try! localFileSystem.writeFileContents(linkTarget) { $0 <<< contents }
+      try! localFileSystem.writeFileContents(linkTarget, bytes: .init(contents.utf8))
     }
 
     try doABuild(
@@ -1346,7 +1346,7 @@ extension IncrementalCompilationTests {
   private func touch(_ path: AbsolutePath) {
     Thread.sleep(forTimeInterval: 1)
     let existingContents = try! localFileSystem.readFileContents(path)
-    try! localFileSystem.writeFileContents(path) { $0 <<< existingContents }
+    try! localFileSystem.writeFileContents(path, bytes: existingContents)
   }
 
   /// Set modification time of a file
@@ -1376,7 +1376,7 @@ extension IncrementalCompilationTests {
     print("*** replacing \(name) ***", to: &stderrStream); stderrStream.flush()
     let path = inputPath(basename: name)
     let previousContents = try! localFileSystem.readFileContents(path).cString
-    try! localFileSystem.writeFileContents(path) { $0 <<< replacement }
+    try! localFileSystem.writeFileContents(path, bytes: .init(replacement.utf8))
     let newContents = try! localFileSystem.readFileContents(path).cString
     XCTAssert(previousContents != newContents, "\(path.pathString) unchanged after write")
     XCTAssert(replacement == newContents, "\(path.pathString) failed to write")
@@ -1384,9 +1384,7 @@ extension IncrementalCompilationTests {
 
   private func write(_ contents: String, to basename: String) {
     print("*** writing \(contents) to \(basename)")
-    try! localFileSystem.writeFileContents(inputPath(basename: basename)) {
-      $0 <<< contents
-    }
+    try! localFileSystem.writeFileContents(inputPath(basename: basename), bytes: .init(contents.utf8))
   }
 
   private func readPriors() -> ByteString? {

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -105,12 +105,8 @@ final class JobExecutorTests: XCTestCase {
       let foo = path.appending(component: "foo.swift")
       let main = path.appending(component: "main.swift")
 
-      try localFileSystem.writeFileContents(foo) {
-        $0 <<< "let foo = 5"
-      }
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "print(foo)"
-      }
+      try localFileSystem.writeFileContents(foo, bytes: "let foo = 5")
+      try localFileSystem.writeFileContents(main, bytes: "print(foo)")
 
       let exec = path.appending(component: "main")
 
@@ -263,9 +259,8 @@ final class JobExecutorTests: XCTestCase {
 
       // Create a file with inpuit
       let inputFile = path.appending(component: "main.swift")
-      try localFileSystem.writeFileContents(inputFile) {
-        $0 <<< "print(\"Hello, World\")"
-      }
+      try localFileSystem.writeFileContents(inputFile, bytes: "print(\"Hello, World\")")
+
       // We are going to override he executors standard input FileHandle to the above
       // input file, to simulate it being piped over standard input to this compilation.
       let testFile: FileHandle = FileHandle(forReadingAtPath: inputFile.description)!
@@ -348,18 +343,14 @@ final class JobExecutorTests: XCTestCase {
 #else
     try withTemporaryDirectory { path in
       let main = path.appending(component: "main.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "let foo = 1"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "let foo = 1")
 
       var driver = try Driver(args: ["swift", main.pathString])
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs.count == 1 && jobs[0].requiresInPlaceExecution)
 
       // Change the file
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "let foo = 1"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "let foo = 1")
 
       XCTAssertThrowsError(try driver.run(jobs: jobs)) {
         XCTAssertEqual($0 as? Job.InputError,
@@ -395,14 +386,10 @@ final class JobExecutorTests: XCTestCase {
   func testInputModifiedDuringMultiJobBuild() throws {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "main.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "let foo = 1"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "let foo = 1")
 
       let other = path.appending(component: "other.swift")
-      try localFileSystem.writeFileContents(other) {
-        $0 <<< "let bar = 2"
-      }
+      try localFileSystem.writeFileContents(other, bytes: "let bar = 2")
 
       let output = path.appending(component: "a.out")
 
@@ -416,9 +403,7 @@ final class JobExecutorTests: XCTestCase {
         XCTAssertTrue(jobs.count > 1)
 
         // Change the file
-        try localFileSystem.writeFileContents(other) {
-          $0 <<< "let bar = 3"
-        }
+        try localFileSystem.writeFileContents(other, bytes: "let bar = 3")
 
         verifier.expect(.error("input file '\(other.description)' was modified during the build"))
         // There's a tool-specific linker error that usually happens here from
@@ -481,9 +466,8 @@ final class JobExecutorTests: XCTestCase {
     do {
       try withTemporaryDirectory { path in
         let main = path.appending(component: "main.swift")
-        try localFileSystem.writeFileContents(main) {
-          $0 <<< "print(\"hello, world!\")"
-        }
+        try localFileSystem.writeFileContents(main, bytes: "print(\"hello, world!\")")
+
         let diags = DiagnosticsEngine()
         let executor = try SwiftDriverExecutor(diagnosticsEngine: diags,
                                                processSet: ProcessSet(),
@@ -518,9 +502,7 @@ final class JobExecutorTests: XCTestCase {
     do {
       try withTemporaryDirectory { path in
         let main = path.appending(component: "main.swift")
-        try localFileSystem.writeFileContents(main) {
-          $0 <<< "print(\"hello, world!\")"
-        }
+        try localFileSystem.writeFileContents(main, bytes: "print(\"hello, world!\")")
         let diags = DiagnosticsEngine()
         let executor = try SwiftDriverExecutor(diagnosticsEngine: diags,
                                                processSet: ProcessSet(),
@@ -556,9 +538,7 @@ final class JobExecutorTests: XCTestCase {
     do {
       try withTemporaryDirectory { path in
         let main = path.appending(component: "main.swift")
-        try localFileSystem.writeFileContents(main) {
-          $0 <<< "print(\"hello, world!\")"
-        }
+        try localFileSystem.writeFileContents(main, bytes: "print(\"hello, world!\")")
         let diags = DiagnosticsEngine()
         let executor = try SwiftDriverExecutor(diagnosticsEngine: diags,
                                                processSet: ProcessSet(),

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -276,13 +276,10 @@ final class NonincrementalCompilationTests: XCTestCase {
     }
     try withTemporaryDirectory { path in
       let main = path.appending(component: "main.swift")
-      try localFileSystem.writeFileContents(main) {
-        $0 <<< "let foo = 1"
-      }
+      try localFileSystem.writeFileContents(main, bytes: "let foo = 1")
       let other = path.appending(component: "other.swift")
-      try localFileSystem.writeFileContents(other) {
-        $0 <<< "let bar = 2"
-      }
+      try localFileSystem.writeFileContents(other, bytes: "let bar = 2")
+      
       try assertDriverDiagnostics(args: [
         "swiftc", "-module-name", "theModule", "-working-directory", path.pathString,
         main.pathString, other.pathString

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -407,9 +407,8 @@ final class ParsableMessageTests: XCTestCase {
         let errorOutput = try withHijackedErrorStream {
           let main = path.appending(component: "main.swift")
           let output = path.appending(component: "main.o")
-          try localFileSystem.writeFileContents(main) {
-            $0 <<< "nonexistentPrint(\"hello, compilation error!\")"
-          }
+          try localFileSystem.writeFileContents(main, bytes: "nonexistentPrint(\"hello, compilation error!\")")
+
           let diags = DiagnosticsEngine()
           let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
           var driver = try Driver(args: ["swiftc", main.pathString,
@@ -432,9 +431,8 @@ final class ParsableMessageTests: XCTestCase {
         let errorOutput = try withHijackedErrorStream {
           let main = path.appending(component: "main.swift")
           let output = path.appending(component: "main.o")
-          try localFileSystem.writeFileContents(main) {
-            $0 <<< "print(\"hello, world!\")"
-          }
+          try localFileSystem.writeFileContents(main, bytes: "print(\"hello, world!\")")
+
           let diags = DiagnosticsEngine()
           let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
           var driver = try Driver(args: ["swiftc", main.pathString,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2335,6 +2335,7 @@ final class SwiftDriverTests: XCTestCase {
                                    pathDynamicReplacementsMac, path5_0iOS,
                                    path5_1iOS, pathDynamicReplacementsiOS,
                                    pathCompatibilityPacksMac] {
+        try localFileSystem.createDirectory(compatibilityLibPath.parentDirectory, recursive: true)
         try localFileSystem.writeFileContents(compatibilityLibPath, bytes: "Empty")
       }
       let commonArgs = ["swiftc", "foo.swift", "bar.swift",  "-module-name", "Test", "-resource-dir", path.pathString]
@@ -4245,6 +4246,7 @@ final class SwiftDriverTests: XCTestCase {
 
     try withTemporaryDirectory { tmpDir in
       let sdk1 = tmpDir.appending(component: "MacOSX10.15.sdk")
+      try localFileSystem.createDirectory(sdk1, recursive: true)
       try localFileSystem.writeFileContents(sdk1.appending(component: "SDKSettings.json"), bytes:
         """
         {
@@ -4265,6 +4267,7 @@ final class SwiftDriverTests: XCTestCase {
       )
 
       let sdk2 = tmpDir.appending(component: "MacOSX10.15.4.sdk")
+      try localFileSystem.createDirectory(sdk2, recursive: true)
       try localFileSystem.writeFileContents(sdk2.appending(component: "SDKSettings.json"), bytes:
         """
         {

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -18,8 +18,8 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
   func testCreateCompilerInvocation() throws {
     try withTemporaryDirectory { path in
       let inputFile = path.appending(components: "test.swift")
-      try localFileSystem.writeFileContents(inputFile) { $0 <<< "public func foo()" }
-
+      try localFileSystem.writeFileContents(inputFile) { $0.send("public func foo()") }
+      
       // Expected success scenarios:
       do {
         let testCommand = inputFile.description


### PR DESCRIPTION
`<<<` operator has been deprecated in TSC, as it mostly duplicates string interpolation, and the latter should be used instead in most cases where `<<<` was used previously. Additionally, `<<<` can't be introduced to scope with a qualified import (which is the case for any operator).