### PR TITLE
Only specify -dwarf-version if the frontend supports it

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -197,7 +197,9 @@ extension Driver {
     try commandLine.appendLast(in: .g, from: &parsedOptions)
     if debugInfo.level != nil {
       commandLine.appendFlag("-debug-info-format=\(debugInfo.format)")
-      commandLine.appendFlag("-dwarf-version=\(debugInfo.dwarfVersion)")
+      if isFrontendArgSupported(.dwarfVersion) {
+        commandLine.appendFlag("-dwarf-version=\(debugInfo.dwarfVersion)")
+      }
     }
     try commandLine.appendLast(.importUnderlyingModule, from: &parsedOptions)
     try commandLine.appendLast(.moduleCachePath, from: &parsedOptions)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -582,15 +582,27 @@ final class SwiftDriverTests: XCTestCase {
       $1.expect(.error("invalid value '6' in '-dwarf-version="))
     }
 
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=dwarf", "-dwarf-version=4") { driver in
-        let jobs = try driver.planBuild()
-        XCTAssertTrue(jobs[0].commandLine.contains(.flag("-dwarf-version=4")))
-    }
-
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-file-compilation-dir", ".") { driver in
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
       XCTAssertTrue(jobs[0].commandLine.contains(.flag(".")))
+    }
+
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-c", "-file-compilation-dir", ".") { driver in
+      let jobs = try driver.planBuild()
+      XCTAssertFalse(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
+    }
+  }
+
+  func testDwarfVersionSetting() throws {
+    let driver = try Driver(args: ["swiftc", "foo.swift"])
+    guard driver.isFrontendArgSupported(.dwarfVersion) else {
+      throw XCTSkip("Skipping: compiler does not support '-dwarf-version'")
+    }
+
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=dwarf", "-dwarf-version=4") { driver in
+        let jobs = try driver.planBuild()
+        XCTAssertTrue(jobs[0].commandLine.contains(.flag("-dwarf-version=4")))
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macosx10.10") { driver in
@@ -624,11 +636,6 @@ final class SwiftDriverTests: XCTestCase {
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64_32-apple-watchos10.0") { driver in
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs[0].commandLine.contains(.flag("-dwarf-version=4")))
-    }
-
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-c", "-file-compilation-dir", ".") { driver in
-      let jobs = try driver.planBuild()
-      XCTAssertFalse(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
     }
   }
 


### PR DESCRIPTION
Follow up to https://github.com/apple/swift-driver/pull/1500.

The `-dwarf-version` frontend option is still relatively new and in some build configurations, a newer driver may be used with an older frontend that does not understand the argument.