### PR TITLE
[NFC] Make sourceFileProvide description extension-agnostic

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/DependencyKey.swift
@@ -212,8 +212,7 @@ public struct DependencyKey {
     /// A source file - acts as the root for all dependencies provided by
     /// declarations in that file.
     ///
-    /// The `name` of the file is a path to the `swiftdeps` file named in
-    /// the output file map for a given Swift file.
+    /// The `name` of the file is the path to the given Swift file.
     ///
     /// Swiftmodule files may contain a special section with swiftdeps information
     /// for the module. In that case the enclosing node should have a fingerprint.
@@ -322,7 +321,7 @@ public struct DependencyKey {
       case let .externalDepend(externalDependency):
         return "import '\(externalDependency.shortDescription)'"
       case let .sourceFileProvide(name: name):
-        return "source file from \((try? VirtualPath(path: name.lookup(in: holder)).basename) ?? name.lookup(in: holder))"
+        return "source file \((try? VirtualPath(path: name.lookup(in: holder)).basenameWithoutExt) ?? name.lookup(in: holder))"
       }
     }
   }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -2086,9 +2086,9 @@ extension DiagVerifiable {
   }
 
   @DiagsBuilder func fingerprintChanged(_ aspect: DependencyKey.DeclAspect, _ input: String) -> [Diagnostic.Message] {
-    "Incremental compilation: Fingerprint changed for existing \(aspect) of source file from \(input).swiftdeps in \(input).swift"
+    "Incremental compilation: Fingerprint changed for existing \(aspect) of source file \(input) in \(input).swift"
   }
- @DiagsBuilder func fingerprintsChanged(_ input: String) -> [Diagnostic.Message] {
+  @DiagsBuilder func fingerprintsChanged(_ input: String) -> [Diagnostic.Message] {
     for aspect: DependencyKey.DeclAspect in [.interface, .implementation] {
       fingerprintChanged(aspect, input)
     }
@@ -2101,7 +2101,7 @@ extension DiagVerifiable {
   }
 
   @DiagsBuilder func newDefinitionOfSourceFile(_ aspect: DependencyKey.DeclAspect, _ input: String) -> [Diagnostic.Message] {
-    "Incremental compilation: New definition: \(aspect) of source file from \(input).swiftdeps in \(input).swift"
+    "Incremental compilation: New definition: \(aspect) of source file \(input) in \(input).swift"
   }
   @DiagsBuilder func newDefinitionOfTopLevelName(_ aspect: DependencyKey.DeclAspect, name: String, input: String) -> [Diagnostic.Message] {
     "Incremental compilation: New definition: \(aspect) of top-level name '\(name)' in \(input).swift"


### PR DESCRIPTION
Use basenameWithoutExt instead of basename for the sourceFileProvide node description, so the diagnostic reads the same regardless of whether the key is a .swiftdeps path or a .swift source file path.

This allows the same diagnostics reguardless if compiler emit swiftdeps or swift file as sourceFileProvide key.