### PR TITLE
[unix] Fix linker argument in Unix toolchains

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -50,9 +50,9 @@ extension GenericUnixToolchain {
     case .executable:
       // Select the linker to use.
       if let arg = parsedOptions.getLastArgument(.useLd)?.asSingle {
-        commandLine.appendFlag("--fuse-ld=\(arg)")
+        commandLine.appendFlag("-fuse-ld=\(arg)")
       } else if lto != nil {
-        commandLine.appendFlag("--fuse-ld=lld")
+        commandLine.appendFlag("-fuse-ld=lld")
       }
 
       if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2372,7 +2372,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       let lastJob = plannedJobs.last!
       XCTAssertTrue(lastJob.tool.name.contains("clang"))
-      XCTAssertTrue(lastJob.commandLine.contains(.flag("--fuse-ld=lld")))
+      XCTAssertTrue(lastJob.commandLine.contains(.flag("-fuse-ld=lld")))
     }
   }
 


### PR DESCRIPTION
The spelling of the linker is `-fuse-ld=`, not `--fuse-ld=`, as it can be seen in [1] and as used in the C++ driver in [2].

The code was correct before #1545 using `-fuse-ld=`, but was changed to `--fuse-ld=`. The test was testing for the command line containing the same spelling, so it would had never failed, but running the actual command line would had failed. That code was eventually reverted and reverted back in #1608.

[1]: https://github.com/apple/llvm-project/blob/e33819dff1cbf7a90b0216a4993126cb11440d45/clang/include/clang/Driver/Options.td#L5267
[2]: https://github.com/apple/swift/blob/319f36b01baa082fd2d2640d6e320594752702d0/lib/Driver/UnixToolChains.cpp#L234