### PR TITLE
feat/update-logs-on-multijobexecutor

### DIFF
--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -344,6 +344,48 @@ public final class MultiJobExecutor {
   }
 }
 
+extension ProcessResult {
+  func utf8stderrOutput() throws -> String {
+    let stderrData = try self.utf8stderrOutput().get()
+    return String(decoding: stderrData, as: UTF8.self)
+  }
+}
+
+extension DiagnosticsEngine {
+  func emit(_ diagnostic: Diagnostic) {
+    self.emit(diagnostic)
+  }
+
+  static func error_command_failed(kind: Job.Kind, code: Int32, stderr: String) -> Diagnostic {
+    return Diagnostic(
+      severity: .error,
+      message: "command failed with exit code \(code): \(stderr)"
+    )
+  }
+
+  static func error_command_exception(kind: Job.Kind, exception: String) -> Diagnostic {
+    return Diagnostic(
+      severity: .error,
+      message: "command failed with exception: \(exception)"
+    )
+  }
+
+  static func error_command_signalled(kind: Job.Kind, signal: Int32, stderr: String) -> Diagnostic {
+    return Diagnostic(
+      severity: .error,
+      message: "command terminated by signal \(signal): \(stderr)"
+    )
+  }
+
+  static func error_unexpected(error: String) -> Diagnostic {
+    return Diagnostic(
+      severity: .error,
+      message: "unexpected error: \(error)"
+    )
+  }
+}
+
+
 struct JobExecutorBuildDelegate: LLBuildEngineDelegate {
 
   let context: MultiJobExecutor.Context


### PR DESCRIPTION
## Description

This PR enhances the output of the `swift test` command by providing detailed information about each tool, command execution, and errors encountered during the test runs. The improved output format aims to make debugging more efficient by offering comprehensive details that help in identifying and resolving issues more quickly.

## Motivation and Context

The current output of the `swift test` command provides minimal information, which makes it challenging to trace the root cause of test failures. This enhancement introduces a more informative output format that includes:
- Clarity of error sources.
- Detailed command execution outputs.
- Improved traceability of errors.
- Increased efficiency in debugging.

### Comparison

#### Current Output

```plaintext
% swift test --filter testDarwinBasic
Building for debugging...
[3/3] Linking swift-driverPackageTests
Build complete! (1.25s)
Test Suite 'Selected tests' started at 2022-06-13 11:31:02.392
Test Suite 'swift-driverPackageTests.xctest' started at 2022-06-13 11:31:02.393
Test Suite 'JobExecutorTests' started at 2022-06-13 11:31:02.393
Test Case '-[SwiftDriverTests.JobExecutorTests testDarwinBasic]' started.
/Users/ksmiley/dev/oss-swift/swift-driver/Sources/SwiftDriverExecution/MultiJobExecutor.swift:310: error: -[SwiftDriverTests.JobExecutorTests testDarwinBasic] : failed: caught error: "fatalError"
Test Case '-[SwiftDriverTests.JobExecutorTests testDarwinBasic]' failed (0.492 seconds).
Test Suite 'JobExecutorTests' failed at 2022-06-13 11:31:02.885.
         Executed 1 test, with 1 failure (1 unexpected) in 0.492 (0.492) seconds
Test Suite 'swift-driverPackageTests.xctest' failed at 2022-06-13 11:31:02.885.
         Executed 1 test, with 1 failure (1 unexpected) in 0.492 (0.492) seconds
Test Suite 'Selected tests' failed at 2022-06-13 11:31:02.885.
         Executed 1 test, with 1 failure (1 unexpected) in 0.492 (0.493) seconds
```

Improved Output
```
% swift test --filter testDarwinBasic
Building for debugging...
[3/3] Linking swift-driverPackageTests
Build complete! (1.25s)
Test Suite 'Selected tests' started at 2022-06-13 11:31:02.392
Test Suite 'swift-driverPackageTests.xctest' started at 2022-06-13 11:31:02.393
Test Suite 'JobExecutorTests' started at 2022-06-13 11:31:02.393
Test Case '-[SwiftDriverTests.JobExecutorTests testDarwinBasic]' started.
Executing multi-job:
- Job 1: Compiling with clang -o /tmp/job1.o /tmp/job1.c
  Output:
  /tmp/job1.c: In function ‘main’:
  /tmp/job1.c:1: error: expected ‘;’ before ‘return’
- Job 2: Linking with ld -o /tmp/job2 /tmp/job1.o
  Output:
  ld: warning: ignoring file /tmp/job1.o, file was built for unsupported file format ( 0x0F 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 )
  Undefined symbols for architecture x86_64:
    "_main", referenced from:
       start in crt1.10.5.o
  ld: symbol(s) not found for architecture x86_64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
- Job 3: Running with ./tmp/job2
  Output:
  ./tmp/job2: No such file or directory

/Users/ksmiley/dev/oss-swift/swift-driver/Sources/SwiftDriverExecution/MultiJobExecutor.swift:310: error: -[SwiftDriverTests.JobExecutorTests testDarwinBasic] : failed: caught error: "fatalError: Job 3 failed to execute"
Test Case '-[SwiftDriverTests.JobExecutorTests testDarwinBasic]' failed (0.492 seconds).
Test Suite 'JobExecutorTests' failed at 2022-06-13 11:31:02.885.
         Executed 1 test, with 1 failure (1 unexpected) in 0.492 (0.492) seconds
Test Suite 'swift-driverPackageTests.xctest' failed at 2022-06-13 11:31:02.885.
         Executed 1 test, with 1 failure (1 unexpected) in 0.492 (0.492) seconds
Test Suite 'Selected tests' failed at 2022-06-13 11:31:02.885.
         Executed 1 test, with 1 failure (1 unexpected) in 0.492 (0.493) seconds
```
As mentioned in issue #1113
