### PR TITLE
Mark `Triple` and its nested types as `Sendable`

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -377,9 +377,9 @@ extension Triple {
   /// `tripleVersion >= featureVersion`.
   ///
   /// - SeeAlso: `Triple.supports(_:)`
-  public struct FeatureAvailability {
+  public struct FeatureAvailability: Sendable {
 
-    public enum Availability {
+    public enum Availability: Sendable {
       case unavailable
       case available(since: Version)
       case availableInAllVersions

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -32,7 +32,7 @@
 ///
 /// This is a port of https://github.com/apple/swift-llvm/blob/stable/include/llvm/ADT/Triple.h
 @dynamicMemberLookup
-public struct Triple {
+public struct Triple: Sendable {
   /// `Triple` proxies predicates from `Triple.OS`, returning `false` for an unknown OS.
   public subscript(dynamicMember predicate: KeyPath<OS, Bool>) -> Bool {
     os?[keyPath: predicate] ?? false
@@ -415,7 +415,7 @@ extension Triple {
     }
   }
 
-  public enum Arch: String, CaseIterable, Decodable {
+  public enum Arch: String, CaseIterable, Decodable, Sendable {
     /// ARM (little endian): arm, armv.*, xscale
     case arm
     // ARM (big endian): armeb
@@ -841,11 +841,11 @@ extension Triple {
 // MARK: - Parse SubArch
 
 extension Triple {
-  public enum SubArch: Hashable {
+  public enum SubArch: Hashable, Sendable {
 
-    public enum ARM {
+    public enum ARM: Sendable {
 
-      public enum Profile {
+      public enum Profile: Sendable {
         case a, r, m
       }
 
@@ -913,13 +913,13 @@ extension Triple {
       }
     }
 
-    public enum Kalimba {
+    public enum Kalimba: Sendable {
       case v3
       case v4
       case v5
     }
 
-    public enum MIPS {
+    public enum MIPS: Sendable {
       case r6
     }
 
@@ -1019,7 +1019,7 @@ extension Triple {
 // MARK: - Parse Vendor
 
 extension Triple {
-  public enum Vendor: String, CaseIterable, TripleComponent {
+  public enum Vendor: String, CaseIterable, TripleComponent, Sendable {
     case apple
     case pc
     case scei
@@ -1084,7 +1084,7 @@ extension Triple {
 // MARK: - Parse OS
 
 extension Triple {
-  public enum OS: String, CaseIterable, TripleComponent {
+  public enum OS: String, CaseIterable, TripleComponent, Sendable {
     case ananas
     case cloudABI = "cloudabi"
     case darwin
@@ -1261,7 +1261,7 @@ extension Triple {
     }
   }
 
-  public enum Environment: String, CaseIterable, Equatable {
+  public enum Environment: String, CaseIterable, Equatable, Sendable {
     case eabihf
     case eabi
     case elfv1
@@ -1357,7 +1357,7 @@ extension Triple {
 // MARK: - Parse Object Format
 
 extension Triple {
-  public enum ObjectFormat {
+  public enum ObjectFormat: Sendable {
     case coff
     case elf
     case macho

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -60,7 +60,7 @@ public struct Triple {
   public let objectFormat: ObjectFormat?
 
   /// Represents a version that may be present in the target triple.
-  public struct Version: Equatable, Comparable, CustomStringConvertible {
+  public struct Version: Equatable, Comparable, CustomStringConvertible, Sendable {
     public static let zero = Version(0, 0, 0)
 
     public var major: Int


### PR DESCRIPTION
This fixes concurrency warnings when building with Swift 6.