### PR TITLE
SwiftDriver: explicitly select RSP handling on Windows

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -44,6 +44,10 @@ extension GenericUnixToolchain {
     sanitizers: Set<Sanitizer>,
     targetInfo: FrontendTargetInfo
   ) throws -> ResolvedTool {
+#if os(Windows)
+    commandLine.appendFlag("--rsp-quoting=windows")
+#endif
+
     let targetTriple = targetInfo.target.triple
     switch linkerOutputType {
     case .dynamicLibrary:


### PR DESCRIPTION
When cross-compiling from Windows to Android, if we spill past the command line limit, we would need to emit a response file. The response file is emitted into the style of the build rather than the host. This means that on Unix platforms, we need to indicate that the response file is Windows not Unix.

We rely on the internal behaviour of the second flag being special cased and emit the `--rsp-quoting=windows` parameter in the second argument position to ensure that it is passed on the command line (as if the argument is pushed into the response file, it will not be possible to honour it for processing the file).