### PR TITLE
Decrease the number of padding bytes in the Node Struct so it fits a lower quanta

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/Node.swift
@@ -38,6 +38,12 @@ extension ModuleDependencyGraph {
     /*@_spi(Testing)*/ public var key: DependencyKey { keyAndFingerprint.key }
     /*@_spi(Testing)*/ public var fingerprint: InternedString? { keyAndFingerprint.fingerprint }
 
+    /// When integrating a change, the driver finds untraced nodes so it can kick off jobs that have not been
+    /// kicked off yet. (Within any one driver invocation, compiling a source file is idempotent.)
+    /// When reading a serialized, prior graph, *don't* recover this state, since it will be a new driver
+    /// invocation that has not kicked off any compiles yet.
+    @_spi(Testing) public private(set) var isTraced: Bool = false
+      
     /// Each Node corresponds to a declaration, somewhere. If the definition has been already found,
     /// the `definitionLocation` will point to it.
     /// If uses are encountered before the definition (in reading swiftdeps files), the `definitionLocation`
@@ -46,11 +52,6 @@ extension ModuleDependencyGraph {
     /// compilation.
 
     @_spi(Testing) public let definitionLocation: DefinitionLocation
-    /// When integrating a change, the driver finds untraced nodes so it can kick off jobs that have not been
-    /// kicked off yet. (Within any one driver invocation, compiling a source file is idempotent.)
-    /// When reading a serialized, prior graph, *don't* recover this state, since it will be a new driver
-    /// invocation that has not kicked off any compiles yet.
-    @_spi(Testing) public private(set) var isTraced: Bool = false
 
     private let cachedHash: Int
 


### PR DESCRIPTION
Heap --showInternalFragmentation shows that we are loosing 14 bytes to padding in Node instances.
Class: 'Node' [instance size 104, allocation size 112] - Swift, ARC {
...
  }
   16:  keyAndFingerprint;
   << 7 alignment bytes >>
   64:  definitionLocation;
   88:  isTraced;
   << 7 alignment bytes >>
   96:  cachedHash;
}
Moving isTraced up here will push Node instance allocations to the next quanta (96)