### PR TITLE
[6.2 🍒] Perform response file write atomically

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -15,6 +15,7 @@ import class Foundation.NSLock
 import func TSCBasic.withTemporaryDirectory
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
 import struct TSCBasic.SHA256
 
 /// How the resolver is to handle usage of response files
@@ -184,9 +185,8 @@ public final class ArgsResolver {
 
       // FIXME: Need a way to support this for distributed build systems...
       if let absPath = responseFilePath.absolutePath {
-        try fileSystem.writeFileContents(absPath) {
-          $0.send(resolvedArguments[2...].map { $0.spm_shellEscaped() }.joined(separator: "\n"))
-        }
+        let argumentBytes = ByteString(resolvedArguments[2...].map { $0.spm_shellEscaped() }.joined(separator: "\n").utf8)
+        try fileSystem.writeFileContents(absPath, bytes: argumentBytes, atomically: true)
         resolvedArguments = [resolvedArguments[0], resolvedArguments[1], "@\(absPath.pathString)"]
       }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-driver/pull/1939
--------------------------

- **Explanation**: On builds where multiple targets are being build with the driver which end up having a common module dependency with an identical command line, writing a response file to the file system with said command line's arguments may race across driver invocations, causing the resulting tasks getting corrupted response file inputs. This change switches over to using the atomic  `FileSystem.writeFileContents(_ path:, bytes:, atomically:)`. 

- **Scope**: Builds which enable Explicitly built modules and have multiple targets with common identical module dependencies.

- **Risk**: Low. This change only switches over the filesystem write operation to be performed atomically and does not change anything else.

- **Reviewed By**: @owenv, @cachemeifyoucan 

- **Problem**: rdar://134596003

- **Original PR**: https://github.com/swiftlang/swift-driver/pull/1939