### PR TITLE
[NFC] Correctly implement sharedLibraryName for all platforms

### DIFF
--- a/Sources/SwiftDriver/Driver/WindowsExtensions.swift
+++ b/Sources/SwiftDriver/Driver/WindowsExtensions.swift
@@ -25,13 +25,12 @@ internal func executableName(_ name: String) -> String {
 
 @_spi(Testing) public func sharedLibraryName(_ name: String) -> String {
 #if canImport(Darwin)
-  let ext = ".dylib"
+  return "lib" + name + ".dylib"
 #elseif os(Windows)
-  let ext = ".dll"
+  return name + ".dll"
 #else
-  let ext = ".so"
+  return "lib" + name + ".so"
 #endif
-  return name + ext
 }
 
 // FIXME: This can be subtly wrong, we should rather

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -1188,7 +1188,7 @@ extension Driver {
 #if os(Windows)
       commandLine.appendPath(pluginPathRoot.appending(components: "bin", sharedLibraryName("SwiftInProcPluginServer")))
 #else
-      commandLine.appendPath(pluginPathRoot.appending(components: "lib", "swift", "host", sharedLibraryName("libSwiftInProcPluginServer")))
+      commandLine.appendPath(pluginPathRoot.appending(components: "lib", "swift", "host", sharedLibraryName("SwiftInProcPluginServer")))
 #endif
     }
 

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -272,13 +272,13 @@ extension Toolchain {
        let path = try? AbsolutePath(validating: overrideString) {
       return path
     }
+    let libraryName = sharedLibraryName("_InternalSwiftScan")
 #if os(Windows)
     // no matter if we are in a build tree or an installed tree, the layout is
     // always: `bin/_InternalSwiftScan.dll`
     return try getToolPath(.swiftCompiler).parentDirectory // bin
-                                          .appending(component: "_InternalSwiftScan.dll")
+                                          .appending(component: libraryName)
 #else
-    let libraryName = sharedLibraryName("lib_InternalSwiftScan")
     let compilerPath = try getToolPath(.swiftCompiler)
     let toolchainRootPath = compilerPath.parentDirectory // bin
                                         .parentDirectory // toolchain root

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -9026,7 +9026,7 @@ final class SwiftDriverTests: XCTestCase {
 
     try withTemporaryDirectory { toolsDirectory in
       let customSwiftFrontend = toolsDirectory.appending(component: executableName("swift-frontend"))
-      let customSwiftScan = toolsDirectory.appending(component: sharedLibraryName("lib_InternalSwiftScan"))
+      let customSwiftScan = toolsDirectory.appending(component: sharedLibraryName("_InternalSwiftScan"))
       try localFileSystem.createSymbolicLink(customSwiftFrontend, pointingAt: defaultSwiftFrontend, relative: false)
 
       try withTemporaryDirectory { tempDirectory in


### PR DESCRIPTION

<!-- Please fill out the following form: --> 
- **Explanation**: `sharedLibraryName` wasn't provide the correct naming convention for Windows platform, even it is in WindowsExtensions.swift. Now fix the implementation so `sharedLibraryName` can be used to get the name of the shared library with the same name passed for all platforms.

  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: NFC change.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Risk**: Low. NFC change.
  <!--
  The (specific) risk to the release for taking the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
