### PR TITLE
[6.2 🍒][Incremental Builds] Separately check whether we can skip 'emit-module' on an incremental module-only build

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -134,11 +134,23 @@ extension IncrementalCompilationState.FirstWaveComputer {
       jobCreatingPch: jobCreatingPch)
 
     // In the case where there are no compilation jobs to run on this build (no source-files were changed),
-    // we can skip running `beforeCompiles` jobs if we also ensure that none of the `afterCompiles` jobs
-    // have any dependencies on them.
-    let skipAllJobs = batchedCompilationJobs.isEmpty ? !nonVerifyAfterCompileJobsDependOnBeforeCompileJobs() : false
-    let beforeCompileJobs = skipAllJobs ? [] : jobsInPhases.beforeCompiles
-    var skippedNonCompileJobs = skipAllJobs ? jobsInPhases.beforeCompiles : []
+    // and the emit-module task does not need to be re-run, we can skip running `beforeCompiles` jobs if we
+    // also ensure that none of the `afterCompiles` jobs have any dependencies on them.
+    let skippingAllCompileJobs = batchedCompilationJobs.isEmpty
+    let skipEmitModuleJobs = try skippingAllCompileJobs && computeCanSkipEmitModuleTasks(buildRecord)
+    let skipAllJobs = skippingAllCompileJobs && skipEmitModuleJobs && !nonVerifyAfterCompileJobsDependOnBeforeCompileJobs()
+
+    let beforeCompileJobs: [Job]
+    var skippedNonCompileJobs: [Job] = []
+    if skipAllJobs {
+      beforeCompileJobs = []
+      skippedNonCompileJobs = jobsInPhases.beforeCompiles
+    } else if skipEmitModuleJobs {
+      beforeCompileJobs = jobsInPhases.beforeCompiles.filter { $0.kind != .emitModule }
+      skippedNonCompileJobs.append(contentsOf: jobsInPhases.beforeCompiles.filter { $0.kind == .emitModule })
+    } else {
+      beforeCompileJobs = jobsInPhases.beforeCompiles
+    }
 
     // Schedule emitModule job together with verify module interface job.
     let afterCompileJobs = jobsInPhases.afterCompiles.compactMap { job -> Job? in
@@ -170,6 +182,27 @@ extension IncrementalCompilationState.FirstWaveComputer {
     }
   }
 
+  /// Figure out if the emit-module tasks are *not* mandatory. This functionality only runs if there are not actual
+  /// compilation tasks to be run in this build, for example on an emit-module-only build.
+  private func computeCanSkipEmitModuleTasks(_ buildRecord: BuildRecord) throws -> Bool {
+    guard let emitModuleJob = jobsInPhases.beforeCompiles.first(where: { $0.kind == .emitModule }) else {
+      return false // Nothing to skip, so no special handling is required
+    }
+    // If a non-emit-module task exists in 'beforeCompiles', it may be another kind of
+    // changed dependency so we should re-run the module task as well
+    guard jobsInPhases.beforeCompiles.allSatisfy({ $0.kind == .emitModule }) else {
+      return false
+    }
+    // If any of the outputs do not exist, they must be re-computed
+    guard try emitModuleJob.outputs.allSatisfy({ try fileSystem.exists($0.file) }) else {
+      return false
+    }
+
+    // Ensure that no output is older than any of the inputs
+    let oldestOutputModTime: TimePoint = try emitModuleJob.outputs.map { try fileSystem.lastModificationTime(for: $0.file) }.min() ?? .distantPast
+    return try emitModuleJob.inputs.swiftSourceFiles.allSatisfy({ try fileSystem.lastModificationTime(for: $0.typedFile.file) < oldestOutputModTime })
+  }
+
   /// Figure out which compilation inputs are *not* mandatory at the start
   private func computeInitiallySkippedCompilationInputs(
     inputsInvalidatedByExternals: TransitivelyInvalidatedSwiftSourceFileSet,
@@ -178,7 +211,7 @@ extension IncrementalCompilationState.FirstWaveComputer {
   ) -> Set<TypedVirtualPath> {
     let allCompileJobs = jobsInPhases.compileJobs
     // Input == source file
-    let changedInputs = computeChangedInputs(moduleDependencyGraph, buildRecord)
+    let changedInputs = computeChangedInputs(buildRecord)
 
     if let reporter = reporter {
       for input in inputsInvalidatedByExternals {
@@ -274,7 +307,6 @@ extension IncrementalCompilationState.FirstWaveComputer {
 
   // Find the inputs that have changed since last compilation, or were marked as needed a build
   private func computeChangedInputs(
-    _ moduleDependencyGraph: ModuleDependencyGraph,
     _ outOfDateBuildRecord: BuildRecord
   ) -> [ChangedInput] {
     jobsInPhases.compileJobs.compactMap { job in

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -815,6 +815,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
         }
         """
       )
+      // After writing out the inputs, ensure we do not immediately produce an
+      // output, as unfortunately on some platforms the time interval precision
+      // of filesystem update checks is rather coarse for this test
+      Thread.sleep(forTimeInterval: 1)
       let outputFileMap = path.appending(component: "output-file-map.json")
       try localFileSystem.writeFileContents(outputFileMap, bytes: ByteString(encodingAsUTF8: """
       {


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-driver/pull/1905
----------------------------------
- **Explanation**: When the incremental machinery is in a state that no source files require to be re-compiled, it may also determine that all the corresponding before-compile tasks may also be skipped, such as emit-module. On emit-module-only builds however, this logic is invalid because the individual file compilation is always skipped by not being included in the build plan.
This change adds logic for specifically cases where no source files must be compiled on an incremental build because the build plan does not require source compilation, adding logic to ensure that the emit-module tasks are skipped only when all of the .swift inputs to the tasks are older than all of the existing outputs of such tasks.

- **Scope**: Invocations of the driver which only emit a module (no object files or executable) and use Incremental Builds (`-incremental`). 

- **Risk**: Low, the new logic adds checks for whether an emitted module is up-to-date in order to ensure it gets re-compiled when needed. It should only ever result in more compilation tasks. 

• **Problem**: rdar://151626629

- **Reviewed By**: @cachemeifyoucan, @owenv  

- **Original PR**: https://github.com/swiftlang/swift-driver/pull/1905
