### PR TITLE
[github-workflow] Stop hard code Xcode version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       windows_swift_versions: '["nightly-main"]'
       windows_build_command: 'Invoke-Program swift test --parallel'
       enable_macos_checks: true
-      macos_xcode_versions: "[\"26.0\"]"
+      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.4\"}]"
       macos_build_command: swift test --parallel
 
   soundness:


### PR DESCRIPTION
Instead of hard code xcode version to use to test, follow the defaults set by the github-workflow, and only exclude the old versions that are known to not working with current test suite.

