### PR TITLE
[6.2][Options] -Isystem doesn't work everywhere -I does

### DIFF
--- a/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
+++ b/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
@@ -194,6 +194,10 @@ extension Driver {
     commandLine.appendPath(VirtualPath.lookup(frontendTargetInfo.runtimeResourcePath.path))
 
     try commandLine.appendAll(.I, from: &parsedOptions)
+    for systemImport in parsedOptions.arguments(for: .Isystem) {
+      commandLine.appendFlag(.isystem)
+      commandLine.appendFlag(systemImport.argument.asSingle)
+    }
     try commandLine.appendAll(.F, from: &parsedOptions)
     for systemFramework in parsedOptions.arguments(for: .Fsystem) {
       commandLine.appendFlag(.iframework)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -190,7 +190,7 @@ extension Driver {
     }
 
     // TODO: Can we drop all search paths for compile jobs for explicit module build?
-    try addAllArgumentsWithPath(.I, to: &commandLine, remap: jobNeedPathRemap)
+    try addAllArgumentsWithPath(.I, .Isystem, to: &commandLine, remap: jobNeedPathRemap)
     try addAllArgumentsWithPath(.F, .Fsystem, to: &commandLine, remap: jobNeedPathRemap)
     try addAllArgumentsWithPath(.vfsoverlay, to: &commandLine, remap: jobNeedPathRemap)
 

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -601,6 +601,7 @@ extension Option {
   public static let h: Option = Option("-h", .flag, alias: Option.help)
   public static let IEQ: Option = Option("-I=", .joined, alias: Option.I, attributes: [.frontend, .argumentIsPath])
   public static let iframework: Option = Option("-iframework", .joinedOrSeparate, attributes: [.noDriver, .argumentIsPath], helpText: "add a directory to the clang importer system framework search path")
+  public static let isystem: Option = Option("-isystem", .joinedOrSeparate, attributes: [.noDriver, .argumentIsPath], helpText: "add a directory to the clang importer system header search path")
   public static let ignoreAlwaysInline: Option = Option("-ignore-always-inline", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Ignore @inline(__always) attributes.")
   public static let ignoreModuleSourceInfo: Option = Option("-ignore-module-source-info", .flag, attributes: [.frontend, .noDriver], helpText: "Avoid getting source location from .swiftsourceinfo files")
   public static let ignoreSpiGroups: Option = Option("-ignore-spi-group", .separate, attributes: [.noDriver], helpText: "SPI group name to not diagnose about")


### PR DESCRIPTION
Explanation: `-Isystem` isn't making it from the driver to jobs' command lines.
Scope: Narrow. Makes the new `-Isystem` flag propagate correctly through the driver.
Original PR: https://github.com/swiftlang/swift-driver/pull/1908
Risk: Very low; only affects the new `-Isystem` flag.
Testing: CI, local testing with Xcode.
Reviewed by: @cachemeifyoucan