### PR TITLE
[5.10] Revert 'Add missing dependency (#1414)'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -141,7 +141,6 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "swift-llbuild"),
-            .product(name: "llbuild", package: "swift-llbuild"),
         ]
     } else {
         // In Swift CI, use a local path to llbuild to interoperate with tools
@@ -151,7 +150,6 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "llbuild"),
-            .product(name: "llbuild", package: "llbuild"),
         ]
     }
 }


### PR DESCRIPTION
Cherrypick of #1481

__Explanation:__ The llbuild executable is not a dependency of this library.

__Scope:__ Removes wrongly added llbuild dependency

__Issue:__ None

__Risk:__ low, as less code is built after this

__Testing:__ Passed all CI on trunk

__Reviewer:__ @artemcm