### PR TITLE
[NFC] Add `Decodable` conformance to `Triple.Arch`

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -415,7 +415,7 @@ extension Triple {
     }
   }
 
-  public enum Arch: String, CaseIterable {
+  public enum Arch: String, CaseIterable, Decodable {
     /// ARM (little endian): arm, armv.*, xscale
     case arm
     // ARM (big endian): armeb


### PR DESCRIPTION
With retroactive conformances triggering warnings in Swift 5.11, it makes more sense to declare `Decodable` on the original declaration instead of adding it retroactively in modules where `Triple.Arch` is used.