### PR TITLE
6.2: Update `testExecutableFallbackPath` to pass on all platforms

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5725,15 +5725,10 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testExecutableFallbackPath() throws {
-    let driver1 = try Driver(args: ["swift", "main.swift"])
-    if !driver1.targetTriple.isDarwin {
-      XCTAssertThrowsError(try driver1.toolchain.getToolPath(.dsymutil))
-    }
-
     var env = ProcessEnv.vars
     env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
-    let driver2 = try Driver(args: ["swift", "main.swift"], env: env)
-    XCTAssertNoThrow(try driver2.toolchain.getToolPath(.dsymutil))
+    let driver = try Driver(args: ["swift", "main.swift"], env: env)
+    XCTAssertNoThrow(try driver.toolchain.getToolPath(.dsymutil))
   }
 
   func testVersionRequest() throws {


### PR DESCRIPTION
Cherry-pick of #1981, merged as 35d84e35f5d22242efd84dd35725894d6da2fdc3

**Explanation**: Amazon Linux 2023 includes a dsymutil in its LLVM package, which is installed on our builders (checking separately if that is actually required). The intent of this test seems to be mostly to make sure we are able to find all tools when allowing fallbacks, so update it to just check for that.

Exposed by `oss-swift-6.2-bootstrap-amazonlinux-2023-aarch64` job: https://ci.swift.org/job/oss-swift-6.2-bootstrap-amazonlinux-2023-aarch64/74/

**Scope**: limited to test coverage
**Risk**: Low, due to isolation of changes to a test case exercised on CI.
**Testing**: updated to make tests pass on AL2023
**Issue**: rdar://165709218
**Reviewer**: @bnbarham 
