### PR TITLE
[Explicit Module Builds] Do not specify Clang dependency `module.modulemap` files as task inputs

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -219,7 +219,6 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
       // The only required input is the .modulemap for this module.
       // Command line options in the dependency scanner output will include the
       // required modulemap, so here we must only add it to the list of inputs.
-      inputs.append(moduleMapPath)
       let cacheKeys : [TypedVirtualPath : String]
       if let key = moduleDetails.moduleCacheKey {
         cacheKeys = [moduleMapPath: key]
@@ -276,11 +275,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
       let clangModulePath =
         TypedVirtualPath(file: moduleArtifactInfo.clangModulePath.path,
                          type: .pcm)
-      let clangModuleMapPath =
-        TypedVirtualPath(file: moduleArtifactInfo.clangModuleMapPath.path,
-                         type: .clangModuleMap)
       inputs.append(clangModulePath)
-      inputs.append(clangModuleMapPath)
     }
 
     // Swift Main Module dependencies are passed encoded in a JSON file as described by
@@ -445,11 +440,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
       let clangModulePath =
         TypedVirtualPath(file: moduleArtifactInfo.clangModulePath.path,
                          type: .pcm)
-      let clangModuleMapPath =
-        TypedVirtualPath(file: moduleArtifactInfo.clangModuleMapPath.path,
-                         type: .clangModuleMap)
       inputs.append(clangModulePath)
-      inputs.append(clangModuleMapPath)
     }
 
     // Return if depscanner provided build commands.

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -56,13 +56,9 @@ throws {
       for command in extraCommandLine {
         XCTAssertTrue(job.commandLine.contains(.flag(command)))
       }
-    case .clang(let clangModuleDetails):
-      let moduleMapPath =
-        TypedVirtualPath(file: clangModuleDetails.moduleMapPath.path,
-                         type: .clangModuleMap)
+    case .clang(_):
       XCTAssertEqual(job.kind, .generatePCM)
       XCTAssertEqual(job.description, "Compiling Clang module \(moduleId.moduleName)")
-      XCTAssertTrue(job.inputs.contains(moduleMapPath))
     case .swiftPrebuiltExternal(_):
       XCTFail("Unexpected prebuilt external module dependency found.")
     case .swiftPlaceholder(_):
@@ -167,11 +163,7 @@ private func checkCachingBuildJobDependencies(job: Job,
     let clangDependencyModulePathString = dependencyInfo.modulePath.path
     let clangDependencyModulePath =
       TypedVirtualPath(file: clangDependencyModulePathString, type: .pcm)
-    let clangDependencyModuleMapPath =
-      TypedVirtualPath(file: clangDependencyDetails.moduleMapPath.path,
-                       type: .clangModuleMap)
     XCTAssertTrue(job.inputs.contains(clangDependencyModulePath))
-    XCTAssertTrue(job.inputs.contains(clangDependencyModuleMapPath))
     XCTAssertTrue(job.commandLine.contains(
       .flag(String("-fmodule-file=\(dependencyId.moduleName)=\(clangDependencyModulePathString)"))))
     XCTAssertTrue(job.commandLine.contains(

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -50,13 +50,9 @@ throws {
         }
         XCTAssertTrue(job.commandLine.filter {$0 == .flag("-candidate-module-file")}.count == compiledCandidateList.count)
       }
-    case .clang(let clangModuleDetails):
-      let moduleMapPath =
-        TypedVirtualPath(file: clangModuleDetails.moduleMapPath.path,
-                         type: .clangModuleMap)
+    case .clang(_):
       XCTAssertEqual(job.kind, .generatePCM)
       XCTAssertEqual(job.description, "Compiling Clang module \(moduleId.moduleName)")
-      XCTAssertTrue(job.inputs.contains(moduleMapPath))
     case .swiftPrebuiltExternal(_):
       XCTFail("Unexpected prebuilt external module dependency found.")
     case .swiftPlaceholder(_):
@@ -88,11 +84,7 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
     let clangDependencyModulePathString = dependencyInfo.modulePath.path
     let clangDependencyModulePath =
       TypedVirtualPath(file: clangDependencyModulePathString, type: .pcm)
-    let clangDependencyModuleMapPath =
-      TypedVirtualPath(file: clangDependencyDetails.moduleMapPath.path,
-                       type: .clangModuleMap)
     XCTAssertTrue(job.inputs.contains(clangDependencyModulePath))
-    XCTAssertTrue(job.inputs.contains(clangDependencyModuleMapPath))
     XCTAssertTrue(job.commandLine.contains(
       .flag(String("-fmodule-file=\(dependencyId.moduleName)=\(clangDependencyModulePathString)"))))
     XCTAssertTrue(job.commandLine.contains(


### PR DESCRIPTION
These files exist outside the task execution graph and are not produced by any of the tasks involved, so we rely on trusting they are present. This is crucial because these paths may be pre-VFS-remap paths which means that the driver (not-VFS-aware) may not have access to their "external" path and thus unable to verify their actual existence.