### PR TITLE
[Caching] Handle emit module job correctly for swift caching

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -119,6 +119,12 @@ extension Driver {
       commandLine.appendPath(abiPath.file)
       outputs.append(abiPath)
     }
+    let cacheContributingInputs = inputs.enumerated().reduce(into: [(TypedVirtualPath, Int)]()) { result, input in
+      // only the first swift input contributes cache key to an emit module job.
+      guard result.isEmpty, input.element.type == .swift else { return }
+      result.append((input.element, input.offset))
+    }
+    let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: cacheContributingInputs)
     return Job(
       moduleName: moduleOutputInfo.name,
       kind: .emitModule,
@@ -126,7 +132,8 @@ extension Driver {
       commandLine: commandLine,
       inputs: inputs,
       primaryInputs: [],
-      outputs: outputs
+      outputs: outputs,
+      outputCacheKeys: cacheKeys
     )
   }
 


### PR DESCRIPTION
There are two situations when emiting modules are not correctly handled when swift caching is enabled:
* When only `-emit-module` task is requested from driver, in this case, we are contructing a `CompileJob` but only generating module output. SwiftDriver still expects all swift inputs will have a cache key even only the first file is generating outputs and has a cache key.
* When using `-experimental-emit-module-separately`, then swift-driver needs to construct a `EmitModuleJob`, which wasn't taught the concept of caching and not producing any cache key.

rdar://127768967