### PR TITLE
Fix typos and warnings in `SwiftDriver` module and its tests

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -363,8 +363,6 @@ extension Driver {
       commandLine.appendFlag(map)
     }
 
-    let expirementalFeatures = parsedOptions.arguments(for: .enableExperimentalFeature)
-
     try commandLine.appendLast(.trackSystemDependencies, from: &parsedOptions)
     try commandLine.appendLast(.CrossModuleOptimization, from: &parsedOptions)
     try commandLine.appendLast(.ExperimentalPerformanceAnnotations, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -107,8 +107,8 @@ extension Driver {
       commandLine.appendFlag("-aarch64-use-tbi")
     }
 
-    let expirementalFeatures = parsedOptions.arguments(for: .enableExperimentalFeature)
-    let embeddedEnabled = expirementalFeatures.map(\.argument).map(\.asSingle).contains("Embedded")
+    let experimentalFeatures = parsedOptions.arguments(for: .enableExperimentalFeature)
+    let embeddedEnabled = experimentalFeatures.map(\.argument).map(\.asSingle).contains("Embedded")
 
     // Enable or disable ObjC interop appropriately for the platform
     if targetTriple.isDarwin && !embeddedEnabled {

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -117,8 +117,8 @@ extension DarwinToolchain {
       }
     }
 
-    let expirementalFeatures = parsedOptions.arguments(for: .enableExperimentalFeature)
-    let embeddedEnabled = expirementalFeatures.map(\.argument).map(\.asSingle).contains("Embedded")
+    let experimentalFeatures = parsedOptions.arguments(for: .enableExperimentalFeature)
+    let embeddedEnabled = experimentalFeatures.map(\.argument).map(\.asSingle).contains("Embedded")
 
     if !embeddedEnabled {
       for compatibilityLib in targetInfo.target.compatibilityLibraries {

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -254,7 +254,7 @@ final class CachingBuildTests: XCTestCase {
           }
         } else {
           switch (outputFilePath) {
-            case .relative(RelativePath("testCachingBuildJobs")):
+            case .relative(try RelativePath(validating: "testCachingBuildJobs")):
               XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
               XCTAssertEqual(job.kind, .link)
             case .temporary(_):
@@ -399,7 +399,7 @@ final class CachingBuildTests: XCTestCase {
           }
         } else {
           switch (outputFilePath) {
-            case .relative(RelativePath("testExplicitModuleVerifyInterfaceJobs")):
+            case .relative(try RelativePath(validating: "testExplicitModuleVerifyInterfaceJobs")):
               XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
               XCTAssertEqual(job.kind, .link)
             case .temporary(_):


### PR DESCRIPTION
`experimentalFeatures` -> `experimentalFeatures`.

Also fixed uses of deprecated `RelativePath` initializer.