### PR TITLE
[6.2][Options] Sync Options.swift with compiler

### DIFF
--- a/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
+++ b/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
@@ -195,7 +195,7 @@ extension Driver {
 
     try commandLine.appendAll(.I, from: &parsedOptions)
     for systemImport in parsedOptions.arguments(for: .Isystem) {
-      commandLine.appendFlag(.isystem)
+      commandLine.appendFlag("-isystem")
       commandLine.appendFlag(systemImport.argument.asSingle)
     }
     try commandLine.appendAll(.F, from: &parsedOptions)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -601,7 +601,6 @@ extension Option {
   public static let h: Option = Option("-h", .flag, alias: Option.help)
   public static let IEQ: Option = Option("-I=", .joined, alias: Option.I, attributes: [.frontend, .argumentIsPath])
   public static let iframework: Option = Option("-iframework", .joinedOrSeparate, attributes: [.noDriver, .argumentIsPath], helpText: "add a directory to the clang importer system framework search path")
-  public static let isystem: Option = Option("-isystem", .joinedOrSeparate, attributes: [.noDriver, .argumentIsPath], helpText: "add a directory to the clang importer system header search path")
   public static let ignoreAlwaysInline: Option = Option("-ignore-always-inline", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Ignore @inline(__always) attributes.")
   public static let ignoreModuleSourceInfo: Option = Option("-ignore-module-source-info", .flag, attributes: [.frontend, .noDriver], helpText: "Avoid getting source location from .swiftsourceinfo files")
   public static let ignoreSpiGroups: Option = Option("-ignore-spi-group", .separate, attributes: [.noDriver], helpText: "SPI group name to not diagnose about")
@@ -682,6 +681,7 @@ extension Option {
   public static let moduleCachePath: Option = Option("-module-cache-path", .separate, attributes: [.frontend, .doesNotAffectIncrementalBuild, .synthesizeInterface, .argumentIsPath], helpText: "Specifies the module cache path")
   public static let moduleCanImportVersion: Option = Option("-module-can-import-version", .multiArg, attributes: [.frontend, .noDriver], metaVar: "<moduleName> <version> <underlyingVersion>", helpText: "Specify canImport module and versions", numArgs: 3)
   public static let moduleCanImport: Option = Option("-module-can-import", .separate, attributes: [.frontend, .noDriver], metaVar: "<moduleName>", helpText: "Specify canImport module name")
+  public static let moduleImportFromCas: Option = Option("-module-import-from-cas", .flag, attributes: [.frontend, .noDriver], helpText: "Import modules from CAS instead of file system")
   public static let moduleInterfacePreserveTypesAsWritten: Option = Option("-module-interface-preserve-types-as-written", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "When emitting a module interface, preserve types as they were written in the source")
   public static let moduleLinkNameEQ: Option = Option("-module-link-name=", .joined, alias: Option.moduleLinkName, attributes: [.frontend])
   public static let moduleLinkName: Option = Option("-module-link-name", .separate, attributes: [.frontend, .moduleInterface], helpText: "Library to link against when using this module")
@@ -1644,6 +1644,7 @@ extension Option {
       Option.moduleCachePath,
       Option.moduleCanImportVersion,
       Option.moduleCanImport,
+      Option.moduleImportFromCas,
       Option.moduleInterfacePreserveTypesAsWritten,
       Option.moduleLinkNameEQ,
       Option.moduleLinkName,


### PR DESCRIPTION
- **Explanation**: Sync the options to add support for -module-import-from-cas.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Sync options and also fixes an option that is misaligned with `Options.td` from swift compiler.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://153095247
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift-driver/pull/1920
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: N/A
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @artemcm 

