### PR TITLE
[6.2][Macro] Do not drop `in-process-plugin-server-path` option

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -566,23 +566,23 @@ extension Driver {
       .appending(components: frontendTargetInfo.target.triple.platformName() ?? "", "Swift.swiftmodule")
     let hasToolchainStdlib = try fileSystem.exists(toolchainStdlibPath)
 
-    let skipMacroOptions = isPlanJobForExplicitModule && isFrontendArgSupported(.loadResolvedPlugin)
+    let skipMacroSearchPath = isPlanJobForExplicitModule && isFrontendArgSupported(.loadResolvedPlugin)
     // If the resource directory has the standard library, prefer the toolchain's plugins
     // to the platform SDK plugins.
     // For explicit module build, the resolved plugins are provided by scanner.
-    if hasToolchainStdlib, !skipMacroOptions {
-      try addPluginPathArguments(commandLine: &commandLine)
+    if hasToolchainStdlib {
+      try addPluginPathArguments(commandLine: &commandLine, skipMacroSearchPath: skipMacroSearchPath)
     }
 
     try toolchain.addPlatformSpecificCommonFrontendOptions(commandLine: &commandLine,
                                                            inputs: &inputs,
                                                            frontendTargetInfo: frontendTargetInfo,
                                                            driver: &self,
-                                                           skipMacroOptions: skipMacroOptions)
+                                                           skipMacroOptions: skipMacroSearchPath)
 
     // Otherwise, prefer the platform's plugins.
-    if !hasToolchainStdlib, !skipMacroOptions {
-      try addPluginPathArguments(commandLine: &commandLine)
+    if !hasToolchainStdlib {
+      try addPluginPathArguments(commandLine: &commandLine, skipMacroSearchPath: skipMacroSearchPath)
     }
 
     if let passPluginPath = parsedOptions.getLastArgument(.loadPassPluginEQ),
@@ -937,7 +937,7 @@ extension Driver {
     try explicitDependencyBuildPlanner?.resolveBridgingHeaderDependencies(inputs: &inputs, commandLine: &commandLine)
   }
 
-  mutating func addPluginPathArguments(commandLine: inout [Job.ArgTemplate]) throws {
+  mutating func addPluginPathArguments(commandLine: inout [Job.ArgTemplate], skipMacroSearchPath: Bool) throws {
     guard isFrontendArgSupported(.pluginPath) else {
       return
     }
@@ -950,6 +950,10 @@ extension Driver {
 #else
       commandLine.appendPath(pluginPathRoot.appending(components: "lib", "swift", "host", sharedLibraryName("libSwiftInProcPluginServer")))
 #endif
+    }
+
+    guard !skipMacroSearchPath else {
+      return
     }
 
     // Default paths for compiler plugins found within the toolchain

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -939,6 +939,9 @@ final class CachingBuildTests: XCTestCase {
         })
         /// command-line that compiles swift should contains -cache-replay-prefix-map
         XCTAssertTrue(command.contains { $0 == "-cache-replay-prefix-map" })
+        if job.kind == .compile {
+          XCTAssertTrue(command.contains { $0 == "-in-process-plugin-server-path" })
+        }
         XCTAssertFalse(command.contains { $0 == "-plugin-path" || $0 == "-external-plugin-path" ||
                                           $0 == "-load-plugin-library" || $0 == "-load-plugin-executable" })
       }


### PR DESCRIPTION
- **Explanation**: Fix a regression that `in-process-plugin-server-path` is accidentally dropped in explicit module build.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Library macro plugins doesn't work when turn on explicit module and cause build failures.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://154780122
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift-driver/pull/1947
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Preserve an additional flag
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit Test
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @artemcm 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
