### PR TITLE
[Caching] Abstract clang module map path with prefix mapping

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -654,7 +654,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         }
         let updatedInfo = try ClangModuleArtifactInfo(name: info.moduleName,
                                                       modulePath: abstractPath(info.moduleName, suffix: ".pcm"),
-                                                      moduleMapPath: info.clangModuleMapPath,
+                                                      moduleMapPath: nil,
                                                       moduleCacheKey: info.clangModuleCacheKey,
                                                       isBridgingHeaderDependency: info.isBridgingHeaderDependency,
                                                       libraryLevel: info.libraryLevel)

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/SerializableModuleArtifacts.swift
@@ -60,7 +60,7 @@
   /// The path for the module's .pcm file
   public let clangModulePath: TextualVirtualPath
   /// The path for this module's .modulemap file
-  public let clangModuleMapPath: TextualVirtualPath
+  public let clangModuleMapPath: TextualVirtualPath?
   /// A flag to indicate whether this module is a framework
   public let isFramework: Bool
   /// A flag to indicate whether this module is a dependency
@@ -71,7 +71,7 @@
   /// The library level of the module (e.g. "api", "spi").
   public let libraryLevel: LibraryLevel?
 
-  init(name: String, modulePath: TextualVirtualPath, moduleMapPath: TextualVirtualPath,
+  init(name: String, modulePath: TextualVirtualPath, moduleMapPath: TextualVirtualPath? = nil,
        moduleCacheKey: String? = nil, isBridgingHeaderDependency: Bool = true,
        libraryLevel: LibraryLevel? = nil) {
     self.moduleName = name


### PR DESCRIPTION
When using prefix mapping, don't serialize clang module path to swift-frontend. This removes the absolute path dependency when building with compilation caching and prefix mapping.

Clang module path is not actually used by the swift compiler when loading modules. It is only serialized in swift binary module and allows lldb to some fallback paths when the PCM cannot be loaded. This is not used with prefix mapping.


<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift-driver repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift-driver will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: Drop clang module map path when using caching + prefix mapping.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Affect cache hit rate for caching + prefix mapping.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://175017181
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. Only affect caching + prefix mapping.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Local testing. Once everything landed, tests can be enabled in swift-build.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
