### PR TITLE
[Explicit Module Builds] Cache explicit dependency additions to main module command-lines

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -55,6 +55,13 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
   /// Does this compile support `.explicitInterfaceModuleBuild`
   private var supportsExplicitInterfaceBuild: Bool
 
+  /// Cached command-line additions for all main module compile jobs
+  private struct ResolvedModuleDependenciesCommandLineComponents {
+    let inputs: [TypedVirtualPath]
+    let commandLine: [Job.ArgTemplate]
+  }
+  private var resolvedMainModuleDependenciesArgs: ResolvedModuleDependenciesCommandLineComponents? = nil
+
   public init(dependencyGraph: InterModuleDependencyGraph,
               toolchain: Toolchain,
               dependencyOracle: InterModuleDependencyOracle,
@@ -396,18 +403,31 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
   /// inputs and command line flags.
   public mutating func resolveMainModuleDependencies(inputs: inout [TypedVirtualPath],
                                                      commandLine: inout [Job.ArgTemplate]) throws {
-    let mainModuleId: ModuleDependencyId = .swift(dependencyGraph.mainModuleName)
-
-    let mainModuleDetails = try dependencyGraph.swiftModuleDetails(of: mainModuleId)
-    if let additionalArgs = mainModuleDetails.commandLine {
-      additionalArgs.forEach { commandLine.appendFlag($0) }
+    // If not previously computed, gather all dependency input files and command-line arguments
+    if resolvedMainModuleDependenciesArgs == nil {
+      var inputAdditions: [TypedVirtualPath] = []
+      var commandLineAdditions: [Job.ArgTemplate] = []
+      let mainModuleId: ModuleDependencyId = .swift(dependencyGraph.mainModuleName)
+      let mainModuleDetails = try dependencyGraph.swiftModuleDetails(of: mainModuleId)
+      if let additionalArgs = mainModuleDetails.commandLine {
+        additionalArgs.forEach { commandLine.appendFlag($0) }
+      }
+      commandLineAdditions.appendFlags("-disable-implicit-swift-modules",
+                                       "-Xcc", "-fno-implicit-modules",
+                                       "-Xcc", "-fno-implicit-module-maps")
+      try resolveExplicitModuleDependencies(moduleId: mainModuleId,
+                                            inputs: &inputAdditions,
+                                            commandLine: &commandLineAdditions)
+      resolvedMainModuleDependenciesArgs = ResolvedModuleDependenciesCommandLineComponents(
+        inputs: inputAdditions,
+        commandLine: commandLineAdditions
+      )
     }
-    commandLine.appendFlags("-disable-implicit-swift-modules",
-                            "-Xcc", "-fno-implicit-modules",
-                            "-Xcc", "-fno-implicit-module-maps")
-    try resolveExplicitModuleDependencies(moduleId: mainModuleId,
-                                          inputs: &inputs,
-                                          commandLine: &commandLine)
+    guard let mainModuleDependenciesArgs = resolvedMainModuleDependenciesArgs else {
+      fatalError("Failed to compute resolved explicit dependency arguments.")
+    }
+    inputs.append(contentsOf: mainModuleDependenciesArgs.inputs)
+    commandLine.append(contentsOf: mainModuleDependenciesArgs.commandLine)
   }
 
   /// Resolve all module dependencies of the main module and add them to the lists of

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -736,30 +736,21 @@ extension Driver {
 
   /// Adds all dependencies required for an explicit module build
   /// to inputs and command line arguments of a compile job.
-  func addExplicitModuleBuildArguments(inputs: inout [TypedVirtualPath],
-                                       commandLine: inout [Job.ArgTemplate]) throws {
-    guard var dependencyPlanner = explicitDependencyBuildPlanner else {
-      fatalError("No dependency planner in Explicit Module Build mode.")
-    }
-    try dependencyPlanner.resolveMainModuleDependencies(inputs: &inputs, commandLine: &commandLine)
+  mutating func addExplicitModuleBuildArguments(inputs: inout [TypedVirtualPath],
+                                                commandLine: inout [Job.ArgTemplate]) throws {
+    try explicitDependencyBuildPlanner?.resolveMainModuleDependencies(inputs: &inputs, commandLine: &commandLine)
   }
 
   /// Adds all dependencies required for an explicit module build of the bridging header
   /// to inputs and command line arguments of a compile job.
-  func addExplicitPCHBuildArguments(inputs: inout [TypedVirtualPath],
-                                    commandLine: inout [Job.ArgTemplate]) throws {
-    guard var dependencyPlanner = explicitDependencyBuildPlanner else {
-      fatalError("No dependency planner in Explicit Module Build mode.")
-    }
-    try dependencyPlanner.resolveBridgingHeaderDependencies(inputs: &inputs, commandLine: &commandLine)
+  mutating func addExplicitPCHBuildArguments(inputs: inout [TypedVirtualPath],
+                                             commandLine: inout [Job.ArgTemplate]) throws {
+    try explicitDependencyBuildPlanner?.resolveBridgingHeaderDependencies(inputs: &inputs, commandLine: &commandLine)
   }
 
   /// If explicit dependency planner supports creating bridging header pch command.
   public func supportsBridgingHeaderPCHCommand() throws -> Bool {
-    guard let dependencyPlanner = explicitDependencyBuildPlanner else {
-      return false
-    }
-    return try dependencyPlanner.supportsBridgingHeaderPCHCommand()
+    return try explicitDependencyBuildPlanner?.supportsBridgingHeaderPCHCommand() ?? false
   }
 
   /// In Explicit Module Build mode, distinguish between main module jobs and intermediate dependency build jobs,


### PR DESCRIPTION
Cache input files and command-line argument additions describing main module explicit module dependencies to each individual job. Instead of re-computing them for each compile task, which includes serializing a whole new `.json` file with the inputs.