### PR TITLE
[BridgingHeader] Provide a deterministic unique pch file path

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -425,6 +425,13 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     commandLine.append(contentsOf: mainModuleDependenciesArgs.commandLine)
   }
 
+  /// Get the context hash for the main module.
+  public func getMainModuleContextHash() throws -> String? {
+    let mainModuleId: ModuleDependencyId = .swift(dependencyGraph.mainModuleName)
+    let mainModuleDetails = try dependencyGraph.swiftModuleDetails(of: mainModuleId)
+    return mainModuleDetails.contextHash
+  }
+
   /// Resolve all module dependencies of the main module and add them to the lists of
   /// inputs and command line flags.
   public mutating func resolveBridgingHeaderDependencies(inputs: inout [TypedVirtualPath],

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -324,7 +324,7 @@ final class CachingBuildTests: XCTestCase {
               let baseName = "testCachingBuildJobs"
               XCTAssertTrue(matchTemporary(outputFilePath, basename: baseName, fileExtension: "o") ||
                             matchTemporary(outputFilePath, basename: baseName, fileExtension: "autolink") ||
-                            matchTemporary(outputFilePath, basename: "Bridging-", fileExtension: "pch"))
+                            matchTemporary(outputFilePath, basename: "Bridging", fileExtension: "pch"))
             default:
               XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -388,7 +388,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
               let baseName = "testExplicitModuleBuildJobs"
               XCTAssertTrue(matchTemporary(outputFilePath, basename: baseName, fileExtension: "o") ||
                             matchTemporary(outputFilePath, basename: baseName, fileExtension: "autolink") ||
-                            matchTemporary(outputFilePath, basename: "Bridging-", fileExtension: "pch"))
+                            matchTemporary(outputFilePath, basename: "Bridging", fileExtension: "pch"))
             default:
               XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }


### PR DESCRIPTION
Teach swift driver to use a deterministic path for compiled PCH output. Also when dependency scanner is updated to return a module scanning or PCH hash from the scanning result, it will add that to the code path to have an unique PCH file path for the specific compilation.