### PR TITLE
[6.0🍒] Fix parsed name of the newly-added `SDKPlatformKind` to use raw toolchain name

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -289,8 +289,8 @@ public final class DarwinToolchain: Toolchain {
       case watchsimulator
       case appletvos
       case appletvsimulator
-      case visionos
-      case visionsimulator
+      case visionos = "xros"
+      case visionsimulator = "xrsimulator"
       case unknown
     }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4413,6 +4413,27 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testDarwinSDKToolchainName() throws {
+    var envVars = ProcessEnv.vars
+    envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)
+
+    try withTemporaryDirectory { tmpDir in
+      let sdk = tmpDir.appending(component: "XROS1.0.sdk")
+      try localFileSystem.createDirectory(sdk, recursive: true)
+      try localFileSystem.writeFileContents(sdk.appending(component: "SDKSettings.json"), bytes:
+        """
+        {
+          "Version":"1.0",
+          "CanonicalName": "xros1.0"
+        }
+        """
+      )
+
+      let sdkInfo = DarwinToolchain.readSDKInfo(localFileSystem, VirtualPath.absolute(sdk).intern())
+      XCTAssertEqual(sdkInfo?.platformKind, .visionos)
+    }
+  }
+
   // Test cases ported from Driver/macabi-environment.swift
   func testDarwinSDKVersioning() throws {
     var envVars = ProcessEnv.vars


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1598
-----------------------------------------
**Explanation**: This change fixes the enum used to represent platform kind to correctly detect the VisionOS SDK platform by using its toolchain name string as the raw value.

**Risk**: Low. The change seems to only affect code-paths used by the `swift-generate-sdk-interfaces` tool and will not affect other platforms.

**Testing**: Automated test added to the compiler test suite.

Resolves rdar://127704084