### PR TITLE
tests: avoid unnecessary escaping of paths

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -228,15 +228,14 @@ final class CachingBuildTests: XCTestCase {
           cHeadersPath.appending(component: "Bridging.h")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
-
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       let dependencyGraph = try driver.scanModuleDependencies()
       let mainModuleInfo = try dependencyGraph.moduleInfo(of: .swift("testCachingBuildJobs"))
@@ -368,18 +367,18 @@ final class CachingBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-swift-version", "5",
                                      "-module-name", "ModuleOnly",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: true),
-                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: false),
+                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-emit-module-separately-wmo", "-disable-cmo", "-Rcache-compile-job",
                                      "-enable-library-evolution", "-O", "-whole-module-optimization",
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-emit-module", "-o", modulePath.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true), other.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-emit-module", "-o", modulePath.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false), other.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -425,20 +424,20 @@ final class CachingBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-swift-version", "5",
                                      "-module-name", "SeparateModuleJob",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-emit-module-path", modulePath.nativePathString(escaped: true),
-                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: true),
-                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-emit-module-path", modulePath.nativePathString(escaped: false),
+                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: false),
+                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-experimental-emit-module-separately", "-Rcache-compile-job",
                                      "-enable-library-evolution", "-O",
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
                                      "-Xfrontend", "-disable-implicit-concurrency-module-import",
                                      "-Xfrontend", "-disable-implicit-string-processing-module-import",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       for job in jobs {
@@ -482,17 +481,16 @@ final class CachingBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
                                      "-swift-version", "5",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
-                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: true),
-                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
+                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: false),
+                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-verify-emitted-module-interface",
                                      "-enable-library-evolution",
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
-
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       guard driver.supportExplicitModuleVerifyInterface() else {
         throw XCTSkip("-typecheck-module-from-interface doesn't support explicit build.")
       }
@@ -624,13 +622,13 @@ final class CachingBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let dependencyOracle = InterModuleDependencyOracle()
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-Rcache-compile-job",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -678,14 +676,14 @@ final class CachingBuildTests: XCTestCase {
 
       var fooBuildDriver = try Driver(args: ["swiftc",
                                              "-explicit-module-build",
-                                             "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                             "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                             "-working-directory", path.nativePathString(escaped: true),
-                                             foo.nativePathString(escaped: true),
+                                             "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                             "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                             "-working-directory", path.nativePathString(escaped: false),
+                                             foo.nativePathString(escaped: false),
                                              "-emit-module", "-wmo", "-module-name", "Foo",
-                                             "-emit-module-path", FooInstallPath.appending(component: "Foo.swiftmodule").nativePathString(escaped: true),
-                                             "-import-objc-header", fooHeader.nativePathString(escaped: true),
-                                             "-pch-output-dir", PCHPath.nativePathString(escaped: true)]
+                                             "-emit-module-path", FooInstallPath.appending(component: "Foo.swiftmodule").nativePathString(escaped: false),
+                                             "-import-objc-header", fooHeader.nativePathString(escaped: false),
+                                             "-pch-output-dir", PCHPath.nativePathString(escaped: false)]
                                       + sdkArgumentsForTesting,
                                       interModuleDependencyOracle: dependencyOracle)
 
@@ -708,13 +706,13 @@ final class CachingBuildTests: XCTestCase {
       try checkCASForResults(jobs: fooJobs, cas: cas, fs: fooBuildDriver.fileSystem)
 
       var driver = try Driver(args: ["swiftc",
-                                     "-I", FooInstallPath.nativePathString(escaped: true),
+                                     "-I", FooInstallPath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-emit-module", "-emit-module-path",
-                                     path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: true),
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: false),
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       for job in jobs {
@@ -750,15 +748,15 @@ final class CachingBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let dependencyOracle = InterModuleDependencyOracle()
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "/tmp/Foo.o",
                                      "-explicit-module-build",
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     "-Xcc", "-ivfsoverlay", "-Xcc", vfsoverlay.nativePathString(escaped: true),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     "-Xcc", "-ivfsoverlay", "-Xcc", vfsoverlay.nativePathString(escaped: false),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
       // Plan a build to initialize the scanner and the CAS underneath.
       _ = try driver.planBuild()
@@ -851,7 +849,7 @@ final class CachingBuildTests: XCTestCase {
                                       // FIXME: We need to differentiate the scanning action hash,
                                       // though the module-name above should be sufficient.
                                       "-I/tmp/bad",
-                                      "-cas-path", casPath2.nativePathString(escaped: true),
+                                      "-cas-path", casPath2.nativePathString(escaped: false),
                                       ]
       var scanDiagnostics: [ScannerDiagnosticPayload] = []
       do {
@@ -888,19 +886,19 @@ final class CachingBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let mockBlocklistDir = try testInputsPath.appending(components: "Dummy.xctoolchain", "usr", "bin")
       var env = ProcessEnv.block
-      env["_SWIFT_DRIVER_MOCK_BLOCK_LIST_DIR"] = mockBlocklistDir.nativePathString(escaped: true)
+      env["_SWIFT_DRIVER_MOCK_BLOCK_LIST_DIR"] = mockBlocklistDir.nativePathString(escaped: false)
       let dependencyOracle = InterModuleDependencyOracle()
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-g", "-explicit-module-build",
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-disable-clang-target", "-scanner-prefix-map-sdk", "/^sdk",
                                      "-scanner-prefix-map-toolchain", "/^toolchain",
                                      "-scanner-prefix-map", testInputsPath.description + "=/^src",
                                      "-scanner-prefix-map", path.description + "=/^tmp",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               env: env,
                               interModuleDependencyOracle: dependencyOracle)
       guard driver.isFrontendArgSupported(.scannerPrefixMapPaths) else {
@@ -972,15 +970,15 @@ final class CachingBuildTests: XCTestCase {
           cHeadersPath.appending(component: "Bridging.h")
       let dependencyOracle = InterModuleDependencyOracle()
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-Rcache-compile-job", "-incremental",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     "-output-file-map", ofm.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     "-output-file-map", ofm.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -1027,15 +1025,15 @@ final class CachingBuildTests: XCTestCase {
           cHeadersPath.appending(component: "Bridging.h")
       let dependencyOracle = InterModuleDependencyOracle()
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-Rcache-compile-job", "-incremental",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     "-output-file-map", ofm.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     "-output-file-map", ofm.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -1073,16 +1071,16 @@ final class CachingBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var env = ProcessEnv.block
-      env["SWIFT_CRASH_DIAGNOSTICS_DIR"] = path.nativePathString(escaped: true)
+      env["SWIFT_CRASH_DIAGNOSTICS_DIR"] = path.nativePathString(escaped: false)
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-enable-deterministic-check",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-Xfrontend", "-debug-crash-after-parse",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting,
                               env: env)
       guard driver.isFrontendArgSupported(.genReproducer) else {
         throw XCTSkip("crash reproducer not supported")
@@ -1121,14 +1119,14 @@ final class CachingBuildTests: XCTestCase {
       let bridgingHeaderpath: AbsolutePath =
           cHeadersPath.appending(component: "Bridging.h")
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-enable-deterministic-check",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       jobs.forEach { job in
         guard job.kind == .compile else {
@@ -1187,13 +1185,13 @@ final class CachingBuildTests: XCTestCase {
 
       func createDriver(main: AbsolutePath) throws -> Driver {
         return try Driver(args: ["swiftc",
-                                 "-I", cHeadersPath.nativePathString(escaped: true),
-                                 "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                 "-I", cHeadersPath.nativePathString(escaped: false),
+                                 "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                  "-explicit-module-build", "-Rcache-compile-job",
-                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                 "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-                                 "-working-directory", path.nativePathString(escaped: true),
-                                 main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                 "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+                                 "-working-directory", path.nativePathString(escaped: false),
+                                 main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       }
 
       func buildAndGetSwiftCASKeys(main: AbsolutePath, forceCASLimit: Bool) throws -> [String] {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -241,15 +241,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     source0.nativePathString(escaped: true),
-                                     source1.nativePathString(escaped: true)] + sdkArgumentsForTesting)
-
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     source0.nativePathString(escaped: false),
+                                     source1.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       let compileJobs = jobs.filter({ $0.kind == .compile })
       XCTAssertEqual(compileJobs.count, 2)
@@ -294,13 +293,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
         .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       let compileJob = try XCTUnwrap(jobs.first(where: { $0.kind == .compile }))
 
@@ -372,13 +371,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       var fooBuildDriver = try Driver(args: ["swiftc",
                                              "-explicit-module-build", "-auto-bridging-header-chaining",
-                                             "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                             "-working-directory", path.nativePathString(escaped: true),
-                                             foo.nativePathString(escaped: true),
+                                             "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                             "-working-directory", path.nativePathString(escaped: false),
+                                             foo.nativePathString(escaped: false),
                                              "-emit-module", "-wmo", "-module-name", "Foo",
-                                             "-emit-module-path", FooInstallPath.appending(component: "Foo.swiftmodule").nativePathString(escaped: true),
-                                             "-import-objc-header", fooHeader.nativePathString(escaped: true),
-                                             "-pch-output-dir", PCHPath.nativePathString(escaped: true)]
+                                             "-emit-module-path", FooInstallPath.appending(component: "Foo.swiftmodule").nativePathString(escaped: false),
+                                             "-import-objc-header", fooHeader.nativePathString(escaped: false),
+                                             "-pch-output-dir", PCHPath.nativePathString(escaped: false)]
                                       + sdkArgumentsForTesting)
 
       let fooJobs = try fooBuildDriver.planBuild()
@@ -387,15 +386,15 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       // If no chained bridging header is used, always pass pch through -import-objc-header
       var driver = try Driver(args: ["swiftc",
-                                     "-I", FooInstallPath.nativePathString(escaped: true),
+                                     "-I", FooInstallPath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-no-auto-bridging-header-chaining",
-                                     "-pch-output-dir", FooInstallPath.nativePathString(escaped: true),
-                                     "-import-objc-header", userHeader.nativePathString(escaped: true),
+                                     "-pch-output-dir", FooInstallPath.nativePathString(escaped: false),
+                                     "-import-objc-header", userHeader.nativePathString(escaped: false),
                                      "-emit-module", "-emit-module-path",
-                                     path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: true),
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: false),
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       var jobs = try driver.planBuild()
       XCTAssertTrue(jobs.contains { $0.kind == .generatePCH })
       XCTAssertTrue(jobs.allSatisfy {
@@ -410,14 +409,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       // Warn if -disable-bridging-pch is used with auto bridging header chaining.
       driver = try Driver(args: ["swiftc",
-                                 "-I", FooInstallPath.nativePathString(escaped: true),
+                                 "-I", FooInstallPath.nativePathString(escaped: false),
                                  "-explicit-module-build", "-auto-bridging-header-chaining", "-disable-bridging-pch",
-                                 "-pch-output-dir", FooInstallPath.nativePathString(escaped: true),
+                                 "-pch-output-dir", FooInstallPath.nativePathString(escaped: false),
                                  "-emit-module", "-emit-module-path",
-                                 path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: true),
-                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                 "-working-directory", path.nativePathString(escaped: true),
-                                 main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                 path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: false),
+                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                 "-working-directory", path.nativePathString(escaped: false),
+                                 main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       jobs = try driver.planBuild()
       XCTAssertTrue(driver.diagnosticEngine.diagnostics.contains {
         $0.behavior == .warning && $0.message.text == "-auto-bridging-header-chaining requires generatePCH job, no chaining will be performed"
@@ -425,14 +424,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertFalse(jobs.contains { $0.kind == .generatePCH })
 
       driver = try Driver(args: ["swiftc",
-                                 "-I", FooInstallPath.nativePathString(escaped: true),
+                                 "-I", FooInstallPath.nativePathString(escaped: false),
                                  "-explicit-module-build", "-auto-bridging-header-chaining",
-                                 "-pch-output-dir", FooInstallPath.nativePathString(escaped: true),
+                                 "-pch-output-dir", FooInstallPath.nativePathString(escaped: false),
                                  "-emit-module", "-emit-module-path",
-                                 path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: true),
-                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                 "-working-directory", path.nativePathString(escaped: true),
-                                 main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                 path.appending(component: "testEMBETEWBHD.swiftmodule").nativePathString(escaped: false),
+                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                 "-working-directory", path.nativePathString(escaped: false),
+                                 main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       jobs = try driver.planBuild()
       XCTAssertTrue(jobs.contains { $0.kind == .generatePCH })
       XCTAssertTrue(jobs.allSatisfy {
@@ -474,13 +473,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
         throw XCTSkip("libSwiftScan does not support link library reporting.")
       }
 
-      let args = ["swiftc",
-                  "-I", cHeadersPath.nativePathString(escaped: true),
-                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                  "-explicit-module-build", "-explicit-auto-linking",
-                  "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                  main.nativePathString(escaped: true)] + sdkArgumentsForTesting
-      var driver = try Driver(args: args)
+      var driver = try Driver(args: ["swiftc",
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-explicit-module-build", "-explicit-auto-linking",
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
 
       let linkJob = try jobs.findJob(.link)
@@ -531,12 +529,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       }
 
       let args = ["swiftc",
-                  "-I", cHeadersPath.nativePathString(escaped: true),
-                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                  "-I", cHeadersPath.nativePathString(escaped: false),
+                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                   "-explicit-module-build",
                   "-Xfrontend", "-disable-implicit-concurrency-module-import",
                   "-Xfrontend", "-disable-implicit-string-processing-module-import",
-                  main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                  main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       var driver = try Driver(args: args)
       let _ = try driver.planBuild()
       let dependencyGraph = try XCTUnwrap(driver.intermoduleDependencyGraph)
@@ -550,20 +548,20 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                                           sourceLocations: [])))
       XCTAssertTrue(mainModuleImports.contains(ImportInfo(importIdentifier: "C",
                                                           accessLevel: ImportInfo.ImportAccessLevel.Public,
-                                                          sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
+                                                          sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: false),
                                                                                                             lineNumber: 1,
                                                                                                             columnNumber: 15),
-                                                                            ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
+                                                                            ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: false),
                                                                                                             lineNumber: 4,
                                                                                                             columnNumber: 17)])))
       XCTAssertTrue(mainModuleImports.contains(ImportInfo(importIdentifier: "E",
                                                           accessLevel: ImportInfo.ImportAccessLevel.Internal,
-                                                          sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
+                                                          sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: false),
                                                                                                             lineNumber: 2,
                                                                                                             columnNumber: 17)])))
       XCTAssertTrue(mainModuleImports.contains(ImportInfo(importIdentifier: "G",
                                                           accessLevel: ImportInfo.ImportAccessLevel.Private,
-                                                          sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
+                                                          sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: false),
                                                                                                             lineNumber: 3,
                                                                                                             columnNumber: 16)])))
     }
@@ -598,11 +596,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
       }
 
       let args = ["swiftc",
-                  "-I", cHeadersPath.nativePathString(escaped: true),
-                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                  "-I", cHeadersPath.nativePathString(escaped: false),
+                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                   "-explicit-module-build",
-                  "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                  main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                  "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                  main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       var driver = try Driver(args: args)
       // If this is a supported flow, then it is currently required for this test
       if driver.isFrontendArgSupported(.scannerModuleValidation) {
@@ -685,15 +683,15 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
                                      "-disable-implicit-concurrency-module-import",
                                      "-disable-implicit-string-processing-module-import",
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
 
       let jobs = try driver.planBuild()
       // Figure out which Triples to use.
@@ -837,19 +835,19 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
 
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-disable-implicit-concurrency-module-import",
                                      "-disable-implicit-string-processing-module-import",
                                      "-register-module-dependency", "E",
                                      "-register-module-dependency", "G",
                                      "-emit-loaded-module-trace",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let dependencyGraph = try driver.scanModuleDependencies()
       let jobs = try driver.planBuild()
       // E and G SHOULD be in the dependency graph (registered for scanning)
@@ -916,12 +914,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let invocationArguments = ["swiftc",
                                  "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
-                                 "-I", cHeadersPath.nativePathString(escaped: true),
-                                 "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                 "-I", cHeadersPath.nativePathString(escaped: false),
+                                 "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                  "-explicit-module-build",
-                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                 "-working-directory", path.nativePathString(escaped: true),
-                                 main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                 "-working-directory", path.nativePathString(escaped: false),
+                                 main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       var driver = try Driver(args: invocationArguments)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -1003,14 +1001,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                  "-emit-module",
                                  "-enable-library-evolution", "-emit-module-interface", "-driver-show-incremental",
                                  "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
-                                 "-I", cHeadersPath.nativePathString(escaped: true),
-                                 "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                 "-I", cHeadersPath.nativePathString(escaped: false),
+                                 "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                  "-explicit-module-build",
-                                 "-emit-module-interface-path", swiftInterfaceOutput.nativePathString(escaped: true),
-                                 "-output-file-map", outputFileMap.nativePathString(escaped: true),
-                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                 "-working-directory", path.nativePathString(escaped: true),
-                                 main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                                 "-emit-module-interface-path", swiftInterfaceOutput.nativePathString(escaped: false),
+                                 "-output-file-map", outputFileMap.nativePathString(escaped: false),
+                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                 "-working-directory", path.nativePathString(escaped: false),
+                                 main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       var driver = try Driver(args: invocationArguments)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -1057,15 +1055,15 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
                                      "-swift-version", "5",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
-                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: true),
-                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
+                                     "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: false),
+                                     "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: false),
                                      "-explicit-module-build", "-verify-emitted-module-interface",
                                      "-enable-library-evolution",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
 
       guard driver.supportExplicitModuleVerifyInterface() else {
         throw XCTSkip("-typecheck-module-from-interface doesn't support explicit build.")
@@ -1220,15 +1218,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let pchOutputDir: AbsolutePath = path
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
-                                     "-pch-output-dir", pchOutputDir.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
-
+                                     "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: false),
+                                     "-pch-output-dir", pchOutputDir.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       // Figure out which Triples to use.
       let dependencyGraph = try driver.scanModuleDependencies()
@@ -1354,12 +1351,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swift",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
 
       let jobs = try driver.planBuild()
 
@@ -1460,21 +1457,21 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let (stdLibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
 
       let srcBar = path.appending(component: "bar.swift")
-      let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: true)
+      let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: false)
       try localFileSystem.writeFileContents(srcBar, bytes: "public class KlassBar {}")
 
       // Create Bar.swiftmodule
       var driver = try Driver(args: ["swiftc",
                                      "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                      "-explicit-module-build",
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     srcBar.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     srcBar.nativePathString(escaped: false),
                                      "-module-name", "Bar",
                                      "-emit-module",
                                      "-emit-module-path", moduleBarPath,
-                                     "-module-cache-path", path.nativePathString(escaped: true),
-                                     "-I", stdLibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-module-cache-path", path.nativePathString(escaped: false),
+                                     "-I", stdLibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                               ] + sdkArgumentsForTesting)
       guard driver.isFrontendArgSupported(.moduleAlias) else {
         throw XCTSkip("Skipping: compiler does not support '-module-alias'")
@@ -1502,12 +1499,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       "-nonlib-dependency-scanner",
                                       "-explicit-module-build",
                                       "-working-directory",
-                                      path.nativePathString(escaped: true),
-                                      srcFoo.nativePathString(escaped: true),
+                                      path.nativePathString(escaped: false),
+                                      srcFoo.nativePathString(escaped: false),
                                       "-module-alias", "Car=Bar",
-                                      "-I", path.nativePathString(escaped: true),
-                                      "-I", stdLibPath.nativePathString(escaped: true),
-                                      "-I", shimsPath.nativePathString(escaped: true),
+                                      "-I", path.nativePathString(escaped: false),
+                                      "-I", stdLibPath.nativePathString(escaped: false),
+                                      "-I", shimsPath.nativePathString(escaped: false),
                                      ] + sdkArgumentsForTesting)
 
       // Resulting graph should contain the real module name Bar
@@ -1529,12 +1526,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driverB = try Driver(args: ["swiftc",
                                       "-explicit-module-build",
                                       "-working-directory",
-                                      path.nativePathString(escaped: true),
-                                      srcFoo.nativePathString(escaped: true),
+                                      path.nativePathString(escaped: false),
+                                      srcFoo.nativePathString(escaped: false),
                                       "-module-alias", "Car=Bar",
-                                      "-I", path.nativePathString(escaped: true),
-                                      "-I", stdLibPath.nativePathString(escaped: true),
-                                      "-I", shimsPath.nativePathString(escaped: true),
+                                      "-I", path.nativePathString(escaped: false),
+                                      "-I", stdLibPath.nativePathString(escaped: false),
+                                      "-I", shimsPath.nativePathString(escaped: false),
                                      ] + sdkArgumentsForTesting)
 
       // Resulting graph should contain the real module name Bar
@@ -1574,11 +1571,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driverA = try Driver(args: ["swiftc",
                                       "-nonlib-dependency-scanner",
                                       "-explicit-module-build",
-                                      srcFoo.nativePathString(escaped: true),
+                                      srcFoo.nativePathString(escaped: false),
                                       "-module-alias", "Car=E",
-                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                      "-I", stdLibPath.nativePathString(escaped: true),
-                                      "-I", shimsPath.nativePathString(escaped: true),
+                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                      "-I", stdLibPath.nativePathString(escaped: false),
+                                      "-I", shimsPath.nativePathString(escaped: false),
                                      ] + sdkArgumentsForTesting)
       guard driverA.isFrontendArgSupported(.moduleAlias) else {
         throw XCTSkip("Skipping: compiler does not support '-module-alias'")
@@ -1602,12 +1599,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // Module alias with the default scanner (driver scanner)
       var driverB = try Driver(args: ["swiftc",
                                       "-explicit-module-build",
-                                      srcFoo.nativePathString(escaped: true),
+                                      srcFoo.nativePathString(escaped: false),
                                       "-module-alias", "Car=E",
-                                      "-working-directory", path.nativePathString(escaped: true),
-                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                      "-I", stdLibPath.nativePathString(escaped: true),
-                                      "-I", shimsPath.nativePathString(escaped: true),
+                                      "-working-directory", path.nativePathString(escaped: false),
+                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                      "-I", stdLibPath.nativePathString(escaped: false),
+                                      "-I", shimsPath.nativePathString(escaped: false),
                                      ] + sdkArgumentsForTesting)
 
       // Resulting graph should contain the real module name Bar
@@ -1654,7 +1651,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             "-import-prescan",
                             "-module-alias",
                             "Car=Bar",
-                            main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                            main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       var scanDiagnostics: [ScannerDiagnosticPayload] = []
       let deps =
         try dependencyOracle.getImports(workingDirectory: path,
@@ -1674,7 +1671,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let moduleCachePath = path.appending(component: "ModuleCache")
       try localFileSystem.createDirectory(moduleCachePath)
       let srcBar = path.appending(component: "bar.swift")
-      let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: true)
+      let moduleBarPath = path.appending(component: "Bar.swiftmodule").nativePathString(escaped: false)
       try localFileSystem.writeFileContents(srcBar, bytes: "public class KlassBar {}")
 
       // Explicitly use an output file map to avoid an in-place job.
@@ -1694,14 +1691,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                       "-explicit-module-build",
                                       "-module-name", "Bar",
-                                      "-working-directory", path.nativePathString(escaped: true),
+                                      "-working-directory", path.nativePathString(escaped: false),
                                       "-output-file-map", outputFileMap.nativePathString(escaped: false),
                                       "-emit-module",
                                       "-emit-module-path", moduleBarPath,
-                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                      srcBar.nativePathString(escaped: true),
-                                      "-I", stdLibPath.nativePathString(escaped: true),
-                                      "-I", shimsPath.nativePathString(escaped: true),
+                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                      srcBar.nativePathString(escaped: false),
+                                      "-I", stdLibPath.nativePathString(escaped: false),
+                                      "-I", shimsPath.nativePathString(escaped: false),
                                      ] + sdkArgumentsForTesting)
       guard driver1.isFrontendArgSupported(.moduleAlias) else {
         throw XCTSkip("Skipping: compiler does not support '-module-alias'")
@@ -1713,7 +1710,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertTrue(FileManager.default.fileExists(atPath: moduleBarPath))
 
       let srcFoo = path.appending(component: "foo.swift")
-      let moduleFooPath = path.appending(component: "Foo.swiftmodule").nativePathString(escaped: true)
+      let moduleFooPath = path.appending(component: "Foo.swiftmodule").nativePathString(escaped: false)
 
       // Module Foo imports Car but it's mapped to Bar (real name)
       // `-module-alias Car=Bar` allows Car (alias) to be referenced
@@ -1727,18 +1724,18 @@ final class ExplicitModuleBuildTests: XCTestCase {
       )
       var driver2 = try Driver(args: ["swiftc",
                                       "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
-                                      "-I", path.nativePathString(escaped: true),
+                                      "-I", path.nativePathString(escaped: false),
                                       "-explicit-module-build",
                                       "-module-name", "Foo",
-                                      "-working-directory", path.nativePathString(escaped: true),
+                                      "-working-directory", path.nativePathString(escaped: false),
                                       "-output-file-map", outputFileMap.nativePathString(escaped: false),
                                       "-emit-module",
                                       "-emit-module-path", moduleFooPath,
-                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
+                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
                                       "-module-alias", "Car=Bar",
-                                      srcFoo.nativePathString(escaped: true),
-                                      "-I", stdLibPath.nativePathString(escaped: true),
-                                      "-I", shimsPath.nativePathString(escaped: true),
+                                      srcFoo.nativePathString(escaped: false),
+                                      "-I", stdLibPath.nativePathString(escaped: false),
+                                      "-I", shimsPath.nativePathString(escaped: false),
                                       ] + sdkArgumentsForTesting)
       let jobs2 = try driver2.planBuild()
       try driver2.run(jobs: jobs2)
@@ -1770,12 +1767,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
                                      "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
@@ -1796,19 +1793,19 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // Setup the build plan
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", stdLibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", stdLibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
                                      "-dependency-scan-serialize-diagnostics-path",
                                      serializedDiagnosticsOutputPath.nativePathString(escaped: false),
                                      "-module-name", "main",
                                      "-target", hostTriple.triple,
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-clang-scanner-module-cache-path",
                                      scannerCachePath.nativePathString(escaped: false),
                                      "-module-cache-path",
-                                     moduleCachePath.nativePathString(escaped: true),
-                                     mainSourcePath.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     moduleCachePath.nativePathString(escaped: false),
+                                     mainSourcePath.nativePathString(escaped: false)] + sdkArgumentsForTesting)
 
       // Set up the in-memory dependency scan using the dependency oracle
       let dependencyOracle = driver.interModuleDependencyOracle
@@ -1855,14 +1852,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // 1. Build Foo module
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driverFoo = try Driver(args: ["swiftc",
-                                        "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
+                                        "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
                                         "-module-name", "Foo",
                                         "-emit-module",
                                         "-emit-module-path",
-                                        frameworkModulePath.nativePathString(escaped: true),
+                                        frameworkModulePath.nativePathString(escaped: false),
                                         "-working-directory",
-                                        path.nativePathString(escaped: true),
-                                        fooSourcePath.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                        path.nativePathString(escaped: false),
+                                        fooSourcePath.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driverFoo.planBuild()
       try driverFoo.run(jobs: jobs)
       XCTAssertFalse(driverFoo.diagnosticEngine.hasErrors)
@@ -1876,13 +1873,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
       }
 
       var driver = try Driver(args: ["swiftc",
-                                     "-I", stdLibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
-                                     "-F", frameworksPath.nativePathString(escaped: true),
+                                     "-I", stdLibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
+                                     "-F", frameworksPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
                                      "-module-name", "main",
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     mainSourcePath.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     mainSourcePath.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       if scannerCommand.first == "-frontend" {
@@ -1934,11 +1931,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let scannerCommand = ["-scan-dependencies",
                             "-import-prescan",
-                            "-I", cHeadersPath.nativePathString(escaped: true),
-                            "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                            "-I", stdLibPath.nativePathString(escaped: true),
-                            "-I", shimsPath.nativePathString(escaped: true),
-                            main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                            "-I", cHeadersPath.nativePathString(escaped: false),
+                            "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                            "-I", stdLibPath.nativePathString(escaped: false),
+                            "-I", shimsPath.nativePathString(escaped: false),
+                            main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       var scanDiagnostics: [ScannerDiagnosticPayload] = []
       let imports =
         try dependencyOracle.getImports(workingDirectory: path,
@@ -1972,8 +1969,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
                                      "-explicit-module-build",
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + lotsOfInputs + sdkArgumentsForTesting)
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + lotsOfInputs + sdkArgumentsForTesting)
       let scannerJob = try driver.dependencyScanningJob()
 
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
@@ -1996,9 +1993,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-clang-scanner-module-cache-path",
                                      scannerCachePath.nativePathString(escaped: false),
                                      "-module-cache-path",
-                                     moduleCachePath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     moduleCachePath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       guard driver.isFrontendArgSupported(.clangScannerModuleCachePath) else {
         throw XCTSkip("Skipping: compiler does not support '-clang-scanner-module-cache-path'")
       }
@@ -2033,14 +2030,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
                         .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       if scannerCommand.first == "-frontend" {
@@ -2106,12 +2103,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try localFileSystem.writeFileContents(main, bytes: "import FooBar")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "-explicit-module-build",
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       if scannerCommand.first == "-frontend" {
@@ -2192,16 +2189,16 @@ final class ExplicitModuleBuildTests: XCTestCase {
         .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "/tmp/Foo.o",
                                      "-plugin-path", "PluginA", "-external-plugin-path", "Plugin~B#Bexe",
                                      "-explicit-module-build",
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       XCTAssertTrue(scannerCommand.contains("-plugin-path"))
@@ -2246,15 +2243,15 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-I", cHeadersPath.nativePathString(escaped: true),
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-I", stdlibPath.nativePathString(escaped: true),
-                                     "-I", shimsPath.nativePathString(escaped: true),
+                                     "-I", cHeadersPath.nativePathString(escaped: false),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                     "-I", stdlibPath.nativePathString(escaped: false),
+                                     "-I", shimsPath.nativePathString(escaped: false),
                                      "/tmp/Foo.o",
                                      "-explicit-module-build",
-                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: false),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       // We generate full swiftc -frontend -scan-dependencies invocations in order to also be
@@ -2352,7 +2349,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       try localFileSystem.writeFileContents(dummyBrokenDylib, bytes: "n/a")
 
       var environment = ProcessEnv.block
-      environment["SWIFT_DRIVER_SWIFTSCAN_LIB"] = dummyBrokenDylib.nativePathString(escaped: true)
+      environment["SWIFT_DRIVER_SWIFTSCAN_LIB"] = dummyBrokenDylib.nativePathString(escaped: false)
 
       let cHeadersPath: AbsolutePath =
       try testInputsPath.appending(component: "ExplicitModuleBuilds")
@@ -2362,20 +2359,20 @@ final class ExplicitModuleBuildTests: XCTestCase {
         .appending(component: "Swift")
       let sdkArgumentsForTesting: [String] = (try? Driver.sdkArgumentsForTesting()) ?? []
       let driverArgs: [String] = ["swiftc",
-                                  "-I", cHeadersPath.nativePathString(escaped: true),
-                                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                  "-I", stdlibPath.nativePathString(escaped: true),
-                                  "-I", shimsPath.nativePathString(escaped: true),
+                                  "-I", cHeadersPath.nativePathString(escaped: false),
+                                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                  "-I", stdlibPath.nativePathString(escaped: false),
+                                  "-I", shimsPath.nativePathString(escaped: false),
                                   "/tmp/Foo.o",
                                   "-explicit-module-build",
-                                  "-working-directory", path.nativePathString(escaped: true),
+                                  "-working-directory", path.nativePathString(escaped: false),
                                   "-disable-clang-target",
-                                  main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                                  main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       do {
         var driver = try Driver(args: driverArgs, env: environment)
         let interModuleDependencyGraph = try driver.performDependencyScan()
         XCTAssertTrue(driver.diagnosticEngine.diagnostics.contains { $0.behavior == .warning &&
-          $0.message.text == "In-process dependency scan query failed due to incompatible libSwiftScan (\(dummyBrokenDylib.nativePathString(escaped: true))). Fallback to `swift-frontend` dependency scanner invocation. Specify '-nonlib-dependency-scanner' to silence this warning."})
+          $0.message.text == "In-process dependency scan query failed due to incompatible libSwiftScan (\(dummyBrokenDylib.nativePathString(escaped: false))). Fallback to `swift-frontend` dependency scanner invocation. Specify '-nonlib-dependency-scanner' to silence this warning."})
         XCTAssertTrue(interModuleDependencyGraph.mainModule.directDependencies?.contains(where: { $0.moduleName == "C" }))
       }
 
@@ -2384,7 +2381,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         var driver = try Driver(args: driverArgs + ["-nonlib-dependency-scanner"], env: environment)
         let _ = try driver.performDependencyScan()
         XCTAssertFalse(driver.diagnosticEngine.diagnostics.contains { $0.behavior == .warning &&
-          $0.message.text == "In-process dependency scan query failed due to incompatible libSwiftScan (\(dummyBrokenDylib.nativePathString(escaped: true))). Fallback to `swift-frontend` dependency scanner invocation. Specify '-nonlib-dependency-scanner' to silence this warning."})
+          $0.message.text == "In-process dependency scan query failed due to incompatible libSwiftScan (\(dummyBrokenDylib.nativePathString(escaped: false))). Fallback to `swift-frontend` dependency scanner invocation. Specify '-nonlib-dependency-scanner' to silence this warning."})
       }
 
       // Ensure error is emitted when caching is enabled
@@ -2392,7 +2389,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         var driver = try Driver(args: driverArgs + ["-cache-compile-job"], env: environment)
         let _ = try driver.performDependencyScan()
         XCTAssertFalse(driver.diagnosticEngine.diagnostics.contains { $0.behavior == .error &&
-          $0.message.text == "Swift Caching enabled - libSwiftScan load failed (\(dummyBrokenDylib.nativePathString(escaped: true))."})
+          $0.message.text == "Swift Caching enabled - libSwiftScan load failed (\(dummyBrokenDylib.nativePathString(escaped: false))."})
       }
     }
   }
@@ -2417,13 +2414,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let baseDriverArgs = ["swiftc",
-                            "-I", cHeadersPath.nativePathString(escaped: true),
-                            "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                            "-I", stdlibPath.nativePathString(escaped: true),
-                            "-I", shimsPath.nativePathString(escaped: true),
+                            "-I", cHeadersPath.nativePathString(escaped: false),
+                            "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                            "-I", stdlibPath.nativePathString(escaped: false),
+                            "-I", shimsPath.nativePathString(escaped: false),
                             "/tmp/Foo.o",
                             "-explicit-module-build",
-                            "-working-directory", path.nativePathString(escaped: true),
+                            "-working-directory", path.nativePathString(escaped: false),
                             "-disable-clang-target"] + sdkArgumentsForTesting
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let numFiles = 10
@@ -2434,7 +2431,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         files.append(path.appending(component: "testParallelDependencyScanningDiagnostics\(fileIndex).swift"))
         try localFileSystem.writeFileContents(files.last!, bytes: ByteString(encodingAsUTF8: "import UnknownModule\(fileIndex);"))
         var driver = try Driver(args: baseDriverArgs +
-                                      [files.last!.nativePathString(escaped: true)] +
+                                      [files.last!.nativePathString(escaped: false)] +
                                       ["-module-name","testParallelDependencyScanningDiagnostics\(fileIndex)"] +
                                        // FIXME: We need to differentiate the scanning action hash,
                                        // though the module-name above should be sufficient.
@@ -2513,9 +2510,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
 
       let baseCommandLine = ["swiftc",
-                             "-I", cHeadersPath.nativePathString(escaped: true),
-                             "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                             main.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                             "-I", cHeadersPath.nativePathString(escaped: false),
+                             "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                             main.nativePathString(escaped: false)] + sdkArgumentsForTesting
       do {
         let diagnosticEngine = DiagnosticsEngine()
         var driver = try Driver(args: baseCommandLine + ["-print-explicit-dependency-graph"],
@@ -2611,14 +2608,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
                               .appending(component: "Swift")
         let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
         var driver = try Driver(args: ["swiftc",
-                                       "-I", cHeadersPath.nativePathString(escaped: true),
-                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                       "-I", stdlibPath.nativePathString(escaped: true),
-                                       "-I", shimsPath.nativePathString(escaped: true),
+                                       "-I", cHeadersPath.nativePathString(escaped: false),
+                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                       "-I", stdlibPath.nativePathString(escaped: false),
+                                       "-I", shimsPath.nativePathString(escaped: false),
                                        "-explicit-module-build",
-                                       "-working-directory", path.nativePathString(escaped: true),
+                                       "-working-directory", path.nativePathString(escaped: false),
                                        "-disable-clang-target",
-                                       main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                       main.nativePathString(escaped: false)] + sdkArgumentsForTesting)
         let resolver = try ArgsResolver(fileSystem: localFileSystem)
         var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
         if scannerCommand.first == "-frontend" {
@@ -2744,13 +2741,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
         try assertDriverDiagnostics(args: [
             "swiftc",
             "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
-            "-I", cHeadersPath.nativePathString(escaped: true),
-            "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+            "-I", cHeadersPath.nativePathString(escaped: false),
+            "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
             "-explicit-module-build",
-            "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-            "-working-directory", path.nativePathString(escaped: true),
+            "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+            "-working-directory", path.nativePathString(escaped: false),
             "-explain-module-dependency-detailed", "A",
-            main.nativePathString(escaped: true)
+            main.nativePathString(escaped: false)
         ] + sdkArgumentsForTesting) { driver, diagnostics in
           diagnostics.forbidUnexpected(.error, .warning, .note, .remark)
           diagnostics.expect(.remark("Module 'testTraceDependency' depends on 'A'"))
@@ -2765,13 +2762,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
         try assertDriverDiagnostics(args:[
             "swiftc",
             "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
-            "-I", cHeadersPath.nativePathString(escaped: true),
-            "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+            "-I", cHeadersPath.nativePathString(escaped: false),
+            "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
             "-explicit-module-build",
-            "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-            "-working-directory", path.nativePathString(escaped: true),
+            "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+            "-working-directory", path.nativePathString(escaped: false),
             "-explain-module-dependency", "A",
-            main.nativePathString(escaped: true)
+            main.nativePathString(escaped: false)
         ] + sdkArgumentsForTesting) { driver, diagnostics in
           diagnostics.forbidUnexpected(.error, .warning, .note, .remark)
           diagnostics.expect(.remark("Module 'testTraceDependency' depends on 'A'"))
@@ -2806,11 +2803,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                      "-explicit-module-build", "-module-name", "Test",
-                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                     "-working-directory", path.nativePathString(escaped: true),
-                                     "-emit-module", "-emit-module-path", outputModule.nativePathString(escaped: true),
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                     "-working-directory", path.nativePathString(escaped: false),
+                                     "-emit-module", "-emit-module-path", outputModule.nativePathString(escaped: false),
                                      "-experimental-emit-module-separately",
-                                     fileA.nativePathString(escaped: true), fileB.nativePathString(escaped: true)] + sdkArgumentsForTesting)
+                                     fileA.nativePathString(escaped: false), fileB.nativePathString(escaped: false)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       let compileJobs = jobs.filter({ $0.kind == .compile })
       XCTAssertEqual(compileJobs.count, 0)
@@ -2847,12 +2844,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-Xfrontend", "-disable-implicit-string-processing-module-import",
                                        "-emit-module",
                                        "-emit-module-path", "foo.swiftmodule/target.swiftmodule",
-                                       "-I", cHeadersPath.nativePathString(escaped: true),
-                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                       "-I", stdlibPath.nativePathString(escaped: true),
-                                       "-I", shimsPath.nativePathString(escaped: true),
+                                       "-I", cHeadersPath.nativePathString(escaped: false),
+                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                       "-I", stdlibPath.nativePathString(escaped: false),
+                                       "-I", shimsPath.nativePathString(escaped: false),
                                        "-explicit-module-build",
-                                       "-sdk", mockSDKPath.nativePathString(escaped: true),
+                                       "-sdk", mockSDKPath.nativePathString(escaped: false),
                                        main.pathString])
         let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
         let emitModuleJob = try XCTUnwrap(plannedJobs.findJobs(.emitModule).spm_only)
@@ -2877,12 +2874,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-Xfrontend", "-disable-implicit-string-processing-module-import",
                                        "-emit-module",
                                        "-emit-module-path", "foo.swiftmodule/target.swiftmodule",
-                                       "-I", cHeadersPath.nativePathString(escaped: true),
-                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                       "-I", stdlibPath.nativePathString(escaped: true),
-                                       "-I", shimsPath.nativePathString(escaped: true),
+                                       "-I", cHeadersPath.nativePathString(escaped: false),
+                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                       "-I", stdlibPath.nativePathString(escaped: false),
+                                       "-I", shimsPath.nativePathString(escaped: false),
                                        "-explicit-module-build",
-                                       "-sdk", mockSDKPath.nativePathString(escaped: true),
+                                       "-sdk", mockSDKPath.nativePathString(escaped: false),
                                        main.pathString])
         let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
         let emitModuleJob = try XCTUnwrap(plannedJobs.findJobs(.emitModule).spm_only)
@@ -2908,12 +2905,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-Xfrontend", "-disable-implicit-string-processing-module-import",
                                        "-emit-module",
                                        "-emit-module-path", "foo.swiftmodule/target.swiftmodule",
-                                       "-I", cHeadersPath.nativePathString(escaped: true),
-                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                       "-I", stdlibPath.nativePathString(escaped: true),
-                                       "-I", shimsPath.nativePathString(escaped: true),
+                                       "-I", cHeadersPath.nativePathString(escaped: false),
+                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                       "-I", stdlibPath.nativePathString(escaped: false),
+                                       "-I", shimsPath.nativePathString(escaped: false),
                                        "-explicit-module-build",
-                                       "-sdk", mockSDKPath.nativePathString(escaped: true),
+                                       "-sdk", mockSDKPath.nativePathString(escaped: false),
                                        main.pathString])
         let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
         let emitModuleJob = try XCTUnwrap(plannedJobs.findJobs(.emitModule).spm_only)
@@ -2941,12 +2938,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-Xfrontend", "-disable-implicit-string-processing-module-import",
                                        "-emit-module",
                                        "-emit-module-path", "foo.swiftmodule/target.swiftmodule",
-                                       "-I", cHeadersPath.nativePathString(escaped: true),
-                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                       "-I", stdlibPath.nativePathString(escaped: true),
-                                       "-I", shimsPath.nativePathString(escaped: true),
+                                       "-I", cHeadersPath.nativePathString(escaped: false),
+                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                       "-I", stdlibPath.nativePathString(escaped: false),
+                                       "-I", shimsPath.nativePathString(escaped: false),
                                        "-explicit-module-build",
-                                       "-sdk", mockSDKPath.nativePathString(escaped: true),
+                                       "-sdk", mockSDKPath.nativePathString(escaped: false),
                                        main.pathString])
         let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
         let emitModuleJob = try XCTUnwrap(plannedJobs.findJobs(.emitModule).spm_only)
@@ -2993,10 +2990,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-emit-variant-module-interface-path", "foo.swiftmodule/variant.swiftinterface",
                                        "-Xfrontend", "-disable-implicit-concurrency-module-import",
                                        "-Xfrontend", "-disable-implicit-string-processing-module-import",
-                                       "-I", cHeadersPath.nativePathString(escaped: true),
-                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                       "-I", stdlibPath.nativePathString(escaped: true),
-                                       "-I", shimsPath.nativePathString(escaped: true),
+                                       "-I", cHeadersPath.nativePathString(escaped: false),
+                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                       "-I", stdlibPath.nativePathString(escaped: false),
+                                       "-I", shimsPath.nativePathString(escaped: false),
                                        "-explicit-module-build",
                                        main.pathString] + sdkArgumentsForTesting)
 
@@ -3096,12 +3093,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-emit-variant-module-path", "foo.swiftmodule/variant.swiftmodule",
                                        "-Xfrontend", "-disable-implicit-concurrency-module-import",
                                        "-Xfrontend", "-disable-implicit-string-processing-module-import",
-                                       "-I", cHeadersPath.nativePathString(escaped: true),
-                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                       "-I", stdlibPath.nativePathString(escaped: true),
-                                       "-I", shimsPath.nativePathString(escaped: true),
-                                       "-import-objc-header", fooHeader.nativePathString(escaped: true),
-                                       "-pch-output-dir", PCHPath.nativePathString(escaped: true),
+                                       "-I", cHeadersPath.nativePathString(escaped: false),
+                                       "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+                                       "-I", stdlibPath.nativePathString(escaped: false),
+                                       "-I", shimsPath.nativePathString(escaped: false),
+                                       "-import-objc-header", fooHeader.nativePathString(escaped: false),
+                                       "-pch-output-dir", PCHPath.nativePathString(escaped: false),
                                        "-explicit-module-build",
                                        main.pathString] + sdkArgumentsForTesting)
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6869,11 +6869,11 @@ final class SwiftDriverTests: XCTestCase {
       let swiftModuleInterfacesPath: AbsolutePath =
       try testInputsPath.appending(component: "testLoadPackageInterface")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
-      var driver = try Driver(args: ["swiftc", main.nativePathString(escaped: true),
+      var driver = try Driver(args: ["swiftc", main.nativePathString(escaped: false),
                                      "-typecheck",
                                      "-package-name", "foopkg",
                                      "-experimental-package-interface-load",
-                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+                                     "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
                                      "-enable-library-evolution"] + sdkArgumentsForTesting,
                               env: envVars)
 
@@ -7973,12 +7973,12 @@ final class SwiftDriverTests: XCTestCase {
       func doBuild() throws -> Bool {
         let sdkArguments = try XCTUnwrap(try Driver.sdkArgumentsForTesting())
         var driver = try Driver(args: ["swiftc",
-                                       "-working-directory", tmpDir.nativePathString(escaped: true),
+                                       "-working-directory", tmpDir.nativePathString(escaped: false),
                                        "-module-name", "mod",
                                        "-c",
                                        "-incremental",
-                                       "-output-file-map", ofm.nativePathString(escaped: true),
-                                       main.nativePathString(escaped: true)] + sdkArguments)
+                                       "-output-file-map", ofm.nativePathString(escaped: false),
+                                       main.nativePathString(escaped: false)] + sdkArguments)
         let jobs = try driver.planBuild()
         do {try driver.run(jobs: jobs)}
         catch {return false}
@@ -8459,7 +8459,7 @@ final class SwiftDriverTests: XCTestCase {
   func testEmitAPIDescriptorEmitModule() throws {
     try withTemporaryDirectory { path in
       do {
-        let apiDescriptorPath = path.appending(component: "api.json").nativePathString(escaped: true)
+        let apiDescriptorPath = path.appending(component: "api.json").nativePathString(escaped: false)
         var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "baz.swift",
                                        "-emit-module", "-module-name", "Test",
                                        "-emit-api-descriptor-path", apiDescriptorPath])
@@ -8500,7 +8500,7 @@ final class SwiftDriverTests: XCTestCase {
   func testEmitAPIDescriptorWholeModuleOptimization() throws {
     try withTemporaryDirectory { path in
       do {
-        let apiDescriptorPath = path.appending(component: "api.json").nativePathString(escaped: true)
+        let apiDescriptorPath = path.appending(component: "api.json").nativePathString(escaped: false)
         var driver = try Driver(args: ["swiftc", "-whole-module-optimization",
                                        "-driver-filelist-threshold=0",
                                        "foo.swift", "bar.swift", "baz.swift",
@@ -8660,12 +8660,12 @@ final class SwiftDriverTests: XCTestCase {
                                  "-parse-as-library",
                                  "-emit-library",
                                  "-driver-filelist-threshold", "0",
-                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
-                                 "-working-directory", path.nativePathString(escaped: true),
-                                 one.nativePathString(escaped: true),
-                                 two.nativePathString(escaped: true),
-                                 three.nativePathString(escaped: true),
-                                 four.nativePathString(escaped: true)] + sdkArgumentsForTesting
+                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+                                 "-working-directory", path.nativePathString(escaped: false),
+                                 one.nativePathString(escaped: false),
+                                 two.nativePathString(escaped: false),
+                                 three.nativePathString(escaped: false),
+                                 four.nativePathString(escaped: false)] + sdkArgumentsForTesting
       var driver = try Driver(args: invocationArguments)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)


### PR DESCRIPTION
The extra escaping of paths results in the lookup for the dependencies in the CAS to be quoted further than desired. As a result, the `VirtualPath` fails to resolve and the test fails. Avoid the unnecessary escaping to allow the test to pass.