### PR TITLE
[CAS] Don't create the same CAS multiple times from the same Oracle

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -275,7 +275,7 @@ public struct Driver {
   let useClangIncludeTree: Bool
 
   /// CAS instance used for compilation.
-  var cas: SwiftScanCAS? = nil
+  @_spi(Testing) public var cas: SwiftScanCAS? = nil
 
   /// Is swift caching enabled.
   lazy var isCachingEnabled: Bool = {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -173,9 +173,9 @@ public extension Driver {
       }
     }
     if !fallbackToFrontend && isCachingEnabled {
-      self.cas = try interModuleDependencyOracle.createCAS(pluginPath: try getCASPluginPath(),
-                                                           onDiskPath: try getOnDiskCASPath(),
-                                                           pluginOptions: try getCASPluginOptions())
+      self.cas = try interModuleDependencyOracle.getOrCreateCAS(pluginPath: try getCASPluginPath(),
+                                                                onDiskPath: try getOnDiskCASPath(),
+                                                                pluginOptions: try getCASPluginOptions())
     }
     return fallbackToFrontend
   }

--- a/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
@@ -244,6 +244,12 @@ public final class SwiftScanCAS {
   }
 }
 
+extension SwiftScanCAS: Equatable {
+  static public func == (lhs: SwiftScanCAS, rhs: SwiftScanCAS) -> Bool {
+    return lhs.cas == rhs.cas
+  }
+}
+
 extension swiftscan_cached_compilation_t {
   func convert(_ lib: SwiftScan) -> CachedCompilation {
     return CachedCompilation(self, lib: lib)

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -23,7 +23,8 @@ extension Driver {
     env: [String: String] = ProcessEnv.vars,
     diagnosticsEngine: DiagnosticsEngine = DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
     fileSystem: FileSystem = localFileSystem,
-    integratedDriver: Bool = true
+    integratedDriver: Bool = true,
+    interModuleDependencyOracle: InterModuleDependencyOracle? = nil
   ) throws {
     let executor = try SwiftDriverExecutor(diagnosticsEngine: diagnosticsEngine,
                                        processSet: ProcessSet(),
@@ -34,7 +35,8 @@ extension Driver {
                   diagnosticsOutput: .engine(diagnosticsEngine),
                   fileSystem: fileSystem,
                   executor: executor,
-                  integratedDriver: integratedDriver)
+                  integratedDriver: integratedDriver,
+                  interModuleDependencyOracle: interModuleDependencyOracle)
   }
 
   /// For tests that need to set the sdk path.


### PR DESCRIPTION
If the oracle has been used to create a CAS for the path, reuse the CAS if it is asked to create the same CAS again. This not only save the work of creating the CAS, but also avoid a potential problem that the CAS closing synchronization doesn't work across threads in the same process due to its uses of file lock.