### PR TITLE
[SwiftCaching] Don't drop `-Xcc` during dependency scanning

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -387,7 +387,8 @@ extension Driver {
     // Pass through any subsystem flags.
     try commandLine.appendAll(.Xllvm, from: &parsedOptions)
 
-    if !(isCachingEnabled && useClangIncludeTree) {
+    // If using clang-include-tree, `-Xcc` should only be passed to scanDependencies job.
+    if (kind == .scanDependencies) || !(isCachingEnabled && useClangIncludeTree) {
       try commandLine.appendAll(.Xcc, from: &parsedOptions)
     }
 


### PR DESCRIPTION
When using swift caching, `-Xcc` should not be appended to compilation commmands because dependency scanner returns the cc1 command needed to create clang importer. But `-Xcc` options were accidentally dropped from scan-dependencies command, causing them to be ignored.

rdar://119391228