### PR TITLE
Supply -z,nobtcfi on x86_64 as well.

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -128,7 +128,7 @@ extension GenericUnixToolchain {
         }
       }
 
-      if targetTriple.os == .openbsd && targetTriple.arch == .aarch64 {
+      if targetTriple.os == .openbsd && (targetTriple.arch == .aarch64 || targetTriple.arch == .x86_64) {
         let btcfiEnabled = targetInfo.target.openbsdBTCFIEnabled ?? false
         if !btcfiEnabled {
           commandLine.appendFlag("-Xlinker")

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -170,7 +170,7 @@ public final class GenericUnixToolchain: Toolchain {
       try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
     }
 
-    if driver.targetTriple.os == .openbsd && driver.targetTriple.arch == .aarch64 {
+    if driver.targetTriple.os == .openbsd && (driver.targetTriple.arch == .aarch64 || driver.targetTriple.arch == .x86_64) {
       if frontendTargetInfo.target.openbsdBTCFIEnabled ?? false {
         commandLine.appendFlag(.Xcc)
         commandLine.appendFlag("-Xclang=-msign-return-address=non-leaf")


### PR DESCRIPTION
On older x86_64 hardware, this isn't a problem since CET IBT hardware support may not have been available. However, newer x86_64 hardware supports the feature, which will lead to BTCFI failures. Therefore ensure the same BTCFI disabling logic applies on x86_64 as well as aarch64.