### PR TITLE
Wasm: bump default stack size to 128K

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -166,6 +166,12 @@ extension WebAssemblyToolchain {
       commandLine.appendFlag(.Xlinker)
       commandLine.appendFlag("--table-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
 
+      // Set slightly higher than the default (64K) stack size so that basic
+      // workflows like Swift Testing can run within this limited stack space.
+      let SWIFT_WASM_DEFAULT_STACK_SIZE = 1024 * 128
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag("--stack-size=\(SWIFT_WASM_DEFAULT_STACK_SIZE)")
+
       // Delegate to Clang for sanitizers. It will figure out the correct linker
       // options.
       if linkerOutputType == .executable && !sanitizers.isEmpty {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2766,6 +2766,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(cmd.contains(.responseFilePath(.absolute(path.appending(components: "wasi", "static-executable-args.lnk")))))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--global-base=4096")]))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--table-base=4096")]))
+        XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--stack-size=\(128 * 1024)")]))
         XCTAssertTrue(cmd.contains(.flag("-O3")))
         XCTAssertEqual(linkJob.outputs[0].file, try toPath("Test"))
 


### PR DESCRIPTION
The default of 64K is too low, especially as tail calls are not available by default on Wasm. It also means Swift Testing is unusable in `main` development snapshots due to stack overflows.

rdar://160218251