### PR TITLE
SwiftDriverTests: adjust indentation (NFC)

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -910,13 +910,13 @@ extension IncrementalCompilationTests {
     XCTAssertTrue(mandatoryJobs.isEmpty)
   }
 
-    func testNullBuildNoVerify() throws {
-      let extraArguments = ["-experimental-emit-module-separately", "-emit-module", "-emit-module-interface", "-enable-library-evolution", "-verify-emitted-module-interface"]
-      try buildInitialState(extraArguments: extraArguments)
-      let driver = try checkNullBuild(extraArguments: extraArguments)
-      let mandatoryJobs = try XCTUnwrap(driver.incrementalCompilationState?.mandatoryJobsInOrder)
-      XCTAssertTrue(mandatoryJobs.isEmpty)
-    }
+  func testNullBuildNoVerify() throws {
+    let extraArguments = ["-experimental-emit-module-separately", "-emit-module", "-emit-module-interface", "-enable-library-evolution", "-verify-emitted-module-interface"]
+    try buildInitialState(extraArguments: extraArguments)
+    let driver = try checkNullBuild(extraArguments: extraArguments)
+    let mandatoryJobs = try XCTUnwrap(driver.incrementalCompilationState?.mandatoryJobsInOrder)
+    XCTAssertTrue(mandatoryJobs.isEmpty)
+  }
 
   func testSymlinkModification() throws {
     // Remap


### PR DESCRIPTION
Fix the indentation for a test. This just caught my eye while enabling the rest of the CAS related tests on Windows.