### PR TITLE
Suppress warning about missing SDKSettings.json for non-Darwin platforms

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2805,7 +2805,7 @@ extension Driver {
 
       if !fileSystem.exists(path) {
         diagnosticsEngine.emit(.warning_no_such_sdk(sdkPath))
-      } else if !(targetTriple?.isWindows ?? (defaultToolchainType == WindowsToolchain.self)) {
+      } else if (targetTriple?.isDarwin ?? (defaultToolchainType == DarwinToolchain.self)) {
         if isSDKTooOld(sdkPath: path, fileSystem: fileSystem,
                        diagnosticsEngine: diagnosticsEngine) {
           diagnosticsEngine.emit(.error_sdk_too_old(sdkPath))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4457,6 +4457,29 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testNonDarwinSDK() throws {
+    try withTemporaryDirectory { tmpDir in
+      let sdk = tmpDir.appending(component: "NonDarwin.sdk")
+      // SDK without SDKSettings.json should be ok for non-Darwin platforms
+      try localFileSystem.createDirectory(sdk, recursive: true)
+      for triple in ["x86_64-unknown-linux-gnu", "wasm32-unknown-wasi"] {
+        try assertDriverDiagnostics(args: "swiftc", "-target", triple, "foo.swift", "-sdk", sdk.pathString) {
+          $1.forbidUnexpected(.error, .warning)
+        }
+      }
+    }
+  }
+
+  func testDarwinSDKWithoutSDKSettings() throws {
+    try withTemporaryDirectory { tmpDir in
+      let sdk = tmpDir.appending(component: "MacOSX10.15.sdk")
+      try localFileSystem.createDirectory(sdk, recursive: true)
+      try assertDriverDiagnostics(args: "swiftc", "-target", "x86_64-apple-macosx10.15", "foo.swift", "-sdk", sdk.pathString) {
+        $1.expect(.warning("Could not read SDKSettings.json for SDK at: \(sdk.pathString)"))
+      }
+    }
+  }
+
   func testDarwinSDKToolchainName() throws {
     var envVars = ProcessEnv.vars
     envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)


### PR DESCRIPTION
The SDKSettings.json file is only used for Darwin platforms, so we should not emit a warning about it being missing for non-Darwin platforms.