### PR TITLE
Fail compilation with an error diagnostic when specified `SWIFT_DRIVER_<tool>_EXEC` argument does not exist

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -82,6 +82,7 @@ final class SwiftDriverTests: XCTestCase {
     // so there is no swift-help in the toolchain yet. Set the environment variable
     // as if we had found it for the purposes of testing build planning.
     var env = ProcessEnv.block
+    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_HELP_EXEC"] = "/tmp/.test-swift-help"
     return env
   }
@@ -2504,6 +2505,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testWebAssemblyUnsupportedFeatures() throws {
     var env = ProcessEnv.block
+    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
     do {
       var driver = try Driver(args: ["swift", "-target", "wasm32-unknown-wasi", "foo.swift"], env: env)
@@ -4841,6 +4843,7 @@ final class SwiftDriverTests: XCTestCase {
       // Drop SWIFT_DRIVER_CLANG_EXEC from the environment so it doesn't
       // interfere with tool lookup.
       var env = ProcessEnv.block
+      env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
       env.removeValue(forKey: "SWIFT_DRIVER_CLANG_EXEC")
 
       var driver = try Driver(args: ["swiftc",
@@ -5248,6 +5251,7 @@ final class SwiftDriverTests: XCTestCase {
       // As per Unix conventions, /var/empty is expected to exist and be empty.
       // This gives us a non-existent path that we can use for libtool which
       // allows us to run this this on non-Darwin platforms.
+      env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
       env["SWIFT_DRIVER_LIBTOOL_EXEC"] = "/var/empty/libtool"
 
       // No dSYM generation (-g -emit-library -static)
@@ -6760,6 +6764,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testEmbeddedSwiftOptions() throws {
     var env = ProcessEnv.block
+    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_AUTOLINK_EXTRACT_EXEC"] = "/garbage/swift-autolink-extract"
 
     do {
@@ -6916,6 +6921,7 @@ final class SwiftDriverTests: XCTestCase {
     // better override.
     var env = ProcessEnv.block
     let swiftHelp: AbsolutePath = try AbsolutePath(validating: "/usr/bin/nonexistent-swift-help")
+    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_SWIFT_HELP_EXEC"] = swiftHelp.pathString
     env["SWIFT_DRIVER_CLANG_EXEC"] = "/usr/bin/clang"
     var driver = try Driver(
@@ -6929,6 +6935,7 @@ final class SwiftDriverTests: XCTestCase {
   func testSwiftClangOverride() throws {
     var env = ProcessEnv.block
     let swiftClang = try AbsolutePath(validating: "/A/Path/swift-clang")
+    env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
     env["SWIFT_DRIVER_CLANG_EXEC"] = swiftClang.pathString
 
     var driver = try Driver(


### PR DESCRIPTION
Resolves rdar://128636621