### PR TITLE
[6.0][CAS] Fix task continuation misuse when CAS error happens

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
@@ -344,8 +344,9 @@ extension CachedOutput {
         } else {
           obj.continuation.resume(throwing: DependencyScanningError.casError("unknown output loading error"))
         }
+      } else {
+        obj.continuation.resume(returning: success)
       }
-      obj.continuation.resume(returning: success)
     }
 
     return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Swift.Error>) in
@@ -378,8 +379,9 @@ extension SwiftScanCAS {
         } else {
           obj.continuation.resume(throwing: DependencyScanningError.casError("unknown cache querying error"))
         }
+      } else {
+        obj.continuation.resume(returning: obj.cas.convert(compilation: comp))
       }
-      obj.continuation.resume(returning: obj.cas.convert(compilation: comp))
     }
 
     return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<CachedCompilation?, Swift.Error>) in
@@ -410,8 +412,9 @@ extension SwiftScanCAS {
         } else {
           obj.continuation.resume(throwing: DependencyScanningError.casError("unknown output loading error"))
         }
+      } else {
+        obj.continuation.resume(returning: success)
       }
-      obj.continuation.resume(returning: success)
     }
 
     return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Swift.Error>) in


### PR DESCRIPTION
Explanation: Fix a crash due to misuse continuation when error happens
Scope: This fixes a bug that can cause crashes when error happens when enable remote caching for swift compilation
Original PR: https://github.com/apple/swift-driver/pull/1591
Issue: rdar://127452621
Risk: Low. Only affects compilation caching and when some kind of error happens from CAS
Reviewer: @benlangmuir 

