### PR TITLE
[Explicit Module Builds] Specify which Clang module dependencies are bridging header dependencies

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -155,6 +155,8 @@ typedef struct {
   (*swiftscan_swift_binary_detail_get_is_framework)(swiftscan_module_details_t);
   swiftscan_string_ref_t
   (*swiftscan_swift_binary_detail_get_module_cache_key)(swiftscan_module_details_t);
+  swiftscan_string_set_t *
+  (*swiftscan_swift_binary_detail_get_header_dependency_module_dependencies)(swiftscan_module_details_t);
 
   //=== Swift Placeholder Module Details query APIs -------------------------===//
   swiftscan_string_ref_t

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -253,8 +253,8 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
                                                           inputs: inout [TypedVirtualPath],
                                                           commandLine: inout [Job.ArgTemplate]) throws {
     // Prohibit the frontend from implicitly building textual modules into binary modules.
-    var swiftDependencyArtifacts: [SwiftModuleArtifactInfo] = []
-    var clangDependencyArtifacts: [ClangModuleArtifactInfo] = []
+    var swiftDependencyArtifacts: Set<SwiftModuleArtifactInfo> = []
+    var clangDependencyArtifacts: Set<ClangModuleArtifactInfo> = []
     try addModuleDependencies(of: moduleId,
                               clangDependencyArtifacts: &clangDependencyArtifacts,
                               swiftDependencyArtifacts: &swiftDependencyArtifacts)
@@ -276,8 +276,6 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         inputs.append(TypedVirtualPath(file: headerDep.path, type: .pch))
       }
     }
-
-    // Clang module dependencies are specified on the command line explicitly
     for moduleArtifactInfo in clangDependencyArtifacts {
       let clangModulePath =
         TypedVirtualPath(file: moduleArtifactInfo.clangModulePath.path,
@@ -311,8 +309,9 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
 
   private mutating func addModuleDependency(of moduleId: ModuleDependencyId,
                                             dependencyId: ModuleDependencyId,
-                                            clangDependencyArtifacts: inout [ClangModuleArtifactInfo],
-                                            swiftDependencyArtifacts: inout [SwiftModuleArtifactInfo]
+                                            clangDependencyArtifacts: inout Set<ClangModuleArtifactInfo>,
+                                            swiftDependencyArtifacts: inout Set<SwiftModuleArtifactInfo>,
+                                            bridgingHeaderDeps: Set<ModuleDependencyId>? = nil
   ) throws {
     switch dependencyId {
       case .swift:
@@ -325,7 +324,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         isFramework = swiftModuleDetails.isFramework ?? false
         // Accumulate the required information about this dependency
         // TODO: add .swiftdoc and .swiftsourceinfo for this module.
-        swiftDependencyArtifacts.append(
+        swiftDependencyArtifacts.insert(
           SwiftModuleArtifactInfo(name: dependencyId.moduleName,
                                   modulePath: TextualVirtualPath(path: swiftModulePath.fileHandle),
                                   isFramework: isFramework,
@@ -335,11 +334,12 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         let dependencyClangModuleDetails =
           try dependencyGraph.clangModuleDetails(of: dependencyId)
         // Accumulate the required information about this dependency
-        clangDependencyArtifacts.append(
+        clangDependencyArtifacts.insert(
           ClangModuleArtifactInfo(name: dependencyId.moduleName,
                                   modulePath: TextualVirtualPath(path: dependencyInfo.modulePath.path),
                                   moduleMapPath: dependencyClangModuleDetails.moduleMapPath,
-                                  moduleCacheKey: dependencyClangModuleDetails.moduleCacheKey))
+                                  moduleCacheKey: dependencyClangModuleDetails.moduleCacheKey,
+                                  isBridgingHeaderDependency: bridgingHeaderDeps?.contains(dependencyId) ?? true))
       case .swiftPrebuiltExternal:
         let prebuiltModuleDetails = try dependencyGraph.swiftPrebuiltDetails(of: dependencyId)
         let compiledModulePath = prebuiltModuleDetails.compiledModulePath
@@ -348,7 +348,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
           .init(file: compiledModulePath.path, type: .swiftModule)
         // Accumulate the required information about this dependency
         // TODO: add .swiftdoc and .swiftsourceinfo for this module.
-        swiftDependencyArtifacts.append(
+        swiftDependencyArtifacts.insert(
           SwiftModuleArtifactInfo(name: dependencyId.moduleName,
                                   modulePath: TextualVirtualPath(path: swiftModulePath.fileHandle),
                                   headerDependencies: prebuiltModuleDetails.headerDependencyPaths,
@@ -359,11 +359,37 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     }
   }
 
+  /// Collect the Set of all Clang module dependencies which are dependencies of either
+  /// the `moduleId` bridging header or dependencies of bridging headers
+  /// of any prebuilt binary Swift modules in the dependency graph.
+  private func collectHeaderModuleDeps(of moduleId: ModuleDependencyId) throws -> Set<ModuleDependencyId>?  {
+    var bridgingHeaderDeps: Set<ModuleDependencyId>? = nil
+    guard let moduleDependencies = reachabilityMap[moduleId] else {
+      fatalError("Expected reachability information for the module: \(moduleId.moduleName).")
+    }
+    if let dependencySourceBridingHeaderDeps =
+        try dependencyGraph.moduleInfo(of: moduleId).bridgingHeaderModuleDependencies {
+      bridgingHeaderDeps = Set(dependencySourceBridingHeaderDeps)
+    } else {
+      bridgingHeaderDeps = Set<ModuleDependencyId>()
+    }
+    // Collect all binary Swift module dependnecies' header input module dependencies
+    for dependencyId in moduleDependencies {
+      if case .swiftPrebuiltExternal(_) = dependencyId {
+        let prebuiltDependencyDetails = try dependencyGraph.swiftPrebuiltDetails(of: dependencyId)
+        for headerDependency in prebuiltDependencyDetails.headerDependencyModuleDependencies ?? [] {
+          bridgingHeaderDeps!.insert(headerDependency)
+        }
+      }
+    }
+    return bridgingHeaderDeps
+  }
+
   /// Add a specific module dependency as an input and a corresponding command
   /// line flag.
   private mutating func addModuleDependencies(of moduleId: ModuleDependencyId,
-                                              clangDependencyArtifacts: inout [ClangModuleArtifactInfo],
-                                              swiftDependencyArtifacts: inout [SwiftModuleArtifactInfo]
+                                              clangDependencyArtifacts: inout Set<ClangModuleArtifactInfo>,
+                                              swiftDependencyArtifacts: inout Set<SwiftModuleArtifactInfo>
   ) throws {
     guard let moduleDependencies = reachabilityMap[moduleId] else {
       fatalError("Expected reachability information for the module: \(moduleId.moduleName).")
@@ -371,7 +397,8 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     for dependencyId in moduleDependencies {
       try addModuleDependency(of: moduleId, dependencyId: dependencyId,
                               clangDependencyArtifacts: &clangDependencyArtifacts,
-                              swiftDependencyArtifacts: &swiftDependencyArtifacts)
+                              swiftDependencyArtifacts: &swiftDependencyArtifacts,
+                              bridgingHeaderDeps: try collectHeaderModuleDeps(of: moduleId))
     }
   }
 
@@ -430,8 +457,8 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
   public mutating func resolveBridgingHeaderDependencies(inputs: inout [TypedVirtualPath],
                                                          commandLine: inout [Job.ArgTemplate]) throws {
     let mainModuleId: ModuleDependencyId = .swift(dependencyGraph.mainModuleName)
-    var swiftDependencyArtifacts: [SwiftModuleArtifactInfo] = []
-    var clangDependencyArtifacts: [ClangModuleArtifactInfo] = []
+    var swiftDependencyArtifacts: Set<SwiftModuleArtifactInfo> = []
+    var clangDependencyArtifacts: Set<ClangModuleArtifactInfo> = []
     let mainModuleDetails = try dependencyGraph.swiftModuleDetails(of: mainModuleId)
 
     var addedDependencies: Set<ModuleDependencyId> = []
@@ -491,8 +518,8 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
 
   /// Serialize the output file artifacts for a given module in JSON format.
   private func serializeModuleDependencies(for moduleId: ModuleDependencyId,
-                                           swiftDependencyArtifacts: [SwiftModuleArtifactInfo],
-                                           clangDependencyArtifacts: [ClangModuleArtifactInfo]
+                                           swiftDependencyArtifacts: Set<SwiftModuleArtifactInfo>,
+                                           clangDependencyArtifacts: Set<ClangModuleArtifactInfo>
   ) throws -> Data {
     // The module dependency map in CAS needs to be stable.
     // Sort the dependencies by name.

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -164,24 +164,14 @@ public struct SwiftPrebuiltExternalModuleDetails: Codable, Hashable {
   /// The paths to the binary module's header dependencies
   public var headerDependencyPaths: [TextualVirtualPath]?
 
+  /// Clang module dependencies of the textual header input
+  public var headerDependencyModuleDependencies: [ModuleDependencyId]?
+
   /// A flag to indicate whether or not this module is a framework.
   public var isFramework: Bool?
 
   /// The module cache key of the pre-built module.
   public var moduleCacheKey: String?
-
-  public init(compiledModulePath: TextualVirtualPath,
-              moduleDocPath: TextualVirtualPath? = nil,
-              moduleSourceInfoPath: TextualVirtualPath? = nil,
-              headerDependencies: [TextualVirtualPath]? = nil,
-              isFramework: Bool, moduleCacheKey: String? = nil) throws {
-    self.compiledModulePath = compiledModulePath
-    self.moduleDocPath = moduleDocPath
-    self.moduleSourceInfoPath = moduleSourceInfoPath
-    self.headerDependencyPaths = headerDependencies
-    self.isFramework = isFramework
-    self.moduleCacheKey = moduleCacheKey
-  }
 }
 
 /// Details specific to Clang modules.
@@ -201,18 +191,6 @@ public struct ClangModuleDetails: Codable, Hashable {
 
   /// The module cache key of the output module.
   public var moduleCacheKey: String?
-
-  public init(moduleMapPath: TextualVirtualPath,
-              contextHash: String,
-              commandLine: [String],
-              capturedPCMArgs: Set<[String]>?,
-              moduleCacheKey: String? = nil) {
-    self.moduleMapPath = moduleMapPath
-    self.contextHash = contextHash
-    self.commandLine = commandLine
-    self.capturedPCMArgs = capturedPCMArgs
-    self.moduleCacheKey = moduleCacheKey
-  }
 }
 
 public struct ModuleInfo: Codable, Hashable {
@@ -298,6 +276,19 @@ extension ModuleInfo.Details: Codable {
         try container.encode(details, forKey: .swiftPrebuiltExternal)
       case .clang(let details):
         try container.encode(details, forKey: .clang)
+    }
+  }
+}
+
+extension ModuleInfo {
+  var bridgingHeaderModuleDependencies: [ModuleDependencyId]? {
+    switch details {
+    case .swift(let swiftDetails):
+      return swiftDetails.bridgingHeaderDependencies
+    case .swiftPrebuiltExternal(let swiftPrebuiltDetails):
+      return swiftPrebuiltDetails.headerDependencyModuleDependencies
+    default:
+      return nil
     }
   }
 }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -132,6 +132,13 @@ public class InterModuleDependencyOracle {
     return swiftScan.hasBinarySwiftModuleIsFramework
   }
 
+  @_spi(Testing) public func supportsBinaryModuleHeaderModuleDependencies() throws -> Bool {
+    guard let swiftScan = swiftScanLibInstance else {
+      fatalError("Attempting to query supported scanner API with no scanner instance.")
+    }
+    return swiftScan.hasBinarySwiftModuleHeaderModuleDependencies
+  }
+
   @_spi(Testing) public func supportsScannerDiagnostics() throws -> Bool {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to query supported scanner API with no scanner instance.")

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -249,15 +249,22 @@ private extension SwiftScan {
     } else {
       isFramework = false
     }
+
+    let headerDependencyModuleDependencies: [ModuleDependencyId]? =
+      hasBinarySwiftModuleHeaderModuleDependencies ?
+        try getOptionalStringArrayDetail(from: moduleDetailsRef,
+                                         using: api.swiftscan_swift_binary_detail_get_header_dependency_module_dependencies)?.map { .clang($0) } : nil
+
     let moduleCacheKey = supportsCaching ? try getOptionalStringDetail(from: moduleDetailsRef,
                                                      using: api.swiftscan_swift_binary_detail_get_module_cache_key) : nil
 
-    return try SwiftPrebuiltExternalModuleDetails(compiledModulePath: compiledModulePath,
-                                                  moduleDocPath: moduleDocPath,
-                                                  moduleSourceInfoPath: moduleSourceInfoPath,
-                                                  headerDependencies: headerDependencies,
-                                                  isFramework: isFramework,
-                                                  moduleCacheKey: moduleCacheKey)
+    return SwiftPrebuiltExternalModuleDetails(compiledModulePath: compiledModulePath,
+                                              moduleDocPath: moduleDocPath,
+                                              moduleSourceInfoPath: moduleSourceInfoPath,
+                                              headerDependencyPaths: headerDependencies,
+                                              headerDependencyModuleDependencies: headerDependencyModuleDependencies,
+                                              isFramework: isFramework,
+                                              moduleCacheKey: moduleCacheKey)
   }
 
   /// Construct a `SwiftPlaceholderModuleDetails` from a `swiftscan_module_details_t` reference

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -268,6 +268,10 @@ internal extension swiftscan_diagnostic_severity_t {
     api.swiftscan_swift_binary_detail_get_is_framework != nil
   }
 
+  @_spi(Testing) public var hasBinarySwiftModuleHeaderModuleDependencies : Bool {
+    api.swiftscan_swift_binary_detail_get_header_dependency_module_dependencies != nil
+  }
+
   @_spi(Testing) public var canLoadStoreScannerCache : Bool {
     api.swiftscan_scanner_cache_load != nil &&
     api.swiftscan_scanner_cache_serialize != nil &&
@@ -534,6 +538,11 @@ private extension swiftscan_functions_t {
     self.swiftscan_swift_binary_detail_get_is_framework =
       try loadOptional("swiftscan_swift_binary_detail_get_is_framework")
 
+    // Clang module dependencies of header input of binary module dependencies
+    self.swiftscan_swift_binary_detail_get_header_dependency_module_dependencies =
+      try loadOptional("swiftscan_swift_binary_detail_get_header_dependency_module_dependencies")
+
+    // Bridging PCH build command-line
     self.swiftscan_swift_textual_detail_get_bridging_pch_command_line =
       try loadOptional("swiftscan_swift_textual_detail_get_bridging_pch_command_line")
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -278,6 +278,76 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
   /// Test generation of explicit module build jobs for dependency modules when the driver
   /// is invoked with -explicit-module-build
+  func testBridgingHeaderDeps() throws {
+    try withTemporaryDirectory { path in
+      let main = path.appending(component: "testExplicitModuleBuildJobs.swift")
+      try localFileSystem.writeFileContents(main, bytes:
+        """
+        import C;\
+        import E;\
+        import G;
+        """
+      )
+      let cHeadersPath: AbsolutePath =
+      try testInputsPath.appending(component: "ExplicitModuleBuilds")
+        .appending(component: "CHeaders")
+      let bridgingHeaderpath: AbsolutePath =
+      cHeadersPath.appending(component: "Bridging.h")
+      let swiftModuleInterfacesPath: AbsolutePath =
+      try testInputsPath.appending(component: "ExplicitModuleBuilds")
+        .appending(component: "Swift")
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "x86_64-apple-macosx11.0",
+                                     "-I", cHeadersPath.nativePathString(escaped: true),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-explicit-module-build",
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+      let jobs = try driver.planBuild()
+      let compileJob = try XCTUnwrap(jobs.first(where: { $0.kind == .compile }))
+
+      // Load the dependency JSON and verify this dependency was encoded correctly
+      let explicitDepsFlag =
+        SwiftDriver.Job.ArgTemplate.flag(String("-explicit-swift-module-map-file"))
+      XCTAssert(compileJob.commandLine.contains(explicitDepsFlag))
+      let jsonDepsPathIndex = compileJob.commandLine.firstIndex(of: explicitDepsFlag)
+      let jsonDepsPathArg = compileJob.commandLine[jsonDepsPathIndex! + 1]
+      guard case .path(let jsonDepsPath) = jsonDepsPathArg else {
+        XCTFail("No JSON dependency file path found.")
+        return
+      }
+      guard case let .temporaryWithKnownContents(_, contents) = jsonDepsPath else {
+        XCTFail("Unexpected path type")
+        return
+      }
+      let jsonDepsDecoded = try JSONDecoder().decode(Array<ModuleDependencyArtifactInfo>.self, from: contents)
+
+      // Ensure that "F" is specified as a bridging dependency
+      XCTAssertTrue(jsonDepsDecoded.contains { artifactInfo in
+        if case .clang(let details) = artifactInfo {
+          return details.moduleName == "F" && details.isBridgingHeaderDependency == true
+        } else {
+          return false
+        }
+      })
+
+      // If the scanner supports the feature, ensure that "C" is reported as *not* a bridging
+      // header dependency
+      if try driver.interModuleDependencyOracle.supportsBinaryModuleHeaderModuleDependencies() {
+        XCTAssertTrue(jsonDepsDecoded.contains { artifactInfo in
+          if case .clang(let details) = artifactInfo {
+            return details.moduleName == "C" && details.isBridgingHeaderDependency == false
+          } else {
+            return false
+          }
+        })
+      }
+    }
+  }
+
+  /// Test generation of explicit module build jobs for dependency modules when the driver
+  /// is invoked with -explicit-module-build
   func testExplicitModuleBuildJobs() throws {
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testExplicitModuleBuildJobs.swift")
@@ -541,7 +611,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let swiftModuleInterfacesPath: AbsolutePath =
           try testInputsPath.appending(component: "ExplicitModuleBuilds")
-                            .appending(component: "Swift")      
+                            .appending(component: "Swift")
       let cHeadersPath: AbsolutePath =
           try testInputsPath.appending(component: "ExplicitModuleBuilds")
                             .appending(component: "CHeaders")


### PR DESCRIPTION
When passing in '-explicit-swift-module-map-file', specify which Clang modules are dependencies of textual headers of the main module and binary Swift module dependencies. This relies on a new entry-point in 'libSwiftScan': 'swiftscan_swift_binary_detail_get_header_dependency_module_dependencies'. The compiler will then use this information to determine which Clang modules require an explicit '-fmodule-map-file' ClangImporter input.

Companion to the compiler's: https://github.com/apple/swift/pull/72668