### PR TITLE
Fix optimization record path support for multi-threaded WMO

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -264,12 +264,50 @@ extension Driver {
     // -save-optimization-record and -save-optimization-record= have different meanings.
     // In this case, we specifically want to pass the EQ variant to the frontend
     // to control the output type of optimization remarks (YAML or bitstream).
+
+    // If the output file map has optimization record entries, we need to tell the frontend
+    // to generate them even if no explicit option was passed on the command line.
+    let hasOptRecordFileMapEntries = outputFileMap?.hasEntries(for: optimizationRecordFileType ?? .yamlOptimizationRecord) ?? false
+    if hasOptRecordFileMapEntries &&
+       !parsedOptions.hasArgument(.saveOptimizationRecord) &&
+       !parsedOptions.hasArgument(.saveOptimizationRecordEQ) {
+      commandLine.appendFlag("-save-optimization-record")
+    }
+
+    try commandLine.appendLast(.saveOptimizationRecord, from: &parsedOptions)
     try commandLine.appendLast(.saveOptimizationRecordEQ, from: &parsedOptions)
     try commandLine.appendLast(.saveOptimizationRecordPasses, from: &parsedOptions)
 
     let inputsGeneratingCodeCount = primaryInputs.isEmpty
       ? inputs.count
       : primaryInputs.count
+
+    // If explicit paths are provided, need one path per input file
+    let optRecordPathCount = parsedOptions.arguments(for: .saveOptimizationRecordPath).count
+
+    if !compilerMode.usesPrimaryFileInputs && numThreads > 1 && inputs.count > 1 &&
+       optRecordPathCount > 0 && optRecordPathCount < inputs.count && !hasOptRecordFileMapEntries {
+      diagnosticEngine.emit(.error_single_opt_record_path_with_multi_threaded_wmo)
+      throw ErrorDiagnostics.emitted
+    }
+
+    // If we have N explicit optimization record paths for N files, collect them
+    var explicitOptRecordPaths: [VirtualPath.Handle]? = nil
+    if optRecordPathCount == inputs.count && !hasOptRecordFileMapEntries {
+      let allPaths = parsedOptions.arguments(for: .saveOptimizationRecordPath)
+
+      // In multi-threaded WMO, all paths go to the single job
+      if !compilerMode.usesPrimaryFileInputs && numThreads > 1 {
+        for optPath in allPaths {
+          commandLine.appendFlag("-save-optimization-record-path")
+          try commandLine.appendPath(VirtualPath(path: optPath.argument.asSingle))
+        }
+      }
+      // In non-WMO mode, collect paths to pass to addFrontendSupplementaryOutputArguments
+      else if compilerMode.usesPrimaryFileInputs {
+        explicitOptRecordPaths = try allPaths.map { try VirtualPath(path: $0.argument.asSingle).intern() }
+      }
+    }
 
     outputs += try addFrontendSupplementaryOutputArguments(
       commandLine: &commandLine,
@@ -280,7 +318,8 @@ extension Driver {
       moduleOutputPaths: self.moduleOutputPaths,
       includeModuleTracePath: emitModuleTrace,
       indexFilePaths: indexFilePaths,
-      allInputs: inputs)
+      allInputs: inputs,
+      explicitOptRecordPaths: explicitOptRecordPaths)
 
     // Forward migrator flags.
     try commandLine.appendLast(.apiDiffDataFile, from: &parsedOptions)

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -182,4 +182,8 @@ extension Diagnostic.Message {
   static var error_no_objc_interop_embedded: Diagnostic.Message {
     .error("Objective-C interop cannot be enabled with embedded Swift.")
   }
+
+  static var error_single_opt_record_path_with_multi_threaded_wmo: Diagnostic.Message {
+    .error("multi-threaded whole-module optimization requires one '-save-optimization-record-path' per source file")
+  }
 }

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -311,6 +311,13 @@ extension FileType {
 }
 
 extension FileType {
+  /// Whether this file type represents an optimization record
+  public var isOptimizationRecord: Bool {
+    self == .yamlOptimizationRecord || self == .bitstreamOptimizationRecord
+  }
+}
+
+extension FileType {
 
   private static let typesByName = Dictionary(uniqueKeysWithValues: FileType.allCases.map { ($0.name, $0) })
 


### PR DESCRIPTION
Handles multiple producers error by ensuring each input file gets a unique optimization record output path across all compilation modes.