### PR TITLE
[System] Use a larger limit for when to use response file

### DIFF
--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -62,17 +62,15 @@ func quoteArgument(_ argument: String) -> String {
 #if canImport(Darwin) || os(Linux) || os(Android) || os(OpenBSD) || os(FreeBSD)
 // Adapted from llvm::sys::commandLineFitsWithinSystemLimits.
 func commandLineFitsWithinSystemLimits(path: String, args: [String]) -> Bool {
-  let upperBound = sysconf(Int32(_SC_ARG_MAX))
-  guard upperBound != -1 else {
+  let systemLimit = sysconf(Int32(_SC_ARG_MAX))
+  guard systemLimit != -1 else {
     // The system reports no limit.
     return true
   }
   // The lower bound for ARG_MAX on a POSIX system
-  let lowerBound = Int(_POSIX_ARG_MAX)
-  // This the same baseline used by xargs.
-  let baseline = 128 * 1024
+  let posixLimit = Int(_POSIX_ARG_MAX)
 
-  var effectiveArgMax = max(min(baseline, upperBound), lowerBound)
+  var effectiveArgMax = max(systemLimit, posixLimit)
   // Conservatively assume environment variables consume half the space.
   effectiveArgMax /= 2
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1766,7 +1766,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testUsingResponseFiles() throws {
-    let manyArgs = (1...20000).map { "-DTEST_\($0)" }
+    let manyArgs = (1...200000).map { "-DTEST_\($0)" }
     // Needs response file
     do {
       let source = try AbsolutePath(validating: "/foo.swift")
@@ -1879,7 +1879,7 @@ final class SwiftDriverTests: XCTestCase {
     // The jobs below often take large command lines (e.g., when passing a large number of Clang
     // modules to Swift). Ensure that they don't regress in their ability to pass response files
     // from the driver to the frontend.
-    let manyArgs = (1...20000).map { "-DTEST_\($0)" }
+    let manyArgs = (1...200000).map { "-DTEST_\($0)" }
 
     // Compile + separate emit module job
     do {


### PR DESCRIPTION
Drop the baseline number used by `xarg` when determining if a response file is needed when generating command. macOS on apple silicon actually has a really large limit when it comes to command-line limit and less response file means faster build and build logs easier to read.