### PR TITLE
[CAS] Fix pluginCAS initialization

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -3610,8 +3610,8 @@ extension Driver {
 // CAS and Caching.
 extension Driver {
   mutating func getCASPluginPath() throws -> AbsolutePath? {
-    if let pluginOpt = parsedOptions.getLastArgument(.casPluginOption)?.asSingle {
-      return try AbsolutePath(validating: pluginOpt.description)
+    if let pluginPath = parsedOptions.getLastArgument(.casPluginPath)?.asSingle {
+      return try AbsolutePath(validating: pluginPath.description)
     }
     return try toolchain.lookupToolchainCASPluginLib()
   }

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -287,33 +287,13 @@ extension Toolchain {
 #endif
   }
 
-  /// Looks for the executable in the `SWIFT_DRIVER_TOOLCHAIN_CASPLUGIN_LIB` environment variable, if found nothing,
-  /// looks in the `lib` relative to the compiler executable.
+  /// Looks for the executable in the `SWIFT_DRIVER_TOOLCHAIN_CASPLUGIN_LIB` environment variable.
   @_spi(Testing) public func lookupToolchainCASPluginLib() throws -> AbsolutePath? {
     if let overrideString = env["SWIFT_DRIVER_TOOLCHAIN_CASPLUGIN_LIB"],
        let path = try? AbsolutePath(validating: overrideString) {
       return path
     }
-#if os(Windows)
     return nil
-#else
-    // Try to look for libToolchainCASPlugin in the developer dir, if found,
-    // prefer using that. Otherwise, just return nil, and auto fallback to
-    // builtin CAS.
-    let libraryName = sharedLibraryName("libToolchainCASPlugin")
-    let compilerPath = try getToolPath(.swiftCompiler)
-    let developerPath = compilerPath.parentDirectory // bin
-                                    .parentDirectory // toolchain root
-                                    .parentDirectory // toolchains
-                                    .parentDirectory // developer
-    let libraryPath = developerPath.appending(component: "usr")
-                                   .appending(component: "lib")
-                                   .appending(component: libraryName)
-    if fileSystem.isFile(libraryPath) {
-      return libraryPath
-    }
-    return nil
-#endif
   }
 
   private func xcrunFind(executable: String) throws -> AbsolutePath {


### PR DESCRIPTION
Fix a typo in pluginCAS creation to use the plugin path from the correct option. Also do not eagerly trying to look for a pluginCAS if not requested.