### PR TITLE
[Embedded] disable using `-lswiftCore` for embedded targets

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -183,6 +183,9 @@ extension GenericUnixToolchain {
         }
       }
 
+      let expirementalFeatures = parsedOptions.arguments(for: .enableExperimentalFeature)
+      let embeddedEnabled = expirementalFeatures.map(\.argument).map(\.asSingle).contains("Embedded")
+
       if !parsedOptions.hasArgument(.nostartfiles) {
         let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
           .appending(
@@ -251,6 +254,8 @@ extension GenericUnixToolchain {
         linkFilePath = linkFilePath?.appending(component: "static-executable-args.lnk")
       } else if staticStdlib {
         linkFilePath = linkFilePath?.appending(component: "static-stdlib-args.lnk")
+      } else if embeddedEnabled {
+        linkFilePath = nil
       } else {
         linkFilePath = nil
         commandLine.appendFlag("-lswiftCore")

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2245,6 +2245,14 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(cmd.contains(.flag("-lsomelib")))
       XCTAssertTrue(cmd.contains(.flag("-lotherlib")))
     }
+    
+    do {
+      // Linker flags when embedded is enabled should not contain `-lswiftCore`
+      var driver = try Driver(args: commonArgs + ["-target", "armv6-none-none-eabi", "-emit-executable", "-whole-module-optimization", "-enable-experimental-feature", "Embedded"], env: env)
+      let plannedJobs = try driver.planBuild()
+      let cmd = plannedJobs.last!.commandLine
+      XCTAssertFalse(cmd.contains(.flag("-lswiftCore")))
+    }
 
     do {
       // The Android NDK only uses the lld linker now


### PR DESCRIPTION
This is a port of the changes made here: https://github.com/apple/swift/pull/69258 to avoid passing `-lswiftCore` to embedded targets.