### PR TITLE
Remove dependency on swift-system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,6 @@ find_package(dispatch QUIET)
 find_package(Foundation QUIET)
 find_package(Yams CONFIG REQUIRED)
 find_package(ArgumentParser CONFIG REQUIRED)
-find_package(SwiftSystem CONFIG REQUIRED)
 
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ all with CMake:
   ```
   cmake -B <llbuild-build-dir> -G Ninja <llbuild-source-dir> -DLLBUILD_SUPPORT_BINDINGS="Swift" -DCMAKE_OSX_ARCHITECTURES=x86_64
   ```
-* [swift-system](https://github.com/apple/swift-system)
 * [swift-argument-parser](https://github.com/apple/swift-argument-parser)
 * [Yams](https://github.com/jpsim/Yams)
 

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -247,7 +247,6 @@ def install_swiftdriver(args, build_dir, prefix, targets) :
   # swift-driver: SwiftDriver.swiftmodule, SwiftOptions.swiftmodule
   # swift-tools-support-core: TSCUtility.swiftmodule, TSCBasic.swiftmodule
   # swift-argument-parser: ArgumentParser.swiftmodule (disabled until needed)
-  # swift-system: SystemPackage.swiftmodule
   install_binary_swift_modules(args, build_dir, install_lib, targets)
 
   # Modulemaps for C Modules:
@@ -324,11 +323,6 @@ def install_libraries(args, build_dir, universal_lib_dir, toolchain_lib_dir, tar
     install_library(args, build_dir, package_subpath, lib, shared_lib_ext,
                     universal_lib_dir, toolchain_lib_dir, 'swift-tools-support-core', targets)
 
-  # Install the swift-system shared library into the toolchain lib
-  package_subpath = os.path.join(args.configuration, 'dependencies', 'swift-system')
-  install_library(args, build_dir, package_subpath, 'libSystemPackage', shared_lib_ext,
-                  universal_lib_dir, toolchain_lib_dir, 'swift-system', targets)
-
   # Install the swift-argument-parser shared libraries into the toolchain lib
   package_subpath = os.path.join(args.configuration, 'dependencies', 'swift-argument-parser')
   for (lib, ext) in [('libArgumentParser', shared_lib_ext), ('libArgumentParserToolInfo', static_lib_ext)]:
@@ -375,11 +369,6 @@ def install_binary_swift_modules(args, build_dir, toolchain_lib_dir, targets):
   package_subpath = os.path.join(args.configuration, 'dependencies', 'swift-argument-parser',
                                  product_subpath)
   install_module(args, build_dir, package_subpath, toolchain_lib_dir, 'ArgumentParser', targets)
-
-  # swift-system
-  package_subpath = os.path.join(args.configuration, 'dependencies', 'swift-system',
-                                 product_subpath)
-  install_module(args, build_dir, package_subpath, toolchain_lib_dir, 'SystemPackage', targets)
 
 
 # Install the modulemaps and headers of the driver's C module dependencies into the toolchain
@@ -442,9 +431,6 @@ def build_using_cmake(args, toolchain_bin, build_dir, targets):
     # LLBuild
     build_llbuild_using_cmake(args, target, swiftc_exec, dependencies_dir,
                               base_cmake_flags, swift_flags)
-    # SwiftSystem
-    build_system_using_cmake(args, target, swiftc_exec, dependencies_dir,
-                             base_cmake_flags, swift_flags)
 
     # TSC
     build_tsc_using_cmake(args, target, swiftc_exec, dependencies_dir,
@@ -485,24 +471,11 @@ def build_llbuild_using_cmake(args, target, swiftc_exec, build_dir, base_cmake_f
   cmake_build(args, swiftc_exec, llbuild_cmake_flags, llbuild_swift_flags,
               llbuild_source_dir, llbuild_build_dir, 'products/all')
 
-def build_system_using_cmake(args, target, swiftc_exec, build_dir, base_cmake_flags, swift_flags):
-  print('Building Swift Driver dependency: Swift System')
-  system_source_dir = os.path.join(os.path.dirname(args.package_path), 'swift-system')
-  system_build_dir = os.path.join(build_dir, 'swift-system')
-  flags = [
-      # required due to swift-autolink-extract bug ("The file was not recognized as a valid object file")
-      "-DBUILD_SHARED_LIBS=YES"]
-  system_cmake_flags = base_cmake_flags + flags
-  system_swift_flags = swift_flags[:]
-  cmake_build(args, swiftc_exec, system_cmake_flags, system_swift_flags,
-              system_source_dir, system_build_dir)
-
 def build_tsc_using_cmake(args, target, swiftc_exec, build_dir, base_cmake_flags, swift_flags):
   print('Building Swift Driver dependency: TSC')
   tsc_source_dir = os.path.join(os.path.dirname(args.package_path), 'swift-tools-support-core')
   tsc_build_dir = os.path.join(build_dir, 'swift-tools-support-core')
-  flags = [
-      '-DSwiftSystem_DIR=' + os.path.join(os.path.join(build_dir, 'swift-system'), 'cmake/modules')]
+  flags = []
   tsc_cmake_flags = base_cmake_flags + flags
 
   tsc_swift_flags = swift_flags[:]
@@ -550,8 +523,7 @@ def build_swift_driver_using_cmake(args, target, swiftc_exec, build_dir, base_cm
         '-DLLBuild_DIR=' + os.path.join(os.path.join(dependencies_dir, 'llbuild'), 'cmake/modules'),
         '-DTSC_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-tools-support-core'), 'cmake/modules'),
         '-DYams_DIR=' + os.path.join(os.path.join(dependencies_dir, 'yams'), 'cmake/modules'),
-        '-DArgumentParser_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-argument-parser'), 'cmake/modules'),
-        '-DSwiftSystem_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-system'), 'cmake/modules')]
+        '-DArgumentParser_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-argument-parser'), 'cmake/modules')]
   driver_cmake_flags = base_cmake_flags + flags
   cmake_build(args, swiftc_exec, driver_cmake_flags, driver_swift_flags,
               driver_source_dir, driver_build_dir)


### PR DESCRIPTION
This dependency is unused and just unnecessarily complicates things.