### PR TITLE
[ExplicitModuleBuilds][NFC] Remove lazy module loading check in explicit module tests

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -87,8 +87,6 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
     XCTAssertTrue(job.inputs.contains(clangDependencyModulePath))
     XCTAssertTrue(job.commandLine.contains(
       .flag(String("-fmodule-file=\(dependencyId.moduleName)=\(clangDependencyModulePathString)"))))
-    XCTAssertTrue(job.commandLine.contains(
-      .flag(String("-fmodule-map-file=\(clangDependencyDetails.moduleMapPath.path.description)"))))
   }
 
   for dependencyId in moduleInfo.directDependencies! {


### PR DESCRIPTION
We are evaluating doing eager module loading in: https://github.com/apple/swift/pull/72471