### PR TITLE
Only pass down the `-no-verify-emitted-module-interface` flag if the frontend accepts it

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -423,7 +423,8 @@ extension Driver {
     // Pass along -no-verify-emitted-module-interface only if it's effective.
     // Assume verification by default as we want to know only when the user skips
     // the verification.
-    if !parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
+    if isFrontendArgSupported(.noVerifyEmittedModuleInterface) &&
+       !parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
                               negative: .noVerifyEmittedModuleInterface,
                               default: true) {
       commandLine.appendFlag("-no-verify-emitted-module-interface")

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5621,7 +5621,9 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 2)
       let emitJob = try plannedJobs.findJob(.emitModule)
-      XCTAssertTrue(emitJob.commandLine.contains("-no-verify-emitted-module-interface"))
+      if driver.isFrontendArgSupported(.noVerifyEmittedModuleInterface) {
+        XCTAssertTrue(emitJob.commandLine.contains("-no-verify-emitted-module-interface"))
+      }
     }
 
     // Disabled by default in merge-module
@@ -5694,7 +5696,9 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
       let compileJob = try plannedJobs.findJob(.compile)
-      XCTAssertTrue(compileJob.commandLine.contains("-no-verify-emitted-module-interface"))
+      if driver.isFrontendArgSupported(.noVerifyEmittedModuleInterface) {
+        XCTAssertTrue(compileJob.commandLine.contains("-no-verify-emitted-module-interface"))
+      }
     }
 
     // Enabled by default when the library-level is api.


### PR DESCRIPTION
The flag `-no-verify-emitted-module-interface` may still rejected by older frontends, make sure the local frontend accepts it before passing down the flag.

rdar://123345345