### PR TITLE
[5.10] Add -experimental-skip-non-exportable-decls to lazy typechecking emit module jobs

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -84,6 +84,11 @@ extension Driver {
 
     commandLine.appendFlags("-frontend", "-emit-module", "-experimental-skip-non-inlinable-function-bodies-without-types")
 
+    if parsedOptions.hasArgument(.experimentalLazyTypecheck) {
+      commandLine.appendFlag("-experimental-lazy-typecheck")
+      commandLine.appendFlag("-experimental-skip-non-exportable-decls")
+    }
+
     // Add the inputs.
     for input in self.inputFiles where input.type.isPartOfSwiftCompilation {
       commandLine.append(.path(input.file))
@@ -102,9 +107,6 @@ extension Driver {
     try addCommonSymbolGraphOptions(commandLine: &commandLine)
 
     try commandLine.appendLast(.checkApiAvailabilityOnly, from: &parsedOptions)
-    if isFrontendArgSupported(.experimentalLazyTypecheck) {
-      try commandLine.appendLast(.experimentalLazyTypecheck, from: &parsedOptions)
-    }
 
     if parsedOptions.hasArgument(.parseAsLibrary, .emitLibrary) {
       commandLine.appendFlag(.parseAsLibrary)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -1241,6 +1241,7 @@ extension Option {
       Option.ExperimentalPerformanceAnnotations,
       Option.platformCCallingConventionEQ,
       Option.platformCCallingConvention,
+      Option.experimentalLazyTypecheck,
       Option.experimentalPrintFullConvention,
       Option.experimentalSkipAllFunctionBodies,
       Option.experimentalSkipNonInlinableFunctionBodiesWithoutTypes,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7266,12 +7266,10 @@ final class SwiftDriverTests: XCTestCase {
     var driver = try Driver(args: [
       "swiftc", "test.swift", "-module-name", "Test", "-experimental-lazy-typecheck", "-emit-module-interface"
     ])
-    guard driver.isFrontendArgSupported(.experimentalLazyTypecheck) else {
-      throw XCTSkip("Skipping: compiler does not support '-experimental-lazy-typecheck'")
-    }
     let jobs = try driver.planBuild().removingAutolinkExtractJobs()
     let emitModuleJob = try XCTUnwrap(jobs.first(where: {$0.kind == .emitModule}))
     XCTAssertTrue(emitModuleJob.commandLine.contains(.flag("-experimental-lazy-typecheck")))
+    XCTAssertTrue(emitModuleJob.commandLine.contains(.flag("-experimental-skip-non-exportable-decls")))
   }
 }
 


### PR DESCRIPTION
Cherry picks of https://github.com/apple/swift-driver/pull/1465/ and https://github.com/apple/swift-driver/pull/1419.

Resolves rdar://115731361.