### PR TITLE
Enable CAS and associated tests on Windows

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -259,10 +259,6 @@ private extension String {
   }
 
   @_spi(Testing) public var supportsCaching : Bool {
-#if os(Windows)
-    // Caching is currently not supported on Windows hosts.
-    return false
-#else
     return api.swiftscan_cas_options_create != nil &&
            api.swiftscan_cas_options_dispose != nil &&
            api.swiftscan_cas_options_set_ondisk_path != nil &&
@@ -276,18 +272,12 @@ private extension String {
            api.swiftscan_swift_textual_detail_get_module_cache_key != nil &&
            api.swiftscan_swift_binary_detail_get_module_cache_key != nil &&
            api.swiftscan_clang_detail_get_module_cache_key != nil
-#endif
   }
 
   @_spi(Testing) public var supportsCASSizeManagement : Bool {
-#if os(Windows)
-    // CAS is currently not supported on Windows hosts.
-    return false
-#else
     return api.swiftscan_cas_get_ondisk_size != nil &&
            api.swiftscan_cas_set_ondisk_size_limit != nil &&
            api.swiftscan_cas_prune_ondisk_data != nil
-#endif
   }
 
   @_spi(Testing) public var supportsBridgingHeaderPCHCommand : Bool {

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -156,9 +156,6 @@ final class IncrementalCompilationTests: XCTestCase {
     if driver.isFrontendArgSupported(.moduleLoadMode) {
       self.extraExplicitBuildArgs = ["-Xfrontend", "-module-load-mode", "-Xfrontend", "prefer-interface"]
     }
-
-    // Disable incremental tests on windows due to very different module setup.
-    try XCTSkipIf(driver.targetTriple.isWindows, "https://github.com/swiftlang/swift-driver/issues/2029")
   }
 
   deinit {
@@ -773,14 +770,11 @@ extension IncrementalCompilationTests {
 // MARK: - Explicit compilation caching incremental tests
 extension IncrementalCompilationTests {
   func testIncrementalCompilationCaching() throws {
-#if os(Windows)
-    throw XCTSkip("caching not supported on windows")
-#else
     let driver = try Driver(args: ["swiftc"])
     guard driver.isFeatureSupported(.compilation_caching) else {
       throw XCTSkip("caching not supported")
     }
-#endif
+
     let extraArguments = ["-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true), "-O", "-parse-stdlib"]
     replace(contentsOf: "other", with: "import O;")
     // Simplified initial build.


### PR DESCRIPTION
CAS on Windows is now supported. Adjust the feature support reporting from SwiftScan to ensure that we can use the CAS on Windows.

Enable the incremental compilation tests on Windows. Now that CAS is supported on Windows and the Swift scanner issues resulted, we can enable the incremental module tests.

Enable the caching build tests on Windows. Now that CAS is supported on Windows, we can enable the caching build tests.

Fixes: #2039, #2040