### PR TITLE
[wasm] Respect `leastValidPointerValue` reported by the frontend `-print-target-info`

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -90,6 +90,9 @@ public struct FrontendTargetInfo: Codable {
     /// The triple used for module names.
     let moduleTriple: Triple
 
+    /// The least valid pointer value for the target.
+    let leastValidPointerValue: Int
+
     /// The version of the Swift runtime that is present in the runtime
     /// environment of the target.
     var swiftRuntimeCompatibilityVersion: SwiftVersion?

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -157,14 +157,11 @@ extension WebAssemblyToolchain {
       // and memory footprint are significantly degraded. So we reserve the
       // low addresses to use them as extra inhabitants by telling the lowest
       // valid address to the linker.
-      // The value of lowest valid address, called "global base", must be always
-      // synchronized with `SWIFT_ABI_WASM32_LEAST_VALID_POINTER` defined in
-      // apple/swift's runtime library.
-      let SWIFT_ABI_WASM32_LEAST_VALID_POINTER = 4096
+      let leastValidPointerValue = targetInfo.target.leastValidPointerValue
       commandLine.appendFlag(.Xlinker)
-      commandLine.appendFlag("--global-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
+      commandLine.appendFlag("--global-base=\(leastValidPointerValue)")
       commandLine.appendFlag(.Xlinker)
-      commandLine.appendFlag("--table-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
+      commandLine.appendFlag("--table-base=\(leastValidPointerValue)")
 
       // Delegate to Clang for sanitizers. It will figure out the correct linker
       // options.


### PR DESCRIPTION
Addressing a review feedback from Doug: https://github.com/swiftlang/swift-driver/pull/1988#discussion_r2349545624