### PR TITLE
[6.0 🍒] Introduce VisionOS Platform

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -3165,7 +3165,7 @@ extension Driver {
 extension Triple {
   @_spi(Testing) public func toolchainType(_ diagnosticsEngine: DiagnosticsEngine) throws -> Toolchain.Type {
     switch os {
-    case .darwin, .macosx, .ios, .tvos, .watchos:
+    case .darwin, .macosx, .ios, .tvos, .watchos, .visionos:
       return DarwinToolchain.self
     case .linux:
       return GenericUnixToolchain.self

--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -293,6 +293,10 @@ private extension DarwinPlatform {
       return ["watchos"]
     case .watchOS(.simulator):
       return ["watchossim", "watchos"]
+    case .visionOS(.device):
+      return ["xros"]
+    case .visionOS(.simulator):
+      return ["xrossim", "xros"]
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -479,6 +479,10 @@ public struct SDKPrebuiltModuleInputsCollector {
       return "arm64-apple-tvos\(version)"
     case .appletvsimulator:
       return "arm64-apple-tvos\(version)-simulator"
+    case .visionos:
+      return "arm64-apple-xros\(version)"
+    case .visionsimulator:
+      return "arm64-apple-xros\(version)-simulator"
     case .unknown:
       fatalError("unknown platform kind")
     }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -239,7 +239,8 @@ public final class DarwinToolchain: Toolchain {
       .macosx: (.macOS, Triple.Version(10, 9, 0)),
       .ios: (.iOS(targetTriple._isSimulatorEnvironment ? .simulator : .device), Triple.Version(7, 0, 0)),
       .tvos: (.tvOS(targetTriple._isSimulatorEnvironment ? .simulator : .device), Triple.Version(9, 0, 0)),
-      .watchos: (.watchOS(targetTriple._isSimulatorEnvironment ? .simulator : .device), Triple.Version(2, 0, 0))
+      .watchos: (.watchOS(targetTriple._isSimulatorEnvironment ? .simulator : .device), Triple.Version(2, 0, 0)),
+      .visionos: (.visionOS(targetTriple._isSimulatorEnvironment ? .simulator : .device), Triple.Version(1, 0, 0))
     ]
     if let (platform, minVersion) = minVersions[os], targetTriple.version(for: platform) < minVersion {
       throw ToolchainValidationError.osVersionBelowMinimumDeploymentTarget(platform: platform, version: minVersion)
@@ -288,6 +289,8 @@ public final class DarwinToolchain: Toolchain {
       case watchsimulator
       case appletvos
       case appletvsimulator
+      case visionos
+      case visionsimulator
       case unknown
     }
 

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -32,6 +32,9 @@ public enum DarwinPlatform: Hashable {
   /// watchOS, corresponding to the `watchos` OS name.
   case watchOS(EnvironmentWithoutCatalyst)
 
+  /// visionOS, corresponding to the `visionos` OS name.
+  case visionOS(EnvironmentWithoutCatalyst)
+
   /// The most general form of environment information attached to a
   /// `DarwinPlatform`.
   ///
@@ -76,6 +79,9 @@ public enum DarwinPlatform: Hashable {
     case .watchOS:
     guard let withoutCatalyst = environment.withoutCatalyst else { return nil }
       return .watchOS(withoutCatalyst)
+    case .visionOS:
+      guard let withoutCatalyst = environment.withoutCatalyst else { return nil }
+      return .visionOS(withoutCatalyst)
     }
   }
 
@@ -97,6 +103,10 @@ public enum DarwinPlatform: Hashable {
       return "watchOS"
     case .watchOS(.simulator):
       return "watchOS Simulator"
+    case .visionOS(.device):
+      return "visionOS"
+    case .visionOS(.simulator):
+      return "visionOS Simulator"
     }
   }
 
@@ -120,6 +130,10 @@ public enum DarwinPlatform: Hashable {
       return "watchos"
     case .watchOS(.simulator):
       return "watchsimulator"
+    case .visionOS(.device):
+      return "xros"
+    case .visionOS(.simulator):
+      return "xrsimulator"
     }
   }
 
@@ -142,6 +156,10 @@ public enum DarwinPlatform: Hashable {
       return "watchos"
     case .watchOS(.simulator):
       return "watchos-simulator"
+    case .visionOS(.device):
+      return "xros"
+    case .visionOS(.simulator):
+      return "xros-simulator"
     }
   }
 
@@ -165,6 +183,10 @@ public enum DarwinPlatform: Hashable {
       return "watchos"
     case .watchOS(.simulator):
       return "watchossim"
+    case .visionOS(.device):
+      return "xros"
+    case .visionOS(.simulator):
+      return "xrossim"
     }
   }
 }
@@ -197,6 +219,8 @@ extension Triple {
       return _iOSVersion
     case .watchOS:
       return _watchOSVersion
+    case .visionOS:
+      return _visionOSVersion
     }
   }
 
@@ -223,6 +247,8 @@ extension Triple {
       return .watchOS(makeEnvironment())
     case .tvos:
       return .tvOS(makeEnvironment())
+    case .visionos:
+      return .visionOS(makeEnvironment())
     default:
       return nil
     }
@@ -272,6 +298,8 @@ extension Triple {
       }
 
       return osVersion
+    case .visionOS(_):
+      return _visionOSVersion
     }
   }
 
@@ -285,7 +313,7 @@ extension Triple {
     switch os {
     case nil:
       fatalError("unknown OS")
-    case .darwin, .macosx, .ios, .tvos, .watchos:
+    case .darwin, .macosx, .ios, .tvos, .watchos, .visionos:
       guard let darwinPlatform = darwinPlatform else {
         fatalError("unsupported darwin platform kind?")
       }
@@ -361,6 +389,7 @@ extension Triple {
     public let iOS: Availability
     public let tvOS: Availability
     public let watchOS: Availability
+    public var visionOS: Availability
 
     // TODO: We should have linux, windows, etc.
     public let nonDarwin: Bool
@@ -379,8 +408,14 @@ extension Triple {
       self.tvOS = tvOS
       self.watchOS = watchOS
       self.nonDarwin = nonDarwin
+      self.visionOS = iOS
     }
 
+    public func withVisionOS(_ visionOS: Availability) -> FeatureAvailability {
+      var res = self
+      res.visionOS = visionOS
+      return res
+    }
     /// Returns the version when the feature was introduced on the specified Darwin
     /// platform, or `.unavailable` if the feature has not been introduced there.
     public subscript(darwinPlatform: DarwinPlatform) -> Availability {
@@ -393,6 +428,8 @@ extension Triple {
         return tvOS
       case .watchOS:
         return watchOS
+      case .visionOS:
+        return visionOS
       }
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -660,6 +660,16 @@ final class SwiftDriverTests: XCTestCase {
       let jobs = try driver.planBuild()
       XCTAssertTrue(jobs[0].commandLine.contains(.flag("-dwarf-version=4")))
     }
+
+    // TODO: Enable once compiler support lands
+//    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-xros1.0-simulator") { driver in
+//      let jobs = try driver.planBuild()
+//      XCTAssertTrue(jobs[0].commandLine.contains(.flag("-dwarf-version=4")))
+//    }
+//    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-xros1.0") { driver in
+//      let jobs = try driver.planBuild()
+//      XCTAssertTrue(jobs[0].commandLine.contains(.flag("-dwarf-version=4")))
+//    }
   }
 
   func testCoverageSettings() throws {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1577
------------------------

**Explanation**: This change introduces a new compilation target platform to the Swift compiler - visionOS.
Companion change to https://github.com/apple/swift/pull/73062
**Risk**: Low, additional code-paths should have little effect on compilation for existing platforms.
**Testing**: Automated tests added to the compiler test suite. Existing tests adjusted for the new platform.
**Reviewed By**: @CodaFi 