### PR TITLE
Add fallback to auxiliary legacy driver executable on '--disallow-use-new-driver'

### DIFF
--- a/Tests/SwiftDriverTests/IntegrationTests.swift
+++ b/Tests/SwiftDriverTests/IntegrationTests.swift
@@ -224,6 +224,7 @@ final class IntegrationTests: IntegrationTestCase {
       let extraEnv = [
         "SWIFT": swift.pathString,
         "SWIFTC": swiftc.pathString,
+        "SWIFT_FORCE_TEST_NEW_DRIVER": "1",
         "SWIFT_DRIVER_SWIFT_EXEC": swiftFile.pathString,
         "SWIFT_DRIVER_SWIFT_FRONTEND_EXEC": frontendFile.pathString,
         "LC_ALL": "en_US.UTF-8"


### PR DESCRIPTION
With the swift-driver executable becoming the default target of `swift` and `swiftc` symlinks, we need to allow for the prior mechanism afforded by this flag.

Companion to:
https://github.com/apple/swift/pull/69834