### PR TITLE
[IncrementalCompilation] Support prefix-mapped paths and external module resolution

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -72,6 +72,25 @@ public final class IncrementalCompilationState {
       reporter: reporter)
       .compute(batchJobFormer: &driver)
 
+    // Re-populate the external module path map from fresh scanning results.
+    // The deserialized map from priors was already used by FirstWaveComputer
+    // above for currency checks; this overwrites it so that priors serialized
+    // at the end of this build reflect up-to-date paths.
+    if let planner = explicitModulePlanner {
+      initialState.graph.blockingConcurrentAccessOrMutation {
+        let map = Dictionary(uniqueKeysWithValues:
+          planner.dependencyGraph.modules.compactMap {
+            moduleId, moduleInfo -> (String, VirtualPath.Handle)? in
+            guard case .swiftPrebuiltExternal = moduleId,
+                  case .swiftPrebuiltExternal(let details) = moduleInfo.details
+            else { return nil }
+            let abstractPath = moduleId.moduleName + "." + FileType.swiftModule.rawValue
+            return (abstractPath, details.compiledModulePath.path)
+          })
+        initialState.graph.setExternalModulePathMap(map)
+      }
+    }
+
     self.info = initialState.graph.info
 
     self.protectedState = ProtectedState(

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -17,6 +17,7 @@ import class Dispatch.DispatchQueue
 
 import class TSCBasic.DiagnosticsEngine
 import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
 
 // Initial incremental state computation
 extension IncrementalCompilationState {
@@ -56,7 +57,8 @@ extension IncrementalCompilationState {
           buildRecordInfo,
           reporter, driver.inputFiles,
           driver.fileSystem,
-          driver.diagnosticEngine
+          driver.diagnosticEngine,
+          prefixMapping: driver.prefixMapping
         ).computeInitialStateForPlanning(driver: &driver)
     else {
       Self.removeDependencyGraphFile(driver)
@@ -114,6 +116,10 @@ extension IncrementalCompilationState {
     @_spi(Testing) public let inputFiles: [TypedVirtualPath]
     @_spi(Testing) public let fileSystem: FileSystem
 
+    /// Prefix mapping from the driver, used to reverse-map paths in .swiftdeps
+    /// files that were written with prefix mapping active.
+    @_spi(Testing) public let prefixMapping: [(AbsolutePath, AbsolutePath)]
+
     /// The state managing incremental compilation gets mutated every time a compilation job completes.
     /// This queue ensures that the access and mutation of that state is thread-safe.
     @_spi(Testing) public let incrementalCompilationQueue: DispatchQueue
@@ -147,7 +153,8 @@ extension IncrementalCompilationState {
       _ reporter: IncrementalCompilationState.Reporter?,
       _ inputFiles: [TypedVirtualPath],
       _ fileSystem: FileSystem,
-      _ diagnosticEngine: DiagnosticsEngine
+      _ diagnosticEngine: DiagnosticsEngine,
+      prefixMapping: [(AbsolutePath, AbsolutePath)] = []
     ) {
       self.outputFileMap = outputFileMap
       self.buildRecordInfo = buildRecordInfo
@@ -155,6 +162,7 @@ extension IncrementalCompilationState {
       self.options = options
       self.inputFiles = inputFiles
       self.fileSystem = fileSystem
+      self.prefixMapping = prefixMapping
       assert(outputFileMap.onlySourceFilesHaveSwiftDeps())
       self.diagnosticEngine = diagnosticEngine
       self.incrementalCompilationQueue = DispatchQueue(
@@ -180,6 +188,27 @@ extension IncrementalCompilationState {
     /// - Returns: true iff this file was in the command-line invocation of the driver
     func isPartOfBuild(_ sourceFile: SwiftSourceFile) -> Bool {
       return self.inputFiles.contains(sourceFile.typedFile)
+    }
+
+    /// Reverse prefix-map a path string that was written with prefix mapping
+    /// active. Converts e.g. "/^tmp/foo.swift" back to "/real/path/foo.swift".
+    func reverseMapPath(_ mappedPath: String) -> String {
+      guard !prefixMapping.isEmpty,
+            let mappedAbsPath = try? AbsolutePath(validating: mappedPath)
+      else {
+        return mappedPath
+      }
+      for (original, mapped) in prefixMapping {
+        if mappedAbsPath.isDescendantOfOrEqual(to: mapped) {
+          return original.appending(mappedAbsPath.relative(to: mapped)).pathString
+        }
+      }
+      return mappedPath
+    }
+
+    /// A closure for deserialization routines to reverse prefix-mapped paths.
+    var pathReverser: (String) -> String {
+      { self.reverseMapPath($0) }
     }
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -50,6 +50,13 @@ import struct Foundation.TimeInterval
     self.phase = newPhase
   }
 
+  /// Update the external module path map (from explicit module planner) and
+  /// propagate it to the currency cache for filesystem resolution.
+  func setExternalModulePathMap(_ map: [String: VirtualPath.Handle]) {
+    mutationSafetyPrecondition()
+    self.currencyCache.externalModulePathMap = map
+  }
+
   /// The phase when the graph was created. Used to help diagnose later failures
   let creationPhase: Phase
 
@@ -575,6 +582,8 @@ extension ModuleDependencyGraph {
     private var currencyCache = [ExternalDependency: Bool]()
     public internal(set) var externalDependencyFileHashes: [ExternalDependency: String]
     private let useFileHashes: Bool
+    /// Maps abstract module paths (e.g. "B.swiftmodule") to on-disk paths for filesystem checks.
+    var externalModulePathMap: [String: VirtualPath.Handle] = [:]
 
     init(_ fileSystem: FileSystem, buildStartTime: TimePoint, externalDependencyFileHashes: Dictionary<ExternalDependency, String>, useFileHashes: Bool) {
       self.fileSystem = fileSystem
@@ -583,11 +592,20 @@ extension ModuleDependencyGraph {
       self.useFileHashes = useFileHashes
     }
 
+    /// Resolve an external dependency to a filesystem path, using the module
+    /// path map for abstract paths.
+    private func resolvedPath(for externalDependency: ExternalDependency) -> VirtualPath? {
+      if let handle = externalModulePathMap[externalDependency.fileNameString] {
+        return VirtualPath.lookup(handle)
+      }
+      return externalDependency.path
+    }
+
     mutating func updateHash(_ externalDependency: ExternalDependency) {
         guard useFileHashes else {
           return
         }
-        if let depFile = externalDependency.path, 
+        if let depFile = resolvedPath(for: externalDependency),
         let data = try? fileSystem.readFileContents(depFile) {
             externalDependencyFileHashes[externalDependency] = SHA256().hash(data).hexadecimalRepresentation
         }
@@ -619,7 +637,7 @@ extension ModuleDependencyGraph {
     }
 
     private func isCurrentWRTFileHash(_ externalDependency: ExternalDependency) -> Bool {
-      if let depFile = externalDependency.path, 
+      if let depFile = resolvedPath(for: externalDependency),
         let data = try? fileSystem.readFileContents(depFile) {
             return self.externalDependencyFileHashes[externalDependency] == SHA256().hash(data).hexadecimalRepresentation
         }
@@ -627,12 +645,12 @@ extension ModuleDependencyGraph {
     }
 
     private func isCurrentWRTFileSystem(_ externalDependency: ExternalDependency) -> Bool {
-      if let depFile = externalDependency.path,
-         let fileModTime = try? self.fileSystem.lastModificationTime(for: depFile),
-         fileModTime < self.buildStartTime {
-        return true
+      guard let depFile = resolvedPath(for: externalDependency),
+            let fileModTime = try? self.fileSystem.lastModificationTime(for: depFile)
+      else {
+        return false
       }
-      return false
+      return fileModTime < self.buildStartTime
     }
   }
 }
@@ -668,19 +686,21 @@ extension ModuleDependencyGraph {
   /// - Minor number 2: Use `.swift` files instead of `.swiftdeps` in ``DependencySource``
   /// - Minor number 3: Use interned strings, including for fingerprints and use empty dependency source file for no DependencySource
   /// - Minor number 4: Absorb the data in the ``BuildRecord`` into the module dependency graph.
-  /// - Minor number 5: SHA256 hashes for files in externalDepNode and inputInfo blobs. 
-  @_spi(Testing) public static let serializedGraphVersion = Version(1, 5, 0)
+  /// - Minor number 5: SHA256 hashes for files in externalDepNode and inputInfo blobs.
+  /// - Minor number 6: externalModulePathNode for resolving abstract module paths.
+  @_spi(Testing) public static let serializedGraphVersion = Version(1, 6, 0)
 
   /// The IDs of the records used by the module dependency graph.
   fileprivate enum RecordID: UInt64 {
-    case metadata           = 1
-    case moduleDepGraphNode = 2
-    case dependsOnNode      = 3
-    case useIDNode          = 4
-    case externalDepNode    = 5
-    case identifierNode     = 6
-    case buildRecord        = 7
-    case inputInfo          = 8
+    case metadata                = 1
+    case moduleDepGraphNode      = 2
+    case dependsOnNode           = 3
+    case useIDNode               = 4
+    case externalDepNode         = 5
+    case identifierNode          = 6
+    case buildRecord             = 7
+    case inputInfo               = 8
+    case externalModulePathNode  = 9
 
     /// The human-readable name of this record.
     ///
@@ -705,6 +725,8 @@ extension ModuleDependencyGraph {
         return "BUILD_RECORD"
       case .inputInfo:
         return "INPUT_INFO"
+      case .externalModulePathNode:
+        return "EXTERNAL_MODULE_PATH_NODE"
       }
     }
   }
@@ -749,6 +771,8 @@ extension ModuleDependencyGraph {
         self = .malformedBuildRecord
       case .inputInfo:
         self = .malformedInputInfo
+      case .externalModulePathNode:
+        self = .malformedMapRecord
       }
     }
   }
@@ -795,6 +819,7 @@ extension ModuleDependencyGraph {
       private var nodeUses: [(DependencyKey, Int)] = []
       private var fingerprintedExternalDependencies = Set<FingerprintedExternalDependency>()
       private var externalDependencyFileHashes = Dictionary<ExternalDependency, String>()
+      private var externalModulePathMap = Dictionary<String, VirtualPath.Handle>()
 
       /// Deserialized nodes, in order appearing in the priors file. If `nil`, the node is for a removed source file.
       ///
@@ -842,6 +867,7 @@ extension ModuleDependencyGraph {
             .record(def: dependencyKey, use: use)
           assert(isNewUse, "Duplicate use def-use arc in graph?")
         }
+        graph.setExternalModulePathMap(self.externalModulePathMap)
         return graph
       }
 
@@ -1044,7 +1070,20 @@ extension ModuleDependencyGraph {
           else {
             throw malformedError
           }
-          _ = (String(decoding: identifierBlob, as: UTF8.self)).intern(in: internedStringTable)
+          var identifier = String(decoding: identifierBlob, as: UTF8.self)
+          identifier = info.pathReverser(identifier)
+          _ = identifier.intern(in: internedStringTable)
+        case .externalModulePathNode:
+          guard record.fields.count == 2 else {
+            throw malformedError
+          }
+          let abstractPath = try internedString(field: 0)
+          let resolvedPath = try internedString(field: 1)
+          let resolvedPathString = resolvedPath.lookup(in: internedStringTable)
+          guard let handle = try? VirtualPath.intern(path: resolvedPathString) else {
+            throw malformedError
+          }
+          externalModulePathMap[abstractPath.lookup(in: internedStringTable)] = handle
         }
       }
     }
@@ -1181,6 +1220,7 @@ extension ModuleDependencyGraph {
         self.emitRecordID(.identifierNode)
         self.emitRecordID(.buildRecord)
         self.emitRecordID(.inputInfo)
+        self.emitRecordID(.externalModulePathNode)
       }
     }
 
@@ -1240,6 +1280,12 @@ extension ModuleDependencyGraph {
 
       for (input, _) in sortedInputInfo {
         _ = input.name.intern(in: self.internedStringTable)
+      }
+
+      // Ensure external module path map strings are interned
+      for (abstractPath, resolvedHandle) in graph.currencyCache.externalModulePathMap.sorted(by: { $0.key < $1.key }) {
+        _ = abstractPath.intern(in: self.internedStringTable)
+        _ = VirtualPath.lookup(resolvedHandle).name.intern(in: self.internedStringTable)
       }
 
       for str in internedStringTable.strings {
@@ -1336,6 +1382,13 @@ extension ModuleDependencyGraph {
         // identifier data
         .blob
       ])
+      self.abbreviate(.externalModulePathNode, [
+        .literal(RecordID.externalModulePathNode.rawValue),
+        // abstract path ID
+        .vbr(chunkBitWidth: 13),
+        // resolved path ID
+        .vbr(chunkBitWidth: 13),
+      ])
     }
 
     private func abbreviate(
@@ -1413,6 +1466,15 @@ extension ModuleDependencyGraph {
               for: fingerprintedExternalDependency.fingerprint))
           }, 
           blob: graph.currencyCache.externalDependencyFileHashes[fingerprintedExternalDependency.externalDependency] ?? "")
+        }
+        for (abstractPath, resolvedHandle) in graph.currencyCache.externalModulePathMap.sorted(by: { $0.key < $1.key }) {
+          let abstractInternedString = abstractPath.intern(in: graph.internedStringTable)
+          let resolvedInternedString = VirtualPath.lookup(resolvedHandle).name.intern(in: graph.internedStringTable)
+          serializer.stream.writeRecord(serializer.abbreviations[.externalModulePathNode]!) {
+            $0.append(RecordID.externalModulePathNode)
+            $0.append(serializer.lookupIdentifierCode(for: abstractInternedString))
+            $0.append(serializer.lookupIdentifierCode(for: resolvedInternedString))
+          }
         }
       }
       return ByteString(serializer.stream.data)

--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraphParts/DependencySource.swift
@@ -77,7 +77,8 @@ extension DependencySource {
       info.reporter?.report("Reading dependencies from \(description)")
       return try SourceFileDependencyGraph.read(from: fileToRead,
                                                 on: info.fileSystem,
-                                                internedStringTable: internedStringTable)
+                                                internedStringTable: internedStringTable,
+                                                pathReverser: info.pathReverser)
     }
     catch {
       let msg = "Could not read \(fileToRead) \(error.localizedDescription)"

--- a/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/SourceFileDependencyGraph.swift
@@ -140,9 +140,12 @@ extension SourceFileDependencyGraph {
   static func read(
     from typedFile: TypedVirtualPath,
     on fileSystem: FileSystem,
-    internedStringTable: InternedStringTable
+    internedStringTable: InternedStringTable,
+    pathReverser: ((String) -> String)? = nil
   ) throws -> Self? {
-    try self.init(contentsOf: typedFile, on: fileSystem, internedStringTable: internedStringTable)
+    try self.init(contentsOf: typedFile, on: fileSystem,
+                  internedStringTable: internedStringTable,
+                  pathReverser: pathReverser)
   }
 
   /*@_spi(Testing)*/ public init(nodesForTesting: [Node],
@@ -157,29 +160,35 @@ extension SourceFileDependencyGraph {
   /*@_spi(Testing)*/ public init?(
     contentsOf typedFile: TypedVirtualPath,
     on fileSystem: FileSystem,
-    internedStringTable: InternedStringTable
+    internedStringTable: InternedStringTable,
+    pathReverser: ((String) -> String)? = nil
   ) throws {
     assert(typedFile.type == .swiftDeps || typedFile.type == .swiftModule)
     let data = try fileSystem.readFileContents(typedFile.file)
     try self.init(internedStringTable: internedStringTable,
                   data: data,
-                  fromSwiftModule: typedFile.type == .swiftModule)
+                  fromSwiftModule: typedFile.type == .swiftModule,
+                  pathReverser: pathReverser)
   }
 
   /// Returns nil for a swiftmodule with no dependencies
   /*@_spi(Testing)*/ public init?(
     internedStringTable: InternedStringTable,
     data: ByteString,
-    fromSwiftModule extractFromSwiftModule: Bool = false
+    fromSwiftModule extractFromSwiftModule: Bool = false,
+    pathReverser: ((String) -> String)? = nil
   ) throws {
     struct Visitor: BitstreamVisitor, InternedStringTableHolder {
       let extractFromSwiftModule: Bool
       let internedStringTable: InternedStringTable
+      let pathReverser: ((String) -> String)?
 
       init(extractFromSwiftModule: Bool,
-           internedStringTable: InternedStringTable) {
+           internedStringTable: InternedStringTable,
+           pathReverser: ((String) -> String)?) {
         self.extractFromSwiftModule = extractFromSwiftModule
         self.internedStringTable = internedStringTable
+        self.pathReverser = pathReverser
         self.identifiers = ["".intern(in: internedStringTable)]
       }
 
@@ -292,14 +301,19 @@ extension SourceFileDependencyGraph {
           else {
             throw ReadError.malformedIdentifierRecord
           }
-          identifiers.append(String(decoding: identifierBlob, as: UTF8.self).intern(in: internedStringTable))
+          var identifier = String(decoding: identifierBlob, as: UTF8.self)
+          if let reverser = pathReverser {
+            identifier = reverser(identifier)
+          }
+          identifiers.append(identifier.intern(in: internedStringTable))
         }
       }
     }
 
     var visitor = Visitor(
       extractFromSwiftModule: extractFromSwiftModule,
-      internedStringTable: internedStringTable)
+      internedStringTable: internedStringTable,
+      pathReverser: pathReverser)
     do {
       try Bitcode.read(bytes: data, using: &visitor)
     } catch ReadError.swiftModuleHasNoDependencies {

--- a/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
+++ b/Tests/SwiftDriverTests/Helpers/MockingIncrementalCompilation.swift
@@ -135,7 +135,8 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
     options: IncrementalCompilationState.Options = [.verifyDependencyGraphAfterEveryImport],
     outputFileMap: OutputFileMap,
     fileSystem: FileSystem = localFileSystem,
-    diagnosticEngine: DiagnosticsEngine = DiagnosticsEngine()
+    diagnosticEngine: DiagnosticsEngine = DiagnosticsEngine(),
+    prefixMapping: [(AbsolutePath, AbsolutePath)] = []
   ) -> Self {
     // Must set input files in order to avoid graph deserialization from culling
     let inputFiles = outputFileMap.entries.keys
@@ -153,7 +154,8 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
       nil,
       inputFiles,
       fileSystem,
-      diagnosticEngine
+      diagnosticEngine,
+      prefixMapping: prefixMapping
     )
   }
 }

--- a/Tests/SwiftDriverTests/IncrementalExplicitBuildTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalExplicitBuildTests.swift
@@ -83,7 +83,7 @@ struct IncrementalExplicitBuildTests: DiagVerifiable {
   //
   // On this graph, inputs of 'G' are updated, causing it to be re-built
   // as well as all modules on paths from root to it: 'Y', 'H', 'T','J'
-  @Test(arguments: TestBuildConfig.explicitOnlyConfigs)
+  @Test(arguments: TestBuildConfig.availableExplicitConfigs)
   func changedDependencyInvalidatesUpstream(config: TestBuildConfig) async throws {
     let h = try IncrementalTestHarness(config: config)
     h.replace(contentsOf: "other", with: "import Y;import T")
@@ -140,7 +140,7 @@ struct IncrementalExplicitBuildTests: DiagVerifiable {
 
   // Source file and external deps timestamps updated but contents are the same,
   // and file-hashing is enabled.
-  @Test(arguments: TestBuildConfig.explicitOnlyConfigs)
+  @Test(arguments: TestBuildConfig.availableExplicitConfigs)
   func explicitIncrementalBuildWithHashing(config: TestBuildConfig) async throws {
     let h = try IncrementalTestHarness(config: config)
     h.replace(contentsOf: "other", with: "import E;let bar = foo")


### PR DESCRIPTION
- Add prefixMapping to IncrementalDependencyAndInputSetup, threaded from Driver. Provide reverseMapPath() to convert prefix-mapped paths back to real paths during .swiftdeps and priors deserialization.
- Add pathReverser to SourceFileDependencyGraph deserialization so all identifier strings in .swiftdeps files are reverse-mapped at read time.
- Apply pathReverser during priors graph deserialization as well.
- Add externalModulePathMap to ExternalDependencyCurrencyCache for resolving abstract module paths (e.g. "B.swiftmodule") to absolute paths during filesystem currency checks. Populated from ExplicitDependencyBuildPlanner scanning results.
- Serialize/deserialize externalModulePathMap in priors file via new externalModulePathNode record (version bumped to 1.6.0).
- Add integration tests for caching and prefix-mapped caching incremental builds, including upstream dependency invalidation with diagnostics.


Assisted-By: Claude

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift-driver repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift-driver will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: Fixes incremental build for caching prefix mapping configuration to correctly identify unchanged dependency to avoid rebuilds.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Caching incremental build only.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://174330691
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. Limited scope and supports a configuration that wasn't previously well supported.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit-tests
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
