### PR TITLE
Added functionality to -register-module-dependency flag

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -145,6 +145,14 @@ public extension Driver {
       commandLine.appendFlag(.dependencyScanCacheRemarks)
     }
 
+    // command-line flag registers a dependency with the dependency scanner
+    // without causing it to be implicitly imported in compilation tasks
+    for moduleNameArg in parsedOptions.arguments(for: .registerModuleDependency) {
+      let moduleName = moduleNameArg.argument.asSingle
+      commandLine.appendFlag(.importModule)
+      commandLine.appendFlag(moduleName)
+    }
+
     if shouldAttemptIncrementalCompilation &&
        parsedOptions.contains(.incrementalDependencyScan) {
       if let serializationPath = buildRecordInfo?.dependencyScanSerializedResultPath {


### PR DESCRIPTION
rdar://164596852
This flag tells the driver to include the module in the dependency scanning, but not load it. Added test for the flag.