### PR TITLE
[SwiftScan] Fix headerDependencies in SwiftPrebuiltExternalModuleDetails

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -165,14 +165,18 @@ typedef struct {
   (*swiftscan_swift_binary_detail_get_module_doc_path)(swiftscan_module_details_t);
   swiftscan_string_ref_t
   (*swiftscan_swift_binary_detail_get_module_source_info_path)(swiftscan_module_details_t);
-  swiftscan_string_set_t *
-  (*swiftscan_swift_binary_detail_get_header_dependencies)(swiftscan_module_details_t);
+  swiftscan_string_ref_t
+  (*swiftscan_swift_binary_detail_get_header_dependency)(swiftscan_module_details_t);
   bool
   (*swiftscan_swift_binary_detail_get_is_framework)(swiftscan_module_details_t);
   swiftscan_string_ref_t
   (*swiftscan_swift_binary_detail_get_module_cache_key)(swiftscan_module_details_t);
   swiftscan_string_set_t *
   (*swiftscan_swift_binary_detail_get_header_dependency_module_dependencies)(swiftscan_module_details_t);
+
+  //=== Swift Binary Module Details deprecated APIs--------------------------===//
+  swiftscan_string_set_t *
+  (*swiftscan_swift_binary_detail_get_header_dependencies)(swiftscan_module_details_t);
 
   //=== Swift Placeholder Module Details query APIs -------------------------===//
   swiftscan_string_ref_t

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -150,7 +150,7 @@ public class InterModuleDependencyOracle {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to query supported scanner API with no scanner instance.")
     }
-    return swiftScan.supportsBinaryModuleHeaderDependencies
+    return swiftScan.supportsBinaryModuleHeaderDependencies || swiftScan.supportsBinaryModuleHeaderDependency
   }
 
   @_spi(Testing) public func supportsBridgingHeaderPCHCommand() throws -> Bool {

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -264,6 +264,10 @@ private extension SwiftScan {
     if supportsBinaryModuleHeaderDependencies {
       headerDependencies = try getOptionalPathArrayDetail(from: moduleDetailsRef,
                                                           using: api.swiftscan_swift_binary_detail_get_header_dependencies)
+    } else if supportsBinaryModuleHeaderDependency,
+              let header = try getOptionalPathDetail(from: moduleDetailsRef,
+                                                     using: api.swiftscan_swift_binary_detail_get_header_dependency) {
+      headerDependencies = [header]
     } else {
       headerDependencies = nil
     }

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -298,6 +298,10 @@ private extension String {
     return api.swiftscan_swift_binary_detail_get_header_dependencies != nil
   }
 
+  @_spi(Testing) public var supportsBinaryModuleHeaderDependency : Bool {
+    return api.swiftscan_swift_binary_detail_get_header_dependency != nil
+  }
+
   @_spi(Testing) public var supportsStringDispose : Bool {
     return api.swiftscan_string_dispose != nil
   }
@@ -655,6 +659,8 @@ private extension swiftscan_functions_t {
     // Header dependencies of binary modules
     self.swiftscan_swift_binary_detail_get_header_dependencies =
       try loadOptional("swiftscan_swift_binary_detail_get_header_dependencies")
+    self.swiftscan_swift_binary_detail_get_header_dependency =
+      try loadOptional("swiftscan_swift_binary_detail_get_header_dependency")
 
     // Per-scan-query diagnostic output
     self.swiftscan_dependency_graph_get_diagnostics =


### PR DESCRIPTION
Due to C API renaming, swift-driver failed to record the bridging header path from a binary swift module dependencies. Fix the issue by supporting both old and new C APIs for querying bridging header path.

rdar://129703095