### PR TITLE
[build-script-helper] Add caching support for Swift compilation

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -682,6 +682,30 @@ def build_using_cmake(args, toolchain_bin, build_dir, targets):
         )
     )
 
+    if args.enable_caching and args.caching_cas_path:
+        base_swift_flags.append("-explicit-module-build")
+        base_swift_flags.append("-cache-compile-job")
+        base_swift_flags.append("-cas-path")
+        base_swift_flags.append(args.caching_cas_path)
+        if args.caching_plugin_path:
+            base_swift_flags.append("-cas-plugin-path")
+            base_swift_flags.append(args.caching_plugin_path)
+        for opt in (args.caching_plugin_option or []):
+            base_swift_flags.append("-cas-plugin-option")
+            base_swift_flags.append(opt)
+        if args.caching_prefix_map:
+            base_swift_flags.append("-scanner-prefix-map-sdk")
+            base_swift_flags.append("/^sdk")
+            base_swift_flags.append("-scanner-prefix-map-toolchain")
+            base_swift_flags.append("/^toolchain")
+            base_swift_flags.append("-scanner-prefix-map")
+            base_swift_flags.append(args.package_path + "=/^src")
+        if args.caching_enable_mccas:
+            base_swift_flags.append("-Xfrontend")
+            base_swift_flags.append("-cas-backend")
+            base_swift_flags.append("-Xllvm")
+            base_swift_flags.append("-cas-friendly-debug-info")
+
     for target in targets:
         base_cmake_flags = []
         swift_flags = base_swift_flags.copy()
@@ -1045,6 +1069,38 @@ def main():
             "--enable-asan",
             action="store_true",
             help="driver is being built with ASAN support",
+        )
+        parser.add_argument(
+            "--enable-caching",
+            action="store_true",
+            help="enable Swift compilation caching",
+        )
+        parser.add_argument(
+            "--caching-cas-path",
+            metavar="PATH",
+            help="the CAS directory path for compilation caching",
+        )
+        parser.add_argument(
+            "--caching-plugin-path",
+            metavar="PATH",
+            help="the path to the CAS plugin for compilation caching",
+        )
+        parser.add_argument(
+            "--caching-plugin-option",
+            action="append",
+            default=[],
+            help="options to pass to the CAS plugin "
+                 "(can be specified multiple times)",
+        )
+        parser.add_argument(
+            "--caching-prefix-map",
+            action="store_true",
+            help="enable prefix mapping for cached builds",
+        )
+        parser.add_argument(
+            "--caching-enable-mccas",
+            action="store_true",
+            help="enable CAS backend and CAS-friendly debug info",
         )
 
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
Forward --enable-caching, --caching-cas-path, --caching-plugin-path, --caching-plugin-option, --caching-prefix-map, and --caching-enable-mccas flags from the Swift build script. When enabled, appends explicit module build, compilation caching, plugin, prefix mapping, and CAS backend Swift compiler flags.

rdar://155876033

Assisted-By: Claude

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift-driver repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift-driver will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: swift-driver build system change for: https://github.com/swiftlang/swift/pull/88608
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Support caching build from build-script. NFC outside that.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://155876033
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. NFC outside new function added.
  <!--
  The (specific) risk to the release for taking the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
