### PR TITLE
Execution: special case the first two arguments in RSP mode

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -216,9 +216,9 @@ public final class ArgsResolver {
         //   Wrap all arguments in double quotes to ensure that both Unix and
         //   Windows tools understand the response file.
         try fileSystem.writeFileContents(absPath) {
-          $0.send(resolvedArguments[1...].map { quote($0) }.joined(separator: "\n"))
+          $0.send(resolvedArguments[2...].map { quote($0) }.joined(separator: "\n"))
         }
-        resolvedArguments = [resolvedArguments[0], "@\(absPath.pathString)"]
+        resolvedArguments = [resolvedArguments[0], resolvedArguments[1], "@\(absPath.pathString)"]
       }
 
       return true

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1613,11 +1613,12 @@ final class SwiftDriverTests: XCTestCase {
       let interpretJob = jobs[0]
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob)
-      XCTAssertTrue(resolvedArgs.count == 2)
-      XCTAssertEqual(resolvedArgs[1].first, "@")
-      let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[1].dropFirst()))
+      XCTAssertTrue(resolvedArgs.count == 3)
+      XCTAssertEqual(resolvedArgs[1], "-frontend")
+      XCTAssertEqual(resolvedArgs[2].first, "@")
+      let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
       let contents = try localFileSystem.readFileContents(responseFilePath).description
-      XCTAssertTrue(contents.hasPrefix("\"-frontend\"\n\"-interpret\"\n\"foo.swift\""))
+      XCTAssertTrue(contents.hasPrefix("\"-interpret\"\n\"foo.swift\""))
       XCTAssertTrue(contents.contains("\"-D\"\n\"TEST_20000\""))
       XCTAssertTrue(contents.contains("\"-D\"\n\"TEST_1\""))
     }
@@ -1641,11 +1642,12 @@ final class SwiftDriverTests: XCTestCase {
       let interpretJob = jobs[0]
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob, useResponseFiles: .forced)
-      XCTAssertTrue(resolvedArgs.count == 2)
-      XCTAssertEqual(resolvedArgs[1].first, "@")
-      let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[1].dropFirst()))
+      XCTAssertTrue(resolvedArgs.count == 3)
+      XCTAssertEqual(resolvedArgs[1], "-frontend")
+      XCTAssertEqual(resolvedArgs[2].first, "@")
+      let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
       let contents = try localFileSystem.readFileContents(responseFilePath).description
-      XCTAssertTrue(contents.hasPrefix("\"-frontend\"\n\"-interpret\"\n\"foo.swift\""))
+      XCTAssertTrue(contents.hasPrefix("\"-interpret\"\n\"foo.swift\""))
     }
 
     // No response file
@@ -1679,16 +1681,16 @@ final class SwiftDriverTests: XCTestCase {
       let emitModuleJob = try jobs.findJob(.emitModule)
       let emitModuleResolvedArgs: [String] =
         try resolver.resolveArgumentList(for: emitModuleJob)
-      XCTAssertEqual(emitModuleResolvedArgs.count, 2)
-      XCTAssertEqual(emitModuleResolvedArgs[1].first, "@")
+      XCTAssertEqual(emitModuleResolvedArgs.count, 3)
+      XCTAssertEqual(emitModuleResolvedArgs[2].first, "@")
 
       let compileJobs = jobs.filter { $0.kind == .compile }
       XCTAssertEqual(compileJobs.count, 2)
       for compileJob in compileJobs {
         let compileResolvedArgs: [String] =
           try resolver.resolveArgumentList(for: compileJob)
-        XCTAssertEqual(compileResolvedArgs.count, 2)
-        XCTAssertEqual(compileResolvedArgs[1].first, "@")
+        XCTAssertEqual(compileResolvedArgs.count, 3)
+        XCTAssertEqual(compileResolvedArgs[2].first, "@")
       }
     }
 
@@ -1705,16 +1707,16 @@ final class SwiftDriverTests: XCTestCase {
       let mergeModuleJob = try jobs.findJob(.mergeModule)
       let mergeModuleResolvedArgs: [String] =
         try resolver.resolveArgumentList(for: mergeModuleJob)
-      XCTAssertEqual(mergeModuleResolvedArgs.count, 2)
-      XCTAssertEqual(mergeModuleResolvedArgs[1].first, "@")
+      XCTAssertEqual(mergeModuleResolvedArgs.count, 3)
+      XCTAssertEqual(mergeModuleResolvedArgs[2].first, "@")
 
       let compileJobs = jobs.filter { $0.kind == .compile }
       XCTAssertEqual(compileJobs.count, 2)
       for compileJob in compileJobs {
         let compileResolvedArgs: [String] =
           try resolver.resolveArgumentList(for: compileJob)
-        XCTAssertEqual(compileResolvedArgs.count, 2)
-        XCTAssertEqual(compileResolvedArgs[1].first, "@")
+        XCTAssertEqual(compileResolvedArgs.count, 3)
+        XCTAssertEqual(compileResolvedArgs[2].first, "@")
       }
     }
 
@@ -1730,8 +1732,8 @@ final class SwiftDriverTests: XCTestCase {
       let generatePCMJob = jobs[0]
       let generatePCMResolvedArgs: [String] =
         try resolver.resolveArgumentList(for: generatePCMJob)
-      XCTAssertEqual(generatePCMResolvedArgs.count, 2)
-      XCTAssertEqual(generatePCMResolvedArgs[1].first, "@")
+      XCTAssertEqual(generatePCMResolvedArgs.count, 3)
+      XCTAssertEqual(generatePCMResolvedArgs[2].first, "@")
     }
   }
 


### PR DESCRIPTION
The second argument is often treated specially as a mode specifier for tools. This is particularly important for Windows where `-lib` or `/lib` passed to `link` or `ld.lld-link` will change the linker to the librarian. This argument may not be sunk into the response file as it is not treated as the mode specifier then. Special case the first two arguments to ensure that the mode switch parameter is always passed for any tools.