### PR TITLE
[Build Script Helper] Use new SwiftPM flag to remove `$ORIGIN` from installed ELF executable runpaths

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -98,6 +98,9 @@ def get_swiftpm_options(args):
     if args.cross_compile_hosts:
       swiftpm_args += ['--destination', args.cross_compile_config]
 
+    if args.action == 'install':
+      swiftpm_args += ['--disable-local-rpath']
+
     if '-android' in args.build_target:
       swiftpm_args += [
         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/android',


### PR DESCRIPTION
The latest trunk snapshot toolchain shows five executables built by SwiftPM that incorrectly have this runpath, three from this repo:
```
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/*|ag "File:|runpath"|ag "ORIGIN[^/]" -B1
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/docc
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/sourcekit-lsp
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-build-sdk-interfaces
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-driver
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-10-10-a-ubuntu20.04/usr/bin/swift-help
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib/swift/linux]
```
This will remove that unneeded runpath, as I just did for `swift-package` in apple/swift-package-manager#6947. I limited this to non-Darwin installs because I have no idea if this would be useful on Darwin too.