### PR TITLE
[6.0] Prefer toolchain's plugins to SDK plugins if the toolchain has stdlib 

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7342,7 +7342,15 @@ final class SwiftDriverTests: XCTestCase {
 
     let toolchainPluginPathIndex = job.commandLine.firstIndex(of: .path(.absolute(try driver.toolchain.executableDir.parentDirectory.appending(components: "lib", "swift", "host", "plugins"))))
     XCTAssertNotNil(toolchainPluginPathIndex)
-    XCTAssertLessThan(platformLocalPluginPathIndex!, toolchainPluginPathIndex!)
+
+    let toolchainStdlibPath = VirtualPath.lookup(driver.frontendTargetInfo.runtimeResourcePath.path)
+      .appending(components: driver.frontendTargetInfo.target.triple.platformName() ?? "", "Swift.swiftmodule")
+    let hasToolchainStdlib = try driver.fileSystem.exists(toolchainStdlibPath)
+    if hasToolchainStdlib {
+      XCTAssertGreaterThan(platformLocalPluginPathIndex!, toolchainPluginPathIndex!)
+    } else {
+      XCTAssertLessThan(platformLocalPluginPathIndex!, toolchainPluginPathIndex!)
+    }
     #endif
 
     XCTAssertTrue(job.commandLine.contains(.flag("-plugin-path")))


### PR DESCRIPTION
**Description**:  For example, when using a swift.org toolchain, which contains the stdlib in the resource directory, we should use toolchain's SwiftMacros plugin instead of the platform's one. This is necessary because `@TaskLocal` now have become macros, and other projects within swift project must be using it (and thus be able to find the macro).
**Scope/Impact**: 
**Risk:** Low
**Testing**: CI testing and @rintaro manually verified
**Reviewed by**: @ktoso (making cherry-pick on behalf of @rintaro who did the PR)

**Original PR:** https://github.com/apple/swift-driver/pull/1590