### PR TITLE
Revert "[Explicit Module Builds][Incremental Builds] Re-compile module dependencies whose dependencies are up-to-date themselves but are themselves newer"

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import func TSCBasic.topologicalSort
-import protocol TSCBasic.FileSystem
 
 @_spi(Testing) public extension InterModuleDependencyGraph {
   /// For targets that are built alongside the driver's current module, the scanning action will report them as
@@ -253,82 +252,6 @@ extension InterModuleDependencyGraph {
                       directDependencies: combinedDependencies,
                       linkLibraries: combinedLinkLibraries,
                       details: .clang(combinedModuleDetails))
-  }
-}
-
-/// Incremental Build Machinery
-internal extension InterModuleDependencyGraph {
-  /// We must determine if any of the module dependencies require re-compilation
-  /// Since we know that a prior dependency graph was not completely up-to-date,
-  /// there must be at least *some* dependencies that require being re-built.
-  ///
-  /// If a dependency is deemed as requiring a re-build, then every module
-  /// between it and the root (source module being built by this driver
-  /// instance) must also be re-built.
-  func computeInvalidatedModuleDependencies(fileSystem: FileSystem,
-                                            reporter: IncrementalCompilationState.Reporter? = nil)
-  throws -> Set<ModuleDependencyId> {
-    let mainModuleInfo = mainModule
-    var modulesRequiringRebuild: Set<ModuleDependencyId> = []
-    var visited: Set<ModuleDependencyId> = []
-    // Scan from the main module's dependencies to avoid reporting
-    // the main module itself in the results.
-    for dependencyId in mainModuleInfo.directDependencies ?? [] {
-      try outOfDateModuleScan(from: dependencyId, visited: &visited,
-                              modulesRequiringRebuild: &modulesRequiringRebuild,
-                              fileSystem: fileSystem, reporter: reporter)
-    }
-
-    reporter?.reportExplicitDependencyReBuildSet(Array(modulesRequiringRebuild))
-    return modulesRequiringRebuild
-  }
-
-  /// Perform a postorder DFS to locate modules which are out-of-date with respect
-  /// to their inputs. Upon encountering such a module, add it to the set of invalidated
-  /// modules, along with the path from the root to this module.
-  func outOfDateModuleScan(from sourceModuleId: ModuleDependencyId,
-                           visited: inout Set<ModuleDependencyId>,
-                           modulesRequiringRebuild: inout Set<ModuleDependencyId>,
-                           fileSystem: FileSystem,
-                           reporter: IncrementalCompilationState.Reporter? = nil) throws {
-    let sourceModuleInfo = try moduleInfo(of: sourceModuleId)
-    // Visit the module's dependencies
-    var hasOutOfDateModuleDependency = false
-    var mostRecentlyUpdatedDependencyOutput: TimePoint = .zero
-    for dependencyId in sourceModuleInfo.directDependencies ?? [] {
-      // If we have not already visited this module, recurse.
-      if !visited.contains(dependencyId) {
-        try outOfDateModuleScan(from: dependencyId, visited: &visited,
-                                modulesRequiringRebuild: &modulesRequiringRebuild,
-                                fileSystem: fileSystem, reporter: reporter)
-      }
-      // Even if we're not revisiting a dependency, we must check if it's already known to be out of date.
-      hasOutOfDateModuleDependency = hasOutOfDateModuleDependency || modulesRequiringRebuild.contains(dependencyId)
-
-      // Keep track of dependencies' output file time stamp to determine if it is newer than the current module.
-      if let depOutputTimeStamp = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(moduleInfo(of: dependencyId).modulePath.path)),
-         depOutputTimeStamp > mostRecentlyUpdatedDependencyOutput {
-        mostRecentlyUpdatedDependencyOutput = depOutputTimeStamp
-      }
-    }
-
-    if hasOutOfDateModuleDependency {
-      reporter?.reportExplicitDependencyWillBeReBuilt(sourceModuleId.moduleNameForDiagnostic, reason: "Invalidated by downstream dependency")
-      modulesRequiringRebuild.insert(sourceModuleId)
-    } else if try !IncrementalCompilationState.IncrementalDependencyAndInputSetup.verifyModuleDependencyUpToDate(moduleID: sourceModuleId, moduleInfo: sourceModuleInfo,
-                                                                                                                 fileSystem: fileSystem, reporter: reporter) {
-      reporter?.reportExplicitDependencyWillBeReBuilt(sourceModuleId.moduleNameForDiagnostic, reason: "Out-of-date")
-      modulesRequiringRebuild.insert(sourceModuleId)
-    } else if let outputModTime = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(sourceModuleInfo.modulePath.path)),
-              outputModTime < mostRecentlyUpdatedDependencyOutput {
-      // If a prior variant of this module dependnecy exists, and is older than any of its direct or transitive
-      // module dependency outputs, it must also be re-built.
-      reporter?.reportExplicitDependencyWillBeReBuilt(sourceModuleId.moduleNameForDiagnostic, reason: "Has newer module dependency inputs")
-      modulesRequiringRebuild.insert(sourceModuleId)
-    }
-
-    // Now that we've determined if this module must be rebuilt, mark it as visited.
-    visited.insert(sourceModuleId)
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -184,7 +184,7 @@ import class Dispatch.DispatchQueue
     try? fileSystem.removeFileTree(absPath)
   }
 
-  func readPriorInterModuleDependencyGraph(
+  func readOutOfDateInterModuleDependencyGraph(
     reporter: IncrementalCompilationState.Reporter?
   ) -> InterModuleDependencyGraph? {
     let decodedGraph: InterModuleDependencyGraph

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -155,9 +155,7 @@ extension IncrementalCompilationState.FirstWaveComputer {
 
     // Determine which module pre-build jobs must be re-run
     let modulesRequiringReBuild =
-      try moduleDependencyGraph.computeInvalidatedModuleDependencies(fileSystem: fileSystem,
-                                                                     forRebuild: true,
-                                                                     reporter: reporter)
+      try moduleDependencyGraph.computeInvalidatedModuleDependencies(fileSystem: fileSystem, reporter: reporter)
 
     // Filter the `.generatePCM` and `.compileModuleFromInterface` jobs for 
     // modules which do *not* need re-building.

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -138,6 +138,75 @@ extension IncrementalCompilationState.FirstWaveComputer {
             mandatoryJobsInOrder: mandatoryJobsInOrder)
   }
 
+  /// We must determine if any of the module dependencies require re-compilation
+  /// Since we know that a prior dependency graph was not completely up-to-date,
+  /// there must be at least *some* dependencies that require being re-built.
+  ///
+  /// If a dependency is deemed as requiring a re-build, then every module
+  /// between it and the root (source module being built by this driver
+  /// instance) must also be re-built.
+  private func computeInvalidatedModuleDependencies(on moduleDependencyGraph: InterModuleDependencyGraph)
+  throws -> Set<ModuleDependencyId> {
+    let mainModuleInfo = moduleDependencyGraph.mainModule
+    var modulesRequiringRebuild: Set<ModuleDependencyId> = []
+    var visited: Set<ModuleDependencyId> = []
+    // Scan from the main module's dependencies to avoid reporting
+    // the main module itself in the results.
+    for dependencyId in mainModuleInfo.directDependencies ?? [] {
+      try outOfDateModuleScan(on: moduleDependencyGraph, from: dependencyId, 
+                              visited: &visited, modulesRequiringRebuild: &modulesRequiringRebuild)
+    }
+
+    reporter?.reportExplicitDependencyReBuildSet(Array(modulesRequiringRebuild))
+    return modulesRequiringRebuild
+  }
+
+  /// Perform a postorder DFS to locate modules which are out-of-date with respect
+  /// to their inputs. Upon encountering such a module, add it to the set of invalidated
+  /// modules, along with the path from the root to this module.
+  private func outOfDateModuleScan(on moduleDependencyGraph: InterModuleDependencyGraph,
+                                   from moduleId: ModuleDependencyId,
+                                   visited: inout Set<ModuleDependencyId>,
+                                   modulesRequiringRebuild: inout Set<ModuleDependencyId>) throws {
+    let moduleInfo = try moduleDependencyGraph.moduleInfo(of: moduleId)
+    // Visit the module's dependencies
+    var hasOutOfDateModuleDependency = false
+    var mostRecentlyUpdatedDependencyOutput: TimePoint = .zero
+    for dependencyId in moduleInfo.directDependencies ?? [] {
+      // If we have not already visited this module, recurse.
+      if !visited.contains(dependencyId) {
+        try outOfDateModuleScan(on: moduleDependencyGraph, from: dependencyId,
+                                visited: &visited, modulesRequiringRebuild: &modulesRequiringRebuild)
+      }
+      // Even if we're not revisiting a dependency, we must check if it's already known to be out of date.
+      hasOutOfDateModuleDependency = hasOutOfDateModuleDependency || modulesRequiringRebuild.contains(dependencyId)
+
+      // Keep track of dependencies' output file time stamp to determine if it is newer than the current module.
+      if let depOutputTimeStamp = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(moduleDependencyGraph.moduleInfo(of: dependencyId).modulePath.path)),
+         depOutputTimeStamp > mostRecentlyUpdatedDependencyOutput {
+        mostRecentlyUpdatedDependencyOutput = depOutputTimeStamp
+      }
+    }
+
+    if hasOutOfDateModuleDependency {
+      reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Invalidated by downstream dependency")
+      modulesRequiringRebuild.insert(moduleId)
+    } else if try !IncrementalCompilationState.IncrementalDependencyAndInputSetup.verifyModuleDependencyUpToDate(moduleID: moduleId, moduleInfo: moduleInfo,
+                                                                                                                 fileSystem: fileSystem, reporter: reporter) {
+      reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Out-of-date")
+      modulesRequiringRebuild.insert(moduleId)
+    } else if let outputModTime = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(moduleInfo.modulePath.path)),
+              outputModTime < mostRecentlyUpdatedDependencyOutput {
+      // If a prior variant of this module dependnecy exists, and is older than any of its direct or transitive
+      // module dependency outputs, it must also be re-built.
+      reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Has newer module dependency inputs")
+      modulesRequiringRebuild.insert(moduleId)
+    }
+
+    // Now that we've determined if this module must be rebuilt, mark it as visited.
+    visited.insert(moduleId)
+  }
+
   /// In an explicit module build, filter out dependency module pre-compilation tasks
   /// for modules up-to-date from a prior compile.
   private func computeMandatoryBeforeCompilesJobs() throws -> [Job] {
@@ -155,7 +224,7 @@ extension IncrementalCompilationState.FirstWaveComputer {
 
     // Determine which module pre-build jobs must be re-run
     let modulesRequiringReBuild =
-      try moduleDependencyGraph.computeInvalidatedModuleDependencies(fileSystem: fileSystem, reporter: reporter)
+        try computeInvalidatedModuleDependencies(on: moduleDependencyGraph)
 
     // Filter the `.generatePCM` and `.compileModuleFromInterface` jobs for 
     // modules which do *not* need re-building.

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -149,12 +149,12 @@ extension IncrementalCompilationState.FirstWaveComputer {
   throws -> Set<ModuleDependencyId> {
     let mainModuleInfo = moduleDependencyGraph.mainModule
     var modulesRequiringRebuild: Set<ModuleDependencyId> = []
-    var visited: Set<ModuleDependencyId> = []
+    var visitedModules: Set<ModuleDependencyId> = []
     // Scan from the main module's dependencies to avoid reporting
     // the main module itself in the results.
     for dependencyId in mainModuleInfo.directDependencies ?? [] {
-      try outOfDateModuleScan(on: moduleDependencyGraph, from: dependencyId, 
-                              visited: &visited, modulesRequiringRebuild: &modulesRequiringRebuild)
+      try outOfDateModuleScan(on: moduleDependencyGraph, from: dependencyId, visited: &visitedModules,
+                              modulesRequiringRebuild: &modulesRequiringRebuild)
     }
 
     reporter?.reportExplicitDependencyReBuildSet(Array(modulesRequiringRebuild))
@@ -171,36 +171,24 @@ extension IncrementalCompilationState.FirstWaveComputer {
     let moduleInfo = try moduleDependencyGraph.moduleInfo(of: moduleId)
     // Visit the module's dependencies
     var hasOutOfDateModuleDependency = false
-    var mostRecentlyUpdatedDependencyOutput: TimePoint = .zero
     for dependencyId in moduleInfo.directDependencies ?? [] {
       // If we have not already visited this module, recurse.
       if !visited.contains(dependencyId) {
         try outOfDateModuleScan(on: moduleDependencyGraph, from: dependencyId,
-                                visited: &visited, modulesRequiringRebuild: &modulesRequiringRebuild)
+                                visited: &visited,
+                                modulesRequiringRebuild: &modulesRequiringRebuild)
       }
       // Even if we're not revisiting a dependency, we must check if it's already known to be out of date.
       hasOutOfDateModuleDependency = hasOutOfDateModuleDependency || modulesRequiringRebuild.contains(dependencyId)
-
-      // Keep track of dependencies' output file time stamp to determine if it is newer than the current module.
-      if let depOutputTimeStamp = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(moduleDependencyGraph.moduleInfo(of: dependencyId).modulePath.path)),
-         depOutputTimeStamp > mostRecentlyUpdatedDependencyOutput {
-        mostRecentlyUpdatedDependencyOutput = depOutputTimeStamp
-      }
     }
 
     if hasOutOfDateModuleDependency {
-      reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Invalidated by downstream dependency")
-      modulesRequiringRebuild.insert(moduleId)
+        reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Invalidated by downstream dependency")
+        modulesRequiringRebuild.insert(moduleId)
     } else if try !IncrementalCompilationState.IncrementalDependencyAndInputSetup.verifyModuleDependencyUpToDate(moduleID: moduleId, moduleInfo: moduleInfo,
                                                                                                                  fileSystem: fileSystem, reporter: reporter) {
-      reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Out-of-date")
-      modulesRequiringRebuild.insert(moduleId)
-    } else if let outputModTime = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(moduleInfo.modulePath.path)),
-              outputModTime < mostRecentlyUpdatedDependencyOutput {
-      // If a prior variant of this module dependnecy exists, and is older than any of its direct or transitive
-      // module dependency outputs, it must also be re-built.
-      reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Has newer module dependency inputs")
-      modulesRequiringRebuild.insert(moduleId)
+        reporter?.reportExplicitDependencyWillBeReBuilt(moduleId.moduleNameForDiagnostic, reason: "Out-of-date")
+        modulesRequiringRebuild.insert(moduleId)
     }
 
     // Now that we've determined if this module must be rebuilt, mark it as visited.

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -308,11 +308,6 @@ extension IncrementalCompilationState {
       report("Dependency module '\(moduleOutputPath)' will be re-built: \(reason)")
     }
 
-    func reportPriorExplicitDependencyStale(_ moduleOutputPath: String,
-                                               reason: String) {
-      report("Dependency module '\(moduleOutputPath)' info is stale: \(reason)")
-    }
-
     func reportExplicitDependencyReBuildSet(_ modules: [ModuleDependencyId]) {
       report("Following explicit module dependencies will be re-built: [\(modules.map { $0.moduleNameForDiagnostic }.sorted().joined(separator: ", "))]")
     }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -106,7 +106,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
   ) throws -> InterModuleDependencyGraph? {
     // Attempt to read a serialized inter-module dependency graph from a prior build
     guard let priorInterModuleDependencyGraph =
-        buildRecordInfo.readPriorInterModuleDependencyGraph(reporter: reporter),
+        buildRecordInfo.readOutOfDateInterModuleDependencyGraph(reporter: reporter),
           let priorImports = priorInterModuleDependencyGraph.mainModule.directDependencies?.map({ $0.moduleName }) else {
       reporter?.reportExplicitBuildMustReScan("Could not read inter-module dependency graph at \(buildRecordInfo.interModuleDependencyGraphPath)")
       return nil

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -120,15 +120,108 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     }
 
     // Verify that each dependnecy is up-to-date with respect to its inputs
-    guard try priorInterModuleDependencyGraph.computeInvalidatedModuleDependencies(fileSystem: buildRecordInfo.fileSystem,
-                                                                                   forRebuild: false,
-                                                                                   reporter: reporter).isEmpty else {
+    guard try verifyInterModuleDependenciesUpToDate(in: priorInterModuleDependencyGraph,
+                                                    buildRecordInfo: buildRecordInfo,
+                                                    reporter: reporter) else {
       reporter?.reportExplicitBuildMustReScan("Not all dependencies are up-to-date.")
       return nil
     }
 
     reporter?.report("Confirmed prior inter-module dependency graph is up-to-date at: \(buildRecordInfo.interModuleDependencyGraphPath)")
     return priorInterModuleDependencyGraph
+  }
+
+  static func verifyModuleDependencyUpToDate(moduleID: ModuleDependencyId, moduleInfo: ModuleInfo,
+                                             fileSystem: FileSystem,
+                                             reporter: IncrementalCompilationState.Reporter?) throws -> Bool {
+    // Verify that the specified input exists and is older than the specified output
+    let verifyInputOlderThanOutputModTime: (String, VirtualPath, VirtualPath, TimePoint) -> Bool =
+    { moduleName, inputPath, outputPath, outputModTime in
+      guard let inputModTime =
+              try? fileSystem.lastModificationTime(for: inputPath) else {
+        reporter?.report("Unable to 'stat' \(inputPath.description)")
+        return false
+      }
+      if inputModTime > outputModTime {
+        reporter?.reportExplicitDependencyOutOfDate(moduleName,
+                                                    inputPath: inputPath.description)
+        return false
+      }
+      return true
+    }
+
+    switch moduleInfo.details {
+    case .swift(let swiftDetails):
+      guard let outputModTime = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(moduleInfo.modulePath.path)) else {
+        reporter?.report("Module output not found: '\(moduleID.moduleNameForDiagnostic)'")
+        return false
+      }
+      if let moduleInterfacePath = swiftDetails.moduleInterfacePath {
+        if !verifyInputOlderThanOutputModTime(moduleID.moduleName,
+                                              VirtualPath.lookup(moduleInterfacePath.path),
+                                              VirtualPath.lookup(moduleInfo.modulePath.path),
+                                              outputModTime) {
+          return false
+        }
+      }
+      if let bridgingHeaderPath = swiftDetails.bridgingHeaderPath {
+        if !verifyInputOlderThanOutputModTime(moduleID.moduleName,
+                                              VirtualPath.lookup(bridgingHeaderPath.path),
+                                              VirtualPath.lookup(moduleInfo.modulePath.path),
+                                              outputModTime) {
+          return false
+        }
+      }
+      for bridgingSourceFile in swiftDetails.bridgingSourceFiles ?? [] {
+        if !verifyInputOlderThanOutputModTime(moduleID.moduleName,
+                                              VirtualPath.lookup(bridgingSourceFile.path),
+                                              VirtualPath.lookup(moduleInfo.modulePath.path),
+                                              outputModTime) {
+          return false
+        }
+      }
+    case .clang(_):
+      guard let outputModTime = try? fileSystem.lastModificationTime(for: VirtualPath.lookup(moduleInfo.modulePath.path)) else {
+        reporter?.report("Module output not found: '\(moduleID.moduleNameForDiagnostic)'")
+        return false
+      }
+      for inputSourceFile in moduleInfo.sourceFiles ?? [] {
+        if !verifyInputOlderThanOutputModTime(moduleID.moduleName,
+                                              try VirtualPath(path: inputSourceFile),
+                                              VirtualPath.lookup(moduleInfo.modulePath.path),
+                                              outputModTime) {
+          return false
+        }
+      }
+    case .swiftPrebuiltExternal(_):
+      // TODO: We have to give-up here until we have a way to verify the timestamp of the binary module.
+      // We can do better here by knowing if this module hasn't change - which would allows us to not
+      // invalidate any of the dependencies that depend on it.
+      reporter?.report("Unable to verify binary module dependency up-to-date: \(moduleID.moduleNameForDiagnostic)")
+      return false;
+    case .swiftPlaceholder(_):
+      // TODO: This should never ever happen. Hard error?
+      return false;
+    }
+    return true
+  }
+
+  /// For each direct and transitive module dependency, check if any of the inputs are newer than the output
+  static func verifyInterModuleDependenciesUpToDate(in graph: InterModuleDependencyGraph,
+                                                    buildRecordInfo: BuildRecordInfo,
+                                                    reporter: IncrementalCompilationState.Reporter?) throws -> Bool {
+    for module in graph.modules {
+      if module.key == .swift(graph.mainModuleName) {
+        continue
+      }
+      if try !verifyModuleDependencyUpToDate(moduleID: module.key, 
+                                             moduleInfo: module.value,
+                                             fileSystem: buildRecordInfo.fileSystem,
+                                             reporter: reporter) {
+        return false
+      }
+    }
+    return true
   }
 }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -382,6 +382,7 @@ extension IncrementalCompilationTests {
   // On this graph, inputs of 'G' are updated, causing it to be re-built
   // as well as all modules on paths from root to it: 'Y', 'H', 'T','J'
   func testExplicitIncrementalBuildChangedDependencyInvalidatesUpstreamDependencies() throws {
+    // Add an import of 'B', 'C' to make sure followup changes has consistent inputs
     replace(contentsOf: "other", with: "import Y;import T")
     try buildInitialState(checkDiagnostics: false, explicitModuleBuild: true)
 
@@ -426,62 +427,6 @@ extension IncrementalCompilationTests {
       compilingExplicitSwiftDependency("T")
       compilingExplicitSwiftDependency("Y")
       compilingExplicitSwiftDependency("H")
-      schedulingPostCompileJobs
-      linking
-    }
-  }
-
-  // A dependency has been re-built to be newer than its dependents
-  // so we must ensure the dependents get re-built even though all the
-  // modules are up-to-date with respect to their textual source inputs.
-  //
-  //             test
-  //                 \
-  //                  J
-  //                   \
-  //                    G
-  //
-  // On this graph, after the initial build, if G module binary file is newer
-  // than that of J, even if each of the modules is up-to-date w.r.t. their source inputs
-  // we still expect that J gets re-built
-  func testExplicitIncrementalBuildChangedDependencyBinaryInvalidatesUpstreamDependencies() throws {
-    replace(contentsOf: "other", with: "import J;")
-    try buildInitialState(checkDiagnostics: false, explicitModuleBuild: true)
-
-    let modCacheEntries = try localFileSystem.getDirectoryContents(explicitModuleCacheDir)
-    let nameOfGModule = try XCTUnwrap(modCacheEntries.first { $0.hasPrefix("G") && $0.hasSuffix(".swiftmodule")})
-    let pathToGModule = explicitModuleCacheDir.appending(component: nameOfGModule)
-    // Just update the time-stamp of one of the module dependencies' outputs.
-    // Also add a dependency to cause a re-scan.
-    touch(pathToGModule)
-    replace(contentsOf: "other", with: "import J;import R")
-
-    // Changing a dependency will mean that we both re-run the dependency scan,
-    // and also ensure that all source-files are re-built with a non-cascading build
-    // since the source files themselves have not changed.
-    try doABuild(
-      "update dependency (G) result timestamp",
-      checkDiagnostics: true,
-      extraArguments: explicitBuildArgs,
-      whenAutolinking: autolinkLifecycleExpectedDiags
-    ) {
-      readGraph
-      enablingCrossModule
-      readInterModuleGraph
-      explicitMustReScanDueToChangedImports
-      maySkip("main")
-      schedulingChangedInitialQueuing("other")
-      skipping("main")
-      findingBatchingCompiling("other")
-      reading(deps: "other")
-      fingerprintsChanged("other")
-      moduleOutputNotFound("R")
-      moduleWillBeRebuiltOutOfDate("R")
-      compilingExplicitSwiftDependency("R")
-      explicitModulesWillBeRebuilt(["J", "R"])
-      explicitDependencyNewerModuleInputs("J")
-      compilingExplicitSwiftDependency("J")
-      skipped("main")
       schedulingPostCompileJobs
       linking
     }
@@ -1699,9 +1644,6 @@ extension DiagVerifiable {
   }
   @DiagsBuilder func explicitDependencyInvalidatedDownstream(_ moduleName: String) -> [Diagnostic.Message] {
     "Incremental compilation: Dependency module '\(moduleName)' will be re-built: Invalidated by downstream dependency"
-  }
-  @DiagsBuilder func explicitDependencyNewerModuleInputs(_ moduleName: String) -> [Diagnostic.Message] {
-    "Incremental compilation: Dependency module '\(moduleName)' will be re-built: Has newer module dependency inputs"
   }
 
   // MARK: - misc


### PR DESCRIPTION
Reverts apple/swift-driver#1628

Reverting because the test here fails nondeterministically when run in parallel. Need to make changes to the test harness to isolate it better. 