### PR TITLE
Don't normalize `*-unknown-windows-coff` as `*-unknown-windows-msvc`

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -126,7 +126,7 @@ public struct Triple {
         parser.components.resize(toCount: 4, paddingWith: "")
         parser.components[2] = "windows"
         if parsedEnv?.value.environment == nil {
-          if let objectFormat = parsedEnv?.value.objectFormat, objectFormat != .coff {
+          if let objectFormat = parsedEnv?.value.objectFormat {
             parser.components[3] = Substring(objectFormat.name)
           } else {
             parser.components[3] = "msvc"

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -816,6 +816,9 @@ final class TripleTests: XCTestCase {
 
     assertNormalizesEqual("i686-pc-windows-elf-elf",
               "i686-pc-windows-elf")
+
+    assertNormalizesEqual("i686-unknown-windows-coff", "i686-unknown-windows-coff")
+    assertNormalizesEqual("x86_64-unknown-windows-coff", "x86_64-unknown-windows-coff")
   }
 
   func testNormalizeARM() {
@@ -1065,6 +1068,7 @@ final class TripleTests: XCTestCase {
     XCTAssertEqual(.macho, Triple("i686---macho").objectFormat)
 
     XCTAssertEqual(.coff, Triple("i686--win32").objectFormat)
+    XCTAssertEqual(.coff, Triple("i686-unknown-windows-coff").objectFormat)
 
     XCTAssertEqual(.elf, Triple("i686-pc-windows-msvc-elf").objectFormat)
     XCTAssertEqual(.elf, Triple("i686-pc-cygwin-elf").objectFormat)


### PR DESCRIPTION
This fixes the inability to use `x86_64-unknown-windows-coff` and `i686-unknown-windows-coff` triples with Embedded Swift.

*Steps to reproduce:*

1. Install latest development snapshot off `main`, e.g. `swift-DEVELOPMENT-SNAPSHOT-2024-03-01-a-osx`.
2. Try to build with `swiftc -target i686-unknown-windows-coff -enable-experimental-feature Embedded -wmo -c test.swift`

*Expected result:*

Code compiles successfully or an actionable diagnostic message is produced.

*Actual result:*

<unknown>:0: error: could not find module 'Swift' for target 'i686-unknown-windows-msvc'