### PR TITLE
Response files should be named using the hash of the command line arguments only

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -15,6 +15,7 @@ import class Foundation.NSLock
 import func TSCBasic.withTemporaryDirectory
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.SHA256
 
 @_implementationOnly import Yams
 
@@ -208,7 +209,8 @@ public final class ArgsResolver {
       assert(!forceResponseFiles || job.supportsResponseFiles,
              "Platform does not support response files for job: \(job)")
       // Match the integrated driver's behavior, which uses response file names of the form "arguments-[0-9a-zA-Z].resp".
-      let responseFilePath = temporaryDirectory.appending(component: "arguments-\(abs(job.hashValue)).resp")
+      let hash = SHA256().hash(resolvedArguments.joined(separator: " ")).hexadecimalRepresentation
+      let responseFilePath = temporaryDirectory.appending(component: "arguments-\(hash).resp")
 
       // FIXME: Need a way to support this for distributed build systems...
       if let absPath = responseFilePath.absolutePath {


### PR DESCRIPTION
- Including the full hash of the job can lead to unnecessary duplication of the file, inhibiting job deduplication
- Use a stable hash to ensure the response file name does not change from one process execution to the next