### PR TITLE
[CAS] Swift driver support for CAS sandboxing

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #define SWIFTSCAN_VERSION_MAJOR 2
-#define SWIFTSCAN_VERSION_MINOR 3
+#define SWIFTSCAN_VERSION_MINOR 4
 
 //=== Public Scanner Data Types -------------------------------------------===//
 
@@ -97,6 +97,7 @@ typedef void *swiftscan_scanner_t;
 //=== CAS/Caching Specification -------------------------------------------===//
 typedef struct swiftscan_cas_options_s *swiftscan_cas_options_t;
 typedef struct swiftscan_cas_s *swiftscan_cas_t;
+typedef struct swiftscan_cas_fs_builder_s *swiftscan_cas_fs_builder_t;
 typedef struct swiftscan_cached_compilation_s *swiftscan_cached_compilation_t;
 typedef struct swiftscan_cached_output_s *swiftscan_cached_output_t;
 typedef struct swiftscan_cache_replay_instance_s
@@ -308,6 +309,16 @@ typedef struct {
   swiftscan_cas_t (*swiftscan_cas_create_from_options)(
       swiftscan_cas_options_t options, swiftscan_string_ref_t *error);
   void (*swiftscan_cas_dispose)(swiftscan_cas_t cas);
+  swiftscan_cas_fs_builder_t (*swiftscan_cas_fs_builder_create)(swiftscan_cas_t);
+  void (*swiftscan_cas_fs_builder_dispose)(swiftscan_cas_fs_builder_t);
+  bool (*swiftscan_cas_fs_builder_ingest_path)(swiftscan_cas_fs_builder_t,
+                                            const char *path, bool recursive,
+                                            swiftscan_string_ref_t *error);
+  bool (*swiftscan_cas_fs_builder_merge_root)(swiftscan_cas_fs_builder_t,
+                                           const char *root_id, const char *path,
+                                           swiftscan_string_ref_t *error);
+  swiftscan_string_ref_t (*swiftscan_cas_fs_builder_finish)(
+      swiftscan_cas_fs_builder_t, swiftscan_string_ref_t *error);
   swiftscan_string_ref_t (*swiftscan_cas_store)(swiftscan_cas_t cas,
                                                 uint8_t *data, unsigned size,
                                                 swiftscan_string_ref_t *error);

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -482,6 +482,11 @@ extension Driver {
     }
     addCacheReplayMapping(to: &commandLine)
 
+    if kind == .scanDependencies && isFrontendArgSupported(.scannerCasFs) {
+      try commandLine.appendAll(.scannerCasFs, from: &parsedOptions)
+      try commandLine.appendAll(.casFsEscape, from: &parsedOptions)
+    }
+
     // Pass through any subsystem flags.
     try commandLine.appendAll(.Xllvm, from: &parsedOptions)
 

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -282,6 +282,10 @@ private extension String {
            api.swiftscan_cas_prune_ondisk_data != nil
   }
 
+  @_spi(Testing) public var supportsCASSandbox : Bool {
+    return api.swiftscan_cas_fs_builder_create != nil
+  }
+
   @_spi(Testing) public var supportsBridgingHeaderPCHCommand : Bool {
     return api.swiftscan_swift_textual_detail_get_bridging_pch_command_line != nil
   }
@@ -517,6 +521,12 @@ private extension swiftscan_functions_t {
     self.swiftscan_cache_compute_key = loadOptional("swiftscan_cache_compute_key")
     self.swiftscan_cache_compute_key_from_input_index = loadOptional("swiftscan_cache_compute_key_from_input_index")
     self.swiftscan_cas_store = loadOptional("swiftscan_cas_store")
+
+    self.swiftscan_cas_fs_builder_create = loadOptional("swiftscan_cas_fs_builder_create")
+    self.swiftscan_cas_fs_builder_dispose = loadOptional("swiftscan_cas_fs_builder_dispose")
+    self.swiftscan_cas_fs_builder_ingest_path = loadOptional("swiftscan_cas_fs_builder_ingest_path")
+    self.swiftscan_cas_fs_builder_merge_root = loadOptional("swiftscan_cas_fs_builder_merge_root")
+    self.swiftscan_cas_fs_builder_finish = loadOptional("swiftscan_cas_fs_builder_finish")
 
     self.swiftscan_cache_query = loadOptional("swiftscan_cache_query")
     self.swiftscan_cache_query_async = loadOptional("swiftscan_cache_query_async")

--- a/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
@@ -169,6 +169,44 @@ public final class CacheReplayResult {
   }
 }
 
+public final class CASFSBuilder {
+  let ptr: swiftscan_cas_fs_builder_t
+  private let lib: SwiftScan
+
+  init(_ ptr: swiftscan_cas_fs_builder_t, lib: SwiftScan) {
+    self.ptr = ptr
+    self.lib = lib
+  }
+
+  deinit {
+    lib.api.swiftscan_cas_fs_builder_dispose(ptr)
+  }
+
+  public func ingestPath(_ path: String, recursive: Bool) throws {
+    let failed = try lib.handleCASError { err_msg in
+      lib.api.swiftscan_cas_fs_builder_ingest_path(ptr, path, recursive, &err_msg)
+    }
+    assert(!failed)
+  }
+
+  public func mergeRoot(_ root: String) throws {
+    let failed = try lib.handleCASError { err_msg in
+      lib.api.swiftscan_cas_fs_builder_merge_root(ptr, root, nil, &err_msg)
+    }
+    assert(!failed)
+  }
+
+  public func finish() throws -> String {
+    let casid = try lib.handleCASError { err_msg in
+      lib.api.swiftscan_cas_fs_builder_finish(ptr, &err_msg)
+    }
+    defer {
+      lib.api.swiftscan_string_dispose(casid)
+    }
+    return try lib.toSwiftString(casid)
+  }
+}
+
 public final class SwiftScanCAS {
   let cas: swiftscan_cas_t
   private var scanner: SwiftScan!
@@ -207,6 +245,17 @@ public final class SwiftScanCAS {
       scanner.api.swiftscan_cas_store(cas, bytes, UInt32(data.count), &err_msg)
     }
     return try scanner.toSwiftString(casid)
+  }
+
+  public var supportsCASSandbox: Bool {
+    scanner.supportsCASSandbox
+  }
+
+  public func createCASFSBuilder() throws -> CASFSBuilder {
+    guard supportsCASSandbox else {
+      throw DependencyScanningError.casError("CASFSBuilder is not supported")
+    }
+    return CASFSBuilder(scanner.api.swiftscan_cas_fs_builder_create(cas)!, lib: scanner)
   }
 
   public var supportsSizeManagement: Bool {

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -78,6 +78,7 @@ extension Option {
   public static let casBackendMode: Option = Option("-cas-backend-mode=", .joined, attributes: [.frontend, .noDriver], metaVar: "native|casid|verify", helpText: "CASBackendMode for output kind")
   public static let casBackend: Option = Option("-cas-backend", .flag, attributes: [.frontend, .noDriver], helpText: "Enable using CASBackend for object file output")
   public static let casEmitCasidFile: Option = Option("-cas-emit-casid-file", .flag, attributes: [.frontend, .noDriver], helpText: "Emit .casid file next to object file when CAS Backend is enabled")
+  public static let casFsEscape: Option = Option("-cas-fs-escape", .separate, attributes: [.frontend, .cacheInvariant], metaVar: "<path>", helpText: "Path for using the underlying file system instead of CASFS")
   public static let casPath: Option = Option("-cas-path", .separate, attributes: [.frontend, .cacheInvariant], metaVar: "<path>", helpText: "Path to CAS")
   public static let casPluginOption: Option = Option("-cas-plugin-option", .separate, attributes: [.frontend, .cacheInvariant], metaVar: "<name>=<option>", helpText: "Option pass to CAS Plugin")
   public static let casPluginPath: Option = Option("-cas-plugin-path", .separate, attributes: [.frontend, .cacheInvariant], metaVar: "<path>", helpText: "Path to CAS Plugin")
@@ -872,6 +873,7 @@ extension Option {
   public static let saveOptimizationRecord: Option = Option("-save-optimization-record", .flag, attributes: [.frontend], helpText: "Generate a YAML optimization record file")
   public static let saveTemps: Option = Option("-save-temps", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "Save intermediate compilation results")
   public static let scanDependencies: Option = Option("-scan-dependencies", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Scan dependencies of the given Swift sources", group: .modes)
+  public static let scannerCasFs: Option = Option("-scanner-cas-fs", .separate, attributes: [.frontend, .cacheInvariant], helpText: "Configure the filesystem to read from the provided CAS tree during dep-scanning")
   public static let scannerDebugWriteOutput: Option = Option("-scanner-debug-write-output", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Write generated output from scanner for debugging purpose")
   public static let scannerModuleValidation: Option = Option("-scanner-module-validation", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Validate binary modules in the dependency scanner")
   public static let scannerOutputDir: Option = Option("-scanner-output-dir", .separate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Directory for generated files from swift dependency scanner")
@@ -1125,6 +1127,7 @@ extension Option {
       Option.casBackendMode,
       Option.casBackend,
       Option.casEmitCasidFile,
+      Option.casFsEscape,
       Option.casPath,
       Option.casPluginOption,
       Option.casPluginPath,
@@ -1919,6 +1922,7 @@ extension Option {
       Option.saveOptimizationRecord,
       Option.saveTemps,
       Option.scanDependencies,
+      Option.scannerCasFs,
       Option.scannerDebugWriteOutput,
       Option.scannerModuleValidation,
       Option.scannerOutputDir,

--- a/Tests/SwiftDriverTests/DriverOptionTests.swift
+++ b/Tests/SwiftDriverTests/DriverOptionTests.swift
@@ -843,4 +843,18 @@ import Testing
       verify.expect(.note("filenames are used to distinguish private declarations with the same name"))
     }
   }
+
+  @Test(.requireFrontendArgSupport(.scannerCasFs)) func scannerCASFS() async throws {
+    try await assertNoDriverDiagnostics(args: "swiftc", "a.swift", "-scanner-cas-fs", "abcd", "-cas-fs-escape", "/path1", "-cas-fs-escape", "/path2") { driver in
+      let jobs = try await driver.planBuild()
+      let commandLine = jobs[0].commandLine
+      let casfsIdx = try #require(commandLine.firstIndex(of: .flag("-scanner-cas-fs")))
+      expectEqual(commandLine[casfsIdx.advanced(by: 1)], .flag("abcd"))
+      let index = try #require(commandLine.firstIndex(of: .flag("-cas-fs-escape")))
+      let lastIndex = try #require(commandLine.lastIndex(of: .flag("-cas-fs-escape")))
+      #expect(index != lastIndex)
+      expectEqual(commandLine[index.advanced(by: 1)], .flag("/path1"))
+      expectEqual(commandLine[lastIndex.advanced(by: 1)], .flag("/path2"))
+    }
+  }
 }


### PR DESCRIPTION
* [SwiftOptions] Add handling for `-scanner-cas-fs` and `-cas-fs-escape` options
* [SwiftScan] Add a wrapper for `CASFSBuilder` APIs