### PR TITLE
Do not perform dependency scanning when no source inputs are specified

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -139,8 +139,9 @@ extension Driver {
                                                           IncrementalCompilationState.InitialStateForPlanning?)
   throws -> InterModuleDependencyGraph? {
     let interModuleDependencyGraph: InterModuleDependencyGraph?
-    if parsedOptions.contains(.driverExplicitModuleBuild) ||
-       parsedOptions.contains(.explainModuleDependency) {
+    if (parsedOptions.contains(.driverExplicitModuleBuild) ||
+        parsedOptions.contains(.explainModuleDependency)) &&
+       inputFiles.contains(where: { $0.type.isPartOfSwiftCompilation }) {
       // If the incremental build record's module dependency graph is up-to-date, we
       // can skip dependency scanning entirely.
       interModuleDependencyGraph =

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2906,6 +2906,15 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(firstKey, "foo.swift")
   }
 
+  func testExplicitBuildWithJustObjectInputs() throws {
+    var driver = try Driver(args: [
+      "swiftc", "-explicit-module-build", "foo.o", "bar.o"
+    ])
+    let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+    XCTAssertEqual(plannedJobs.count, 1)
+    XCTAssertEqual(plannedJobs.first?.kind, .link)
+  }
+
   func testWMOWithNonSourceInputFirstAndModuleOutput() throws {
     var driver1 = try Driver(args: [
       "swiftc", "-wmo", "danger.o", "foo.swift", "bar.swift", "wibble.swift", "-module-name", "Test",


### PR DESCRIPTION
Resolves rdar://118900740