### PR TITLE
[Dependency Scanning] Add and use API for per-query diagnostic gathering

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -97,6 +97,8 @@ typedef struct {
   (*swiftscan_dependency_graph_get_main_module_name)(swiftscan_dependency_graph_t);
   swiftscan_dependency_set_t *
   (*swiftscan_dependency_graph_get_dependencies)(swiftscan_dependency_graph_t);
+  swiftscan_diagnostic_set_t *
+  (*swiftscan_dependency_graph_get_diagnostics)(swiftscan_dependency_graph_t);
 
   //=== Dependency Module Info Functions ------------------------------------===//
   swiftscan_string_ref_t
@@ -199,6 +201,8 @@ typedef struct {
   //=== Prescan Result Functions --------------------------------------------===//
   swiftscan_string_set_t *
   (*swiftscan_import_set_get_imports)(swiftscan_import_set_t);
+  swiftscan_diagnostic_set_t *
+  (*swiftscan_import_set_get_diagnostics)(swiftscan_import_set_t);
 
   //=== Scanner Invocation Functions ----------------------------------------===//
   swiftscan_scan_invocation_t

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -46,34 +46,40 @@ public class InterModuleDependencyOracle {
 
   @_spi(Testing) public func getDependencies(workingDirectory: AbsolutePath,
                                              moduleAliases: [String: String]? = nil,
-                                             commandLine: [String])
+                                             commandLine: [String],
+                                             diagnostics: inout [ScannerDiagnosticPayload])
   throws -> InterModuleDependencyGraph {
     precondition(hasScannerInstance)
     return try swiftScanLibInstance!.scanDependencies(workingDirectory: workingDirectory,
                                                       moduleAliases: moduleAliases,
-                                                      invocationCommand: commandLine)
+                                                      invocationCommand: commandLine,
+                                                      diagnostics: &diagnostics)
   }
 
   @_spi(Testing) public func getBatchDependencies(workingDirectory: AbsolutePath,
                                                   moduleAliases: [String: String]? = nil,
                                                   commandLine: [String],
-                                                  batchInfos: [BatchScanModuleInfo])
+                                                  batchInfos: [BatchScanModuleInfo],
+                                                  diagnostics: inout [ScannerDiagnosticPayload])
   throws -> [ModuleDependencyId: [InterModuleDependencyGraph]] {
     precondition(hasScannerInstance)
     return try swiftScanLibInstance!.batchScanDependencies(workingDirectory: workingDirectory,
                                                            moduleAliases: moduleAliases,
                                                            invocationCommand: commandLine,
-                                                           batchInfos: batchInfos)
+                                                           batchInfos: batchInfos,
+                                                           diagnostics: &diagnostics)
   }
 
   @_spi(Testing) public func getImports(workingDirectory: AbsolutePath,
                                         moduleAliases: [String: String]? = nil,
-                                             commandLine: [String])
+                                        commandLine: [String],
+                                        diagnostics: inout [ScannerDiagnosticPayload])
   throws -> InterModuleDependencyImports {
     precondition(hasScannerInstance)
     return try swiftScanLibInstance!.preScanImports(workingDirectory: workingDirectory,
                                                     moduleAliases: moduleAliases,
-                                                    invocationCommand: commandLine)
+                                                    invocationCommand: commandLine,
+                                                    diagnostics: &diagnostics)
   }
 
   /// Given a specified toolchain path, locate and instantiate an instance of the SwiftScan library
@@ -145,6 +151,13 @@ public class InterModuleDependencyOracle {
       fatalError("Attempting to query supported scanner API with no scanner instance.")
     }
     return swiftScan.supportsBridgingHeaderPCHCommand
+  }
+
+  @_spi(Testing) public func supportsPerScanDiagnostics() throws -> Bool {
+    guard let swiftScan = swiftScanLibInstance else {
+      fatalError("Attempting to query supported scanner API with no scanner instance.")
+    }
+    return swiftScan.canQueryPerScanDiagnostics
   }
 
   @_spi(Testing) public func getScannerDiagnostics() throws -> [ScannerDiagnosticPayload]? {

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -666,9 +666,11 @@ final class CachingBuildTests: XCTestCase {
                                                  // though the module-name above should be sufficient.
                                                  "-I/tmp/foo/bar/\(index)"]
         do {
+          var scanDiagnostics: [ScannerDiagnosticPayload] = []
           let dependencyGraph =
             try dependencyOracle.getDependencies(workingDirectory: path,
-                                                 commandLine: iterationCommand)
+                                                 commandLine: iterationCommand,
+                                                 diagnostics: &scanDiagnostics)
 
           // The _Concurrency and _StringProcessing modules are automatically
           // imported in newer versions of the Swift compiler. If they happened to
@@ -712,8 +714,10 @@ final class CachingBuildTests: XCTestCase {
                                       "-I/tmp/bad",
                                       "-cas-path", casPath2.nativePathString(escaped: true),
                                       ]
+      var scanDiagnostics: [ScannerDiagnosticPayload] = []
       XCTAssertThrowsError(try dependencyOracle.getDependencies(workingDirectory: path,
-                                                                commandLine: command)) {
+                                                                commandLine: command,
+                                                                diagnostics: &scanDiagnostics)) {
         XCTAssertTrue($0 is DependencyScanningError)
       }
       let diags = try XCTUnwrap(dependencyOracle.getScannerDiagnostics())


### PR DESCRIPTION
Adopts new API that produces per-scan diagnostics for each query of a dependency graph or an import set
Driver part of https://github.com/apple/swift/pull/71907