### PR TITLE
[Caching] Remap the path in `-file-compilation-dir` if needed

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -372,9 +372,11 @@ extension Driver {
       // TODO: Should we support -fcoverage-compilation-dir?
       commandLine.appendFlag(.fileCompilationDir)
       if let compilationDir = parsedOptions.getLastArgument(.fileCompilationDir)?.asSingle {
-        commandLine.appendFlag(compilationDir)
+        let compDirPath = try VirtualPath.intern(path: compilationDir)
+        try addPathArgument(VirtualPath.lookup(compDirPath), to:&commandLine, remap: jobNeedPathRemap)
       } else if let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory {
-        commandLine.appendFlag(cwd.pathString)
+        let compDirPath = VirtualPath.absolute(cwd)
+        try addPathArgument(compDirPath, to:&commandLine, remap: jobNeedPathRemap)
       }
     }
 

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -748,7 +748,7 @@ final class CachingBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "/tmp/Foo.o", "-v",
+                                     "/tmp/Foo.o", "-v", "-g",
                                      "-explicit-module-build",
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -594,14 +594,16 @@ final class SwiftDriverTests: XCTestCase {
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-file-compilation-dir", ".") { driver in
       let jobs = try driver.planBuild()
+      let path = try VirtualPath.intern(path: ".")
       XCTAssertTrue(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
-      XCTAssertTrue(jobs[0].commandLine.contains(.flag(".")))
+      XCTAssertTrue(jobs[0].commandLine.contains(.path(VirtualPath.lookup(path))))
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-working-directory", "/tmp") { driver in
       let jobs = try driver.planBuild()
+      let path = try VirtualPath.intern(path: "/tmp")
       XCTAssertTrue(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
-      XCTAssertTrue(jobs[0].commandLine.contains(.flag("/tmp")))
+      XCTAssertTrue(jobs[0].commandLine.contains(.path(VirtualPath.lookup(path))))
     }
 
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c") { driver in


### PR DESCRIPTION
A follow-up to #1557 that when caching is enabled and using the scanner prefix mapping option to canonicalize the path, make sure the path passed via `-file-compilation-dir` is remapped.