### PR TITLE
Retry priors file write with exponential backoff

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(SwiftDriver
   Utilities/DOTModuleDependencyGraphSerializer.swift
   Utilities/DateAdditions.swift
   Utilities/Diagnostics.swift
+  Utilities/ExponentialBackoff.swift
   Utilities/FileList.swift
   Utilities/FileMetadata.swift
   Utilities/FileType.swift

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -1117,9 +1117,9 @@ extension ModuleDependencyGraph {
       mockSerializedGraphVersion ?? Self.serializedGraphVersion)
 
     do {
-      try fileSystem.writeFileContents(path,
-                                       bytes: data,
-                                       atomically: true)
+      try withExponentialBackoff {
+        try fileSystem.writeFileContents(path, bytes: data, atomically: true)
+      }
     } catch {
       throw IncrementalCompilationState.WriteDependencyGraphError.couldNotWrite(
         path: path, error: error)

--- a/Sources/SwiftDriver/Utilities/ExponentialBackoff.swift
+++ b/Sources/SwiftDriver/Utilities/ExponentialBackoff.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import class Foundation.Thread
+import struct Foundation.TimeInterval
+
+/// Retries `body` up to `maxAttempts` times with exponential backoff.
+///
+/// If all attempts fail, the error from the last attempt is thrown.
+///
+/// - Parameters:
+///   - maxAttempts: Maximum number of times to attempt `body` (default: 5).
+///   - initialDelay: The delay before the first retry, in seconds (default: 0.1).
+///   - body: The throwing operation to attempt.
+func withExponentialBackoff<T>(
+  maxAttempts: Int = 5,
+  initialDelay: TimeInterval = 0.1,
+  _ body: () throws -> T
+) throws -> T {
+  // Add a bit randomness to avoid lock stepped back off.
+  var delay = initialDelay * Double.random(in: 0.9...1.1)
+  var lastError: Error?
+
+  for _ in 0..<maxAttempts {
+    do {
+      return try body()
+    } catch {
+      lastError = error
+      Thread.sleep(forTimeInterval: delay)
+      delay *= 2
+    }
+  }
+  throw lastError!
+}


### PR DESCRIPTION
On Windows, atomic file writes (temp file + rename) can fail intermittently with ERROR_ACCESS_DENIED if updates to the file happens really close to the write of the file underload.

This can especially happen to `.priors` file in a tight rebuild loop. Now writes `.priors` file in a retry loop with exponential back off.

Assisted-By: Claude

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift-driver repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift-driver will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: Fix a corner case that can cause driver failures during incremental build.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Mostly invisible to user.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Risk**: Low. Mostly NFC other than the retry added.
  <!--
  The (specific) risk to the release for taking the changes.
  -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
