### PR TITLE
Replace remaining uses of `<<<` operator with `.send`

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -471,12 +471,9 @@ final class CachingBuildTests: XCTestCase {
       let foo = path.appending(component: "foo.swift")
       let casPath = path.appending(component: "cas")
       try localFileSystem.writeFileContents(foo) {
-        $0.send("""
-          extension Profiler {
-              public static let count: Int = 42"
-          }
-          """
-        )
+        $0.send("extension Profiler {")
+        $0.send("    public static let count: Int = 42")
+        $0.send("}")
       }
       let fooHeader = path.appending(component: "foo.h")
       try localFileSystem.writeFileContents(fooHeader) {

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -148,9 +148,7 @@ final class CachingBuildTests: XCTestCase {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testCachingBuildJobs.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
+        $0.send("import C;import E;import G;")
       }
       let casPath = path.appending(component: "cas")
       let swiftModuleInterfacesPath: AbsolutePath =
@@ -278,9 +276,7 @@ final class CachingBuildTests: XCTestCase {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleVerifyInterfaceJobs.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
+        $0.send("import C;import E;import G;")
       }
 
       let swiftModuleInterfacesPath: AbsolutePath =
@@ -427,9 +423,7 @@ final class CachingBuildTests: XCTestCase {
       try localFileSystem.createDirectory(moduleCachePath)
       let main = path.appending(component: "testCachingBuild.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
+        $0.send("import C;import E;import G;")
       }
 
       let cHeadersPath: AbsolutePath =
@@ -477,17 +471,20 @@ final class CachingBuildTests: XCTestCase {
       let foo = path.appending(component: "foo.swift")
       let casPath = path.appending(component: "cas")
       try localFileSystem.writeFileContents(foo) {
-        $0 <<< "extension Profiler {"
-        $0 <<< "    public static let count: Int = 42"
-        $0 <<< "}"
+        $0.send("""
+          extension Profiler {
+              public static let count: Int = 42"
+          }
+          """
+        )
       }
       let fooHeader = path.appending(component: "foo.h")
       try localFileSystem.writeFileContents(fooHeader) {
-        $0 <<< "struct Profiler { void* ptr; };"
+        $0.send("struct Profiler { void* ptr; };")
       }
       let main = path.appending(component: "main.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import Foo"
+        $0.send("import Foo")
       }
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
 
@@ -546,9 +543,7 @@ final class CachingBuildTests: XCTestCase {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testDependencyScanning.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
+        $0.send("import C;import E;import G;")
       }
 
       let cHeadersPath: AbsolutePath =

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1028,8 +1028,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let foo = path.appending(component: "foo.swift")
       try localFileSystem.writeFileContents(foo) {
           $0.send("""
-            extension Profiler {
-                public static let count: Int = 42"
+            extension Profiler {\
+                public static let count: Int = 42"\
             }
             """
           )

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1027,12 +1027,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try localFileSystem.createDirectory(FooInstallPath)
       let foo = path.appending(component: "foo.swift")
       try localFileSystem.writeFileContents(foo) {
-          $0.send("""
-            extension Profiler {\
-                public static let count: Int = 42"\
-            }
-            """
-          )
+        $0.send("extension Profiler {")
+        $0.send("    public static let count: Int = 42")
+        $0.send("}")
       }
       let fooHeader = path.appending(component: "foo.h")
       try localFileSystem.writeFileContents(fooHeader) {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -362,9 +362,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleVerifyInterfaceJobs.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import C;"
-        $0 <<< "import E;"
-        $0 <<< "import G;"
+        $0.send("import C;import E;import G;")
       }
 
       let swiftModuleInterfacesPath: AbsolutePath =
@@ -1029,17 +1027,20 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try localFileSystem.createDirectory(FooInstallPath)
       let foo = path.appending(component: "foo.swift")
       try localFileSystem.writeFileContents(foo) {
-        $0 <<< "extension Profiler {"
-        $0 <<< "    public static let count: Int = 42"
-        $0 <<< "}"
+          $0.send("""
+            extension Profiler {
+                public static let count: Int = 42"
+            }
+            """
+          )
       }
       let fooHeader = path.appending(component: "foo.h")
       try localFileSystem.writeFileContents(fooHeader) {
-        $0 <<< "struct Profiler { void* ptr; };"
+        $0.send("struct Profiler { void* ptr; };")
       }
       let main = path.appending(component: "main.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import Foo"
+        $0.send("import Foo")
       }
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2043,8 +2043,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       // Linux shared objects (.so) are not offered to autolink-extract
       try withTemporaryDirectory { path in
-        try localFileSystem.writeFileContents(
-          path.appending(components: "libEmpty.so")) { $0 <<< "/* empty */" }
+        try localFileSystem.writeFileContents(path.appending(components: "libEmpty.so")) { $0.send("/* empty */") }
 
         var driver = try Driver(args: commonArgs + ["-emit-executable", "-target", "x86_64-unknown-linux", "libEmpty.so"], env: env)
         let plannedJobs = try driver.planBuild()
@@ -2197,8 +2196,9 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       try withTemporaryDirectory { path in
-        try localFileSystem.writeFileContents(
-          path.appending(components: "wasi", "static-executable-args.lnk")) { $0 <<< "garbage" }
+        try localFileSystem.writeFileContents(path.appending(components: "wasi", "static-executable-args.lnk")) {
+          $0.send("garbage")
+        }
         // Wasm executable linking
         var driver = try Driver(args: commonArgs + ["-emit-executable", "-Ounchecked",
                                                     "-target", "wasm32-unknown-wasi",
@@ -3811,7 +3811,7 @@ final class SwiftDriverTests: XCTestCase {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "Foo.swift")
       try localFileSystem.writeFileContents(main) {
-        $0 <<< "import Swift"
+        $0.send("import Swift")
       }
       var driver = try Driver(args: ["swiftc", "-explicit-module-build",
                                      "-target", "arm64e-apple-ios13.0-macabi",


### PR DESCRIPTION
After merging https://github.com/apple/swift-driver/pull/1444 there are still a few uses of `<<<` left, which should be cleaned up. This fixes remaining deprecation warnings caused by the use of `<<<`.