### PR TITLE
[Caching] Adopt new APIs from libSwiftScan for key computation

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -291,6 +291,9 @@ typedef struct {
   swiftscan_string_ref_t (*swiftscan_cache_compute_key)(
       swiftscan_cas_t cas, int argc, const char **argv, const char *input,
       swiftscan_string_ref_t *error);
+  swiftscan_string_ref_t (*swiftscan_cache_compute_key_from_input_index)(
+      swiftscan_cas_t cas, int argc, const char **argv, unsigned input_index,
+      swiftscan_string_ref_t *error);
 
   //=== Scanner Caching Query/Replay Operations -----------------------------===//
   swiftscan_cached_compilation_t (*swiftscan_cache_query)(

--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -279,7 +279,7 @@ public struct Driver {
 
   /// Is swift caching enabled.
   lazy var isCachingEnabled: Bool = {
-    return enableCaching && isFeatureSupported(.cache_compile_job)
+    return enableCaching && isFeatureSupported(.compilation_caching)
   }()
 
   /// Scanner prefix mapping.
@@ -427,7 +427,7 @@ public struct Driver {
   @_spi(Testing)
   public enum KnownCompilerFeature: String {
     case emit_abi_descriptor = "emit-abi-descriptor"
-    case cache_compile_job = "cache-compile-job"
+    case compilation_caching = "compilation-caching"
   }
 
   lazy var sdkPath: VirtualPath? = {

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -398,7 +398,11 @@ extension Driver {
       displayInputs = primaryInputs
     }
     // Only swift input files are contributing to the cache keys.
-    let cacheContributingInputs = displayInputs.filter() { $0.type == .swift }
+    let cacheContributingInputs = inputs.enumerated().reduce(into: [(TypedVirtualPath, Int)]()) { result, input in
+      if input.element.type == .swift, displayInputs.contains(input.element) {
+        result.append((input.element, input.offset))
+      }
+    }
     let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: cacheContributingInputs)
 
     return Job(

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -853,7 +853,7 @@ extension Driver {
 
 extension Driver {
   public mutating func computeOutputCacheKeyForJob(commandLine: [Job.ArgTemplate],
-                                          inputs: [TypedVirtualPath]) throws -> [TypedVirtualPath: String] {
+                                                   inputs: [(TypedVirtualPath, Int)]) throws -> [TypedVirtualPath: String] {
     // No caching setup, return empty dictionary.
     guard let cas = self.cas else {
       return [:]
@@ -863,13 +863,12 @@ extension Driver {
     let arguments: [String] = try resolver.resolveArgumentList(for: commandLine)
 
     return try inputs.reduce(into: [:]) { keys, input in
-      let remappedPath = remapPath(input.file)
-      keys[input] = try cas.computeCacheKey(commandLine: arguments, input: remappedPath.name)
+      keys[input.0] = try cas.computeCacheKey(commandLine: arguments, index: input.1)
     }
   }
 
   public mutating func computeOutputCacheKey(commandLine: [Job.ArgTemplate],
-                                    input: TypedVirtualPath) throws -> String? {
+                                             index: Int) throws -> String? {
     // No caching setup, return empty dictionary.
     guard let cas = self.cas else {
       return nil
@@ -877,8 +876,7 @@ extension Driver {
     // Resolve command-line first.
     let resolver = try ArgsResolver(fileSystem: fileSystem)
     let arguments: [String] = try resolver.resolveArgumentList(for: commandLine)
-    let remappedPath = remapPath(input.file)
-    return try cas.computeCacheKey(commandLine: arguments, input: remappedPath.name)
+    return try cas.computeCacheKey(commandLine: arguments, index: index)
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -70,7 +70,7 @@ extension Driver {
     inputs.append(input)
     try addPathArgument(input.file, to: &commandLine)
 
-    let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [input])
+    let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [(input, 0)])
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -51,7 +51,7 @@ extension Driver {
       commandLine: &commandLine, inputs: &inputs, kind: .generatePCM, bridgingHeaderHandling: .ignored)
 
     try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
-    let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [input])
+    let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [(input, 0)])
 
     return Job(
       moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -20,7 +20,7 @@ extension Driver {
 
     // Assume swiftinterface file is always the supplementary output for first input file.
     let key =  try computeOutputCacheKey(commandLine: emitModuleJob.commandLine,
-                                         input: emitModuleJob.inputs[0])
+                                         index: 0)
     return key
   }
 
@@ -61,7 +61,7 @@ extension Driver {
       commandLine.appendFlag(.downgradeTypecheckInterfaceError)
     }
 
-    let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [interfaceInput])
+    let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [(interfaceInput, 0)])
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .verifyModuleInterface,

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -287,6 +287,7 @@ internal extension swiftscan_diagnostic_severity_t {
            api.swiftscan_cas_create_from_options != nil &&
            api.swiftscan_cas_dispose != nil &&
            api.swiftscan_cache_compute_key != nil &&
+           api.swiftscan_cache_compute_key_from_input_index != nil &&
            api.swiftscan_cas_store != nil &&
            api.swiftscan_swift_textual_detail_get_module_cache_key != nil &&
            api.swiftscan_swift_binary_detail_get_module_cache_key != nil &&
@@ -507,6 +508,7 @@ private extension swiftscan_functions_t {
     self.swiftscan_cas_create_from_options = try loadOptional("swiftscan_cas_create_from_options")
     self.swiftscan_cas_dispose = try loadOptional("swiftscan_cas_dispose")
     self.swiftscan_cache_compute_key = try loadOptional("swiftscan_cache_compute_key")
+    self.swiftscan_cache_compute_key_from_input_index = try loadOptional("swiftscan_cache_compute_key_from_input_index")
     self.swiftscan_cas_store = try loadOptional("swiftscan_cas_store")
 
     self.swiftscan_cache_query = try loadOptional("swiftscan_cache_query")

--- a/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
@@ -198,6 +198,7 @@ public final class SwiftScanCAS {
     return try scanner.toSwiftString(casid)
   }
 
+  @available(*, deprecated)
   public func computeCacheKey(commandLine: [String], input: String) throws -> String {
     let casid = try scanner.handleCASError { err_msg in
       withArrayOfCStrings(commandLine) { commandArray in
@@ -206,6 +207,19 @@ public final class SwiftScanCAS {
                                                 commandArray,
                                                 input.cString(using: String.Encoding.utf8),
                                                 &err_msg)
+      }
+    }
+    return try scanner.toSwiftString(casid)
+  }
+
+  public func computeCacheKey(commandLine: [String], index: Int) throws -> String {
+    let casid = try scanner.handleCASError { err_msg in
+      withArrayOfCStrings(commandLine) { commandArray in
+        scanner.api.swiftscan_cache_compute_key_from_input_index(cas,
+                                                                 Int32(commandLine.count),
+                                                                 commandArray,
+                                                                 UInt32(index),
+                                                                 &err_msg)
       }
     }
     return try scanner.toSwiftString(casid)

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -215,7 +215,7 @@ final class CachingBuildTests: XCTestCase {
 #if os(Windows)
     throw XCTSkip("caching not supported on windows")
 #else
-    guard driver.isFeatureSupported(.cache_compile_job) else {
+    guard driver.isFeatureSupported(.compilation_caching) else {
       throw XCTSkip("caching not supported")
     }
 #endif


### PR DESCRIPTION
Using the new APIs from libSwiftScan for cache key computation. The new API doesn't require swift-driver and scanner to have the same file system view for the path of the input files, which eliminates one failure point.

rdar://119517627