### PR TITLE
Darwin: Implement sysroot flag

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -218,8 +218,13 @@ extension DarwinToolchain {
       commandLine.appendFlag("-fembed-bitcode=marker")
     }
 
-    // Add the SDK path
-    if let sdkPath = targetInfo.sdkPath?.path {
+    // Add the sysroot: explicit -sysroot takes precedence, then SDK path
+    // This allows using a different sysroot for C/C++ libraries while using
+    // a different SDK for Swift runtime libraries
+    if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
+      commandLine.appendFlag("--sysroot")
+      try commandLine.appendPath(VirtualPath(path: sysroot))
+    } else if let sdkPath = targetInfo.sdkPath?.path {
       commandLine.appendFlag("--sysroot")
       commandLine.appendPath(VirtualPath.lookup(sdkPath))
     }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -464,6 +464,13 @@ public final class DarwinToolchain: Toolchain {
       }
     }
 
+    // Pass explicit -sysroot to clang-importer if provided
+    // This allows testing against different C/C++ system libraries
+    if let sysroot = driver.parsedOptions.getLastArgument(.sysroot)?.asSingle {
+      commandLine.appendFlag("-sysroot")
+      try commandLine.appendPath(VirtualPath(path: sysroot))
+    }
+
     guard let sdkPath, let sdkInfo else { return }
 
     commandLine.append(.flag("-target-sdk-version"))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6084,6 +6084,97 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testDarwinSysrootFlag() throws {
+    var envVars = ProcessEnv.block
+    envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)
+
+    try withTemporaryDirectory { tmpDir in
+      // Create an SDK directory with SDKSettings.json
+      let sdk = tmpDir.appending(component: "MacOSX10.15.sdk")
+      try localFileSystem.createDirectory(sdk, recursive: true)
+      try localFileSystem.writeFileContents(sdk.appending(component: "SDKSettings.json"), bytes:
+        """
+        {
+          "Version":"10.15",
+          "CanonicalName": "macosx10.15"
+        }
+        """
+      )
+
+      // Create a custom sysroot directory
+      let customSysroot = tmpDir.appending(component: "CustomSysroot")
+      try localFileSystem.createDirectory(customSysroot, recursive: true)
+
+      // Test 1: Explicit -sysroot should be passed to frontend (clang-importer)
+      do {
+        var driver = try Driver(args: ["swiftc",
+                                       "-target", "x86_64-apple-macosx10.14",
+                                       "-sdk", sdk.pathString,
+                                       "-sysroot", customSysroot.pathString,
+                                       "test.swift"], env: envVars)
+        let jobs = try driver.planBuild()
+
+        // Check frontend job (compile)
+        let frontendJob = jobs.first(where: { $0.kind == .compile })
+        XCTAssertNotNil(frontendJob)
+        XCTAssertJobInvocationMatches(frontendJob!, .flag("-sysroot"))
+        XCTAssertTrue(frontendJob!.commandLine.containsPathWithBasename(customSysroot.basename))
+      }
+
+      // Test 2: Explicit -sysroot should be passed to linker
+      do {
+        var driver = try Driver(args: ["swiftc",
+                                       "-target", "x86_64-apple-macosx10.14",
+                                       "-sdk", sdk.pathString,
+                                       "-sysroot", customSysroot.pathString,
+                                       "test.swift"], env: envVars)
+        let jobs = try driver.planBuild()
+
+        // Check linker job
+        let linkJob = jobs.first(where: { $0.kind == .link })
+        XCTAssertNotNil(linkJob)
+        XCTAssertJobInvocationMatches(linkJob!, .flag("--sysroot"))
+        XCTAssertTrue(linkJob!.commandLine.containsPathWithBasename(customSysroot.basename))
+      }
+
+      // Test 3: Without explicit -sysroot, linker should use SDK path as sysroot
+      do {
+        var driver = try Driver(args: ["swiftc",
+                                       "-target", "x86_64-apple-macosx10.14",
+                                       "-sdk", sdk.pathString,
+                                       "test.swift"], env: envVars)
+        let jobs = try driver.planBuild()
+
+        // Check linker job defaults to SDK path
+        let linkJob = jobs.first(where: { $0.kind == .link })
+        XCTAssertNotNil(linkJob)
+        XCTAssertJobInvocationMatches(linkJob!, .flag("--sysroot"))
+        XCTAssertTrue(linkJob!.commandLine.containsPathWithBasename(sdk.basename))
+      }
+
+      // Test 4: Without explicit -sysroot, frontend should NOT have -sysroot flag
+      do {
+        var driver = try Driver(args: ["swiftc",
+                                       "-target", "x86_64-apple-macosx10.14",
+                                       "-sdk", sdk.pathString,
+                                       "test.swift"], env: envVars)
+        let jobs = try driver.planBuild()
+
+        // Check frontend job should not have -sysroot
+        let frontendJob = jobs.first(where: { $0.kind == .compile })
+        XCTAssertNotNil(frontendJob)
+        // Frontend should not have -sysroot when not explicitly provided
+        let hasSysroot = frontendJob!.commandLine.contains { arg in
+          if case .flag(let flag) = arg {
+            return flag == "-sysroot"
+          }
+          return false
+        }
+        XCTAssertFalse(hasSysroot)
+      }
+    }
+  }
+
   func testDSYMGeneration() throws {
     let commonArgs = [
       "swiftc", "foo.swift", "bar.swift",


### PR DESCRIPTION
The sysroot flag is designed to control where the compiler looks for the C runtimes and headers that one would normally find in an SDK for a system. Apple SDKs contain both the Swift runtimes and the other platform libraries, so under normal circumstances, this flag isn't needed.

It is useful, however, for consistency and testing purposes. As we're bringing up the split runtime/compiler build on the main repository, having the ability to tell the compiler under test to use the just-built Swift runtimes, but also where to find the existing system libraries (libsystem.tbd, e.g.) is incredibly useful.

If the sysroot flag is set, it take precedence for the clang importer and clang-linker.
If the sysroot flag is left unset but an sdk flag is set, the compiler should implicitly fall back on the sdk flag, which is the current behavior.
Finally, if neither are set, it falls back on whatever default the frontend uses, and no special flags are forwarded.