### PR TITLE
Port `--global-base` option for WebAssembly from legacy driver

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -137,6 +137,17 @@ extension WebAssemblyToolchain {
       // Explicitly pass the target to the linker
       commandLine.appendFlag("--target=\(targetTriple.triple)")
 
+      // WebAssembly doesn't reserve low addresses as its ABI. But without
+      // "extra inhabitants" of the pointer representation, runtime performance
+      // and memory footprint are significantly degraded. So we reserve the
+      // low addresses to use them as extra inhabitants by telling the lowest
+      // valid address to the linker.
+      // The value of lowest valid address, called "global base", must be always
+      // synchronized with `SWIFT_ABI_WASM32_LEAST_VALID_POINTER` defined in
+      // apple/swift's runtime library.
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag("--global-base=4096")
+
       // Delegate to Clang for sanitizers. It will figure out the correct linker
       // options.
       guard sanitizers.isEmpty else {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2315,6 +2315,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(commandContainsTemporaryPath(cmd, "bar.o"))
         XCTAssertTrue(commandContainsTemporaryResponsePath(cmd, "Test.autolink"))
         XCTAssertTrue(cmd.contains(.responseFilePath(.absolute(path.appending(components: "wasi", "static-executable-args.lnk")))))
+        XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--global-base=4096")]))
         XCTAssertTrue(cmd.contains(.flag("-O3")))
         XCTAssertEqual(linkJob.outputs[0].file, try VirtualPath(path: "Test"))
 


### PR DESCRIPTION
Just port a missing part from legacy driver:  https://github.com/apple/swift/blob/387156ae1127983afdc4325ebedbb35d72997f34/lib/Driver/WebAssemblyToolChains.cpp#L190-L193