### PR TITLE
Revert "[Driver] For immediate mode prefer using the default SDK over the `SDKROOT` variable"

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2752,15 +2752,11 @@ extension Driver {
 
     if let arg = parsedOptions.getLastArgument(.sdk) {
       sdkPath = arg.asSingle
+    } else if let SDKROOT = env["SDKROOT"] {
+      sdkPath = SDKROOT
     } else if compilerMode == .immediate || compilerMode == .repl {
       // In immediate modes, query the toolchain for a default SDK.
-      // We avoid using `SDKROOT` because that may be set to a compilation platform (like iOS)
-      // that is different than the host.
       sdkPath = try? toolchain.defaultSDKPath(targetTriple)?.pathString
-    }
-
-    if sdkPath == nil, let SDKROOT = env["SDKROOT"] {
-      sdkPath = SDKROOT
     }
 
     // An empty string explicitly clears the SDK.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3689,17 +3689,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testImmediateMode() throws {
     do {
-      var env: [String: String] = ProcessEnv.vars
-#if os(macOS)
-      let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
-                                             processSet: ProcessSet(),
-                                             fileSystem: localFileSystem,
-                                             env: ProcessEnv.vars)
-      let iosSDKPath = try executor.checkNonZeroExit(
-        args: "xcrun", "-sdk", "iphoneos", "--show-sdk-path").spm_chomp()
-      env["SDKROOT"] = iosSDKPath
-#endif
-      var driver = try Driver(args: ["swift", "foo.swift"], env: env)
+      var driver = try Driver(args: ["swift", "foo.swift"])
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
@@ -3713,12 +3703,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(job.commandLine.contains(.flag("foo")))
 
       if driver.targetTriple.isMacOSX {
-        let sdkIdx = try XCTUnwrap(job.commandLine.firstIndex(of: .flag("-sdk")))
-        if case .path(let path) = job.commandLine[sdkIdx + 1] {
-          XCTAssertTrue(path.name.contains("MacOSX.platform"))
-        } else {
-          XCTFail("Missing SDK path")
-        }
+        XCTAssertTrue(job.commandLine.contains(.flag("-sdk")))
       }
 
       XCTAssertFalse(job.commandLine.contains(.flag("--")))


### PR DESCRIPTION
This reverts commit 3615d0645bc2a32f8cf8b48bb4fc1c0226b60f39.

rdar://117027065