### PR TITLE
build: add the ability to build tools with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
 
-project(SwiftDriver LANGUAGES C Swift)
+project(SwiftDriver
+  LANGUAGES C CXX Swift)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -34,6 +35,7 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-I$<SEMICOLON>${CMAKE_CURRENT_SOURCE_DIR}/Sources/CSwiftScan/include>)
 
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
+option(SWIFT_DRIVER_BUILD_TOOLS "Build makeOption" NO)
 
 # Toolchain Vended Dependencies
 find_package(dispatch QUIET)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -13,3 +13,7 @@ add_subdirectory(SwiftDriverExecution)
 add_subdirectory(swift-build-sdk-interfaces)
 add_subdirectory(swift-driver)
 add_subdirectory(swift-help)
+
+if(SWIFT_DRIVER_BUILD_TOOLS)
+  add_subdirectory(makeOptions)
+endif()

--- a/Sources/makeOptions/CMakeLists.txt
+++ b/Sources/makeOptions/CMakeLists.txt
@@ -1,0 +1,23 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+find_package(LLVM CONFIG REQUIRED)
+find_package(Clang CONFIG REQUIRED)
+find_package(Swift CONFIG REQUIRED)
+
+add_executable(makeOptions
+  main.cpp
+  makeOptions.cpp)
+set_target_properties(makeOptions PROPERTIES
+  CXX_STANDARD 17)
+target_compile_definitions(makeOptions PRIVATE
+  LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+target_include_directories(makeOptions PRIVATE
+  ${SWIFT_INCLUDE_DIRS}
+  ${LLVM_BUILD_BINARY_DIR}/include
+  ${LLVM_BUILD_MAIN_INCLUDE_DIR})


### PR DESCRIPTION
Introduce the ability to build `makeOption` via CMake if desired. This requires passing additional parameters -
`-D LLVM_DIR=... -D Clang_DIR=... -D Swift_DIR=...` to the CMake invocation to allow us to find the required include paths.