### PR TITLE
Prefer `llvm-ar` over `ar` on WebAssembly

### DIFF
--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -95,10 +95,7 @@ public final class WebAssemblyToolchain: Toolchain {
     switch tool {
     case .swiftCompiler:
       return try lookup(executable: "swift-frontend")
-    case .staticLinker(nil):
-      return try lookup(executable: "ar")
-    case .staticLinker(.llvmFull),
-         .staticLinker(.llvmThin):
+    case .staticLinker:
       return try lookup(executable: "llvm-ar")
     case .dynamicLinker:
       // FIXME: This needs to look in the tools_directory first.


### PR DESCRIPTION
Static "ar"chivers not prefixed with "llvm-" rarely support WebAssembly object file formats, and the legacy driver uses "llvm-ar", so it would be better to keep the consistency.

This unblocks the use of swift-driver for WebAssembly target.