### PR TITLE
Align Clang resource directory lookup with Clang driver logic

### DIFF
--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -26,12 +26,7 @@ extension Toolchain {
     for targetInfo: FrontendTargetInfo,
     parsedOptions: inout ParsedOptions
   ) throws -> VirtualPath {
-    var platform = targetInfo.target.triple.platformName(conflatingDarwin: true)!
-    // compiler-rt moved these Android sanitizers into `lib/linux/` a couple
-    // years ago, llvm/llvm-project@a68ccba, so look for them there instead.
-    if platform == "android" {
-      platform = "linux"
-    }
+    let platform = targetInfo.target.triple.clangOSLibName
 
     // NOTE(compnerd) Windows uses the per-target runtime directory for the
     // Windows runtimes. This should also be done for the other platforms, but

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -303,7 +303,28 @@ extension Triple {
     }
   }
 
-  /// The platform name, i.e. the name clang uses to identify this target in its
+
+  /// The "os" component of the Clang compiler resource library directory (`<ResourceDir>/lib/<OSName>`).
+  /// Must be kept in sync with Clang driver:
+  /// https://github.com/llvm/llvm-project/blob/llvmorg-20.1.4/clang/lib/Driver/ToolChain.cpp#L690
+  @_spi(Testing) public var clangOSLibName: String {
+    guard let os else {
+      return osName
+    }
+    if os.isDarwin {
+      return "darwin"
+    }
+
+    switch os {
+    case .freeBSD: return "freebsd"
+    case .netbsd: return "netbsd"
+    case .openbsd: return "openbsd"
+    case .aix: return "aix"
+    default: return osName
+    }
+  }
+
+  /// The platform name, i.e. the name Swift uses to identify this target in its
   /// resource directory.
   ///
   /// - Parameter conflatingDarwin: If true, all Darwin platforms will be

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -1317,6 +1317,15 @@ final class TripleTests: XCTestCase {
                                 shouldHaveJetPacks: true)
   }
 
+  func testClangOSLibName() {
+    XCTAssertEqual("darwin", Triple("x86_64-apple-macosx").clangOSLibName)
+    XCTAssertEqual("darwin", Triple("arm64-apple-ios13.0").clangOSLibName)
+    XCTAssertEqual("linux", Triple("aarch64-unknown-linux-android24").clangOSLibName)
+    XCTAssertEqual("wasi", Triple("wasm32-unknown-wasi").clangOSLibName)
+    XCTAssertEqual("wasip1", Triple("wasm32-unknown-wasip1-threads").clangOSLibName)
+    XCTAssertEqual("none", Triple("arm64-unknown-none").clangOSLibName)
+  }
+
   func testToolchainSelection() {
     let diagnostics = DiagnosticsEngine()
     struct None { }


### PR DESCRIPTION
Previously, we used `Triple.platformName(conflatingDarwin: true)` to derive the OS directory under <ResourceDir>/lib/, which was documented as “the name clang uses”. However, this was in fact closer to what Swift itself uses for resource directories, and it diverged from Clang’s behavior in some cases.

For example, for wasm32-unknown-wasip1-threads, Swift uses "wasi" as the OS name, but Clang uses "wasip1", matching the result of Triple::getOS, in their resource directory lookup.

This patch aligns the behavior with Clang’s logic for looking up the compiler resource directory libraries.