### PR TITLE
Don't add an autolink-extract job unless actually linking ELF/Wasm objects, matching the original C++ driver

### DIFF
--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -18,7 +18,8 @@ import struct TSCBasic.RelativePath
 // FIXME: Also handle Cygwin and MinGW
 extension Driver {
   /*@_spi(Testing)*/ public var isAutolinkExtractJobNeeded: Bool {
-    [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil
+    [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil &&
+    linkerOutputType != nil
   }
 
   mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3347,17 +3347,11 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
-    #if os(Linux) || os(Android)
-    let autoLinkExtractJob = 1
-    #else
-    let autoLinkExtractJob = 0
-    #endif
-
     do {
       // non library-evolution builds require a single job, because cross-module-optimization is enabled by default.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 1 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 1)
       XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
     }
 
@@ -3365,7 +3359,7 @@ final class SwiftDriverTests: XCTestCase {
       // library-evolution builds can emit the module in a separate job.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O", "-enable-library-evolution" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
       XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }
@@ -3374,7 +3368,7 @@ final class SwiftDriverTests: XCTestCase {
       // When disabling cross-module-optimization, the module can be emitted in a separate job.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O", "-disable-cmo" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
       XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }
@@ -3383,7 +3377,7 @@ final class SwiftDriverTests: XCTestCase {
       // non optimized builds can emit the module in a separate job.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
       XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }


### PR DESCRIPTION
This is needed for apple/swift#69564, which enables building the early swift driver and running tests from the compiler validation suite with it for the first time on the linux CI. Looking at those test failures, I noticed that the Swift toolchain wrongly runs `autolink-extract` on linux when simply compiling object files, which is obviously unused:
```
> ./swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/bin/swiftc -c swift/test/Interpreter/hello_toplevel.swift -v
Swift version 5.11-dev (LLVM e22c96610989bdb, Swift bd372c2d6861ce3)
Target: x86_64-unknown-linux-gnu
/home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/bin/swift-frontend -frontend -c -primary-file swift/test/Interpreter/hello_toplevel.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -color-diagnostics -new-driver-path /home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/bin/swift-driver -empty-abi-descriptor -resource-dir /home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/lib/swift -module-name hello_toplevel -plugin-path /home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/lib/swift/host/plugins -plugin-path /home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/local/lib/swift/host/plugins -o hello_toplevel.o
/home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/bin/swift-autolink-extract hello_toplevel.o -o /tmp/TemporaryDirectory.3RqPzu/hello_toplevel-1.autolink
```
and which the old C++ driver doesn't:
```
> ./swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/bin/swiftc -c swift/test/Interpreter/hello_toplevel.swift -disallow-use-new-driver -v
<unknown>:0: warning: legacy driver is now deprecated; consider avoiding specifying '-disallow-use-new-driver'
Swift version 5.11-dev (LLVM e22c96610989bdb, Swift bd372c2d6861ce3)
Target: x86_64-unknown-linux-gnu
/home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/bin/swift-frontend -frontend -c -primary-file swift/test/Interpreter/hello_toplevel.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -color-diagnostics -plugin-path /home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/lib/swift/host/plugins -plugin-path /home/foo/swift-DEVELOPMENT-SNAPSHOT-2023-10-30-a-ubuntu20.04/usr/local/lib/swift/host/plugins -module-name hello_toplevel -o hello_toplevel.o
```
That's because [the old driver checks if it `shouldLink()` before scheduling an `autolink-extract`](https://github.com/apple/swift/blob/22592d22fc3719e9d4c7c4fe1714f06b66d3ba62/lib/Driver/Driver.cpp#L2234), whereas there's no equivalent check in this repo going back to when the `autolink-extract` job was added in c4bf24554. That's why @eeckstein had to add this linux-specific hack for these tests he added in #1019, which can now be removed and acts as a regression test.

The `autolink-extract` could also be disabled for static libraries, but I kept the behavior the same across both drivers instead.