### PR TITLE
Keep paths for prebuilt external swift modules for caching builds

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -389,7 +389,8 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
                                   modulePath: TextualVirtualPath(path: swiftModulePath.fileHandle),
                                   isFramework: isFramework,
                                   moduleCacheKey: swiftModuleDetails.moduleCacheKey,
-                                  libraryLevel: dependencyInfo.libraryLevel))
+                                  libraryLevel: dependencyInfo.libraryLevel,
+                                  isPrebuiltExternal: false))
       case .clang:
         let dependencyInfo = try dependencyGraph.moduleInfo(of: dependencyId)
         let dependencyClangModuleDetails =
@@ -417,7 +418,8 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
                                   headerDependencies: prebuiltModuleDetails.headerDependencyPaths,
                                   isFramework: isFramework,
                                   moduleCacheKey: prebuiltModuleDetails.moduleCacheKey,
-                                  libraryLevel: dependencyInfo.libraryLevel))
+                                  libraryLevel: dependencyInfo.libraryLevel,
+                                  isPrebuiltExternal: true))
     }
   }
 
@@ -625,19 +627,22 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     // The module dependency map in CAS needs to be stable.
     // For caching build, updated the dependency info to exclude paths that are compiler outputs from the mapping.
     // Use abstract names and paths because caching build loads modules directly from CAS.
+    // Exclude prebuilt external swift modules because they aren't outputs of the current build.
     let allDependencyArtifacts: [ModuleDependencyArtifactInfo] =
       try swiftDependencyArtifacts.sorted().map { info in
         if !cachingEnabled {
           return ModuleDependencyArtifactInfo.swift(info)
         }
+        let modulePath = info.isPrebuiltExternal == true ? info.modulePath : try abstractPath(info.moduleName, suffix: ".swiftmodule")
         let updatedInfo = try SwiftModuleArtifactInfo(name: info.moduleName,
-                                                      modulePath: abstractPath(info.moduleName, suffix: ".swiftmodule"),
+                                                      modulePath: modulePath,
                                                       docPath: nil,
                                                       sourceInfoPath: nil,
                                                       headerDependencies: info.prebuiltHeaderDependencyPaths,
                                                       isFramework: info.isFramework,
                                                       moduleCacheKey: info.moduleCacheKey,
-                                                      libraryLevel: info.libraryLevel)
+                                                      libraryLevel: info.libraryLevel,
+                                                      isPrebuiltExternal: info.isPrebuiltExternal)
         return ModuleDependencyArtifactInfo.swift(updatedInfo)
       } +
       clangDependencyArtifacts.sorted().map { info in

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
@@ -34,11 +34,12 @@
   public let moduleCacheKey: String?
   /// The library level of the module (e.g. "api", "spi").
   public let libraryLevel: LibraryLevel?
+  public let isPrebuiltExternal: Bool?
 
   init(name: String, modulePath: TextualVirtualPath, docPath: TextualVirtualPath? = nil,
        sourceInfoPath: TextualVirtualPath? = nil, headerDependencies: [TextualVirtualPath]? = nil,
        isFramework: Bool = false, moduleCacheKey: String? = nil,
-       libraryLevel: LibraryLevel? = nil) {
+       libraryLevel: LibraryLevel? = nil, isPrebuiltExternal: Bool? = nil) {
     self.moduleName = name
     self.modulePath = modulePath
     self.docPath = docPath
@@ -47,6 +48,7 @@
     self.isFramework = isFramework
     self.moduleCacheKey = moduleCacheKey
     self.libraryLevel = libraryLevel
+    self.isPrebuiltExternal = isPrebuiltExternal
   }
 }
 

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -799,6 +799,33 @@ extension IncrementalCompilationTests {
 
 // MARK: - Explicit compilation caching incremental tests
 extension IncrementalCompilationTests {
+  func testIncrementalCompilationCachingBasic() throws {
+    let driver = try Driver(args: ["swiftc"])
+    guard driver.isFeatureSupported(.compilation_caching) else {
+      throw XCTSkip("caching not supported")
+    }
+    let extraArguments = ["-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true), "-explicit-module-build"]
+    // Initial build
+    try doABuildWithPartialExpectations(
+      "initial",
+      extraArguments: extraArguments,
+      whenAutolinking: autolinkLifecycleExpectedDiags
+    ) {
+      compiling("main", "other")
+    }
+    // Touch other noting that it depends on main, but not the other way around
+    touch("other")
+    // Subsequent build, check that it only rebuilds other
+    try doABuildWithPartialExpectations(
+      "subsequent",
+      extraArguments: extraArguments,
+      whenAutolinking: autolinkLifecycleExpectedDiags
+    ) {
+      compiling("other")
+      skipped("main")
+    }
+  }
+
   func testIncrementalCompilationCaching() throws {
 #if os(Windows)
     throw XCTSkip("CAS cannot be removed on windows when test is running")
@@ -1896,6 +1923,33 @@ extension IncrementalCompilationTests {
     @DiagsBuilder expecting expectedDiags: () -> [Diagnostic.Message]
   ) throws -> Driver {
     try doABuild(whenAutolinking: autolinkExpectedDiags, expecting: expectedDiags(), arguments: arguments)
+  }
+
+  @discardableResult
+  fileprivate func doABuildWithPartialExpectations(
+    _ message: String,
+    extraArguments: [String],
+    whenAutolinking autolinkExpectedDiags: [Diagnostic.Message],
+    @DiagsBuilder expecting expectedDiags: () -> [Diagnostic.Message]
+  ) throws -> Driver {
+    print("*** starting build \(message) ***", to: &stderrStream); stderrStream.flush()
+
+    guard let sdkArgumentsForTesting = try Driver.sdkArgumentsForTesting()
+    else {
+      throw XCTSkip("Cannot perform this test on this host")
+    }
+    let allArgs = commonArgs + extraArguments + sdkArgumentsForTesting
+
+    return try assertDriverDiagnostics(args: allArgs) {
+      driver, verifier in
+
+      expectedDiags().forEach {verifier.expect($0)}
+      if driver.isAutolinkExtractJobNeeded {
+        autolinkExpectedDiags.forEach {verifier.expect($0)}
+      }
+      doTheCompile(&driver)
+      return driver
+    }
   }
 
   private func doABuildWithoutExpectations(arguments: [String]) throws -> Driver {


### PR DESCRIPTION
Incremental builds don't currently work on Windows because incremental builds are always invalidated due to an external dependency on the prebuilt Swift module, which fails the currency test as its path is just `Swift.swiftmodule` with no directory. We don't need to use abstract paths for prebuilt external swift modules for caching builds as they aren't the output of the current builds. This fixes incremental builds for Windows.

Issue https://github.com/swiftlang/swift/issues/88113