### PR TITLE
SwiftDriver: repair the generation of CodeView debug info

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -196,7 +196,7 @@ extension Driver {
     try commandLine.appendLast(.enablePrivateImports, from: &parsedOptions)
     try commandLine.appendLast(in: .g, from: &parsedOptions)
     if debugInfo.level != nil {
-      commandLine.appendFlag("-debug-info-format=\(debugInfo.format)")
+      commandLine.appendFlag("-debug-info-format=\(debugInfo.format.rawValue)")
       if isFrontendArgSupported(.dwarfVersion) {
         commandLine.appendFlag("-dwarf-version=\(debugInfo.dwarfVersion)")
       }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -560,6 +560,16 @@ final class SwiftDriverTests: XCTestCase {
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=codeview") { driver in
       XCTAssertEqual(driver.debugInfo.level, .astTypes)
       XCTAssertEqual(driver.debugInfo.format, .codeView)
+
+      let jobs = try driver.planBuild()
+      XCTAssertTrue(jobs[0].commandLine.contains(.flag("-debug-info-format=codeview")))
+    }
+
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=dwarf") { driver in
+      XCTAssertEqual(driver.debugInfo.format, .dwarf)
+
+      let jobs = try driver.planBuild()
+      XCTAssertTrue(jobs[0].commandLine.contains(.flag("-debug-info-format=dwarf")))
     }
 
     try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-debug-info-format=dwarf") {


### PR DESCRIPTION
Correct the spelling for the argument for the `-debug-info-format`.  We were incorrectly emitting the enum name instead of the value, which would break the build when CodeView was enabled.