### PR TITLE
Driver support for linking relocatable object files

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2456,6 +2456,10 @@ extension Driver {
         linkerOutputType = parsedOptions.hasArgument(.static) ? .staticLibrary : .dynamicLibrary
         compilerOutputType = objectLikeFileType
 
+      case .emitRelocatableObject:
+        linkerOutputType = .relocatableObject
+        compilerOutputType = objectLikeFileType
+
       case .emitObject, .c:
         compilerOutputType = objectLikeFileType
 

--- a/Sources/SwiftDriver/Driver/LinkKind.swift
+++ b/Sources/SwiftDriver/Driver/LinkKind.swift
@@ -20,6 +20,9 @@ public enum LinkOutputType {
 
   /// A static library (e.g., .a or .lib)
   case staticLibrary
+
+  /// A relocatable object file.
+  case relocatableObject
 }
 
 /// Describes the kind of link-time-optimization we expect to perform.

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -24,7 +24,7 @@ extension Driver {
         fallthrough
 
       case .elf:
-        return lto == nil && linkerOutputType != nil
+        return lto == nil && linkerOutputType != nil && linkerOutputType != .relocatableObject
 
       default:
         return false

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -14,6 +14,7 @@ import SwiftOptions
 
 import func TSCBasic.lookupExecutablePath
 import struct TSCBasic.AbsolutePath
+import class TSCBasic.DiagnosticsEngine
 
 extension GenericUnixToolchain {
   private func majorArchitectureName(for triple: Triple) -> String {
@@ -42,7 +43,8 @@ extension GenericUnixToolchain {
     shouldUseInputFileList: Bool,
     lto: LTOKind?,
     sanitizers: Set<Sanitizer>,
-    targetInfo: FrontendTargetInfo
+    targetInfo: FrontendTargetInfo,
+    diagnosticsEngine: DiagnosticsEngine
   ) throws -> ResolvedTool {
 #if os(Windows)
     commandLine.appendFlag("--rsp-quoting=windows")
@@ -51,299 +53,49 @@ extension GenericUnixToolchain {
     let targetTriple = targetInfo.target.triple
     switch linkerOutputType {
     case .dynamicLibrary:
-      // Same options as an executable, just with '-shared'
       commandLine.appendFlag("-shared")
-      fallthrough
-    case .executable:
-      // Select the linker to use.
-      if let arg = parsedOptions.getLastArgument(.useLd)?.asSingle {
-        commandLine.appendFlag("-fuse-ld=\(arg)")
-      } else if lto != nil {
-        commandLine.appendFlag("-fuse-ld=lld")
-      }
-
-      if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {
-        commandLine.append(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: arg)))
-      }
-
-      // Configure the toolchain.
-      //
-      // By default use the system `clang` to perform the link.  We use `clang` for
-      // the driver here because we do not wish to select a particular C++ runtime.
-      // Furthermore, until C++ interop is enabled, we cannot have a dependency on
-      // C++ code from pure Swift code.  If linked libraries are C++ based, they
-      // should properly link C++.  In the case of static linking, the user can
-      // explicitly specify the C++ runtime to link against.  This is particularly
-      // important for platforms like android where as it is a Linux platform, the
-      // default C++ runtime is `libstdc++` which is unsupported on the target but
-      // as the builds are usually cross-compiled from Linux, libstdc++ is going to
-      // be present.  This results in linking the wrong version of libstdc++
-      // generating invalid binaries.  It is also possible to use different C++
-      // runtimes than the default C++ runtime for the platform (e.g. libc++ on
-      // Windows rather than msvcprt).  When C++ interop is enabled, we will need to
-      // surface this via a driver flag.  For now, opt for the simpler approach of
-      // just using `clang` and avoid a dependency on the C++ runtime.
-      var cxxCompatEnabled = parsedOptions.hasArgument(.enableExperimentalCxxInterop)
-      if let cxxInteropMode = parsedOptions.getLastArgument(.cxxInteroperabilityMode) {
-        if cxxInteropMode.asSingle != "off" {
-          cxxCompatEnabled = true
-        }
-      }
-
-      let staticStdlib = parsedOptions.hasFlag(positive: .staticStdlib,
-                                               negative: .noStaticStdlib,
-                                                   default: false)
-      let staticExecutable = parsedOptions.hasFlag(positive: .staticExecutable,
-                                                   negative: .noStaticExecutable,
-                                                  default: false)
-      let clangTool: Tool = cxxCompatEnabled ? .clangxx : .clang
-      var clangPath = try getToolPath(clangTool)
-      if let toolsDirPath = parsedOptions.getLastArgument(.toolsDirectory) {
-        // FIXME: What if this isn't an absolute path?
-        let toolsDir = try AbsolutePath(validating: toolsDirPath.asSingle)
-
-        // If there is a clang in the toolchain folder, use that instead.
-        if let tool = lookupExecutablePath(filename: cxxCompatEnabled
-                                                        ? "clang++" : "clang",
-                                           searchPaths: [toolsDir]) {
-          clangPath = tool
-        }
-
-        // Look for binutils in the toolchain folder.
-        commandLine.appendFlag("-B")
-        commandLine.appendPath(toolsDir)
-      }
-
-      // Executables on Linux get -pie
-      if targetTriple.os == .linux && linkerOutputType == .executable && !staticExecutable {
-        commandLine.appendFlag("-pie")
-      }
-
-      // On some platforms we want to enable --build-id
-      if targetTriple.os == .linux
-           || targetTriple.os == .freeBSD
-           || targetTriple.os == .openbsd
-           || parsedOptions.hasArgument(.buildId) {
-        commandLine.appendFlag("-Xlinker")
-        if let buildId = parsedOptions.getLastArgument(.buildId)?.asSingle {
-          commandLine.appendFlag("--build-id=\(buildId)")
-        } else {
-          commandLine.appendFlag("--build-id")
-        }
-      }
-
-      if targetTriple.os == .openbsd && targetTriple.arch == .aarch64 {
-        let btcfiEnabled = targetInfo.target.openbsdBTCFIEnabled ?? false
-        if !btcfiEnabled {
-          commandLine.appendFlag("-Xlinker")
-          commandLine.appendFlag("-z")
-          commandLine.appendFlag("-Xlinker")
-          commandLine.appendFlag("nobtcfi")
-        }
-      }
-
-      let isEmbeddedEnabled = parsedOptions.isEmbeddedEnabled
-
-      let toolchainStdlibRpath = parsedOptions
-                                 .hasFlag(positive: .toolchainStdlibRpath,
-                                          negative: .noToolchainStdlibRpath,
-                                          default: true)
-      let hasRuntimeArgs = !(staticStdlib || staticExecutable || isEmbeddedEnabled)
-
-      let runtimePaths = try runtimeLibraryPaths(
-        for: targetInfo,
+      let resolvedTool = try addDynamicLinkerFlags(
+        inputs: inputs,
+        targetInfo: targetInfo,
         parsedOptions: &parsedOptions,
-        sdkPath: targetInfo.sdkPath?.path,
-        isShared: hasRuntimeArgs
+        commandLine: &commandLine,
+        sanitizers: sanitizers,
+        linkerOutputType: linkerOutputType,
+        lto: lto
       )
-
-      // An exception is made for native Android environments like the Termux
-      // app as they build and run natively like a Unix environment on Android,
-      // so add the stdlib RPATH by default there.
-      #if os(Android)
-      let addRpath = true
-      #else
-      let addRpath = targetTriple.environment != .android
-      #endif
-
-      if hasRuntimeArgs && addRpath && toolchainStdlibRpath {
-        // FIXME: We probably shouldn't be adding an rpath here unless we know
-        //        ahead of time the standard library won't be copied.
-        for path in runtimePaths {
-          commandLine.appendFlag(.Xlinker)
-          commandLine.appendFlag("-rpath")
-          commandLine.appendFlag(.Xlinker)
-          commandLine.appendPath(path)
-        }
-      }
-
-      if targetInfo.sdkPath != nil {
-        for libpath in targetInfo.runtimeLibraryImportPaths {
-          commandLine.appendFlag(.L)
-          commandLine.appendPath(VirtualPath.lookup(libpath.path))
-        }
-      }
-
-      if !isEmbeddedEnabled && !parsedOptions.hasArgument(.nostartfiles) {
-        let rsrc: VirtualPath
-        // Prefer the swiftrt.o runtime file from the SDK if it's specified.
-        if let sdk = targetInfo.sdkPath {
-          let swiftDir: String
-          if staticStdlib || staticExecutable {
-            swiftDir = "swift_static"
-          } else {
-            swiftDir = "swift"
-          }
-          rsrc = VirtualPath.lookup(sdk.path).appending(components: "usr", "lib", swiftDir)
-        } else {
-          rsrc = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-        }
-        let platform: String = targetTriple.platformName() ?? ""
-        let architecture: String = majorArchitectureName(for: targetTriple)
-        commandLine.appendPath(rsrc.appending(components: platform, architecture, "swiftrt.o"))
-      }
-
-      // If we are linking statically, we need to add all
-      // dependencies to a library search group to resolve
-      // potential circular dependencies
-      if staticStdlib || staticExecutable {
-        commandLine.appendFlag(.Xlinker)
-        commandLine.appendFlag("--start-group")
-      }
-
-      let inputFiles: [Job.ArgTemplate] = inputs.compactMap { input in
-        // Autolink inputs are handled specially
-        if input.type == .autolink {
-          return .responseFilePath(input.file)
-        } else if input.type == .object {
-          return .path(input.file)
-        } else if lto != nil && input.type == .llvmBitcode {
-          return .path(input.file)
-        } else {
-          return nil
-        }
-      }
-      commandLine.append(contentsOf: inputFiles)
-
-      if staticStdlib || staticExecutable {
-        commandLine.appendFlag(.Xlinker)
-        commandLine.appendFlag("--end-group")
-      }
-
-      let fSystemArgs = parsedOptions.arguments(for: .F, .Fsystem)
-      for opt in fSystemArgs {
-        if opt.option == .Fsystem {
-          commandLine.appendFlag("-iframework")
-        } else {
-          commandLine.appendFlag(.F)
-        }
-        commandLine.appendPath(try VirtualPath(path: opt.argument.asSingle))
-      }
-
-      if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
-        commandLine.appendFlag("--sysroot")
-        try commandLine.appendPath(VirtualPath(path: sysroot))
-      } else if targetTriple.environment == .android,
-        let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env)
-      {
-        commandLine.appendFlag("--sysroot")
-        try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
-      } else if let path = targetInfo.sdkPath?.path {
-        commandLine.appendFlag("--sysroot")
-        commandLine.appendPath(VirtualPath.lookup(path))
-      }
-
-      // Add the runtime library link paths.
-      for path in runtimePaths {
-        commandLine.appendFlag(.L)
-        commandLine.appendPath(path)
-      }
-
-      // Link the standard library. In two paths, we do this using a .lnk file
-      // if we're going that route, we'll set `linkFilePath` to the path to that
-      // file.
-      var linkFilePath: VirtualPath? = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-        .appending(component: targetTriple.platformName() ?? "")
-
-      if staticExecutable {
-        linkFilePath = linkFilePath?.appending(component: "static-executable-args.lnk")
-      } else if staticStdlib {
-        linkFilePath = linkFilePath?.appending(component: "static-stdlib-args.lnk")
-      } else {
-        linkFilePath = nil
-        if !isEmbeddedEnabled {
-          commandLine.appendFlag("-lswiftCore")
-        }
-      }
-
-      if let linkFile = linkFilePath {
-        guard try fileSystem.exists(linkFile) else {
-          fatalError("\(linkFile) not found")
-        }
-        commandLine.append(.responseFilePath(linkFile))
-      }
-
-      // Pass down an optimization level
-      if let optArg = mapOptimizationLevelToClangArg(from: &parsedOptions) {
-        commandLine.appendFlag(optArg)
-      }
-
-      // Explicitly pass the target to the linker
-      commandLine.appendFlag("--target=\(targetTriple.triple)")
-
-      // Delegate to Clang for sanitizers. It will figure out the correct linker
-      // options.
-      if linkerOutputType == .executable && !sanitizers.isEmpty {
-        let sanitizerNames = sanitizers
-          .map { $0.rawValue }
-          .sorted() // Sort so we get a stable, testable order
-          .joined(separator: ",")
-        commandLine.appendFlag("-fsanitize=\(sanitizerNames)")
-
-        // The TSan runtime depends on the blocks runtime and libdispatch.
-        if sanitizers.contains(.thread) {
-          commandLine.appendFlag("-lBlocksRuntime")
-          commandLine.appendFlag("-ldispatch")
-        }
-      }
-
-      if parsedOptions.hasArgument(.profileGenerate) {
-        let environment = (targetTriple.environment == .android) ? "-android" : ""
-        let libProfile = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-          .appending(components: "clang", "lib", targetTriple.osNameUnversioned,
-                                 "libclang_rt.profile-\(targetTriple.archName)\(environment).a")
-        commandLine.appendPath(libProfile)
-
-        // HACK: Hard-coded from llvm::getInstrProfRuntimeHookVarName()
-        commandLine.appendFlag("-u__llvm_profile_runtime")
-      }
-
-      if let lto = lto {
-        switch lto {
-        case .llvmFull:
-          commandLine.appendFlag("-flto=full")
-        case .llvmThin:
-          commandLine.appendFlag("-flto=thin")
-        }
-      }
-
-      // Run clang++ in verbose mode if "-v" is set
-      try commandLine.appendLast(.v, from: &parsedOptions)
-
-      // These custom arguments should be right before the object file at the
-      // end.
-      try commandLine.appendAllExcept(
-        includeList: [.linkerOption],
-        excludeList: [.l],
-        from: &parsedOptions
-      )
-      addLinkedLibArgs(to: &commandLine, parsedOptions: &parsedOptions)
-      try addExtraClangLinkerArgs(to: &commandLine, parsedOptions: &parsedOptions)
-
       // This should be the last option, for convenience in checking output.
       commandLine.appendFlag(.o)
       commandLine.appendPath(outputFile)
-      return try resolvedTool(clangTool, pathOverride: clangPath)
+      return resolvedTool
+    case .executable:
+      let resolvedTool = try addDynamicLinkerFlags(
+        inputs: inputs,
+        targetInfo: targetInfo,
+        parsedOptions: &parsedOptions,
+        commandLine: &commandLine,
+        sanitizers: sanitizers,
+        linkerOutputType: linkerOutputType,
+        lto: lto
+      )
+      // This should be the last option, for convenience in checking output.
+      commandLine.appendFlag(.o)
+      commandLine.appendPath(outputFile)
+      return resolvedTool
+    case .relocatableObject:
+      commandLine.appendFlag("-r")
+      let resolvedTool = try addDynamicLinkerFlags(
+        inputs: inputs,
+        targetInfo: targetInfo,
+        parsedOptions: &parsedOptions,
+        commandLine: &commandLine,
+        sanitizers: sanitizers,
+        linkerOutputType: linkerOutputType,
+        lto: lto
+      )
+      // This should be the last option, for convenience in checking output.
+      commandLine.appendFlag(.o)
+      commandLine.appendPath(outputFile)
+      return resolvedTool
     case .staticLibrary:
       // We're using 'ar' as a linker
       commandLine.appendFlag("crs")
@@ -361,5 +113,301 @@ extension GenericUnixToolchain {
       }
     }
 
+  }
+
+  private func addDynamicLinkerFlags(inputs: [TypedVirtualPath],
+                                     targetInfo: FrontendTargetInfo,
+                                     parsedOptions: inout ParsedOptions,
+                                     commandLine: inout [Job.ArgTemplate],
+                                     sanitizers: Set<Sanitizer>,
+                                     linkerOutputType: LinkOutputType,
+                                     lto: LTOKind?) throws -> ResolvedTool {
+    // Select the linker to use.
+    if let arg = parsedOptions.getLastArgument(.useLd)?.asSingle {
+      commandLine.appendFlag("-fuse-ld=\(arg)")
+    } else if lto != nil {
+      commandLine.appendFlag("-fuse-ld=lld")
+    }
+
+    if let arg = parsedOptions.getLastArgument(.ldPath)?.asSingle {
+      commandLine.append(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: arg)))
+    }
+
+    // Configure the toolchain.
+    //
+    // By default use the system `clang` to perform the link.  We use `clang` for
+    // the driver here because we do not wish to select a particular C++ runtime.
+    // Furthermore, until C++ interop is enabled, we cannot have a dependency on
+    // C++ code from pure Swift code.  If linked libraries are C++ based, they
+    // should properly link C++.  In the case of static linking, the user can
+    // explicitly specify the C++ runtime to link against.  This is particularly
+    // important for platforms like android where as it is a Linux platform, the
+    // default C++ runtime is `libstdc++` which is unsupported on the target but
+    // as the builds are usually cross-compiled from Linux, libstdc++ is going to
+    // be present.  This results in linking the wrong version of libstdc++
+    // generating invalid binaries.  It is also possible to use different C++
+    // runtimes than the default C++ runtime for the platform (e.g. libc++ on
+    // Windows rather than msvcprt).  When C++ interop is enabled, we will need to
+    // surface this via a driver flag.  For now, opt for the simpler approach of
+    // just using `clang` and avoid a dependency on the C++ runtime.
+    var cxxCompatEnabled = parsedOptions.hasArgument(.enableExperimentalCxxInterop)
+    if let cxxInteropMode = parsedOptions.getLastArgument(.cxxInteroperabilityMode) {
+      if cxxInteropMode.asSingle != "off" {
+        cxxCompatEnabled = true
+      }
+    }
+
+    let staticStdlib = parsedOptions.hasFlag(positive: .staticStdlib,
+                                             negative: .noStaticStdlib,
+                                                 default: false)
+    let staticExecutable = parsedOptions.hasFlag(positive: .staticExecutable,
+                                                 negative: .noStaticExecutable,
+                                                default: false)
+    let clangTool: Tool = cxxCompatEnabled ? .clangxx : .clang
+    var clangPath = try getToolPath(clangTool)
+    if let toolsDirPath = parsedOptions.getLastArgument(.toolsDirectory) {
+      // FIXME: What if this isn't an absolute path?
+      let toolsDir = try AbsolutePath(validating: toolsDirPath.asSingle)
+
+      // If there is a clang in the toolchain folder, use that instead.
+      if let tool = lookupExecutablePath(filename: cxxCompatEnabled
+                                                      ? "clang++" : "clang",
+                                         searchPaths: [toolsDir]) {
+        clangPath = tool
+      }
+
+      // Look for binutils in the toolchain folder.
+      commandLine.appendFlag("-B")
+      commandLine.appendPath(toolsDir)
+    }
+
+    let targetTriple = targetInfo.target.triple
+    // Executables on Linux get -pie
+    if targetTriple.os == .linux && linkerOutputType == .executable && !staticExecutable {
+      commandLine.appendFlag("-pie")
+    }
+
+    // On some platforms we want to enable --build-id
+    if targetTriple.os == .linux
+         || targetTriple.os == .freeBSD
+         || targetTriple.os == .openbsd
+         || parsedOptions.hasArgument(.buildId) {
+      commandLine.appendFlag("-Xlinker")
+      if let buildId = parsedOptions.getLastArgument(.buildId)?.asSingle {
+        commandLine.appendFlag("--build-id=\(buildId)")
+      } else {
+        commandLine.appendFlag("--build-id")
+      }
+    }
+
+    if targetTriple.os == .openbsd && targetTriple.arch == .aarch64 {
+      let btcfiEnabled = targetInfo.target.openbsdBTCFIEnabled ?? false
+      if !btcfiEnabled {
+        commandLine.appendFlag("-Xlinker")
+        commandLine.appendFlag("-z")
+        commandLine.appendFlag("-Xlinker")
+        commandLine.appendFlag("nobtcfi")
+      }
+    }
+
+    let isEmbeddedEnabled = parsedOptions.isEmbeddedEnabled
+
+    let toolchainStdlibRpath = parsedOptions
+                               .hasFlag(positive: .toolchainStdlibRpath,
+                                        negative: .noToolchainStdlibRpath,
+                                        default: true)
+    let hasRuntimeArgs = !(staticStdlib || staticExecutable || isEmbeddedEnabled)
+
+    let runtimePaths = try runtimeLibraryPaths(
+      for: targetInfo,
+      parsedOptions: &parsedOptions,
+      sdkPath: targetInfo.sdkPath?.path,
+      isShared: hasRuntimeArgs
+    )
+
+    // An exception is made for native Android environments like the Termux
+    // app as they build and run natively like a Unix environment on Android,
+    // so add the stdlib RPATH by default there.
+    #if os(Android)
+    let addRpath = true
+    #else
+    let addRpath = targetTriple.environment != .android
+    #endif
+
+    if hasRuntimeArgs && addRpath && toolchainStdlibRpath {
+      // FIXME: We probably shouldn't be adding an rpath here unless we know
+      //        ahead of time the standard library won't be copied.
+      for path in runtimePaths {
+        commandLine.appendFlag(.Xlinker)
+        commandLine.appendFlag("-rpath")
+        commandLine.appendFlag(.Xlinker)
+        commandLine.appendPath(path)
+      }
+    }
+
+    if targetInfo.sdkPath != nil {
+      for libpath in targetInfo.runtimeLibraryImportPaths {
+        commandLine.appendFlag(.L)
+        commandLine.appendPath(VirtualPath.lookup(libpath.path))
+      }
+    }
+
+    if !isEmbeddedEnabled && !parsedOptions.hasArgument(.nostartfiles) {
+      let rsrc: VirtualPath
+      // Prefer the swiftrt.o runtime file from the SDK if it's specified.
+      if let sdk = targetInfo.sdkPath {
+        let swiftDir: String
+        if staticStdlib || staticExecutable {
+          swiftDir = "swift_static"
+        } else {
+          swiftDir = "swift"
+        }
+        rsrc = VirtualPath.lookup(sdk.path).appending(components: "usr", "lib", swiftDir)
+      } else {
+        rsrc = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+      }
+      let platform: String = targetTriple.platformName() ?? ""
+      let architecture: String = majorArchitectureName(for: targetTriple)
+      commandLine.appendPath(rsrc.appending(components: platform, architecture, "swiftrt.o"))
+    }
+
+    // If we are linking statically, we need to add all
+    // dependencies to a library search group to resolve
+    // potential circular dependencies
+    if staticStdlib || staticExecutable {
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag("--start-group")
+    }
+
+    let inputFiles: [Job.ArgTemplate] = inputs.compactMap { input in
+      // Autolink inputs are handled specially
+      if input.type == .autolink {
+        return .responseFilePath(input.file)
+      } else if input.type == .object {
+        return .path(input.file)
+      } else if lto != nil && input.type == .llvmBitcode {
+        return .path(input.file)
+      } else {
+        return nil
+      }
+    }
+    commandLine.append(contentsOf: inputFiles)
+
+    if staticStdlib || staticExecutable {
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag("--end-group")
+    }
+
+    let fSystemArgs = parsedOptions.arguments(for: .F, .Fsystem)
+    for opt in fSystemArgs {
+      if opt.option == .Fsystem {
+        commandLine.appendFlag("-iframework")
+      } else {
+        commandLine.appendFlag(.F)
+      }
+      commandLine.appendPath(try VirtualPath(path: opt.argument.asSingle))
+    }
+
+    if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
+      commandLine.appendFlag("--sysroot")
+      try commandLine.appendPath(VirtualPath(path: sysroot))
+    } else if targetTriple.environment == .android,
+      let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env)
+    {
+      commandLine.appendFlag("--sysroot")
+      try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
+    } else if let path = targetInfo.sdkPath?.path {
+      commandLine.appendFlag("--sysroot")
+      commandLine.appendPath(VirtualPath.lookup(path))
+    }
+
+    // Add the runtime library link paths.
+    for path in runtimePaths {
+      commandLine.appendFlag(.L)
+      commandLine.appendPath(path)
+    }
+
+    // Link the standard library. In two paths, we do this using a .lnk file
+    // if we're going that route, we'll set `linkFilePath` to the path to that
+    // file.
+    var linkFilePath: VirtualPath? = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+      .appending(component: targetTriple.platformName() ?? "")
+
+    if staticExecutable {
+      linkFilePath = linkFilePath?.appending(component: "static-executable-args.lnk")
+    } else if staticStdlib {
+      linkFilePath = linkFilePath?.appending(component: "static-stdlib-args.lnk")
+    } else {
+      linkFilePath = nil
+      if !isEmbeddedEnabled {
+        commandLine.appendFlag("-lswiftCore")
+      }
+    }
+
+    if let linkFile = linkFilePath {
+      guard try fileSystem.exists(linkFile) else {
+        fatalError("\(linkFile) not found")
+      }
+      commandLine.append(.responseFilePath(linkFile))
+    }
+
+    // Pass down an optimization level
+    if let optArg = mapOptimizationLevelToClangArg(from: &parsedOptions) {
+      commandLine.appendFlag(optArg)
+    }
+
+    // Explicitly pass the target to the linker
+    commandLine.appendFlag("--target=\(targetTriple.triple)")
+
+    // Delegate to Clang for sanitizers. It will figure out the correct linker
+    // options.
+    if linkerOutputType == .executable && !sanitizers.isEmpty {
+      let sanitizerNames = sanitizers
+        .map { $0.rawValue }
+        .sorted() // Sort so we get a stable, testable order
+        .joined(separator: ",")
+      commandLine.appendFlag("-fsanitize=\(sanitizerNames)")
+
+      // The TSan runtime depends on the blocks runtime and libdispatch.
+      if sanitizers.contains(.thread) {
+        commandLine.appendFlag("-lBlocksRuntime")
+        commandLine.appendFlag("-ldispatch")
+      }
+    }
+
+    if parsedOptions.hasArgument(.profileGenerate) {
+      let environment = (targetTriple.environment == .android) ? "-android" : ""
+      let libProfile = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+        .appending(components: "clang", "lib", targetTriple.osNameUnversioned,
+                               "libclang_rt.profile-\(targetTriple.archName)\(environment).a")
+      commandLine.appendPath(libProfile)
+
+      // HACK: Hard-coded from llvm::getInstrProfRuntimeHookVarName()
+      commandLine.appendFlag("-u__llvm_profile_runtime")
+    }
+
+    if let lto = lto {
+      switch lto {
+      case .llvmFull:
+        commandLine.appendFlag("-flto=full")
+      case .llvmThin:
+        commandLine.appendFlag("-flto=thin")
+      }
+    }
+
+    // Run clang++ in verbose mode if "-v" is set
+    try commandLine.appendLast(.v, from: &parsedOptions)
+
+    // These custom arguments should be right before the object file at the
+    // end.
+    try commandLine.appendAllExcept(
+      includeList: [.linkerOption],
+      excludeList: [.l],
+      from: &parsedOptions
+    )
+    addLinkedLibArgs(to: &commandLine, parsedOptions: &parsedOptions)
+    try addExtraClangLinkerArgs(to: &commandLine, parsedOptions: &parsedOptions)
+
+    return try resolvedTool(clangTool, pathOverride: clangPath)
   }
 }

--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -73,7 +73,8 @@ extension Driver {
       shouldUseInputFileList: shouldUseInputFileList,
       lto: lto,
       sanitizers: enabledSanitizers,
-      targetInfo: frontendTargetInfo
+      targetInfo: frontendTargetInfo,
+      diagnosticsEngine: diagnosticEngine
     )
 
     if parsedOptions.hasArgument(.explicitAutoLinking) {

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -683,7 +683,7 @@ extension Driver {
     else { return }
 
     switch linkerOutputType {
-    case .none, .some(.staticLibrary):
+    case .none, .some(.staticLibrary), .some(.relocatableObject):
       // Cannot generate a dSYM bundle for a non-image target.
       return
 

--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -172,13 +172,15 @@ extension DarwinToolchain {
       commandLine.appendPath(path)
     }
 
-    let rpaths = StdlibRpathRule(
-      parsedOptions: &parsedOptions,
-      targetInfo: targetInfo
-    )
-    for path in try rpaths.paths(runtimeLibraryPaths: runtimePaths) {
-      commandLine.appendFlag("-rpath")
-      commandLine.appendPath(path)
+    if linkerOutputType != .relocatableObject {
+      let rpaths = StdlibRpathRule(
+        parsedOptions: &parsedOptions,
+        targetInfo: targetInfo
+      )
+      for path in try rpaths.paths(runtimeLibraryPaths: runtimePaths) {
+        commandLine.appendFlag("-rpath")
+        commandLine.appendPath(path)
+      }
     }
   }
 

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -15,6 +15,7 @@ import SwiftOptions
 import func TSCBasic.lookupExecutablePath
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
+import class TSCBasic.DiagnosticsEngine
 
 extension WebAssemblyToolchain {
   public func addPlatformSpecificLinkerArgs(
@@ -26,7 +27,8 @@ extension WebAssemblyToolchain {
     shouldUseInputFileList: Bool,
     lto: LTOKind?,
     sanitizers: Set<Sanitizer>,
-    targetInfo: FrontendTargetInfo
+    targetInfo: FrontendTargetInfo,
+    diagnosticsEngine: DiagnosticsEngine
   ) throws -> ResolvedTool {
     let targetTriple = targetInfo.target.triple
     switch linkerOutputType {
@@ -224,6 +226,10 @@ extension WebAssemblyToolchain {
 
       commandLine.append(contentsOf: inputs.lazy.filter { $0.type != .autolink }.map { .path($0.file) })
       return try resolvedTool(.staticLinker(lto))
+
+    case .relocatableObject:
+      diagnosticsEngine.emit(.error_relocatable_object_unsupported(platform: "WebAssembly"))
+      throw Driver.ErrorDiagnostics.emitted
     }
   }
 }

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -14,6 +14,7 @@ import SwiftOptions
 
 import func TSCBasic.lookupExecutablePath
 import struct TSCBasic.AbsolutePath
+import class TSCBasic.DiagnosticsEngine
 
 private func architecture(for triple: Triple) -> String {
   // The concept of a "major" arch name only applies to Linux triples
@@ -37,7 +38,8 @@ extension WindowsToolchain {
                                             shouldUseInputFileList: Bool,
                                             lto: LTOKind?,
                                             sanitizers: Set<Sanitizer>,
-                                            targetInfo: FrontendTargetInfo)
+                                            targetInfo: FrontendTargetInfo,
+                                            diagnosticsEngine: DiagnosticsEngine)
     throws -> ResolvedTool {
     // Check to see whether we need to use lld as the linker.
     let bForceLLD: Bool = {
@@ -118,6 +120,9 @@ extension WindowsToolchain {
       commandLine.appendFlag("-shared")
     case .executable:
       break
+    case .relocatableObject:
+      diagnosticsEngine.emit(.error_relocatable_object_unsupported(platform: "Windows"))
+      throw Driver.ErrorDiagnostics.emitted
     }
 
     if let arg = parsedOptions.getLastArgument(.toolsDirectory) {

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -113,6 +113,7 @@ public final class DarwinToolchain: Toolchain {
     case .executable: return moduleName
     case .dynamicLibrary: return "lib\(moduleName).dylib"
     case .staticLibrary: return "lib\(moduleName).a"
+    case .relocatableObject: return "\(moduleName).o"
     }
   }
 

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -76,6 +76,7 @@ public final class GenericUnixToolchain: Toolchain {
     case .executable: return moduleName
     case .dynamicLibrary: return "lib\(moduleName).so"
     case .staticLibrary: return "lib\(moduleName).a"
+    case .relocatableObject: return "\(moduleName).o"
     }
   }
 

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -140,7 +140,8 @@ public protocol Toolchain {
     shouldUseInputFileList: Bool,
     lto: LTOKind?,
     sanitizers: Set<Sanitizer>,
-    targetInfo: FrontendTargetInfo
+    targetInfo: FrontendTargetInfo,
+    diagnosticsEngine: DiagnosticsEngine
   ) throws -> ResolvedTool
 
   /// Returns the runtime library name for a given sanitizer (or nil if the sanitizer does not have a runtime library)

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -72,7 +72,7 @@ public final class WebAssemblyToolchain: Toolchain {
     switch type {
     case .executable:
       return moduleName
-    case .dynamicLibrary:
+    case .dynamicLibrary, .relocatableObject:
       // Wasm doesn't support dynamic libraries yet, but we'll report the error later.
       return ""
     case .staticLibrary:

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -111,6 +111,8 @@ extension WindowsToolchain.ToolchainValidationError {
     case .executable: return "\(moduleName).exe"
     case .dynamicLibrary: return "\(moduleName).dll"
     case .staticLibrary: return "lib\(moduleName).lib"
+    // Unsupported
+    case .relocatableObject: return ""
     }
   }
 

--- a/Sources/SwiftDriver/Utilities/Diagnostics.swift
+++ b/Sources/SwiftDriver/Utilities/Diagnostics.swift
@@ -19,6 +19,10 @@ extension Diagnostic.Message {
     .error("-static may not be used with -emit-executable")
   }
 
+  static func error_relocatable_object_unsupported(platform: String) -> Diagnostic.Message {
+    .error("emitting a relocatable object is unsupported when targeting \(platform)")
+  }
+
   static func error_update_code_not_supported(in mode: CompilerMode) -> Diagnostic.Message {
     .error("using '-update-code' in \(mode) mode is not supported")
   }

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -401,6 +401,7 @@ extension Option {
   public static let emitPrivateModuleInterfacePath: Option = Option("-emit-private-module-interface-path", .separate, attributes: [.helpHidden, .frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output private module interface file to <path>")
   public static let emitReferenceDependenciesPath: Option = Option("-emit-reference-dependencies-path", .separate, attributes: [.frontend, .noDriver, .cacheInvariant], metaVar: "<path>", helpText: "Output Swift-style dependencies file to <path>")
   public static let emitReferenceDependencies: Option = Option("-emit-reference-dependencies", .flag, attributes: [.frontend, .noDriver], helpText: "Emit a Swift-style dependencies file")
+  public static let emitRelocatableObject: Option = Option("-emit-relocatable-object", .flag, attributes: [.noInteractive], helpText: "Emit a relocatable object file", group: .modes)
   public static let emitRemapFilePath: Option = Option("-emit-remap-file-path", .separate, attributes: [.frontend, .noDriver, .noInteractive, .doesNotAffectIncrementalBuild], metaVar: "<path>", helpText: "Emit the replacement map describing Swift Migrator changes to <path>")
   public static let emitSibgen: Option = Option("-emit-sibgen", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit serialized AST + raw SIL file(s)", group: .modes)
   public static let emitSib: Option = Option("-emit-sib", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit serialized AST + canonical SIL file(s)", group: .modes)
@@ -508,7 +509,6 @@ extension Option {
   public static let enableObjcInterop: Option = Option("-enable-objc-interop", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable Objective-C interop code generation and config directives")
   public static let enableObjectiveCProtocolSymbolicReferences: Option = Option("-enable-objective-c-protocol-symbolic-references", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable objective-c protocol symbolic references")
   public static let enableOnlyOneDependencyFile: Option = Option("-enable-only-one-dependency-file", .flag, attributes: [.doesNotAffectIncrementalBuild], helpText: "Enables incremental build optimization that only produces one dependencies file")
-  public static let enableOperatorDesignatedTypes: Option = Option("-enable-operator-designated-types", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable operator designated types")
   public static let enableOssaModules: Option = Option("-enable-ossa-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Obsolete. This option is ignored")
   public static let enablePackMetadataStackPromotion: Option = Option("-enable-pack-metadata-stack-promotion=", .joined, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "true|false", helpText: "Whether to skip heapifying stack metadata packs when possible.")
   public static let enablePackMetadataStackPromotionNoArg: Option = Option("-enable-pack-metadata-stack-promotion", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Skip heapifying stack metadata packs when possible.")
@@ -891,9 +891,13 @@ extension Option {
   public static let skipInheritedDocs: Option = Option("-skip-inherited-docs", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Skip emitting doc comments for members inherited through classes or default implementations")
   public static let skipProtocolImplementations: Option = Option("-skip-protocol-implementations", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Skip emitting symbols that are implementations of protocol requirements or inherited from protocol extensions")
   public static let skipSynthesizedMembers: Option = Option("-skip-synthesized-members", .flag, attributes: [.noDriver], helpText: "Skip members inherited through classes or default implementations")
+  public static let solverDisableOptimizeOperatorDefaults: Option = Option("-solver-disable-optimize-operator-defaults", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable experimental optimization to sometimes skip operators in protocol extensions")
+  public static let solverDisablePerformanceHacks: Option = Option("-solver-disable-performance-hacks", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable various constraint solver performance optimizations that have been subsumed by subsequent improvements")
   public static let solverDisablePreparedOverloads: Option = Option("-solver-disable-prepared-overloads", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable experimental prepared overloads optimization")
   public static let solverDisablePruneDisjunctions: Option = Option("-solver-disable-prune-disjunctions", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable experimental disjunction pruning algorithm for lookahead in the solver")
   public static let solverDisableSplitter: Option = Option("-solver-disable-splitter", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable the component splitter phase of expression type checking")
+  public static let solverEnableOptimizeOperatorDefaults: Option = Option("-solver-enable-optimize-operator-defaults", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental optimization to sometimes skip operators in protocol extensions")
+  public static let solverEnablePerformanceHacks: Option = Option("-solver-enable-performance-hacks", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enble various constraint solver performance optimizations that have been subsumed by subsequent improvements")
   public static let solverEnablePreparedOverloads: Option = Option("-solver-enable-prepared-overloads", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental prepared overloads optimization")
   public static let solverEnablePruneDisjunctions: Option = Option("-solver-enable-prune-disjunctions", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable experimental disjunction pruning algorithm for lookahead in the solver")
   public static let solverExpressionTimeThresholdEQ: Option = Option("-solver-expression-time-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Expression type checking timeout, in seconds")
@@ -934,6 +938,7 @@ extension Option {
   public static let sysroot: Option = Option("-sysroot", .separate, attributes: [.frontend, .synthesizeInterface, .argumentIsPath], metaVar: "<sysroot>", helpText: "Native Platform sysroot")
   public static let S: Option = Option("-S", .flag, alias: Option.emitAssembly, attributes: [.frontend, .noInteractive], group: .modes)
   public static let tabWidth: Option = Option("-tab-width", .separate, attributes: [.noInteractive, .noBatch], metaVar: "<n>", helpText: "Width of tab character.", group: .codeFormatting)
+  public static let targetArchVariant: Option = Option("-target-arch-variant", .separate, attributes: [.frontend, .noInteractive, .moduleWrap, .synthesizeInterface, .moduleInterface], metaVar: "<arch-variant>", helpText: "Generate code for an additional arch/slice variant of the target architectureinto fat mach-o binaries")
   public static let targetCpu: Option = Option("-target-cpu", .separate, attributes: [.frontend, .moduleInterface], helpText: "Generate code for a particular CPU variant")
   public static let minInliningTargetVersion: Option = Option("-target-min-inlining-version", .separate, attributes: [.frontend, .moduleInterface], helpText: "Require inlinable code with no '@available' attribute to back-deploy to this version of the '-target' OS")
   public static let targetSdkName: Option = Option("-target-sdk-name", .separate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Canonical name of the target SDK used for compilation")
@@ -1416,6 +1421,7 @@ extension Option {
       Option.emitPrivateModuleInterfacePath,
       Option.emitReferenceDependenciesPath,
       Option.emitReferenceDependencies,
+      Option.emitRelocatableObject,
       Option.emitRemapFilePath,
       Option.emitSibgen,
       Option.emitSib,
@@ -1523,7 +1529,6 @@ extension Option {
       Option.enableObjcInterop,
       Option.enableObjectiveCProtocolSymbolicReferences,
       Option.enableOnlyOneDependencyFile,
-      Option.enableOperatorDesignatedTypes,
       Option.enableOssaModules,
       Option.enablePackMetadataStackPromotion,
       Option.enablePackMetadataStackPromotionNoArg,
@@ -1906,9 +1911,13 @@ extension Option {
       Option.skipInheritedDocs,
       Option.skipProtocolImplementations,
       Option.skipSynthesizedMembers,
+      Option.solverDisableOptimizeOperatorDefaults,
+      Option.solverDisablePerformanceHacks,
       Option.solverDisablePreparedOverloads,
       Option.solverDisablePruneDisjunctions,
       Option.solverDisableSplitter,
+      Option.solverEnableOptimizeOperatorDefaults,
+      Option.solverEnablePerformanceHacks,
       Option.solverEnablePreparedOverloads,
       Option.solverEnablePruneDisjunctions,
       Option.solverExpressionTimeThresholdEQ,
@@ -1949,6 +1958,7 @@ extension Option {
       Option.sysroot,
       Option.S,
       Option.tabWidth,
+      Option.targetArchVariant,
       Option.targetCpu,
       Option.minInliningTargetVersion,
       Option.targetSdkName,


### PR DESCRIPTION
Currently, Swift Build falls back to linking relocatable objects with clang, even when a target contains Swift. Begin adding support to swiftc for the equivalent functionality so we can avoid this and ensure Swift-specific behavior is applied consistently to all linker output types.