### PR TITLE
Revert "Work around lld 13+ issue with --gc-sections for ELF by adding -z nostart-stop-gc"

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -89,17 +89,6 @@ extension GenericUnixToolchain {
         #else
         commandLine.appendFlag("-fuse-ld=\(linker)")
         #endif
-        // Starting with lld 13, Swift stopped working with the lld
-        // --gc-sections implementation for ELF, unless -z nostart-stop-gc is
-        // also passed to lld:
-        //
-        // https://reviews.llvm.org/D96914
-        if linker == "lld" || linker.hasSuffix("ld.lld") {
-          commandLine.appendFlag(.Xlinker)
-          commandLine.appendFlag("-z")
-          commandLine.appendFlag(.Xlinker)
-          commandLine.appendFlag("nostart-stop-gc")
-        }
       }
 
       if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2372,8 +2372,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       let lastJob = plannedJobs.last!
       XCTAssertTrue(lastJob.tool.name.contains("clang"))
-      XCTAssertTrue(lastJob.commandLine.contains(subsequence: [.flag("-fuse-ld=lld"),
-        .flag("-Xlinker"), .flag("-z"), .flag("-Xlinker"), .flag("nostart-stop-gc")]))
+      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
     }
 
     do {


### PR DESCRIPTION
This reverts c771555e1c9, now that it was properly fixed in apple/swift#72061.

@al45tair, another follow-up to your compiler pull.