### PR TITLE
Set `stdout` and `stderr` encodings to UTF-8 in `build-script-helper.py`

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -9,6 +9,9 @@ import subprocess
 import sys
 import errno
 
+sys.stdout.reconfigure(encoding='utf-8')
+sys.stderr.reconfigure(encoding='utf-8')
+
 if platform.system() == 'Darwin':
     shared_lib_ext = '.dylib'
 else:


### PR DESCRIPTION
This will hopefully fix the following error that has been causing the https://ci.swift.org/job/oss-swift-RA-linux-ubuntu-18_04-long-test/ pipeline to fail for a few days:

```
UnicodeEncodeError: 'ascii' codec can't encode character '\u2502' in position 100311: ordinal not in range(128)
```

Resolves rdar://123809082