### PR TITLE
[6.2 🍒] Use UUID for response file names and add 'resolveArgumentList' API which contains original command-line if a response file is used

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1823,6 +1823,28 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
+    // Response file query with full command-line API
+    do {
+      let source = try AbsolutePath(validating: "/foo.swift")
+      var driver = try Driver(args: ["swift"] + [source.nativePathString(escaped: false)])
+      let jobs = try driver.planBuild()
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .interpret)
+      let interpretJob = jobs[0]
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
+      let resolved: ResolvedCommandLine = try resolver.resolveArgumentList(for: interpretJob, useResponseFiles: .forced)
+      guard case .usingResponseFile(resolved: let resolvedArgs, responseFileContents: let contents) = resolved else {
+          XCTFail("Argument wasn't a response file")
+        return
+      }
+      XCTAssertEqual(resolvedArgs.count, 3)
+      XCTAssertEqual(resolvedArgs[1], "-frontend")
+      XCTAssertEqual(resolvedArgs[2].first, "@")
+
+      XCTAssertTrue(contents.contains(subsequence: ["-frontend", "-interpret"]))
+      XCTAssertTrue(contents.contains(subsequence: ["-module-name", "foo"]))
+    }
+
     // No response file
     do {
       var driver = try Driver(args: ["swift"] + ["foo.swift"])
@@ -1833,27 +1855,6 @@ final class SwiftDriverTests: XCTestCase {
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob)
       XCTAssertFalse(resolvedArgs.contains { $0.hasPrefix("@") })
-    }
-  }
-
-  func testResponseFileDeterministicNaming() throws {
-#if !os(macOS)
-    try XCTSkipIf(true, "Test assumes macOS response file quoting behavior")
-#endif
-    do {
-      let testJob = Job(moduleName: "Foo",
-                        kind: .compile,
-                        tool: .init(path: try AbsolutePath(validating: "/swiftc"), supportsResponseFiles: true),
-                        commandLine: (1...20000).map { .flag("-DTEST_\($0)") },
-                        inputs: [],
-                        primaryInputs: [],
-                        outputs: [])
-      let resolver = try ArgsResolver(fileSystem: localFileSystem)
-      let resolvedArgs: [String] = try resolver.resolveArgumentList(for: testJob)
-      XCTAssertEqual(resolvedArgs.count, 3)
-      XCTAssertEqual(resolvedArgs[2].first, "@")
-      let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
-      XCTAssertEqual(responseFilePath.basename, "arguments-847d15e70d97df7c18033735497ca8dcc4441f461d5a9c2b764b127004524e81.resp")
     }
   }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-driver/pull/1989
--------------------------

- **Explanation**:  Using the content hash in the response file name caused us to require using the atomic FS write API, due to a possibility that concurrently-running driver processes may encounter a need to build a common, shared module dependency with an identical command-line recipe. In such a scenario there was a possibility of a race in writing out the response file for this command.
We have since seen challenges with the current atomic FS write APIs and this PR is an alternative approach to tackling this problem. Instead of using the content hash, we will use UUID to ensure that we do not have races when multiple drivers are creating a response file for an identical command. In addition, we add an API for build system clients so that they can directly examine the pre-response-file-creation command line arguments directly from the ArgsResolver, without needing to read the response file from the filesystem.

- **Scope**: Affects builds which contain compilation tasks with command lines which do not fit the system default command line size, triggering response file use.

- **Risk**: Low. The risk is low to build functionality since we expect this to largely not matter to being able to successfully build a given project. There is some risk to build performance if we do not correctly take this change into account in the build system, but we have an accompanying change in SwiftBuild to ensure that does not happen.

- **Reviewed By**: @owenv 

- **Problem**: rdar://159417339

- **Original PR**: https://github.com/swiftlang/swift-driver/pull/1989