### PR TITLE
[-debug-module-path] Prefer the moduleOutputInfo.output path if avail…

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -112,7 +112,9 @@ extension Driver {
     if isPlanJobForExplicitModule && forObject && isFrontendArgSupported(.debugModulePath),
        let explicitModulePlanner {
       let mainModule = explicitModulePlanner.dependencyGraph.mainModule
-      try addPathOption(option: .debugModulePath, path: VirtualPath.lookup(mainModule.modulePath.path), to: &commandLine, remap: jobNeedPathRemap)
+      let pathHandle = moduleOutputInfo.output?.outputPath ?? mainModule.modulePath.path
+      let path = VirtualPath.lookup(pathHandle)
+      try addPathOption(option: .debugModulePath, path: path, to: &commandLine, remap: jobNeedPathRemap)
     }
 
     // Check if dependency scanner has put the job into direct clang cc1 mode.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1075,6 +1075,24 @@ final class ExplicitModuleBuildTests: XCTestCase {
               let baseName = "testExplicitModuleVerifyInterfaceJobs"
               XCTAssertTrue(matchTemporary(outputFilePath, basename: baseName, fileExtension: "o") ||
                             matchTemporary(outputFilePath, basename: baseName, fileExtension: "autolink"))
+            if outputFilePath.extension == FileType.object.rawValue && driver.isFrontendArgSupported(.debugModulePath) {
+              // Check that this is an absolute path pointing to the temporary directory.
+              var found : Bool = false
+              for arg in job.commandLine {
+                if !found && arg == "-debug-module-path" {
+                  found = true
+                } else if found {
+                  if case let .path(vpath) = arg {
+                    XCTAssertTrue(vpath.isTemporary)
+                    XCTAssertTrue(vpath.extension == FileType.swiftModule.rawValue)
+                  } else {
+                    XCTFail("argument is not a path")
+                  }
+                    break
+                }
+              }
+              XCTAssertTrue(found)
+            }
             default:
               XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }


### PR DESCRIPTION
…able.

While testing the LLDB support for enhanced module tracking I noticed that the driver currently always uses a relative path for -debug-module-path, which is an obvious problem when compiling in a different directory, or if the swift module output is in a different path than the object file output. This patch addresses this by preferring moduleOutputInfo.output if available.

rdar://164524241

(Relanding with a relaxed test that doesn't encode the name of a temporary file)

(cherry picked from commit 3999166cc71ac5cca629bd53ed69b7f0bcec47fe)

Explanation: use absolute paths for -debug-module-path when possible
Scope: Debug Info for EBM builds
Issues: rdar://164524241
Original PRs: https://github.com/swiftlang/swift-driver/pull/2004
Risk: Low
Testing: Unit test
Reviewers: @owenv 