### PR TITLE
[Caching] Move unsupportedCachingConfiguration to be scanning error

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -75,8 +75,6 @@ public struct Driver {
     case missingContextHashOnSwiftDependency(String)
     case dependencyScanningFailure(Int, String)
     case missingExternalDependency(String)
-    // Compiler Caching Failures
-    case unsupportedConfigurationForCaching(String)
 
     public var description: String {
       switch self {
@@ -138,8 +136,6 @@ public struct Driver {
         return "unable to load output file map '\(path)': \(error)"
       case .missingExternalDependency(let moduleName):
         return "Missing External dependency info for module: \(moduleName)"
-      case .unsupportedConfigurationForCaching(let reason):
-        return "unsupported configuration for -cache-compile-job: \(reason)"
       case .baselineGenerationRequiresTopLevelModule(let arg):
         return "generating a baseline with '\(arg)' is only supported with '-emit-module' or '-emit-module-path'"
       case .optionRequiresAnother(let first, let second):

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -267,7 +267,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
 
       let prebuiltHeaderDependencyPaths = dependencyModule.prebuiltHeaderDependencyPaths ?? []
       if cas != nil && !prebuiltHeaderDependencyPaths.isEmpty {
-        throw Driver.Error.unsupportedConfigurationForCaching("module \(dependencyModule.moduleName) has prebuilt header dependency")
+        throw DependencyScanningError.unsupportedConfigurationForCaching("module \(dependencyModule.moduleName) has bridging header dependency")
       }
 
       for headerDep in prebuiltHeaderDependencyPaths {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -475,7 +475,7 @@ extension Driver {
 
     assert(pchJob.outputCacheKeys.count == 1, "Expect one and only one cache key from pch job")
     guard let bridgingHeaderCacheKey = pchJob.outputCacheKeys.first?.value else {
-      throw Error.unsupportedConfigurationForCaching("pch job doesn't have an associated cache key")
+      fatalError("pch job doesn't have an associated cache key")
     }
     commandLine.appendFlag("-bridging-header-pch-key")
     commandLine.appendFlag(bridgingHeaderCacheKey)

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -22,7 +22,7 @@ import protocol TSCBasic.DiagnosticData
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.Diagnostic
 
-public enum DependencyScanningError: LocalizedError, DiagnosticData {
+public enum DependencyScanningError: LocalizedError, DiagnosticData, Equatable {
   case missingRequiredSymbol(String)
   case dependencyScanFailed(String)
   case failedToInstantiateScanner
@@ -34,6 +34,7 @@ public enum DependencyScanningError: LocalizedError, DiagnosticData {
   case scanningLibraryInvocationMismatch(AbsolutePath, AbsolutePath)
   case scanningLibraryNotFound(AbsolutePath)
   case argumentQueryFailed
+  case unsupportedConfigurationForCaching(String)
 
   public var description: String {
     switch self {
@@ -59,6 +60,8 @@ public enum DependencyScanningError: LocalizedError, DiagnosticData {
         return "Dependency Scanning library not found at path: \(path)"
       case .argumentQueryFailed:
         return "Supported compiler argument query failed"
+      case .unsupportedConfigurationForCaching(let reason):
+        return "Unsupported configuration for -cache-compile-job, consider turn off swift caching: \(reason)"
     }
   }
 

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -585,7 +585,7 @@ final class CachingBuildTests: XCTestCase {
                               interModuleDependencyOracle: dependencyOracle)
       // This is currently not supported.
       XCTAssertThrowsError(try driver.planBuild()) {
-        XCTAssertEqual($0 as? Driver.Error, .unsupportedConfigurationForCaching("module Foo has prebuilt header dependency"))
+        XCTAssertEqual($0 as? DependencyScanningError, .unsupportedConfigurationForCaching("module Foo has bridging header dependency"))
       }
     }
   }


### PR DESCRIPTION
Refine unsupportedCachingConfiguration to be a DependencyScanningError because:
* It can only be found during dependency scanning that some dependency requirement for caching is not satisfied.
* DependencyScanningError is a LocalizedError that can help build system to better displayed the error.

rdar://123654299