### PR TITLE
Add -experimental-skip-non-exportable-decls to lazy typechecking emit module jobs

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -85,6 +85,11 @@ extension Driver {
 
     commandLine.appendFlags("-frontend", "-emit-module", "-experimental-skip-non-inlinable-function-bodies-without-types")
 
+    if parsedOptions.hasArgument(.experimentalLazyTypecheck) {
+      commandLine.appendFlag("-experimental-lazy-typecheck")
+      commandLine.appendFlag("-experimental-skip-non-exportable-decls")
+    }
+
     // Add the inputs.
     for input in self.inputFiles where input.type.isPartOfSwiftCompilation {
       commandLine.append(.path(input.file))
@@ -103,9 +108,6 @@ extension Driver {
     try addCommonSymbolGraphOptions(commandLine: &commandLine)
 
     try commandLine.appendLast(.checkApiAvailabilityOnly, from: &parsedOptions)
-    if isFrontendArgSupported(.experimentalLazyTypecheck) {
-      try commandLine.appendLast(.experimentalLazyTypecheck, from: &parsedOptions)
-    }
 
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
       commandLine.appendFlag(.parseAsLibrary)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7221,12 +7221,10 @@ final class SwiftDriverTests: XCTestCase {
     var driver = try Driver(args: [
       "swiftc", "test.swift", "-module-name", "Test", "-experimental-lazy-typecheck", "-emit-module-interface"
     ])
-    guard driver.isFrontendArgSupported(.experimentalLazyTypecheck) else {
-      throw XCTSkip("Skipping: compiler does not support '-experimental-lazy-typecheck'")
-    }
     let jobs = try driver.planBuild().removingAutolinkExtractJobs()
     let emitModuleJob = try XCTUnwrap(jobs.first(where: {$0.kind == .emitModule}))
     XCTAssertTrue(emitModuleJob.commandLine.contains(.flag("-experimental-lazy-typecheck")))
+    XCTAssertTrue(emitModuleJob.commandLine.contains(.flag("-experimental-skip-non-exportable-decls")))
   }
   
   func testEmitAPIDescriptorEmitModule() throws {


### PR DESCRIPTION
Also, remove the `isFrontendArgSupported` check for `-experimental-lazy-typecheck` to simplify testing. There's no need to query whether the frontend supports the flags for this feature since `-experimental-lazy-typecheck` would only be specified on the driver command line explicitly.

Resolves rdar://115731361.