### PR TITLE
[5.10][Build Script Helper] Use new SwiftPM flag to remove `$ORIGIN` from installed ELF executable runpaths

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -98,6 +98,9 @@ def get_swiftpm_options(args):
     if args.cross_compile_hosts:
       swiftpm_args += ['--destination', args.cross_compile_config]
 
+    if args.action == 'install':
+      swiftpm_args += ['--disable-local-rpath']
+
     if '-android' in args.build_target:
       swiftpm_args += [
         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/android',


### PR DESCRIPTION
Cherrypick of #1462

__Explanation:__ Without this flag, `swift-driver` and the other installed executables look in `usr/bin/` first for shared libraries, but there are none in that executable directory.

__Scope:__ installed executables' runpaths

__Issue:__ none

__Risk:__ none, there were no shared libraries there

__Testing:__ SwiftPM merged using this flag into trunk and 5.10 last week, no problems with `swift-package` itself so far.

__Reviewer:__ @artemcm