### PR TITLE
[Caching] Issue a warning when caching build without explicit module

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7605,6 +7605,13 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
   }
+
+  func testCachingBuildOptions() throws {
+    try assertDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-cache-compile-job") {
+      $1.expect(.warning("-cache-compile-job cannot be used without explicit module build, turn off caching"))
+    }
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-cache-compile-job", "-explicit-module-build")
+  }
 }
 
 func assertString(


### PR DESCRIPTION
Issue a warning and disable compile job caching when explicit module is not enabled. This prevents swift-driver attempting to planning a caching build using implicit build, which will result into either a build system crash or bad swift-frontend invocations.

rdar://121206439