### PR TITLE
Compute and append -file-compilation-dir when -g options are used

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -368,8 +368,14 @@ extension Driver {
         commandLine.appendFlag(.enableAnonymousContextMangledNames)
       }
 
+      // Always try to append -file-compilation-dir when debug info is used.
       // TODO: Should we support -fcoverage-compilation-dir?
-      try commandLine.appendAll(.fileCompilationDir, from: &parsedOptions)
+      commandLine.appendFlag(.fileCompilationDir)
+      if let compilationDir = parsedOptions.getLastArgument(.fileCompilationDir)?.asSingle {
+        commandLine.appendFlag(compilationDir)
+      } else if let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory {
+        commandLine.appendFlag(cwd.pathString)
+      }
     }
 
     // CAS related options.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -598,6 +598,17 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(jobs[0].commandLine.contains(.flag(".")))
     }
 
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-working-directory", "/tmp") { driver in
+      let jobs = try driver.planBuild()
+      XCTAssertTrue(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
+      XCTAssertTrue(jobs[0].commandLine.contains(.flag("/tmp")))
+    }
+
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c") { driver in
+      let jobs = try driver.planBuild()
+      XCTAssertTrue(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
+    }
+
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-c", "-file-compilation-dir", ".") { driver in
       let jobs = try driver.planBuild()
       XCTAssertFalse(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))


### PR DESCRIPTION
SwiftDriver should compute `-file-compilation-dir` when debug info is used. This can avoid `swift-frontend` to compute its own compilation directory, which can cause `swift-frontend` to generate different code with the same command if current working directory changed.