### PR TITLE
Ensure supplementary output file maps associate Swift Source inputs with expected outputs in WMO

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -686,7 +686,10 @@ extension Driver {
     if let input = input?.fileHandle, input != OutputFileMap.singleInputKey {
       entryInput = input
     } else {
-      entryInput = inputFiles[0].fileHandle
+      guard let firstSourceInputHandle = inputFiles.first(where:{ $0.type == .swift })?.fileHandle else {
+        fatalError("Formulating swift-frontend invocation without any input .swift files")
+      }
+      entryInput = firstSourceInputHandle
     }
     entries[entryInput, default: [:]][output.type] = output.fileHandle
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2929,6 +2929,30 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(firstKey, "foo.swift")
   }
 
+  func testWMOWithNonSourceInputFirstAndModuleOutput() throws {
+    var driver1 = try Driver(args: [
+      "swiftc", "-wmo", "danger.o", "foo.swift", "bar.swift", "wibble.swift", "-module-name", "Test",
+      "-driver-filelist-threshold=0", "-emit-module", "-emit-library"
+    ])
+    let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
+    XCTAssertEqual(plannedJobs.count, 2)
+    let compileJob = plannedJobs[0]
+    XCTAssertEqual(compileJob.kind, .compile)
+    XCTAssert(compileJob.commandLine.contains(.flag("-supplementary-output-file-map")))
+    let argIdx = try XCTUnwrap(compileJob.commandLine.firstIndex(where: { $0 == .flag("-supplementary-output-file-map") }))
+    let supplOutputs = compileJob.commandLine[argIdx+1]
+    guard case let .path(path) = supplOutputs,
+          case let .fileList(_, fileList) = path,
+          case let .outputFileMap(outFileMap) = fileList else {
+      throw StringError("Unexpected argument for output file map")
+    }
+    let firstKeyHandle = try XCTUnwrap(outFileMap.entries.keys.first)
+    let firstKey = try VirtualPath.lookup(firstKeyHandle).description
+    XCTAssertEqual(firstKey, "foo.swift")
+    let firstKeyOutputs = try XCTUnwrap(outFileMap.entries[firstKeyHandle])
+    XCTAssertTrue(firstKeyOutputs.keys.contains(where: { $0 == .swiftModule }))
+  }
+
   func testDashDashPassingDownInput() throws {
     do {
       var driver = try Driver(args: ["swiftc", "-module-name=ThisModule", "-wmo", "-num-threads", "4", "-emit-module", "-o", "test.swiftmodule", "--", "main.swift", "multi-threaded.swift"])


### PR DESCRIPTION
When handling invocations with many input kinds, it is important that the Swift compiler is passed a supplementary output filemap that maps the first `.swift` input to the expected outputs. It is already just a convention that we use the first input for a WMO compilation task. In cases where we use the first input which happens to not be a `.swift` input (e.g. a `.o` input), the Swift compiler fails to map it to expected output kinds of Swift compilation.

Resolves rdar://115577783