### PR TITLE
[NFC] Remove unused constant in `FirstWaveComputer.swift`

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -176,7 +176,6 @@ extension IncrementalCompilationState.FirstWaveComputer {
         for pathModuleId in pathSoFar {
           if !modulesRequiringRebuild.contains(pathModuleId) &&
              !isMainModule {
-            let pathModuleInfo = try moduleDependencyGraph.moduleInfo(of: pathModuleId)
             reporter.reportExplicitDependencyWillBeReBuilt(pathModuleId.moduleNameForDiagnostic,
                                                            reason: "Invalidated by downstream dependency")
           }


### PR DESCRIPTION
Fixes `Initialization of immutable value 'pathModuleInfo' was never used; consider replacing with assignment to '_' or removing it` warning in `FirstWaveComputer.swift`.

The function's body of which result is unused looks to be free of side-effects, so removing this call should in turn have no effect.