### PR TITLE
Add `m68k` to `Triple.swift`

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -438,6 +438,8 @@ extension Triple {
     case bpfeb
     /// Hexagon: hexagon
     case hexagon
+    // M68k: Motorola 680x0 family
+    case m68k
     /// MIPS: mips, mipsallegrex, mipsr6
     case mips
     /// MIPSEL: mipsel, mipsallegrexe, mipsr6el
@@ -561,6 +563,8 @@ extension Triple {
         return .thumbeb
       case "avr":
         return .avr
+      case "m68k":
+        return .m68k
       case "msp430":
         return .msp430
       case "mips", "mipseb", "mipsallegrex", "mipsisa32r6", "mipsr6":
@@ -818,7 +822,7 @@ extension Triple {
       case .arc, .arm, .armeb, .hexagon, .le32, .mips, .mipsel, .nvptx,
            .ppc, .r600, .riscv32, .sparc, .sparcel, .tce, .tcele, .thumb,
            .thumbeb, .x86, .xcore, .amdil, .hsail, .spir, .kalimba,.lanai,
-           .shave, .wasm32, .renderscript32, .aarch64_32:
+           .shave, .wasm32, .renderscript32, .aarch64_32, .m68k:
         return 32
 
       case .aarch64, .aarch64e, .aarch64_be, .amdgcn, .bpfel, .bpfeb, .le64, .mips64,
@@ -1394,6 +1398,7 @@ extension Triple {
         case .kalimba: fallthrough
         case .le32: fallthrough
         case .le64: fallthrough
+        case .m68k: fallthrough
         case .mips: fallthrough
         case .mips64: fallthrough
         case .mips64el: fallthrough

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -18,6 +18,7 @@ final class TripleTests: XCTestCase {
   func testBasics() throws {
     XCTAssertEqual(Triple("").arch, nil)
     XCTAssertEqual(Triple("kalimba").arch, .kalimba)
+    XCTAssertEqual(Triple("m68k-unknown-linux-gnu").arch, .m68k)
     XCTAssertEqual(Triple("x86_64-apple-macosx").arch, .x86_64)
     XCTAssertEqual(Triple("blah-apple").arch, nil)
     XCTAssertEqual(Triple("x86_64-apple-macosx").vendor, .apple)
@@ -260,6 +261,11 @@ final class TripleTests: XCTestCase {
     XCTAssertEqual(T.vendor, nil)
     XCTAssertEqual(T.os, nil)
 
+    T = Triple("m68k-unknown-unknown")
+    XCTAssertEqual(T.arch, Triple.Arch.m68k)
+    XCTAssertEqual(T.vendor, nil)
+    XCTAssertEqual(T.os, nil)
+
     T = Triple("sparcel-unknown-unknown")
     XCTAssertEqual(T.arch, Triple.Arch.sparcel)
     XCTAssertEqual(T.vendor, nil)
@@ -400,6 +406,12 @@ final class TripleTests: XCTestCase {
     XCTAssertEqual(T.vendor, nil)
     XCTAssertEqual(T.os, Triple.OS.haiku)
     XCTAssertEqual(T.environment, nil)
+
+    T = Triple("m68k-suse-linux-gnu")
+    XCTAssertEqual(T.arch, Triple.Arch.m68k)
+    XCTAssertEqual(T.vendor, Triple.Vendor.suse)
+    XCTAssertEqual(T.os, Triple.OS.linux)
+    XCTAssertEqual(T.environment, Triple.Environment.gnu)
 
     T = Triple("mips-mti-linux-gnu")
     XCTAssertEqual(T.arch, Triple.Arch.mips)
@@ -1376,6 +1388,7 @@ final class TripleTests: XCTestCase {
     assertToolchain("armv7hl-suse-linux-gnueabi", GenericUnixToolchain.self)
     assertToolchain("i586-pc-haiku", GenericUnixToolchain.self)
     assertToolchain("x86_64-unknown-haiku", GenericUnixToolchain.self)
+    assertToolchain("m68k-suse-linux-gnu", GenericUnixToolchain.self)
     assertToolchain("mips-mti-linux-gnu", GenericUnixToolchain.self)
     assertToolchain("mipsel-img-linux-gnu", GenericUnixToolchain.self)
     assertToolchain("mips64-mti-linux-gnu", GenericUnixToolchain.self)


### PR DESCRIPTION
This architecture is available in [LLVM's `Triple` implementation](https://github.com/llvm/llvm-project/blob/a01b58aef0e42fb1b52e358adf4c56678a884d37/llvm/include/llvm/TargetParser/Triple.h#L62C55-L63C51) and has [an experimental LLVM backend](https://m680x0.github.io/doc/build-from-source) available in upstream LLVM sources. It would be great to have this triple variation supported in the driver, as this architecture is relatively popular in retrocomputing enthusiast circles. It was used in Amiga, Atari ST, Sega Genesis, and of course Apple Lisa and Apple Macintosh. It is supported by Qemu and multiple Linux distributions, including Debian.