### PR TITLE
[Embedded] correct link paths when building for embedded to avoid stray response file paths

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -253,9 +253,11 @@ extension GenericUnixToolchain {
         linkFilePath = linkFilePath?.appending(component: "static-executable-args.lnk")
       } else if staticStdlib {
         linkFilePath = linkFilePath?.appending(component: "static-stdlib-args.lnk")
-      } else if !isEmbeddedEnabled {
+      } else {
         linkFilePath = nil
-        commandLine.appendFlag("-lswiftCore")
+        if !isEmbeddedEnabled {
+          commandLine.appendFlag("-lswiftCore")
+        }
       }
 
       if let linkFile = linkFilePath {


### PR DESCRIPTION
When building for embedded the link phase invocations would contain `@/path/to/swift` which is a directory and not a valid link list. This corrects that logic to appropriately avoid that link file path.