### PR TITLE
Add -disable-deployment-target-validation-for-parse-stdlib option

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -216,7 +216,8 @@ public final class DarwinToolchain: Toolchain {
     #endif
     // Validating apple platforms deployment targets.
     try validateDeploymentTarget(&parsedOptions, targetTriple: targetTriple,
-                                 compilerOutputType: compilerOutputType)
+                                 compilerOutputType: compilerOutputType,
+                                 diagnosticsEngine: diagnosticsEngine)
     if let targetVariantTriple = targetVariantTriple,
        !targetTriple.isValidForZipperingWithTriple(targetVariantTriple) {
       throw ToolchainValidationError.unsupportedTargetVariant(variant: targetVariantTriple)
@@ -254,10 +255,23 @@ public final class DarwinToolchain: Toolchain {
   }
 
   func validateDeploymentTarget(_ parsedOptions: inout ParsedOptions,
-                                targetTriple: Triple, compilerOutputType: FileType?) throws {
+                                targetTriple: Triple,
+                                compilerOutputType: FileType?,
+                                diagnosticsEngine: DiagnosticsEngine) throws {
     guard let os = targetTriple.os else {
       return
     }
+
+    if parsedOptions.hasArgument(.disableDeploymentTargetValidationForParseStdlib) {
+       if parsedOptions.hasArgument(.parseStdlib){
+         return
+       } else {
+         diagnosticsEngine.emit(
+           .warning("-disable-deployment-target-validation-for-parse-stdlib is ignored without -parse-stdlib"),
+           location: nil
+         )
+       }
+     }
 
     // Embedded Swift should accept all target triples / OS versions / arch combinations
     guard !parsedOptions.isEmbeddedEnabled else {

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -768,6 +768,7 @@ extension Option {
   public static let parseAsLibrary: Option = Option("-parse-as-library", .flag, attributes: [.frontend, .noInteractive], helpText: "Parse the input file(s) as libraries, not scripts")
   public static let parseSil: Option = Option("-parse-sil", .flag, attributes: [.frontend, .noInteractive], helpText: "Parse the input file as SIL code, not Swift source")
   public static let parseStdlib: Option = Option("-parse-stdlib", .flag, attributes: [.helpHidden, .frontend, .moduleInterface], helpText: "Parse the input file(s) as the Swift standard library")
+  public static let disableDeploymentTargetValidationForParseStdlib: Option = Option("-disable-deployment-target-validation-for-parse-stdlib", .flag, attributes: [.helpHidden, .frontend, .moduleInterface], helpText: "Disable deployment target validation when building the Swift standard library")
   public static let parseableOutput: Option = Option("-parseable-output", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "Emit textual output in a parseable format")
   public static let parse: Option = Option("-parse", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Parse input file(s)", group: .modes)
   public static let pcMacro: Option = Option("-pc-macro", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Apply the 'program counter simulation' macro")
@@ -1793,6 +1794,7 @@ extension Option {
       Option.parseAsLibrary,
       Option.parseSil,
       Option.parseStdlib,
+      Option.disableDeploymentTargetValidationForParseStdlib,
       Option.parseableOutput,
       Option.parse,
       Option.pcMacro,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5638,6 +5638,29 @@ final class SwiftDriverTests: XCTestCase {
     #endif
   }
 
+  func testDisableDeploymentTargetValidationForParseStdlib() throws {
+    XCTAssertNoThrow(try Driver(args: ["swiftc", "-c", "-target", "armv7k-apple-watchos10.0", "-parse-stdlib", "-disable-deployment-target-validation-for-parse-stdlib", "foo.swift"]))
+
+    // Without -parse-stdlib, the flag emits a warning and validation still runs.
+    try assertDiagnostics { diags, verifier in
+      verifier.expect(.warning("-disable-deployment-target-validation-for-parse-stdlib is ignored without -parse-stdlib"))
+      XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "armv7k-apple-watchos10.0", "-disable-deployment-target-validation-for-parse-stdlib", "foo.swift"], diagnosticsEngine: diags)) { error in
+        guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR(platform: .watchOS(.device), version: Triple.Version(9, 0, 0), archName: "armv7k") = error else {
+          XCTFail("Unexpected error: \(error)")
+          return
+        }
+      }
+    }
+
+    // Without -disable-deployment-target-validation-for-parse-stdlib, the existing deployment target validation still fires.
+    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "armv7k-apple-watchos10.0", "foo.swift"])) { error in
+      guard case DarwinToolchain.ToolchainValidationError.invalidDeploymentTargetForIR(platform: .watchOS(.device), version: Triple.Version(9, 0, 0), archName: "armv7k") = error else {
+        XCTFail("Unexpected error: \(error)")
+        return
+      }
+    }
+  }
+
   func testProfileArgValidation() throws {
     try assertDriverDiagnostics(args: ["swiftc", "foo.swift", "-profile-generate", "-profile-use=profile.profdata"]) {
       $1.expect(.error(Driver.Error.conflictingOptions(.profileGenerate, .profileUse)))


### PR DESCRIPTION
This PR adds a `-disable-deployment-target-validation-for-parse-stdlib` to be used alongside `-parse-stdlib` which will allow us to build stdlib slices for older targets/archs