### PR TITLE
Schedule an emit-module-separately job even if an input is not compilable

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -90,7 +90,7 @@ extension Driver {
 
     // Add the inputs.
     for input in self.inputFiles where input.type.isPartOfSwiftCompilation {
-      commandLine.append(.path(input.file))
+      try addPathArgument(input.file, to: &commandLine)
       inputs.append(input)
     }
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -136,7 +136,7 @@ extension Driver {
                                           moduleOutputInfo: ModuleOutputInfo,
                                           inputFiles: [TypedVirtualPath]) -> Bool {
     if moduleOutputInfo.output == nil ||
-       !inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation }) {
+       !inputFiles.contains(where: { $0.type.isPartOfSwiftCompilation }) {
       return false
     }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3096,7 +3096,7 @@ final class SwiftDriverTests: XCTestCase {
   func testWMOWithNonSourceInputFirstAndModuleOutput() throws {
     var driver1 = try Driver(args: [
       "swiftc", "-wmo", "danger.o", "foo.swift", "bar.swift", "wibble.swift", "-module-name", "Test",
-      "-driver-filelist-threshold=0", "-emit-module", "-emit-library"
+      "-driver-filelist-threshold=0", "-emit-module", "-emit-library", "-no-emit-module-separately-wmo"
     ])
     let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
     XCTAssertEqual(plannedJobs.count, 2)


### PR DESCRIPTION
The following invocation should schedule an emit-module-separately job for src.swift and include other.dylib in the link job.

```
swiftc src.swift other.dylib -emit-library -emit-module
```

rdar://127238278