### PR TITLE
Stop adding '-external-plugin-path' to SDK directories

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -434,15 +434,6 @@ public final class DarwinToolchain: Toolchain {
     }
 
     if driver.isFrontendArgSupported(.externalPluginPath) {
-      // Default paths for compiler plugins found within an SDK (accessed via
-      // that SDK's plugin server).
-      let sdkPathRoot = VirtualPath.lookup(sdkPath).appending(components: "usr")
-      commandLine.appendFlag(.externalPluginPath)
-      commandLine.appendFlag("\(sdkPathRoot.pluginPath.name)#\(sdkPathRoot.pluginServerPath.name)")
-
-      commandLine.appendFlag(.externalPluginPath)
-      commandLine.appendFlag("\(sdkPathRoot.localPluginPath.name)#\(sdkPathRoot.pluginServerPath.name)")
-
       // Determine the platform path. For simulator platforms, look into the
       // corresponding device platform instance.
       let origPlatformPath = VirtualPath.lookup(sdkPath)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7314,19 +7314,6 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertLessThan(pluginB2Index!, pluginCIndex!)
 
     #if os(macOS)
-    XCTAssertTrue(job.commandLine.contains(.flag("-external-plugin-path")))
-    let sdkServerPath = sdkRoot.appending(components: "usr", "bin", "swift-plugin-server").pathString
-    let sdkPluginPath = sdkRoot.appending(components: "usr", "lib", "swift", "host", "plugins").pathString
-
-    let sdkPluginPathIndex = job.commandLine.firstIndex(of: .flag("\(sdkPluginPath)#\(sdkServerPath)"))
-    XCTAssertNotNil(sdkPluginPathIndex)
-    XCTAssertLessThan(pluginCIndex!, sdkPluginPathIndex!)
-
-    let sdkLocalPluginPath = sdkRoot.appending(components: "usr", "local", "lib", "swift", "host", "plugins").pathString
-    let sdkLocalPluginPathIndex = job.commandLine.firstIndex(of: .flag("\(sdkLocalPluginPath)#\(sdkServerPath)"))
-    XCTAssertNotNil(sdkLocalPluginPathIndex)
-    XCTAssertLessThan(sdkPluginPathIndex!, sdkLocalPluginPathIndex!)
-
     let origPlatformPath =
       sdkRoot.parentDirectory.parentDirectory.parentDirectory.parentDirectory
         .appending(component: "\(searchPlatform).platform")
@@ -7337,7 +7324,6 @@ final class SwiftDriverTests: XCTestCase {
     let platformPluginPath = platformPath.appending(components: "lib", "swift", "host", "plugins")
     let platformPluginPathIndex = job.commandLine.firstIndex(of: .flag("\(platformPluginPath)#\(platformServerPath)"))
     XCTAssertNotNil(platformPluginPathIndex)
-    XCTAssertLessThan(sdkLocalPluginPathIndex!, platformPluginPathIndex!)
 
     let platformLocalPluginPath = platformPath.appending(components: "local", "lib", "swift", "host", "plugins")
     let platformLocalPluginPathIndex = job.commandLine.firstIndex(of: .flag("\(platformLocalPluginPath)#\(platformServerPath)"))


### PR DESCRIPTION
Apple SDK plugins are placed under `{}.platform/Developer/usr` directories, not in the SDK directory. Adding nonexisting paths can be confusing.

rdar://121451763