### PR TITLE
tests: repair the test suite on Windows

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1539,17 +1539,17 @@ final class SwiftDriverTests: XCTestCase {
 
 #if os(Windows)
       try localFileSystem.writeFileContents(fooPath, bytes:
-        """
+        .init(("""
         a\\b c\\\\d e\\\\\"f g\" h\\\"i j\\\\\\\"k \"lmn\" o pqr \"st \\\"u\" \\v"
         @\(barPath.nativePathString(escaped: true))
-        """
+        """).utf8)
       )
       try localFileSystem.writeFileContents(barPath, bytes:
-       #"""
+       .init((#"""
         -Xswiftc -use-ld=lld
         -Xcc -IS:\Library\sqlite-3.36.0\usr\include
         -Xlinker -LS:\Library\sqlite-3.36.0\usr\lib
-        """#
+        """#).utf8)
       )
       let args = try Driver.expandResponseFiles(["@\(fooPath.pathString)"], fileSystem: localFileSystem, diagnosticsEngine: diags)
       XCTAssertEqual(args, ["a\\b", "c\\\\d", "e\\f g", "h\"i", "j\\\"k", "lmn", "o", "pqr", "st \"u", "\\v", "-Xswiftc", "-use-ld=lld", "-Xcc", "-IS:\\Library\\sqlite-3.36.0\\usr\\include", "-Xlinker", "-LS:\\Library\\sqlite-3.36.0\\usr\\lib"])


### PR DESCRIPTION
Recent changes seem to have regressed the test suite on Windows due to the construction of the `ByteString` from the `String`.  Repair this to allow us to test on Windows again.