### PR TITLE
Android: add the stdlib RPATH when natively building on Android with Termux

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -173,8 +173,16 @@ extension GenericUnixToolchain {
         isShared: hasRuntimeArgs
       )
 
-      if hasRuntimeArgs && targetTriple.environment != .android &&
-          toolchainStdlibRpath {
+      // An exception is made for native Android environments like the Termux
+      // app as they build and run natively like a Unix environment on Android,
+      // so add the stdlib RPATH by default there.
+      #if os(Android)
+      let addRpath = true
+      #else
+      let addRpath = targetTriple.environment != .android
+      #endif
+
+      if hasRuntimeArgs && addRpath && toolchainStdlibRpath {
         // FIXME: We probably shouldn't be adding an rpath here unless we know
         //        ahead of time the standard library won't be copied.
         for path in runtimePaths {


### PR DESCRIPTION
This is the equivalent of the already-merged C++ Driver change in apple/swift#69538.

@artemcm, let me know what you think of this small change to align the two drivers and get one of my patches for the native Android toolchain upstreamed. This changes nothing other than when natively building Swift code on an Android device.