### PR TITLE
Add GNUstep Objective-C interop driver option

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -138,8 +138,11 @@ extension Driver {
     // Enable or disable ObjC interop appropriately for the platform
     if targetTriple.isDarwin && !isEmbeddedEnabled {
       commandLine.appendFlag(.enableObjcInterop)
-    } else {
+    } else if !parsedOptions.hasArgument(.gnustepObjcInterop) {
       commandLine.appendFlag(.disableObjcInterop)
+    }
+    if parsedOptions.hasArgument(.gnustepObjcInterop) {
+      commandLine.appendFlag(.gnustepObjcInterop)
     }
 
     // Add flags for C++ interop

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -510,6 +510,7 @@ extension Option {
   public static let enableNskeyedarchiverDiagnostics: Option = Option("-enable-nskeyedarchiver-diagnostics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Diagnose classes with unstable mangled names adopting NSCoding")
   public static let enableObjcAttrRequiresFoundationModule: Option = Option("-enable-objc-attr-requires-foundation-module", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable requiring uses of @objc to require importing the Foundation module")
   public static let enableObjcInterop: Option = Option("-enable-objc-interop", .flag, attributes: [.helpHidden, .frontend, .noDriver, .moduleInterface], helpText: "Enable Objective-C interop code generation and config directives")
+  public static let gnustepObjcInterop: Option = Option("-gnustep-objc-interop", .flag, attributes: [.helpHidden, .frontend, .moduleInterface], helpText: "Enable GNUstep Objective-C interop code generation and config directives")
   public static let enableObjectiveCProtocolSymbolicReferences: Option = Option("-enable-objective-c-protocol-symbolic-references", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable objective-c protocol symbolic references")
   public static let enableOnlyOneDependencyFile: Option = Option("-enable-only-one-dependency-file", .flag, attributes: [.doesNotAffectIncrementalBuild], helpText: "Enables incremental build optimization that only produces one dependencies file")
   public static let enableOssaModules: Option = Option("-enable-ossa-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Obsolete. This option is ignored")
@@ -1535,6 +1536,7 @@ extension Option {
       Option.enableNskeyedarchiverDiagnostics,
       Option.enableObjcAttrRequiresFoundationModule,
       Option.enableObjcInterop,
+      Option.gnustepObjcInterop,
       Option.enableObjectiveCProtocolSymbolicReferences,
       Option.enableOnlyOneDependencyFile,
       Option.enableOssaModules,


### PR DESCRIPTION
This draft promotes the GNUstep Swift Phase 16I branch for review.\n\nIt adds the driver-side GNUstep Objective-C interop option needed by the GNUstep interop proof of concept while keeping the change scoped to option plumbing.\n\nValidation in the GNUstep interop workspace is tracked from the gnustep-swift project roadmap.