### PR TITLE
[Caching] Fix scanner args were dropped when resolveMainModuleDependencies were called multiple times

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -405,7 +405,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
       let mainModuleId: ModuleDependencyId = .swift(dependencyGraph.mainModuleName)
       let mainModuleDetails = try dependencyGraph.swiftModuleDetails(of: mainModuleId)
       if let additionalArgs = mainModuleDetails.commandLine {
-        additionalArgs.forEach { commandLine.appendFlag($0) }
+        additionalArgs.forEach { commandLineAdditions.appendFlag($0) }
       }
       commandLineAdditions.appendFlags("-disable-implicit-swift-modules",
                                        "-Xcc", "-fno-implicit-modules",


### PR DESCRIPTION
Fix a bug that can cause scanner args to be dropped from the main module build command.