### PR TITLE
SwiftDriver: always pass `-sysroot` flag if specified

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -173,6 +173,11 @@ extension Driver {
       try addPathOption(option: .sdk, path: VirtualPath.lookup(sdkPath), to: &commandLine, remap: jobNeedPathRemap)
     }
 
+    if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
+      commandLine.appendFlag(.sysroot)
+      try commandLine.appendPath(VirtualPath(path: sysroot))
+    }
+
     for args: (Option, Option) in [
           (.visualcToolsRoot, .visualcToolsVersion),
           (.windowsSdkRoot, .windowsSdkVersion)

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -152,11 +152,6 @@ public final class GenericUnixToolchain: Toolchain {
     driver: inout Driver,
     skipMacroOptions: Bool
   ) throws {
-    if let sysroot = driver.parsedOptions.getLastArgument(.sysroot)?.asSingle {
-      commandLine.appendFlag("-sysroot")
-      try commandLine.appendPath(VirtualPath(path: sysroot))
-    }
-
     if driver.targetTriple.os == .openbsd && driver.targetTriple.arch == .aarch64 {
       if frontendTargetInfo.target.openbsdBTCFIEnabled ?? false {
         commandLine.appendFlag(.Xcc)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -9397,6 +9397,26 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertJobInvocationMatches(jobs[0], .flag("-autolink-library"), .flag("oldnames"), .flag("-autolink-library"), .flag("libcmtd"), .flag("-Xcc"), .flag("-D_MT"))
     }
   }
+
+  func testSysRootHandling() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-sysroot", "/path/to/sysroot", "-c", "input.swift"])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .compile)
+      XCTAssertJobInvocationMatches(jobs[0], .flag("-sysroot"), try .path(.absolute(.init(validating: "/path/to/sysroot"))))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-sdk", "/path/to/sdk", "-sysroot", "/path/to/sysroot", "-c", "input.swift"])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .compile)
+      XCTAssertJobInvocationMatches(jobs[0], .flag("-sysroot"), try .path(.absolute(.init(validating: "/path/to/sysroot"))))
+    }
+  }
 }
 
 func assertString(


### PR DESCRIPTION
This allows passing the flag on all targets. This is primarily to ensure that the flag is properly handled on foreign targets (i.e. Windows) when cross-compiling.

- **Explanation**: Process `-sysroot` on non-Unix toolchain drivers
- **Scope**: This allows the Windows toolchain to forward `-sysroot` flags as well
- **Issues**:
- **Original PRs**:
- **Risk**: Low risk, the flag handling is just being hoisted to the common shared path
- **Testing**: Built the WASI SDK on Windows
- **Reviewers**: @artemcm 
