### PR TITLE
[TEST-ONLY] Simplify and speed up some explicit module build tests

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -237,7 +237,7 @@ final class CachingBuildTests: XCTestCase {
                                      "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
                                      main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
-      let dependencyGraph = try driver.scanModuleDependencies()
+      let dependencyGraph = try XCTUnwrap(driver.intermoduleDependencyGraph)
       let mainModuleInfo = try dependencyGraph.moduleInfo(of: .swift("testCachingBuildJobs"))
       guard case .swift(_) = mainModuleInfo.details else {
         XCTFail("Main module does not have Swift details field")
@@ -496,8 +496,7 @@ final class CachingBuildTests: XCTestCase {
       }
 
       let jobs = try driver.planBuild()
-      // Figure out which Triples to use.
-      let dependencyGraph = try driver.scanModuleDependencies()
+      let dependencyGraph = try XCTUnwrap(driver.intermoduleDependencyGraph)
       let mainModuleInfo = try dependencyGraph.moduleInfo(of: .swift("testExplicitModuleVerifyInterfaceJobs"))
       guard case .swift(_) = mainModuleInfo.details else {
         XCTFail("Main module does not have Swift details field")

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -694,8 +694,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
 
       let jobs = try driver.planBuild()
-      // Figure out which Triples to use.
-      let dependencyGraph = try driver.scanModuleDependencies()
+      let dependencyGraph = try XCTUnwrap(driver.intermoduleDependencyGraph)
       let mainModuleInfo = try dependencyGraph.moduleInfo(of: .swift("testExplicitModuleBuildJobs"))
 
       guard case .swift(let mainModuleDetails) = mainModuleInfo.details else {
@@ -848,8 +847,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-register-module-dependency", "G",
                                      "-emit-loaded-module-trace",
                                      main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
-      let dependencyGraph = try driver.scanModuleDependencies()
       let jobs = try driver.planBuild()
+      let dependencyGraph = try XCTUnwrap(driver.intermoduleDependencyGraph)
       // E and G SHOULD be in the dependency graph (registered for scanning)
       XCTAssertTrue(dependencyGraph.modules.keys.contains(.swift("E")),
                     "Module E should be in dependency graph when registered via -register-module-dependency")
@@ -1069,8 +1068,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         throw XCTSkip("-typecheck-module-from-interface doesn't support explicit build.")
       }
       let jobs = try driver.planBuild()
-      // Figure out which Triples to use.
-      let dependencyGraph = try driver.scanModuleDependencies()
+      let dependencyGraph = try XCTUnwrap(driver.intermoduleDependencyGraph)
       let mainModuleInfo = try dependencyGraph.moduleInfo(of: .swift("testExplicitModuleVerifyInterfaceJobs"))
       guard case .swift(_) = mainModuleInfo.details else {
         XCTFail("Main module does not have Swift details field")
@@ -1227,8 +1225,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-pch-output-dir", pchOutputDir.nativePathString(escaped: false),
                                      main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
-      // Figure out which Triples to use.
-      let dependencyGraph = try driver.scanModuleDependencies()
+      let dependencyGraph = try XCTUnwrap(driver.intermoduleDependencyGraph)
       let mainModuleInfo = try dependencyGraph.moduleInfo(of: .swift("testExplicitModuleBuildPCHOutputJobs"))
       guard case .swift(_) = mainModuleInfo.details else {
         XCTFail("Main module does not have Swift details field")
@@ -1368,7 +1365,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // XCTAssertJobInvocationMatches(interpretJob, .flag("-disable-implicit-swift-modules"))
       XCTAssertJobInvocationMatches(interpretJob, .flag("-Xcc"), .flag("-fno-implicit-modules"))
 
-      // Figure out which Triples to use.
       let dependencyGraph = try driver.scanModuleDependencies()
       let mainModuleInfo = try dependencyGraph.moduleInfo(of: .swift("testExplicitModuleBuildJobs"))
       guard case .swift(_) = mainModuleInfo.details else {


### PR DESCRIPTION
After planning the explicit module build, tests can directly access the module dependency graph instead of trying to compute the graph again. This will make the test run a bit faster. NFC.