### PR TITLE
EmscriptenToolchain: clean up comments and `linkerOutputType` handling

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmscriptenToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/EmscriptenToolchain+LinkerSupport.swift
@@ -119,12 +119,12 @@ extension EmscriptenToolchain {
         parsedOptions: &parsedOptions,
         sanitizers: sanitizers,
         lto: lto,
-        targetInfo: targetInfo,
-        linkerOutputType: linkerOutputType
+        targetInfo: targetInfo
       )
 
-      // `emcc` supports `-Xlinker` for passing flags to `wasm-ld`, but
-      // `-Xclang-linker` is `clang`-specific and must not be forwarded.
+      // `emcc` supports `-Xlinker` for passing flags to `wasm-ld`. `-Xclang-linker`
+      // is intentionally not forwarded here; `EmscriptenToolchain.validateArgs`
+      // emits a warning at parse time directing users to `-Xemcc-linker` instead.
       for linkerOpt in parsedOptions.arguments(for: .Xlinker) {
         commandLine.appendFlag(.Xlinker)
         commandLine.appendFlag(linkerOpt.argument.asSingle)

--- a/Sources/SwiftDriver/Jobs/WASIToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WASIToolchain+LinkerSupport.swift
@@ -164,8 +164,7 @@ extension WASIToolchain {
         parsedOptions: &parsedOptions,
         sanitizers: sanitizers,
         lto: lto,
-        targetInfo: targetInfo,
-        linkerOutputType: linkerOutputType
+        targetInfo: targetInfo
       )
 
       try addExtraClangLinkerArgs(to: &commandLine, parsedOptions: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchainProtocol+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchainProtocol+LinkerSupport.swift
@@ -72,14 +72,13 @@ extension WebAssemblyToolchainProtocol {
     parsedOptions: inout ParsedOptions,
     sanitizers: Set<Sanitizer>,
     lto: LTOKind?,
-    targetInfo: FrontendTargetInfo,
-    linkerOutputType: LinkOutputType
+    targetInfo: FrontendTargetInfo
   ) throws {
     let targetTriple = targetInfo.target.triple
 
     // Delegate to Clang for sanitizers. It will figure out the correct linker
     // options.
-    if linkerOutputType == .executable && !sanitizers.isEmpty {
+    if !sanitizers.isEmpty {
       let sanitizerNames = sanitizers
         .map { $0.rawValue }
         .sorted() // Sort so we get a stable, testable order


### PR DESCRIPTION
Addressing post-merge feedback on https://github.com/swiftlang/swift-driver/pull/2105