### PR TITLE
Revert "Update Generic Unix linker selection"

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -176,8 +176,8 @@ extension DarwinToolchain {
       }
     }
 
-    if let arg = parsedOptions.getLastArgument(.useLd)?.asSingle {
-      commandLine.appendFlag("-fuse-ld=\(arg)")
+    if let arg = parsedOptions.getLastArgument(.useLd) {
+      commandLine.appendFlag("-fuse-ld=\(arg.asSingle)")
     }
 
     if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -99,8 +99,8 @@ extension WindowsToolchain {
     }
 
     // Select the linker to use.
-    if let arg = parsedOptions.getLastArgument(.useLd)?.asSingle {
-      commandLine.appendFlag("-fuse-ld=\(arg)")
+    if let arg = parsedOptions.getLastArgument(.useLd) {
+      commandLine.appendFlag("-fuse-ld=\(arg.asSingle)")
     } else if lto != nil {
       commandLine.appendFlag("-fuse-ld=lld")
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2368,11 +2368,20 @@ final class SwiftDriverTests: XCTestCase {
 
     do {
       // The Android NDK only uses the lld linker now
-      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "aarch64-unknown-linux-android24", "-use-ld=lld"], env: env)
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "aarch64-unknown-linux-android24"], env: env)
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       let lastJob = plannedJobs.last!
       XCTAssertTrue(lastJob.tool.name.contains("clang"))
-      XCTAssertTrue(lastJob.commandLine.contains(.flag("--fuse-ld=lld")))
+      XCTAssertTrue(lastJob.commandLine.contains(subsequence: [.flag("-fuse-ld=lld"),
+        .flag("-Xlinker"), .flag("-z"), .flag("-Xlinker"), .flag("nostart-stop-gc")]))
+    }
+
+    do {
+      var driver = try Driver(args: commonArgs + ["-emit-library", "-target", "x86_64-unknown-freebsd"], env: env)
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      let lastJob = plannedJobs.last!
+      XCTAssertTrue(lastJob.tool.name.contains("clang"))
+      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
     }
   }
 


### PR DESCRIPTION
Reverts apple/swift-driver#1545

We're hitting issues where the driver is picking up BFD instead of Gold and mislinking:
```
error: link command failed with exit code 1 (use -v to see invocation)
/usr/bin/ld: /home/build-user/build/buildbot_linux/libdispatch-linux-x86_64/src/swift/CMakeFiles/swiftDispatch.dir/Block.swift.o: relocation R_X86_64_PC32 against protected symbol `$s8Dispatch0A13WorkItemFlagsVSYAAMc' can not be used when making a shared object
/usr/bin/ld: final link failed: bad value
```

Telling the built clang to use gold did not work so I'll need to figure out which clang the driver is trying to use here: https://github.com/apple/swift/pull/73463