### PR TITLE
[GithubAction] Enable aarch64 linux github action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       linux_os_versions: '["jammy"]'
+      linux_host_archs: '["x86_64", "aarch64"]'
       linux_pre_build_command: ./.github/scripts/prebuild.sh
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
       windows_swift_versions: '["nightly-main"]'


### PR DESCRIPTION
Enable aarch64 github action tests.