### PR TITLE
Fix explicit modules incremental build failure when only the clang module of a mixed-source module requires rebuild

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -211,7 +211,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
                                                     buildRecordInfo: BuildRecordInfo,
                                                     reporter: IncrementalCompilationState.Reporter?) throws -> Bool {
     for module in graph.modules {
-      if module.key.moduleName == graph.mainModuleName {
+      if module.key == .swift(graph.mainModuleName) {
         continue
       }
       if try !verifyModuleDependencyUpToDate(moduleID: module.key, 


### PR DESCRIPTION
After reading a prior intermodule dependency graph in an incremental explicit module build, the driver loops over each module in the graph to check if it is up to date. The check which is intended to skip the main (Swift) module was skipping a clang module with the same name as well, if it existed. If this clang module was the only one to be updated in an incremental compile, we wouldn't regenerate its pcm, and compilation would later fail since it wasn't up to date.

rdar://121352768