### PR TITLE
[6.0🍒] Do not warn on failure to in-process query target info or supported features

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -70,7 +70,7 @@ extension Driver {
         return supportedArgs
       }
     } catch {
-      diagnosticsEngine.emit(.warning_inprocess_supported_features_query_failed(error.localizedDescription))
+      diagnosticsEngine.emit(.remark_inprocess_supported_features_query_failed(error.localizedDescription))
     }
 
     // Fallback: Invoke `swift-frontend -emit-supported-features` and decode the output

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -256,7 +256,7 @@ extension Driver {
         return targetInfo
       }
     } catch {
-      diagnosticsEngine.emit(.warning_inprocess_target_info_query_failed(error.localizedDescription))
+      diagnosticsEngine.emit(.remark_inprocess_target_info_query_failed(error.localizedDescription))
     }
 
     // Fallback: Invoke `swift-frontend -print-target-info` and decode the output

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -51,12 +51,12 @@ extension Diagnostic.Message {
     .warning("inferring simulator environment for target '\(originalTriple.triple)'; use '-target \(inferredTriple.triple)' instead")
   }
 
-  static func warning_inprocess_target_info_query_failed(_ error: String) -> Diagnostic.Message {
-    .warning("In-process target-info query failed (\(error)). Using fallback mechanism.")
+  static func remark_inprocess_target_info_query_failed(_ error: String) -> Diagnostic.Message {
+    .remark("In-process target-info query failed (\(error)). Using fallback mechanism.")
   }
 
-  static func warning_inprocess_supported_features_query_failed(_ error: String) -> Diagnostic.Message {
-    .warning("In-process supported-compiler-features query failed (\(error)). Using fallback mechanism.")
+  static func remark_inprocess_supported_features_query_failed(_ error: String) -> Diagnostic.Message {
+    .remark("In-process supported-compiler-features query failed (\(error)). Using fallback mechanism.")
   }
 
   static func error_argument_not_allowed_with(arg: String, other: String) -> Diagnostic.Message {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1597
------------------------------
**Explanation**: These warnings are not actionable by the user. Instead issue a remark, so as to avoid having these messages being raised as issues in build logs.

**Risk**: None. Replaces an existing warning with a remark

**Reviewed by**: @owenv 