### PR TITLE
[TEST-ONLY] Fix explicit module clang dependency checking

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -178,14 +178,6 @@ private func checkCachingBuildJobDependencies(job: Job,
       case .clang(let clangDependencyDetails):
         try validateClangCommandLineDependency(dependencyId, dependencyInfo, clangDependencyDetails)
     }
-
-    // Ensure all transitive dependencies got added as well.
-    for transitiveDependencyId in dependencyInfo.allDependencies {
-      try checkCachingBuildJobDependencies(job: job,
-                                           moduleInfo: try dependencyGraph.moduleInfo(of: transitiveDependencyId),
-                                           dependencyGraph: dependencyGraph)
-
-    }
   }
 }
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -96,14 +96,6 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
       case .clang(let clangDependencyDetails):
         validateClangCommandLineDependency(dependencyId, dependencyInfo, clangDependencyDetails)
     }
-
-    // Ensure all transitive dependencies got added as well.
-    for transitiveDependencyId in dependencyInfo.allDependencies {
-      try checkExplicitModuleBuildJobDependencies(job: job,
-                                                  moduleInfo: try dependencyGraph.moduleInfo(of: transitiveDependencyId),
-                                                  dependencyGraph: dependencyGraph)
-
-    }
   }
 }
 


### PR DESCRIPTION
For clang generatePCM jobs, only direct clang dependencies are passed on the command-line but the test actually checks all dependencies.