### PR TITLE
SwiftDriver: correct typo (NFC)

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -131,11 +131,11 @@ public class InterModuleDependencyOracle {
     return swiftScan.supportsImportInfos
   }
 
-  @_spi(Testing) public func supportsSeparateImportOnlyDependencise() throws -> Bool {
+  @_spi(Testing) public func supportsSeparateImportOnlyDependencies() throws -> Bool {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to query supported scanner API with no scanner instance.")
     }
-    return swiftScan.supportsSeparateImportOnlyDependencise
+    return swiftScan.supportsSeparateImportOnlyDependencies
   }
 
   public func getOrCreateCAS(pluginPath: AbsolutePath?, onDiskPath: AbsolutePath?, pluginOptions: [(String, String)]) throws -> SwiftScanCAS {

--- a/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
+++ b/Sources/SwiftDriver/SwiftScan/DependencyGraphBuilder.swift
@@ -251,7 +251,7 @@ private extension SwiftScan {
     }
 
     let sourceImportedDependencies: [ModuleDependencyId]?
-    if supportsSeparateImportOnlyDependencise,
+    if supportsSeparateImportOnlyDependencies,
        let encodedImportedDepsRef = api.swiftscan_swift_textual_detail_get_swift_source_import_module_dependencies(moduleDetailsRef) {
       let encodedImportedDepsendencies = try toSwiftStringArray(encodedImportedDepsRef.pointee)
       sourceImportedDependencies =

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -254,7 +254,7 @@ private extension String {
     return api.swiftscan_swift_textual_detail_get_swift_overlay_dependencies != nil
   }
 
-  @_spi(Testing) public var supportsSeparateImportOnlyDependencise: Bool {
+  @_spi(Testing) public var supportsSeparateImportOnlyDependencies: Bool {
     return api.swiftscan_swift_textual_detail_get_swift_source_import_module_dependencies != nil
   }
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -697,7 +697,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         return
       }
 
-      if try driver.interModuleDependencyOracle.supportsSeparateImportOnlyDependencise() {
+      if try driver.interModuleDependencyOracle.supportsSeparateImportOnlyDependencies() {
           let directImportedDependencies = try XCTUnwrap(mainModuleDetails.sourceImportDependencies)
         XCTAssertFalse(directImportedDependencies.contains(.swift("A")))
         XCTAssertFalse(directImportedDependencies.contains(.clang("D")))


### PR DESCRIPTION
Correct transposition of letters in `dependencies`.