### PR TITLE
Passthrough `-tools-directory` as `-B` to clang linker for Wasm target

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -73,6 +73,10 @@ extension WebAssemblyToolchain {
         if let tool = lookupExecutablePath(filename: "clang", searchPaths: [toolsDir]) {
           clangPath = tool
         }
+
+        // Look for binutils in the toolchain folder.
+        commandLine.appendFlag("-B")
+        commandLine.appendPath(toolsDir)
       }
 
       guard !parsedOptions.hasArgument(.noStaticStdlib, .noStaticExecutable) else {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4368,7 +4368,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(frontendJobs[1].kind, .link)
       XCTAssertEqual(frontendJobs[1].tool.absolutePath!.pathString, ld.pathString)
 
-      // WebAssembly toolchain
+      // WASI toolchain
       do {
         try withTemporaryDirectory { resourceDir in
           try localFileSystem.writeFileContents(resourceDir.appending(components: "wasi", "static-executable-args.lnk")) {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4367,6 +4367,26 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(frontendJobs.count, 2)
       XCTAssertEqual(frontendJobs[1].kind, .link)
       XCTAssertEqual(frontendJobs[1].tool.absolutePath!.pathString, ld.pathString)
+
+      // WebAssembly toolchain
+      do {
+        try withTemporaryDirectory { resourceDir in
+          try localFileSystem.writeFileContents(resourceDir.appending(components: "wasi", "static-executable-args.lnk")) {
+            $0.send("garbage")
+          }
+          var driver = try Driver(args: ["swiftc",
+                                         "-target", "wasm32-unknown-wasi",
+                                         "-resource-dir", resourceDir.pathString,
+                                         "-tools-directory", tmpDir.pathString,
+                                         "foo.swift"],
+                                  env: env)
+          let frontendJobs = try driver.planBuild().removingAutolinkExtractJobs()
+          XCTAssertEqual(frontendJobs.count, 2)
+          XCTAssertTrue(frontendJobs[1].commandLine.contains(subsequence: [
+            .flag("-B"), .path(.absolute(tmpDir))
+          ]))
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This change makes the clang linker driver for Wasm targets respect the `-tools-directory` option. This is necessary to use linker tools from Swift SDK toolset.