### PR TITLE
JobExecutor: consistently avoid canceling job when failure is encountered

### DIFF
--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -228,7 +228,7 @@ public final class MultiJobExecutor {
       case (.abnormal, false):
          isBuildCancelled = true
 #else
-       case (.signalled, _):
+       case (.signalled, false):
          isBuildCancelled = true
 #endif
       default:


### PR DESCRIPTION
When a job is signalled to abort, such as compiler crashers, etc, we should still avoid conceling other jobs if the executor has been configured as such.