### PR TITLE
[Test] Remap test should be guarded by caching feature

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -759,6 +759,9 @@ final class CachingBuildTests: XCTestCase {
                                      "-scanner-prefix-map", path.description + "=/^tmp",
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars)
+      guard driver.isFeatureSupported(.cache_compile_job) else {
+        throw XCTSkip("toolchain does not support caching.")
+      }
       guard driver.isFrontendArgSupported(.scannerPrefixMap) else {
         throw XCTSkip("frontend doesn't support prefix map")
       }


### PR DESCRIPTION
Update cache path remap test to be correctly guarded by remapping because if toolchain doesn't support caching, the remap will be automatically disabled and remap will not happen.