### PR TITLE
Add symbol graph option for long module names to swift-driver.

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -1138,6 +1138,7 @@ extension Driver {
     try commandLine.appendLast(.symbolGraphPrettyPrint, from: &parsedOptions)
     try commandLine.appendLast(.symbolGraphSkipSynthesizedMembers, from: &parsedOptions)
     try commandLine.appendLast(.symbolGraphSkipInheritedDocs, from: &parsedOptions)
+    try commandLine.appendLast(.symbolGraphShortenOutputNames, from: &parsedOptions)
   }
 
   mutating func addEntry(_ entries: inout [VirtualPath.Handle: [FileType: VirtualPath.Handle]], input: TypedVirtualPath?, output: TypedVirtualPath) throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4353,6 +4353,17 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testEmitSymbolGraphShortenModuleNames() throws {
+    do {
+      let root = localFileSystem.currentWorkingDirectory!.appending(components: "foo", "bar")
+
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test", "-emit-module-path", rebase("Test.swiftmodule", at: root), "-emit-symbol-graph", "-emit-symbol-graph-dir", "/foo/bar/", "-symbol-graph-shorten-output-names"])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+
+      XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-symbol-graph-shorten-output-names"))
+    }
+  }
+
   func testEmitModuleSeparately() throws {
     var envVars = ProcessEnv.block
     envVars["SWIFT_DRIVER_LD_EXEC"] = ld.nativePathString(escaped: false)


### PR DESCRIPTION
The compiler has an option `-symbol-graph-shorten-output-names` which needs to be handled by the swift-driver.

https://github.com/swiftlang/swift/pull/83782

https://github.com/swiftlang/swift/pull/83782#issuecomment-3898184305

cc @cachemeifyoucan 