### PR TITLE
[-debug-module-path] Prefer the moduleOutputInfo.output path if avail…

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -112,7 +112,9 @@ extension Driver {
     if isPlanJobForExplicitModule && forObject && isFrontendArgSupported(.debugModulePath),
        let explicitModulePlanner {
       let mainModule = explicitModulePlanner.dependencyGraph.mainModule
-      try addPathOption(option: .debugModulePath, path: VirtualPath.lookup(mainModule.modulePath.path), to: &commandLine, remap: jobNeedPathRemap)
+      let pathHandle = moduleOutputInfo.output?.outputPath ?? mainModule.modulePath.path
+      let path = VirtualPath.lookup(pathHandle)
+      try addPathOption(option: .debugModulePath, path: path, to: &commandLine, remap: jobNeedPathRemap)
     }
 
     // Check if dependency scanner has put the job into direct clang cc1 mode.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1075,6 +1075,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
               let baseName = "testExplicitModuleVerifyInterfaceJobs"
               XCTAssertTrue(matchTemporary(outputFilePath, basename: baseName, fileExtension: "o") ||
                             matchTemporary(outputFilePath, basename: baseName, fileExtension: "autolink"))
+            if outputFilePath.extension == FileType.object.rawValue && driver.isFrontendArgSupported(.debugModulePath) {
+                // Check that this is an absolute path pointing to the temporary directory.
+                XCTAssertTrue(job.commandLine.contains(subsequence: ["-debug-module-path", .path(.temporary(try RelativePath(validating: "testExplicitModuleVerifyInterfaceJobs-3.swiftmodule")))]))
+              }
             default:
               XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }


### PR DESCRIPTION
…able.

While testing the LLDB support for enhanced module tracking I noticed that the driver currently always uses a relative path for -debug-module-path, which is an obvious problem when compiling in a different directory, or if the swift module output is in a different path than the object file output. This patch addresses this by preferring `moduleOutputInfo.output` if available.

rdar://164524241