### PR TITLE
Revert 'Add missing dependency (#1414)'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -145,7 +145,6 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "swift-llbuild"),
-            .product(name: "llbuild", package: "swift-llbuild"),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools
@@ -155,7 +154,6 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "llbuild"),
-            .product(name: "llbuild", package: "llbuild"),
         ]
     }
 }


### PR DESCRIPTION
The llbuild executable is not a dependency of this library.

Looks like I missed removing this when I submitted the similar apple/swift-llbuild#891 for llbuild itself. The issue is that [this breaks cross-compiling this repo for Android armv7, because of some issue with compiling the llbuild executable](https://github.com/finagolfin/termux-packages/actions/runs/6805683976/job/18505666700#step:5:25532), but that executable is not a real dependency in the first place.

@neonichu, please review.