### PR TITLE
Fix dash count to fuse-ld

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -50,9 +50,9 @@ extension GenericUnixToolchain {
     case .executable:
       // Select the linker to use.
       if let arg = parsedOptions.getLastArgument(.useLd)?.asSingle {
-        commandLine.appendFlag("--fuse-ld=\(arg)")
+        commandLine.appendFlag("-fuse-ld=\(arg)")
       } else if lto != nil {
-        commandLine.appendFlag("--fuse-ld=lld")
+        commandLine.appendFlag("-fuse-ld=lld")
       }
 
       if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2372,7 +2372,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       let lastJob = plannedJobs.last!
       XCTAssertTrue(lastJob.tool.name.contains("clang"))
-      XCTAssertTrue(lastJob.commandLine.contains(.flag("--fuse-ld=lld")))
+      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
     }
   }
 


### PR DESCRIPTION
`-fuse-ld` only has one dash, while `--ld-path` has two. We should pass them down correctly.