### PR TITLE
Fix module-level SIL/IR output path generation in WMO mode

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -733,6 +733,27 @@ extension Driver {
           flaggedInputOutputPairs.append((flag: flag, input: nil, output: TypedVirtualPath(file: moduleLevelPath, type: outputType)))
           return
         }
+
+        // If we have a directory option e.g -sil-output-dir generate module-level path
+        if let directory = directory, (outputType == .sil || outputType == .llvmIR) {
+          let filename = "\(moduleOutputInfo.name).\(outputType.extension)"
+          let modulePath = try VirtualPath(path: directory).appending(component: filename)
+          flaggedInputOutputPairs.append((flag: flag, input: nil, output: TypedVirtualPath(file: modulePath.intern(), type: outputType)))
+          return
+        }
+
+        if parsedOptions.hasArgument(.saveTemps), (outputType == .sil || outputType == .llvmIR) {
+          let hasPerFileEntries = inputs.contains { input in
+            (try? outputFileMap?.existingOutput(inputFile: input.fileHandle, outputType: outputType)) != nil
+          }
+
+          if !hasPerFileEntries {
+            let filename = "\(moduleOutputInfo.name).\(outputType.extension)"
+            let modulePath = try VirtualPath(path: ".").appending(component: filename)
+            flaggedInputOutputPairs.append((flag: flag, input: nil, output: TypedVirtualPath(file: modulePath.intern(), type: outputType)))
+            return
+          }
+        }
       }
 
       for inputFile in inputs {


### PR DESCRIPTION
This generates module level paths when using the SIL/IR direcory options e.g. -sil-output-dir with WMO or -ir-output-dir in single-threaded WMO. This aligns the command line options with the the behaviour with these supplementary files in an output file map.

Also adds tests for the precedence rules of the supplementary SIL/IR files with output file map, command line options, including -save-temps and mixed scenarios.