### PR TITLE
[Driver] Inject per-instance stdout/stderr streams

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -15,6 +15,7 @@ import SwiftOptions
 
 import class Dispatch.DispatchQueue
 import class TSCBasic.DiagnosticsEngine
+import class TSCBasic.ThreadSafeOutputByteStream
 import class TSCBasic.UnknownLocation
 import enum TSCBasic.ProcessEnv
 import func TSCBasic.withTemporaryDirectory
@@ -656,6 +657,12 @@ public struct Driver {
   /// A global queue for emitting non-interrupted messages into stderr
   public static let stdErrQueue = DispatchQueue(label: "org.swift.driver.emit-to-stderr")
 
+  /// Output stream the driver writes informational stdout to.
+  public let stdoutStream: ThreadSafeOutputByteStream
+
+  /// Output stream the driver writes informational stderr to.
+  public let stderrStream: ThreadSafeOutputByteStream
+
   @_spi(Testing)
   public enum KnownCompilerFeature: String {
     case emit_abi_descriptor = "emit-abi-descriptor"
@@ -747,7 +754,7 @@ public struct Driver {
   /// Handler for emitting diagnostics to stderr.
   public static let stderrDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in
     stdErrQueue.sync {
-      let stream = stderrStream
+      let stream = TSCBasic.stderrStream
       if !(diagnostic.location is UnknownLocation) {
           stream.send("\(diagnostic.location.description): ")
       }
@@ -854,6 +861,32 @@ public struct Driver {
     )
   }
 
+  @available(*, deprecated, renamed: "init(args:envBlock:diagnosticsOutput:fileSystem:executor:integratedDriver:compilerIntegratedTooling:compilerExecutableDir:interModuleDependencyOracle:stdoutStream:stderrStream:)")
+  @_disfavoredOverload
+  public init(
+    args: [String],
+    envBlock: ProcessEnvironmentBlock = ProcessEnv.block,
+    diagnosticsOutput: DiagnosticsOutput = .engine(DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler])),
+    fileSystem: FileSystem = localFileSystem,
+    executor: DriverExecutor,
+    integratedDriver: Bool = true,
+    compilerIntegratedTooling: Bool = false,
+    compilerExecutableDir: AbsolutePath? = nil,
+    interModuleDependencyOracle: InterModuleDependencyOracle? = nil
+  ) throws {
+    try self.init(
+      args: args,
+      envBlock: envBlock,
+      diagnosticsOutput: diagnosticsOutput,
+      fileSystem: fileSystem,
+      executor: executor,
+      integratedDriver: integratedDriver,
+      compilerIntegratedTooling: compilerIntegratedTooling,
+      compilerExecutableDir: compilerExecutableDir,
+      interModuleDependencyOracle: interModuleDependencyOracle
+    )
+  }
+
   /// Create the driver with the given arguments.
   ///
   /// - Parameter args: The command-line arguments, including the "swift" or "swiftc"
@@ -874,6 +907,8 @@ public struct Driver {
   ///   Used when in `integratedDriver` mode as a substitute for the driver knowing its executable path.
   /// - Parameter interModuleDependencyOracle: An oracle for querying inter-module dependencies,
   ///   shared across different module builds by a build system.
+  /// - Parameter stdoutStream: Stream the driver writes informational stdout to.
+  /// - Parameter stderrStream: Stream the driver writes informational stderr to.
   public init(
     args: [String],
     envBlock: ProcessEnvironmentBlock = ProcessEnv.block,
@@ -883,12 +918,16 @@ public struct Driver {
     integratedDriver: Bool = true,
     compilerIntegratedTooling: Bool = false,
     compilerExecutableDir: AbsolutePath? = nil,
-    interModuleDependencyOracle: InterModuleDependencyOracle? = nil
+    interModuleDependencyOracle: InterModuleDependencyOracle? = nil,
+    stdoutStream: ThreadSafeOutputByteStream = TSCBasic.stdoutStream,
+    stderrStream: ThreadSafeOutputByteStream = TSCBasic.stderrStream
   ) throws {
     self.env = envBlock
     self.fileSystem = fileSystem
     self.integratedDriver = integratedDriver
     self.compilerIntegratedTooling = compilerIntegratedTooling
+    self.stdoutStream = stdoutStream
+    self.stderrStream = stderrStream
 
     let diagnosticsEngine: DiagnosticsEngine
     switch diagnosticsOutput {
@@ -1883,7 +1922,7 @@ extension Driver {
     jobs: [Job]
   ) throws {
     if parsedOptions.hasArgument(.v) {
-      try printVersion(outputStream: &stderrStream)
+      try printVersion(outputStream: stderrStream)
     }
 
     let forceResponseFiles = parsedOptions.contains(.driverForceResponseFiles)
@@ -1923,8 +1962,9 @@ extension Driver {
 
     if parsedOptions.contains(.driverPrintGraphviz) {
       var serializer = DOTJobGraphSerializer(jobs: jobs)
-      serializer.writeDOT(to: &stdoutStream)
-      stdoutStream.flush()
+      var stream = stdoutStream
+      serializer.writeDOT(to: &stream)
+      stream.flush()
       return
     }
 
@@ -2020,7 +2060,9 @@ extension Driver {
       showJobLifecycle: showJobLifecycle,
       argsResolver: executor.resolver,
       diagnosticEngine: diagnosticEngine,
-      reproducerCallback: supportsReproducer ? Driver.generateReproducer : nil)
+      reproducerCallback: supportsReproducer ? Driver.generateReproducer : nil,
+      stdoutStream: stdoutStream,
+      stderrStream: stderrStream)
   }
 
   private mutating func performTheBuild(
@@ -2108,7 +2150,7 @@ extension Driver {
         break
       default:
         while let input = allInputsIterator.next() {
-          Self.printInputIfNew(input, inputIdMap: &inputIdMap, nextId: &nextId)
+          printInputIfNew(input, inputIdMap: &inputIdMap, nextId: &nextId)
         }
       }
       // All input action IDs for this action.
@@ -2131,7 +2173,7 @@ extension Driver {
         }
         if !foundInput {
           while let nextInputAction = allInputsIterator.next() {
-            Self.printInputIfNew(nextInputAction, inputIdMap: &inputIdMap, nextId: &nextId)
+            printInputIfNew(nextInputAction, inputIdMap: &inputIdMap, nextId: &nextId)
             if let id = inputIdMap[input] {
               inputIds.append(id)
               break
@@ -2159,7 +2201,7 @@ extension Driver {
     }
   }
 
-  private static func printInputIfNew(_ input: TypedVirtualPath, inputIdMap: inout [TypedVirtualPath: UInt], nextId: inout UInt) {
+  private func printInputIfNew(_ input: TypedVirtualPath, inputIdMap: inout [TypedVirtualPath: UInt], nextId: inout UInt) {
     if inputIdMap[input] == nil {
       stdoutStream.send("\(nextId): input, ")
       stdoutStream.send("\"\(input.file)\", \(input.type)\n")
@@ -2168,7 +2210,7 @@ extension Driver {
     }
   }
 
-  private func printVersion<S: OutputByteStream>(outputStream: inout S) throws {
+  private func printVersion(outputStream: OutputByteStream) throws {
     outputStream.send("\(frontendTargetInfo.compilerVersion)\n")
     outputStream.send("Target: \(frontendTargetInfo.target.triple.triple)\n")
     outputStream.flush()

--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -30,6 +30,7 @@ import Bionic
 import class TSCBasic.DiagnosticsEngine
 import struct TSCBasic.Diagnostic
 import struct TSCBasic.ProcessResult
+import class TSCBasic.ThreadSafeOutputByteStream
 import var TSCBasic.stderrStream
 import var TSCBasic.stdoutStream
 import class TSCBasic.Process
@@ -60,6 +61,12 @@ import class TSCBasic.Process
   public let diagnosticEngine: DiagnosticsEngine
   public var anyJobHadAbnormalExit: Bool = false
 
+  /// Output stream the delegate writes informational stdout to.
+  public let stdoutStream: ThreadSafeOutputByteStream
+
+  /// Output stream the delegate writes job output and parseable-output messages to.
+  public let stderrStream: ThreadSafeOutputByteStream
+
   private var nextBatchQuasiPID: Int
   private let argsResolver: ArgsResolver
   private var batchJobInputQuasiPIDMap = TwoLevelMap<Job, TypedVirtualPath, Int>()
@@ -70,7 +77,9 @@ import class TSCBasic.Process
                              showJobLifecycle: Bool,
                              argsResolver: ArgsResolver,
                              diagnosticEngine: DiagnosticsEngine,
-                             reproducerCallback: ReproducerCallback? = nil) {
+                             reproducerCallback: ReproducerCallback? = nil,
+                             stdoutStream: ThreadSafeOutputByteStream = TSCBasic.stdoutStream,
+                             stderrStream: ThreadSafeOutputByteStream = TSCBasic.stderrStream) {
     self.mode = mode
     self.buildRecordInfo = buildRecordInfo
     self.showJobLifecycle = showJobLifecycle
@@ -78,6 +87,8 @@ import class TSCBasic.Process
     self.argsResolver = argsResolver
     self.nextBatchQuasiPID = ToolExecutionDelegate.QUASI_PID_START
     self.reproducerCallback = reproducerCallback
+    self.stdoutStream = stdoutStream
+    self.stderrStream = stderrStream
   }
 
   public func jobStarted(job: Job, arguments: [String], pid: Int) {

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -67,7 +67,8 @@ extension Diagnostic.Message {
       if outputFormat == nil || outputFormat == "json" {
         try stdoutStream.send(dependencyGraph.toJSONString())
       } else if outputFormat == "dot" {
-        DOTModuleDependencyGraphSerializer(dependencyGraph).writeDOT(to: &stdoutStream)
+        var stream = stdoutStream
+        DOTModuleDependencyGraphSerializer(dependencyGraph).writeDOT(to: &stream)
       }
       stdoutStream.flush()
     }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -2953,7 +2953,7 @@ func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath
         )
       }
 
-      let _ = try await withHijackedOutputStream {
+      do {
         let diagnosticEngine = DiagnosticsEngine()
         var driver = try TestDriver(
           args: baseCommandLine + [
@@ -2966,7 +2966,7 @@ func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath
         let _ = try await driver.planBuild()
       }
 
-      let output = try await withHijackedOutputStream {
+      do {
         let diagnosticEngine = DiagnosticsEngine()
         var driver = try TestDriver(
           args: baseCommandLine + [
@@ -2977,10 +2977,11 @@ func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath
           diagnosticsEngine: diagnosticEngine
         )
         let _ = try await driver.planBuild()
+        let output = driver.capturedStdout
+        #expect(output.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\""))
       }
-      #expect(output.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\""))
 
-      let output2 = try await withHijackedOutputStream {
+      do {
         let diagnosticEngine = DiagnosticsEngine()
         var driver = try TestDriver(
           args: baseCommandLine + [
@@ -2991,10 +2992,11 @@ func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath
           diagnosticsEngine: diagnosticEngine
         )
         let _ = try await driver.planBuild()
+        let output2 = driver.capturedStdout
+        #expect(output2.contains("\"testPrintingExplicitDependencyGraph\" [shape=box, style=bold, color=navy"))
       }
-      #expect(output2.contains("\"testPrintingExplicitDependencyGraph\" [shape=box, style=bold, color=navy"))
 
-      let output3 = try await withHijackedOutputStream {
+      do {
         let diagnosticEngine = DiagnosticsEngine()
         var driver = try TestDriver(
           args: baseCommandLine + [
@@ -3004,8 +3006,9 @@ func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath
           diagnosticsEngine: diagnosticEngine
         )
         let _ = try await driver.planBuild()
+        let output3 = driver.capturedStdout
+        #expect(output3.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\""))
       }
-      #expect(output3.contains("\"mainModuleName\" : \"testPrintingExplicitDependencyGraph\""))
     }
   }
 

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -20,43 +20,7 @@ import Testing
 import var Foundation.EXIT_SUCCESS
 import class Foundation.NSString
 
-@discardableResult
-internal func withHijackedErrorStream(
-  _ body: () async throws -> Void
-) async throws -> String {
-  // Replace the error stream with one we capture here.
-  let errorStream = stderrStream
-  var output: String = ""
-  try await withTemporaryFile { file in
-    TSCBasic.stderrStream = try ThreadSafeOutputByteStream(LocalFileOutputByteStream(file.path))
-    try await body()
-    TSCBasic.stderrStream.flush()
-    output = try "\(localFileSystem.readFileContents(file.path))".replacingOccurrences(of: "\r\n", with: "\n")
-  }
-  // Restore the error stream to what it was
-  TSCBasic.stderrStream = errorStream
-  return output
-}
-
-@discardableResult
-internal func withHijackedOutputStream(
-  _ body: () async throws -> Void
-) async throws -> String {
-  // Replace the error stream with one we capture here.
-  let outputStream = stdoutStream
-  var output: String = ""
-  try await withTemporaryFile { file in
-    TSCBasic.stdoutStream = try ThreadSafeOutputByteStream(LocalFileOutputByteStream(file.path))
-    try await body()
-    TSCBasic.stdoutStream.flush()
-    output = try localFileSystem.readFileContents(file.path).description
-  }
-  // Restore the error stream to what it was
-  TSCBasic.stdoutStream = outputStream
-  return output
-}
-
-@Suite(.serialized) struct ParsableMessageTests {
+@Suite struct ParsableMessageTests {
   @Test func beganMessage() throws {
     let message = BeganMessage(
       pid: 1,
@@ -189,18 +153,17 @@ internal func withHijackedOutputStream(
         let jobs = try await driver.planBuild()
         let compileJob = jobs[0]
         let args: [String] = try resolver.resolveArgumentList(for: compileJob, useResponseFiles: .disabled)
+
         let toolDelegate = ToolExecutionDelegate(
           mode: .parsableOutput,
           buildRecordInfo: nil,
           showJobLifecycle: false,
           argsResolver: resolver,
-          diagnosticEngine: DiagnosticsEngine()
+          diagnosticEngine: DiagnosticsEngine(),
+          stderrStream: driver.stderrStream
         )
-
-        let errorOutput = try await withHijackedErrorStream {
-          // Emit the began messages and examine the output
-          toolDelegate.jobStarted(job: compileJob, arguments: args, pid: 42)
-        }
+        toolDelegate.jobStarted(job: compileJob, arguments: args, pid: 42)
+        let errorOutput = driver.capturedStderr
 
         // There were 3 messages emitted
         #expect(
@@ -311,31 +274,27 @@ internal func withHijackedOutputStream(
         let jobs = try await driver.planBuild()
         let compileJob = jobs[0]
         let args: [String] = try resolver.resolveArgumentList(for: compileJob)
+
         let toolDelegate = ToolExecutionDelegate(
           mode: .parsableOutput,
           buildRecordInfo: nil,
           showJobLifecycle: false,
           argsResolver: resolver,
-          diagnosticEngine: DiagnosticsEngine()
+          diagnosticEngine: DiagnosticsEngine(),
+          stderrStream: driver.stderrStream
         )
+        // First emit the began messages to set up the quasi-PID mapping
+        toolDelegate.jobStarted(job: compileJob, arguments: args, pid: 42)
 
-        let _ = try await withHijackedErrorStream {
-          // First emit the began messages
-          toolDelegate.jobStarted(job: compileJob, arguments: args, pid: 42)
-        }
-
-        // Now hijack the error stream and emit finished messages
-        let errorOutput = try await withHijackedErrorStream {
-          let resultSuccess = ProcessResult(
-            arguments: args,
-            environmentBlock: ProcessEnv.block,
-            exitStatus: ProcessResult.ExitStatus.terminated(code: EXIT_SUCCESS),
-            output: Result.success([]),
-            stderrOutput: Result.success([])
-          )
-          // Emit the finished messages and examine the output
-          toolDelegate.jobFinished(job: compileJob, result: resultSuccess, pid: 42)
-        }
+        let resultSuccess = ProcessResult(
+          arguments: args,
+          environmentBlock: ProcessEnv.block,
+          exitStatus: ProcessResult.ExitStatus.terminated(code: EXIT_SUCCESS),
+          output: Result.success([]),
+          stderrOutput: Result.success([])
+        )
+        toolDelegate.jobFinished(job: compileJob, result: resultSuccess, pid: 42)
+        let errorOutput = driver.capturedStderr
         #expect(
           errorOutput.contains(
             """
@@ -399,18 +358,6 @@ internal func withHijackedOutputStream(
         let jobs = try await driver.planBuild()
         let compileJob = jobs[0]
         let args: [String] = try resolver.resolveArgumentList(for: compileJob)
-        let toolDelegate = ToolExecutionDelegate(
-          mode: .parsableOutput,
-          buildRecordInfo: nil,
-          showJobLifecycle: false,
-          argsResolver: resolver,
-          diagnosticEngine: DiagnosticsEngine()
-        )
-
-        let _ = try await withHijackedErrorStream {
-          // First emit the began messages
-          toolDelegate.jobStarted(job: compileJob, arguments: args, pid: 42)
-        }
 
         #if os(Windows)
         let status = ProcessResult.ExitStatus.terminated(code: EXIT_SUCCESS)
@@ -425,18 +372,26 @@ internal func withHijackedOutputStream(
           """
         #endif
 
-        // Now hijack the error stream and emit finished messages
-        let errorOutput = try await withHijackedErrorStream {
-          let resultSignalled = ProcessResult(
-            arguments: args,
-            environmentBlock: ProcessEnv.block,
-            exitStatus: status,
-            output: Result.success([]),
-            stderrOutput: Result.success([])
-          )
-          // First emit the began messages
-          toolDelegate.jobFinished(job: compileJob, result: resultSignalled, pid: 42)
-        }
+        let toolDelegate = ToolExecutionDelegate(
+          mode: .parsableOutput,
+          buildRecordInfo: nil,
+          showJobLifecycle: false,
+          argsResolver: resolver,
+          diagnosticEngine: DiagnosticsEngine(),
+          stderrStream: driver.stderrStream
+        )
+        // First emit the began messages to set up the quasi-PID mapping
+        toolDelegate.jobStarted(job: compileJob, arguments: args, pid: 42)
+
+        let resultSignalled = ProcessResult(
+          arguments: args,
+          environmentBlock: ProcessEnv.block,
+          exitStatus: status,
+          output: Result.success([]),
+          stderrOutput: Result.success([])
+        )
+        toolDelegate.jobFinished(job: compileJob, result: resultSignalled, pid: 42)
+        let errorOutput = driver.capturedStderr
         #expect(
           errorOutput.contains(
             """
@@ -498,11 +453,10 @@ internal func withHijackedOutputStream(
           integratedDriver: true
         )
         let jobs = try await driver.planBuild()
-        let errorOutput = try await withHijackedErrorStream {
-          await #expect(throws: (any Error).self) {
-            try await driver.run(jobs: jobs)
-          }
+        await #expect(throws: (any Error).self) {
+          try await driver.run(jobs: jobs)
         }
+        let errorOutput = driver.capturedStderr
         #expect(!errorOutput.contains("error: cannot find 'nonexistentPrint' in scope"))
       }
     }
@@ -531,11 +485,10 @@ internal func withHijackedOutputStream(
         #expect(jobs[0].outputs.count == 1)
         let compileArgs = jobs[0].commandLine
         #expect(compileArgs.contains((.flag("-frontend-parseable-output"))))
-        let errorOutput = try await withHijackedErrorStream {
-          try await driver.run(jobs: jobs)
-        }
+        try await driver.run(jobs: jobs)
+        let captured = driver.capturedStderr
         #expect(
-          errorOutput.contains(
+          captured.contains(
             """
             {
               "kind": "began",
@@ -544,7 +497,7 @@ internal func withHijackedOutputStream(
           )
         )
         #expect(
-          errorOutput.contains(
+          captured.contains(
             """
             {
               "kind": "finished",

--- a/Tests/SwiftDriverTests/SpecialModeTests.swift
+++ b/Tests/SwiftDriverTests/SpecialModeTests.swift
@@ -622,13 +622,7 @@ import CRT
 
   @Test func printOutputFileMap() async throws {
     try await withTemporaryDirectory { path in
-      // Replace the error stream with one we capture here.
-      let errorStream = stderrStream
-
       let root = localFileSystem.currentWorkingDirectory!.appending(components: "build")
-
-      let errorOutputFile = path.appending(component: "dummy_error_stream")
-      TSCBasic.stderrStream = try ThreadSafeOutputByteStream(LocalFileOutputByteStream(errorOutputFile))
 
       let libObj: AbsolutePath = root.appending(component: "lib.o")
       let mainObj: AbsolutePath = root.appending(component: "main.o")
@@ -664,7 +658,7 @@ import CRT
         "-output-file-map", outputFileMap.nativePathString(escaped: false),
       ])
       try await driver.run(jobs: [])
-      let invocationError = try localFileSystem.readFileContents(errorOutputFile).description
+      let invocationError = driver.capturedStderr
 
       #expect(
         invocationError.contains(
@@ -681,9 +675,6 @@ import CRT
           "\(dummyInput.nativePathString(escaped: false)) -> object: \"\(basicOutputFileMapObj.nativePathString(escaped: false))\""
         )
       )
-
-      // Restore the error stream to what it was
-      TSCBasic.stderrStream = errorStream
     }
   }
 

--- a/Tests/TestUtilities/TestDriver.swift
+++ b/Tests/TestUtilities/TestDriver.swift
@@ -53,6 +53,13 @@ private struct StderrOutputStream: TextOutputStream {
 package struct TestDriver {
   private var driver: Driver
 
+  /// Per-instance stdout stream. Defaults to an in-memory buffer so tests can read it via
+  /// `capturedStdout` and concurrent tests don't race on `TSCBasic.stdoutStream`.
+  package let stdoutStream: ThreadSafeOutputByteStream
+
+  /// Per-instance stderr stream. See `stdoutStream`.
+  package let stderrStream: ThreadSafeOutputByteStream
+
   /// Create a test driver with the given arguments.
   package init(
     args: [String],
@@ -61,15 +68,24 @@ package struct TestDriver {
     executor: DriverExecutor? = nil,
     fileSystem: FileSystem? = nil,
     integratedDriver: Bool = true,
-    interModuleDependencyOracle: InterModuleDependencyOracle? = nil
+    interModuleDependencyOracle: InterModuleDependencyOracle? = nil,
+    stdoutStream: ThreadSafeOutputByteStream? = nil,
+    stderrStream: ThreadSafeOutputByteStream? = nil
   ) throws {
     let fs = fileSystem ?? localFileSystem
     let diags = diagnosticsEngine ?? DiagnosticsEngine(handlers: [testDiagnosticsHandler])
-    let exec = try executor ?? SwiftDriverExecutor(
-      diagnosticsEngine: diags,
-      processSet: ProcessSet(),
-      fileSystem: fs,
-      env: env)
+    let exec =
+      try executor
+      ?? SwiftDriverExecutor(
+        diagnosticsEngine: diags,
+        processSet: ProcessSet(),
+        fileSystem: fs,
+        env: env
+      )
+    let stdout = stdoutStream ?? ThreadSafeOutputByteStream(BufferedOutputByteStream())
+    let stderr = stderrStream ?? ThreadSafeOutputByteStream(BufferedOutputByteStream())
+    self.stdoutStream = stdout
+    self.stderrStream = stderr
     self.driver = try Driver(
       args: args,
       envBlock: env,
@@ -77,7 +93,24 @@ package struct TestDriver {
       fileSystem: fs,
       executor: exec,
       integratedDriver: integratedDriver,
-      interModuleDependencyOracle: interModuleDependencyOracle)
+      interModuleDependencyOracle: interModuleDependencyOracle,
+      stdoutStream: stdout,
+      stderrStream: stderr
+    )
+  }
+
+  /// The bytes written to `stdoutStream` so far, decoded as UTF-8 with `\r\n` normalized to `\n`.
+  package var capturedStdout: String {
+    stdoutStream.flush()
+    guard let buffer = stdoutStream.stream as? BufferedOutputByteStream else { return "" }
+    return buffer.bytes.description.replacingOccurrences(of: "\r\n", with: "\n")
+  }
+
+  /// The bytes written to `stderrStream` so far, decoded as UTF-8 with `\r\n` normalized to `\n`.
+  package var capturedStderr: String {
+    stderrStream.flush()
+    guard let buffer = stderrStream.stream as? BufferedOutputByteStream else { return "" }
+    return buffer.bytes.description.replacingOccurrences(of: "\r\n", with: "\n")
   }
 
   // MARK: - Async wrappers
@@ -204,9 +237,13 @@ package struct TestDriver {
     baselineABIDir: AbsolutePath? = nil
   ) throws -> ([Job], [Job]) {
     try driver.generatePrebuiltModuleGenerationJobs(
-      with: inputMap, into: prebuiltModuleDir, exhaustive: exhaustive,
-      dotGraphPath: dotGraphPath, currentABIDir: currentABIDir,
-      baselineABIDir: baselineABIDir)
+      with: inputMap,
+      into: prebuiltModuleDir,
+      exhaustive: exhaustive,
+      dotGraphPath: dotGraphPath,
+      currentABIDir: currentABIDir,
+      baselineABIDir: baselineABIDir
+    )
   }
 
   package func querySupportedArgumentsForTest() throws -> Set<String>? {


### PR DESCRIPTION
Driver and ToolExecutionDelegate now take a ThreadSafeOutputByteStream for stdout and stderr (defaulting to the TSCBasic globals). TestDriver defaults to per-instance in-memory buffers, so parallel tests no longer race by reassigning TSCBasic.stderrStream / stdoutStream while printOutputFileMap and the parseable-output tests run.

rdar://177157368