### PR TITLE
[6.0] Schedule an emit-module-separately job even if an input is not compilable

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -90,7 +90,7 @@ extension Driver {
 
     // Add the inputs.
     for input in self.inputFiles where input.type.isPartOfSwiftCompilation {
-      commandLine.append(.path(input.file))
+      try addPathArgument(input.file, to: &commandLine)
       inputs.append(input)
     }
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -136,7 +136,7 @@ extension Driver {
                                           moduleOutputInfo: ModuleOutputInfo,
                                           inputFiles: [TypedVirtualPath]) -> Bool {
     if moduleOutputInfo.output == nil ||
-       !inputFiles.allSatisfy({ $0.type.isPartOfSwiftCompilation }) {
+       !inputFiles.contains(where: { $0.type.isPartOfSwiftCompilation }) {
       return false
     }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3477,11 +3477,11 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .emitModule, .link]))
 
       let emitJob = try plannedJobs.findJob(.emitModule)
-      XCTAssertTrue(emitJob.commandLine.contains(try toPathOption("foo.swift")))
-      XCTAssertFalse(emitJob.commandLine.contains(try toPathOption("bar.dylib")))
+      XCTAssertTrue(try emitJob.commandLine.contains(where: { $0 == .path(.relative(try .init(validating: "foo.swift")))}))
+      XCTAssertFalse(try emitJob.commandLine.contains(where: { $0 == .path(.relative(try .init(validating: "bar.dylib")))}))
 
       let linkJob = try plannedJobs.findJob(.link)
-      XCTAssertTrue(linkJob.commandLine.contains(try toPathOption("bar.dylib")))
+      XCTAssertTrue(try linkJob.commandLine.contains(where: { $0 == .path(.relative(try .init(validating: "bar.dylib")))}))
     }
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3088,7 +3088,7 @@ final class SwiftDriverTests: XCTestCase {
   func testWMOWithNonSourceInputFirstAndModuleOutput() throws {
     var driver1 = try Driver(args: [
       "swiftc", "-wmo", "danger.o", "foo.swift", "bar.swift", "wibble.swift", "-module-name", "Test",
-      "-driver-filelist-threshold=0", "-emit-module", "-emit-library"
+      "-driver-filelist-threshold=0", "-emit-module", "-emit-library", "-no-emit-module-separately-wmo"
     ])
     let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
     XCTAssertEqual(plannedJobs.count, 2)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3467,6 +3467,22 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs.count, 4)
       XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .emitModule, .link]))
     }
+
+    do {
+      // Schedule an emit-module separately job even if there are non-compilable inputs.
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.dylib", "-emit-library", "foo.dylib", "-emit-module-path", "foo.swiftmodule"],
+                              env: envVars)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 3)
+      XCTAssertEqual(Set(plannedJobs.map { $0.kind }), Set([.compile, .emitModule, .link]))
+
+      let emitJob = try plannedJobs.findJob(.emitModule)
+      XCTAssertTrue(emitJob.commandLine.contains(try toPathOption("foo.swift")))
+      XCTAssertFalse(emitJob.commandLine.contains(try toPathOption("bar.dylib")))
+
+      let linkJob = try plannedJobs.findJob(.link)
+      XCTAssertTrue(linkJob.commandLine.contains(try toPathOption("bar.dylib")))
+    }
   }
 
   func testEmitModuleSeparatelyWMO() throws {


### PR DESCRIPTION
The following invocation should schedule an emit-module-separately job for src.swift and include other.dylib in the link job. This fixes an issue that would make the compiler instead schedule a deprecated merge-module job.

```
swiftc src.swift other.dylib -emit-library -emit-module
```

Risk: Low, not many clients use this path and emit-module-separately is more reliable than merge-module.
Scope: Projects calling the driver as an executable from cmake.
Reviewed by @artemcm 
Cherry-pick of #1588
Resolves rdar://127238278