### PR TITLE
[5.10] Don't add an autolink-extract job unless actually linking ELF/Wasm objects, matching the original C++ driver

### DIFF
--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -18,7 +18,8 @@ import struct TSCBasic.RelativePath
 // FIXME: Also handle Cygwin and MinGW
 extension Driver {
   /*@_spi(Testing)*/ public var isAutolinkExtractJobNeeded: Bool {
-    [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil
+    [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil &&
+    linkerOutputType != nil
   }
 
   mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3358,17 +3358,11 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
-    #if os(Linux) || os(Android)
-    let autoLinkExtractJob = 1
-    #else
-    let autoLinkExtractJob = 0
-    #endif
-
     do {
       // non library-evolution builds require a single job, because cross-module-optimization is enabled by default.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 1 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 1)
       XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
     }
 
@@ -3376,7 +3370,7 @@ final class SwiftDriverTests: XCTestCase {
       // library-evolution builds can emit the module in a separate job.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O", "-enable-library-evolution" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
       XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }
@@ -3385,7 +3379,7 @@ final class SwiftDriverTests: XCTestCase {
       // When disabling cross-module-optimization, the module can be emitted in a separate job.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo", "-O", "-disable-cmo" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
       XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }
@@ -3394,7 +3388,7 @@ final class SwiftDriverTests: XCTestCase {
       // non optimized builds can emit the module in a separate job.
       var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-c", "-o", rebase("test.o", at: root), "-wmo" ])
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 2 + autoLinkExtractJob)
+      XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-enable-default-cmo")))
       XCTAssertFalse(plannedJobs[1].commandLine.contains(.flag("-enable-default-cmo")))
     }


### PR DESCRIPTION
Cherrypick of #1479

__Explanation:__ This driver has long run `autolink-extract` even when it wasn't linking, which the old C++ driver didn't. Get the two matched up.

__Scope:__ Compilation jobs that don't link don't need autolink

__Issue:__ none

__Risk:__ none, this was superfluous

__Testing:__ Tested this on trunk with the newly enabled early swift driver tests on the linux CI, no problem.

__Reviewer:__ @artemcm