### PR TITLE
When terminating because a subprocess failed, don't print `error: fatalError`

### DIFF
--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -318,7 +318,7 @@ public final class MultiJobExecutor {
 
     // Throw the stub error the build didn't finish successfully.
     if !result.success {
-      throw Diagnostics.fatalError
+      throw Driver.ErrorDiagnostics.emitted
     }
   }
 


### PR DESCRIPTION
We already have a way to say "a subprocess failed", use it. Fixes rdar://121627384.