### PR TITLE
[Sanitizer] Add new flag -sanitize-stable-abi flag to link against the

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -209,6 +209,10 @@ extension DarwinToolchain {
         .sorted() // Sort so we get a stable, testable order
         .joined(separator: ",")
       commandLine.appendFlag("-fsanitize=\(sanitizerNames)")
+
+      if parsedOptions.contains(.sanitizeStableAbiEQ) {
+        commandLine.appendFlag("-fsanitize-stable-abi")
+      }
     }
 
     if parsedOptions.contains(.embedBitcode) {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -220,6 +220,9 @@ extension Driver {
     try commandLine.appendLast(.sanitizeEQ, from: &parsedOptions)
     try commandLine.appendLast(.sanitizeRecoverEQ, from: &parsedOptions)
     try commandLine.appendLast(.sanitizeAddressUseOdrIndicator, from: &parsedOptions)
+    if isFrontendArgSupported(.sanitizeStableAbiEQ) {
+      try commandLine.appendLast(.sanitizeStableAbiEQ, from: &parsedOptions)
+    }
     try commandLine.appendLast(.sanitizeCoverageEQ, from: &parsedOptions)
     try commandLine.appendLast(.static, from: &parsedOptions)
     try commandLine.appendLast(.swiftVersion, from: &parsedOptions)

--- a/Sources/SwiftDriver/Utilities/Sanitizer.swift
+++ b/Sources/SwiftDriver/Utilities/Sanitizer.swift
@@ -16,6 +16,9 @@ public enum Sanitizer: String, Hashable {
   /// Address sanitizer (ASan)
   case address
 
+  // Address sanitizer Stable ABI (ASan)
+  case address_stable_abi
+
   /// Thread sanitizer (TSan)
   case thread
 
@@ -34,6 +37,7 @@ public enum Sanitizer: String, Hashable {
   var libraryName: String {
     switch self {
     case .address: return "asan"
+    case .address_stable_abi: return "asan_abi"
     case .thread: return "tsan"
     case .undefinedBehavior: return "ubsan"
     case .fuzzer: return "fuzzer"

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -696,6 +696,7 @@ extension Option {
   public static let sanitizeAddressUseOdrIndicator: Option = Option("-sanitize-address-use-odr-indicator", .flag, attributes: [.helpHidden, .frontend, .noInteractive], helpText: "When using AddressSanitizer enable ODR indicator globals to avoid false ODR violation reports in partially sanitized programs at the cost of an increase in binary size")
   public static let sanitizeCoverageEQ: Option = Option("-sanitize-coverage=", .commaJoined, attributes: [.frontend, .noInteractive], metaVar: "<type>", helpText: "Specify the type of coverage instrumentation for Sanitizers and additional options separated by commas")
   public static let sanitizeRecoverEQ: Option = Option("-sanitize-recover=", .commaJoined, attributes: [.frontend, .noInteractive], metaVar: "<check>", helpText: "Specify which sanitizer runtime checks (see -sanitize=) will generate instrumentation that allows error recovery. Listed checks should be comma separated. Default behavior is to not allow error recovery.")
+  public static let sanitizeStableAbiEQ: Option = Option("-sanitize-stable-abi", .flag, attributes: [.frontend, .noInteractive], helpText: "ABI instrumentation for sanitizer runtime.")
   public static let sanitizeEQ: Option = Option("-sanitize=", .commaJoined, attributes: [.frontend, .noInteractive], metaVar: "<check>", helpText: "Turn on runtime checks for erroneous behavior.")
   public static let saveOptimizationRecordPasses: Option = Option("-save-optimization-record-passes", .separate, attributes: [.frontend], metaVar: "<regex>", helpText: "Only include passes which match a specified regular expression in the generated optimization record (by default, include all passes)")
   public static let saveOptimizationRecordPath: Option = Option("-save-optimization-record-path", .separate, attributes: [.frontend, .argumentIsPath], helpText: "Specify the file name of any generated optimization record")
@@ -1523,6 +1524,7 @@ extension Option {
       Option.sanitizeAddressUseOdrIndicator,
       Option.sanitizeCoverageEQ,
       Option.sanitizeRecoverEQ,
+      Option.sanitizeStableAbiEQ,
       Option.sanitizeEQ,
       Option.saveOptimizationRecordPasses,
       Option.saveOptimizationRecordPath,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2781,6 +2781,30 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testSanitizeStableAbi() throws {
+    var driver = try Driver(args: ["swiftc", "-sanitize=address", "-sanitize-stable-abi", "Test.swift"])
+    guard driver.isFrontendArgSupported(.sanitizeStableAbiEQ) else {
+      return
+    }
+
+    do {
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 2)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      XCTAssert(plannedJobs[0].commandLine.contains(.flag("-sanitize=address")))
+      XCTAssert(plannedJobs[0].commandLine.contains(.flag("-sanitize-stable-abi")))
+
+      XCTAssert(plannedJobs[1].commandLine.contains(.flag("-fsanitize=address")))
+      XCTAssert(plannedJobs[1].commandLine.contains(.flag("-fsanitize-stable-abi")))
+    }
+
+    do {
+      try assertDriverDiagnostics(args: ["swiftc","-sanitize-stable-abi", "Test.swift"]) {
+        $1.expect(.warning("option '-sanitize-stable-abi' has no effect when 'address' sanitizer is disabled. Use -sanitize=address to enable the sanitizer"))
+      }
+    }
+  }
+
   func testADDITIONAL_SWIFT_DRIVER_FLAGS() throws {
     var env = ProcessEnv.vars
     env["ADDITIONAL_SWIFT_DRIVER_FLAGS"] = "-Xfrontend -unknown1 -Xfrontend -unknown2"


### PR DESCRIPTION
new sanitiers stable ABI in compiler-rt.

Compiler-rt recently introduced a stable ABI for sanitizers. This patch adds a flag to pass this flag to swift-frontend during compilation and clang at link time to link against the new stable ABI.

NOTE: this was https://github.com/apple/swift-driver/pull/1495 , but Usama is out till after the new year break, so I need to take over and apply feedback from there

rdar://118997873