### PR TITLE
build-script-helper: print-target-info error

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -580,6 +580,9 @@ def get_build_target(swiftc_path, args, cross_compile=False):
         if '-apple-macosx' in args.target_info["target"]["unversionedTriple"]:
           triple = args.target_info['target']['unversionedTriple']
         return triple
+    except subprocess.CalledProcessError as e:
+        error(f"""Command {e.cmd} terminated with non-zero exit status {e.returncode}
+  Output: {e.output}""")
     except Exception as e:
         error(str(e))
 


### PR DESCRIPTION
Capture output on failure when unable to run `-print-target-info` in the build-script helper. The old behavior only emitted the command line and the exit code, which doesn't provide enough information in logs to be actionable.

`12:01:29  --- build-script-helper.py: error: Command '['/home/ec2-user/jenkins/workspace/oss-swift-package-freebsd-14/latest_toolchain/usr/bin/swiftc', '-print-target-info']' returned non-zero exit status 1.`