### PR TITLE
Embedded: don't link `swiftrt.o` for bare metal

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -185,7 +185,7 @@ extension GenericUnixToolchain {
         }
       }
 
-      if !parsedOptions.hasArgument(.nostartfiles) {
+      if !isEmbeddedEnabled && !parsedOptions.hasArgument(.nostartfiles) {
         let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
           .appending(
             components: targetTriple.platformName() ?? "",


### PR DESCRIPTION
Currently when linking with `swiftc` for `-unknown-none-` triples, it attempts to link `swiftrt.o` runtime file, which is currently not needed and is not present for these triples. We should avoid linking it in these cases.