### PR TITLE
[TEST-ONLY] Relax the caching tests

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -163,8 +163,6 @@ private func checkCachingBuildJobDependencies(job: Job,
       TypedVirtualPath(file: clangDependencyModulePathString, type: .pcm)
     XCTAssertTrue(job.inputs.contains(clangDependencyModulePath))
     XCTAssertTrue(job.commandLine.contains(
-      .flag(String("-fmodule-file=\(dependencyId.moduleName)=\(clangDependencyModulePathString)"))))
-    XCTAssertTrue(job.commandLine.contains(
       .flag(String("-fmodule-file-cache-key"))))
     let cacheKey = try XCTUnwrap(clangDependencyDetails.moduleCacheKey)
     XCTAssertTrue(job.commandLine.contains(.flag(String(cacheKey))))


### PR DESCRIPTION
Relax the caching tests to allow changes to swift scanner to not passing paths to clang modules on command-line.