### PR TITLE
Add option to install without building.

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -301,7 +301,8 @@ def handle_invocation(args):
             install(args, args.build_path, targets)
         else:
             bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, env)
-            swiftpm("build", swift_exec, swiftpm_args, env)
+            if not args.install_only:
+                swiftpm("build", swift_exec, swiftpm_args, env)
             non_darwin_install(args, bin_path)
     else:
         assert False, "unknown action '{}'".format(args.action)
@@ -1101,6 +1102,12 @@ def main():
             "--caching-enable-mccas",
             action="store_true",
             help="enable CAS backend and CAS-friendly debug info",
+        )
+        parser.add_argument(
+            "--install-only",
+            action="store_true",
+            default=False,
+            help="when true, installs without rebuilding",
         )
 
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
This allows the build action to be decoupled from the install action, so packaging systems that expect to be able to do discrete installation steps post-build can do so cheaply, without having to effectively start the build over from scratch.

To match existing behavior, this defaults to being disabled. I have not added this to the macOS branch because I am unable to test the behavior.

This behavior was introduced in other projects that use a similar build-script-helper pattern: see swiftlang/swift-package-manager#9050, swiftlang/sourcekit-lsp#2579, swiftlang/swift-format#1171, and swiftlang/swift-docc#1486.