### PR TITLE
For scripts, use DYLD_FRAMEWORK/LIBRARY_PATH to find frameworks / runtimes.

### DIFF
--- a/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+InterpreterSupport.swift
@@ -43,7 +43,8 @@ extension DarwinToolchain {
 
     addPathEnvironmentVariableIfNeeded("DYLD_FRAMEWORK_PATH", to: &envVars,
                                        currentEnv: env, option: .F,
-                                       parsedOptions: &parsedOptions)
+                                       parsedOptions: &parsedOptions,
+                                       extraPaths: ["/System/Library/Frameworks"])
 
     return envVars
   }


### PR DESCRIPTION
Add DYLD_FRAMEWORK_PATH=/System/Library/Frameworks to the environment when constructing swift-frontend invocations for the interpreter so that dlopen can find autolinked frameworks.

Resolves #68785.