### PR TITLE
Support package interface gen and verification in driver

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -92,7 +92,7 @@ extension Driver {
     case .swiftModule:
       return compilerMode.isSingleCompilation && moduleOutputInfo.output?.isTopLevel ?? false
     case .swift, .image, .dSYM, .dependencies, .emitModuleDependencies, .autolink,
-         .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile,
+         .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface, .swiftSourceInfoFile,
          .diagnostics, .emitModuleDiagnostics, .objcHeader, .swiftDeps, .remap, .tbd,
          .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm, .pch,
          .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
@@ -470,7 +470,7 @@ extension FileType {
     case .swift, .dSYM, .autolink, .dependencies, .emitModuleDependencies,
          .swiftDocumentation, .pcm, .diagnostics, .emitModuleDiagnostics,
          .objcHeader, .image, .swiftDeps, .moduleTrace, .tbd, .yamlOptimizationRecord,
-         .bitstreamOptimizationRecord, .swiftInterface, .privateSwiftInterface,
+         .bitstreamOptimizationRecord, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface,
          .swiftSourceInfoFile, .clangModuleMap, .jsonSwiftArtifacts,
          .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline,
          .swiftConstValues, .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo,

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -32,6 +32,9 @@ extension Driver {
     addSupplementalOutput(path: moduleSourceInfoPath, flag: "-emit-module-source-info-path", type: .swiftSourceInfoFile)
     addSupplementalOutput(path: swiftInterfacePath, flag: "-emit-module-interface-path", type: .swiftInterface)
     addSupplementalOutput(path: swiftPrivateInterfacePath, flag: "-emit-private-module-interface-path", type: .privateSwiftInterface)
+    if let pkgName = packageName, !pkgName.isEmpty {
+      addSupplementalOutput(path: swiftPackageInterfacePath, flag: "-emit-package-module-interface-path", type: .packageSwiftInterface)
+    }
     addSupplementalOutput(path: objcGeneratedHeaderPath, flag: "-emit-objc-header-path", type: .objcHeader)
     addSupplementalOutput(path: tbdPath, flag: "-emit-tbd-path", type: .tbd)
     addSupplementalOutput(path: apiDescriptorFilePath, flag: "-emit-api-descriptor-path", type: .jsonAPIDescriptor)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -233,6 +233,7 @@ extension Driver {
     try commandLine.appendLast(.debugDiagnosticNames, from: &parsedOptions)
     try commandLine.appendLast(.scanDependencies, from: &parsedOptions)
     try commandLine.appendLast(.enableExperimentalConcisePoundFile, from: &parsedOptions)
+    try commandLine.appendLast(.experimentalPackageInterfaceLoad, from: &parsedOptions)
     try commandLine.appendLast(.printEducationalNotes, from: &parsedOptions)
     try commandLine.appendLast(.diagnosticStyle, from: &parsedOptions)
     try commandLine.appendLast(.locale, from: &parsedOptions)
@@ -587,6 +588,13 @@ extension Driver {
           input: nil,
           flag: "-emit-private-module-interface-path")
 
+        if let pkgName = packageName, !pkgName.isEmpty {
+          try addOutputOfType(
+            outputType: .packageSwiftInterface,
+            finalOutputPath: swiftPackageInterfacePath,
+            input: nil,
+            flag: "-emit-package-module-interface-path")
+        }
         try addOutputOfType(
           outputType: .tbd,
           finalOutputPath: tbdPath,

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -353,6 +353,7 @@ public class SwiftAdopter: Codable {
   public let moduleDir: String
   public let hasInterface: Bool
   public let hasPrivateInterface: Bool
+  public let hasPackageInterface: Bool
   public let hasModule: Bool
   public let isFramework: Bool
   public let isPrivate: Bool
@@ -364,6 +365,7 @@ public class SwiftAdopter: Codable {
     self.moduleDir = SwiftAdopter.relativeToSDK(moduleDir)
     self.hasInterface = !hasInterface.isEmpty
     self.hasPrivateInterface = hasInterface.contains { $0.basename.hasSuffix(".private.swiftinterface") }
+    self.hasPackageInterface = hasInterface.contains { $0.basename.hasSuffix(".package.swiftinterface") }
     self.hasModule = !hasModule.isEmpty
     self.isFramework = self.moduleDir.contains("\(name).framework")
     self.isPrivate = self.moduleDir.contains("PrivateFrameworks")

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -54,6 +54,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// An SPI Swift Interface file.
   case privateSwiftInterface = "private.swiftinterface"
 
+  /// An interface file containng package decls as well as SPI and public decls.
+  case packageSwiftInterface = "package.swiftinterface"
+
   /// Serialized source information.
   case swiftSourceInfoFile = "swiftsourceinfo"
 
@@ -194,6 +197,9 @@ extension FileType: CustomStringConvertible {
     case .privateSwiftInterface:
       return "private-swiftinterface"
 
+    case .packageSwiftInterface:
+      return "package-swiftinterface"
+
     case .objcHeader:
       return "objc-header"
 
@@ -275,7 +281,7 @@ extension FileType {
          .emitModuleDependencies, .swiftDocumentation, .pcm, .diagnostics,
          .emitModuleDiagnostics, .objcHeader, .image, .swiftDeps, .moduleTrace,
          .tbd, .yamlOptimizationRecord, .bitstreamOptimizationRecord,
-         .swiftInterface, .privateSwiftInterface, .swiftSourceInfoFile,
+         .swiftInterface, .privateSwiftInterface, .packageSwiftInterface, .swiftSourceInfoFile,
          .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures,
          .jsonSwiftArtifacts, .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline,
          .jsonABIBaseline, .swiftConstValues, .jsonAPIDescriptor,
@@ -324,6 +330,8 @@ extension FileType {
       return "swiftinterface"
     case .privateSwiftInterface:
       return "private-swiftinterface"
+    case .packageSwiftInterface:
+      return "package-swiftinterface"
     case .swiftSourceInfoFile:
       return "swiftsourceinfo"
     case .clangModuleMap:
@@ -401,7 +409,7 @@ extension FileType {
     switch self {
     case .swift, .sil, .dependencies, .emitModuleDependencies, .assembly, .ast,
          .raw_sil, .llvmIR,.objcHeader, .autolink, .importedModules, .tbd,
-         .moduleTrace, .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface,
+         .moduleTrace, .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface,
          .jsonDependencies, .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo,
          .jsonSwiftArtifacts, .jsonAPIBaseline, .jsonABIBaseline, .swiftConstValues,
          .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics:
@@ -422,7 +430,7 @@ extension FileType {
       return true
     case .swift, .sil, .sib, .ast, .image, .dSYM, .dependencies, .emitModuleDependencies,
          .autolink, .swiftModule, .swiftDocumentation, .swiftInterface,
-         .privateSwiftInterface, .swiftSourceInfoFile, .raw_sil, .raw_sib,
+         .privateSwiftInterface, .packageSwiftInterface, .swiftSourceInfoFile, .raw_sil, .raw_sib,
          .diagnostics, .emitModuleDiagnostics, .objcHeader, .swiftDeps, .remap,
          .importedModules, .tbd, .moduleTrace, .indexData, .yamlOptimizationRecord,
          .modDepCache, .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies,
@@ -445,7 +453,7 @@ extension FileType {
       return false
     case .assembly, .llvmIR, .llvmBitcode, .object, .sil, .sib, .ast,
          .dependencies, .emitModuleDependencies, .swiftModule,
-         .swiftDocumentation, .swiftInterface, .privateSwiftInterface,
+         .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface,
          .swiftSourceInfoFile, .raw_sil, .raw_sib, .objcHeader, .swiftDeps, .tbd,
          .moduleTrace, .indexData, .yamlOptimizationRecord,
          .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -327,6 +327,7 @@ extension Option {
   public static let emitObjcHeaderPath: Option = Option("-emit-objc-header-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Emit an Objective-C header file to <path>")
   public static let emitObjcHeader: Option = Option("-emit-objc-header", .flag, attributes: [.frontend, .noInteractive, .supplementaryOutput], helpText: "Emit an Objective-C header file")
   public static let emitObject: Option = Option("-emit-object", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit object file(s) (-c)", group: .modes)
+  public static let emitPackageModuleInterfacePath: Option = Option("-emit-package-module-interface-path", .separate, attributes: [.helpHidden, .frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output package module interface file to <path>")
   public static let emitParseableModuleInterfacePath: Option = Option("-emit-parseable-module-interface-path", .separate, alias: Option.emitModuleInterfacePath, attributes: [.helpHidden, .frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant])
   public static let emitParseableModuleInterface: Option = Option("-emit-parseable-module-interface", .flag, alias: Option.emitModuleInterface, attributes: [.helpHidden, .noInteractive, .supplementaryOutput])
   public static let emitParse: Option = Option("-emit-parse", .flag, alias: Option.dumpParse, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild])
@@ -455,6 +456,7 @@ extension Option {
   public static let experimentalHermeticSealAtLink: Option = Option("-experimental-hermetic-seal-at-link", .flag, attributes: [.helpHidden, .frontend], helpText: "Library code can assume that all clients are visible at linktime, and aggressively strip unused code")
   public static let experimentalLazyTypecheck: Option = Option("-experimental-lazy-typecheck", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Type-check lazily as needed to produce requested outputs")
   public static let experimentalOneWayClosureParams: Option = Option("-experimental-one-way-closure-params", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental support for one-way closure parameters")
+  public static let experimentalPackageInterfaceLoad: Option = Option("-experimental-package-interface-load", .flag, attributes: [.helpHidden, .frontend, .moduleInterface], helpText: "Supports loading a module via .package.swiftinterface in the same package")
   public static let ExperimentalPerformanceAnnotations: Option = Option("-experimental-performance-annotations", .flag, attributes: [.helpHidden, .frontend], helpText: "Deprecated, has no effect")
   public static let platformCCallingConventionEQ: Option = Option("-experimental-platform-c-calling-convention=", .joined, alias: Option.platformCCallingConvention, attributes: [.helpHidden, .frontend, .noDriver])
   public static let platformCCallingConvention: Option = Option("-experimental-platform-c-calling-convention", .separate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Which calling convention is used to perform non-swift calls. Defaults to llvm's standard C calling convention.")
@@ -1149,6 +1151,7 @@ extension Option {
       Option.emitObjcHeaderPath,
       Option.emitObjcHeader,
       Option.emitObject,
+      Option.emitPackageModuleInterfacePath,
       Option.emitParseableModuleInterfacePath,
       Option.emitParseableModuleInterface,
       Option.emitParse,
@@ -1277,6 +1280,7 @@ extension Option {
       Option.experimentalHermeticSealAtLink,
       Option.experimentalLazyTypecheck,
       Option.experimentalOneWayClosureParams,
+      Option.experimentalPackageInterfaceLoad,
       Option.ExperimentalPerformanceAnnotations,
       Option.platformCCallingConventionEQ,
       Option.platformCCallingConvention,

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -2086,6 +2086,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     XCTAssertFalse(A.isPrivate)
     XCTAssertFalse(A.hasModule)
     XCTAssertFalse(A.hasPrivateInterface)
+    XCTAssertFalse(A.hasPackageInterface)
     XCTAssertTrue(A.hasInterface)
 
     let B = adopters.first {$0.name == "B"}!
@@ -2093,6 +2094,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
     XCTAssertFalse(B.isPrivate)
     XCTAssertFalse(B.hasModule)
     XCTAssertTrue(B.hasPrivateInterface)
+    XCTAssertFalse(B.hasPackageInterface)
   }
 
   func testCollectSwiftAdoptersWhetherMixed() throws {


### PR DESCRIPTION
Support package interface generation.
Generate .package.swiftinterface if `-package-name` is passed.
Add package interface to Module Verification step.
Support `-experimental-package-interface-load` for frontend.
Downgrade typecheck interface error for package.swiftinterface.

Resolves rdar://118469253