### PR TITLE
[5.10] Fix forwarding of `-ld-path`

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -181,7 +181,9 @@ extension DarwinToolchain {
       commandLine.appendFlag("-fuse-ld=\(arg.asSingle)")
     }
 
-    try commandLine.appendLast(.ldPath, from: &parsedOptions)
+    if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {
+      commandLine.append(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: arg)))
+    }
 
     let fSystemArgs = parsedOptions.arguments(for: .F, .Fsystem)
     for opt in fSystemArgs {

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -101,7 +101,9 @@ extension GenericUnixToolchain {
         }
       }
 
-      try commandLine.appendLast(.ldPath, from: &parsedOptions)
+      if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {
+        commandLine.append(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: arg)))
+      }
 
       // Configure the toolchain.
       //

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -43,7 +43,9 @@ extension WebAssemblyToolchain {
         commandLine.appendFlag("-fuse-ld=\(linkerArg)")
       }
 
-      try commandLine.appendLast(.ldPath, from: &parsedOptions)
+      if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {
+        commandLine.append(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: arg)))
+      }
 
       // Configure the toolchain.
       //

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -105,7 +105,9 @@ extension WindowsToolchain {
       commandLine.appendFlag("-fuse-ld=lld")
     }
 
-    try commandLine.appendLast(.ldPath, from: &parsedOptions)
+    if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {
+      commandLine.append(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: arg)))
+    }
 
     switch lto {
     case .some(.llvmThin):

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1691,7 +1691,7 @@ final class SwiftDriverTests: XCTestCase {
       let cmd = linkJob.commandLine
       XCTAssertTrue(cmd.contains(.flag("-dynamiclib")))
       XCTAssertTrue(cmd.contains(.flag("-fuse-ld=foo")))
-      XCTAssertTrue(cmd.contains(.joinedOptionAndPath("-ld-path=", try VirtualPath(path: "/bar/baz"))))
+      XCTAssertTrue(cmd.contains(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: "/bar/baz"))))
       XCTAssertTrue(cmd.contains(.flag("--target=x86_64-apple-macosx10.15")))
       XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "libTest.dylib"))
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1447.

The Clang linker driver spells this as `--ld-path` so we can't forward the argument wholesale anymore, since we spell it `-ld-path`.

(cherry picked from commit https://github.com/apple/swift-driver/commit/9a357eea6edcd9ab071b2dc379eb838997084e5b)