### PR TITLE
Fix wrong -Xlinker propagation to Clang with WebAssembly

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -272,13 +272,7 @@ extension DarwinToolchain {
       from: &parsedOptions
     )
     addLinkedLibArgs(to: &commandLine, parsedOptions: &parsedOptions)
-    // Because we invoke `clang` as the linker executable, we must still
-    // use `-Xlinker` for linker-specific arguments.
-    for linkerOpt in parsedOptions.arguments(for: .Xlinker) {
-      commandLine.appendFlag(.Xlinker)
-      commandLine.appendFlag(linkerOpt.argument.asSingle)
-    }
-    try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+    try addExtraClangLinkerArgs(to: &commandLine, parsedOptions: &parsedOptions)
   }
 }
 

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -321,13 +321,7 @@ extension GenericUnixToolchain {
         from: &parsedOptions
       )
       addLinkedLibArgs(to: &commandLine, parsedOptions: &parsedOptions)
-      // Because we invoke `clang` as the linker executable, we must still
-      // use `-Xlinker` for linker-specific arguments.
-      for linkerOpt in parsedOptions.arguments(for: .Xlinker) {
-        commandLine.appendFlag(.Xlinker)
-        commandLine.appendFlag(linkerOpt.argument.asSingle)
-      }
-      try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+      try addExtraClangLinkerArgs(to: &commandLine, parsedOptions: &parsedOptions)
 
       // This should be the last option, for convenience in checking output.
       commandLine.appendFlag(.o)

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -90,6 +90,19 @@ extension Toolchain {
       commandLine.appendFlag(match.option.spelling + match.argument.asSingle)
     }
   }
+
+  func addExtraClangLinkerArgs(
+    to commandLine: inout [Job.ArgTemplate],
+    parsedOptions: inout ParsedOptions
+  ) throws {
+    // Because we invoke `clang` as the linker executable, we must still
+    // use `-Xlinker` for linker-specific arguments.
+    for linkerOpt in parsedOptions.arguments(for: .Xlinker) {
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag(linkerOpt.argument.asSingle)
+    }
+    try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+  }
 }
 
 // MARK: - Common argument routines

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -158,8 +158,7 @@ extension WebAssemblyToolchain {
         from: &parsedOptions
       )
       addLinkedLibArgs(to: &commandLine, parsedOptions: &parsedOptions)
-      try commandLine.appendAllArguments(.Xlinker, from: &parsedOptions)
-      try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+      try addExtraClangLinkerArgs(to: &commandLine, parsedOptions: &parsedOptions)
 
         // This should be the last option, for convenience in checking output.
       commandLine.appendFlag(.o)

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -197,12 +197,7 @@ extension WindowsToolchain {
       commandLine.appendFlag("-lclang_rt.profile")
     }
 
-    for option in parsedOptions.arguments(for: .Xlinker) {
-      commandLine.appendFlag(.Xlinker)
-      commandLine.appendFlag(option.argument.asSingle)
-    }
-    // TODO(compnerd) is there a separate equivalent to OPT_linker_option_group?
-    try commandLine.appendAllArguments(.XclangLinker, from: &parsedOptions)
+    try addExtraClangLinkerArgs(to: &commandLine, parsedOptions: &parsedOptions)
 
     if parsedOptions.contains(.v) {
       commandLine.appendFlag("-v")


### PR DESCRIPTION
The `-Xlinker` values should be passed to Clang with `-Xlinker` but it was not done for WebAssembly. This patch fixes it by factoring out the common logic for processing `-Xlinker` and `-Xclang-linker` options and using it in all toolchains.