### PR TITLE
Bump `swift-tools-version` to 5.10 in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.10
 
 import PackageDescription
 import class Foundation.ProcessInfo


### PR DESCRIPTION
As Swift CI nodes use Swift 5.10 or later, we no longer need to maintain compatibility with Swift 5.7. This allows adopting features introduced in that span of versions, e.g. `package` access control.