### PR TITLE
Remove swiftmodule from linker filelist input

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -119,7 +119,6 @@ extension DarwinToolchain {
       var inputModules = [VirtualPath]()
       for input in inputs {
         if input.type == .swiftModule && linkerOutputType != .staticLibrary {
-          inputPaths.append(input.file)
           inputModules.append(input.file)
         } else if input.type == .object {
           inputPaths.append(input.file)


### PR DESCRIPTION
The swiftmodule isn't something the linker can operate on. It should be passed to the clang linker, but not to the underlying linker through the use of the linker input filelist.

This exposes itself as a linker error when trying to link with a filelist and debug info. With debug info, the driver schedules an `emit-module` job and an object compile job, which are both fed into the link job.

```
> swiftc hello.swift -g -emit-executable -driver-filelist-threshold=0
  0: input, "hello.swift", swift
  1: emit-module, {0}, swiftmodule
  2: compile, {0}, object
  3: link, {1, 2}, image
  4: generate-dSYM, {3}, dSYM
```

Without generating debug info, the driver does not schedule an emit-module job, so the swiftmodule is never generated in the first place and not included in the filelist where it can cause trouble.

```
> swiftc hello.swift -emit-executable -driver-filelist-threshold=0
  0: input, "hello.swift", swift
  1: compile, {0}, object
  2: link, {1}, image
```

I've removed the module from the linker filelist, but kept it in the module input list. This lines up more cleanly with the non-filelist path, which passes the swiftmodule to the clang-linker via a direct `-Wl,-add_ast_path`.

Fixes: rdar://125936639