### PR TITLE
Allow setting the clang++ environment variable

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -196,7 +196,10 @@ extension Toolchain {
 
   /// - Returns: String in the form of: `SWIFT_DRIVER_TOOLNAME_EXEC`
   private func envVarName(for toolName: String) -> String {
-    let lookupName = toolName.replacingOccurrences(of: "-", with: "_").uppercased()
+    let lookupName = toolName
+        .replacingOccurrences(of: "-", with: "_")
+        .replacingOccurrences(of: "+", with: "X")
+        .uppercased()
     return "SWIFT_DRIVER_\(lookupName)_EXEC"
   }
 


### PR DESCRIPTION
'+' isn't allowed in environment variable names so it's impossible to set the Clang++ executable at the moment. Replace `+` with `X` so that we can set `SWIFT_DRIVER_CLANGXX_EXEC` to set the clang++ executable.

Fixes: rdar://128007218