### PR TITLE
Wasm: Use `-sysroot` value as the clang linker sysroot if provided

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -114,7 +114,11 @@ extension WebAssemblyToolchain {
       }
       commandLine.append(contentsOf: inputFiles)
 
-      if let path = targetInfo.sdkPath?.path {
+      // Prefer -sysroot as the native sysroot path if provided.
+      if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
+        commandLine.appendFlag("--sysroot")
+        try commandLine.appendPath(VirtualPath(path: sysroot))
+      } else if let path = targetInfo.sdkPath?.path {
         commandLine.appendFlag("--sysroot")
         commandLine.appendPath(VirtualPath.lookup(path))
       }


### PR DESCRIPTION
For other Unix-like platforms, the driver already respects `-sysroot` over `-sdk` as the native sysroot (not Swift "SDK"). See the following PRs for reference:
* https://github.com/swiftlang/swift-driver/pull/1811
* https://github.com/swiftlang/swift/pull/72352

For WebAssembly, this change makes the driver behave consistently with other platforms. This consistency is important for supporting swiftc as a swift-build's underlying linker driver for Wasm targets, as UnixLd.xcspec now uses `-sysroot` by default:
https://github.com/swiftlang/swift-build/blob/02e9f6778b621375b5a5a2fe40f9a4b55bb44ba0/Sources/SWBGenericUnixPlatform/Specs/UnixLd.xcspec#L61-L68