### PR TITLE
[Driver] Restrict flags to dependency scanner under explicit module b…

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -195,15 +195,24 @@ extension Driver {
     }
 
     // If caching is enabled and this is planning arguments for a job where prefix map can be applied,
-    // do not include search path options like include paths, vfsoverlay or module cache path since swift-frontend does not
+    // do not include search path options like include paths or vfsoverlay since swift-frontend does not
     // need to perform searching in those jobs.
     // TODO: Can the options be dropped from all explicit module builds?
     if !enableCaching || !jobNeedPathRemap {
       try addAllArgumentsWithPath(.I, .Isystem, to: &commandLine, remap: jobNeedPathRemap)
       try addAllArgumentsWithPath(.F, .Fsystem, to: &commandLine, remap: jobNeedPathRemap)
       try addAllArgumentsWithPath(.vfsoverlay, to: &commandLine, remap: jobNeedPathRemap)
+    }
 
+    // In explicit module build mode, the module cache and Clang build session
+    // are only consulted by the dependency scanner.
+    if !parsedOptions.contains(.driverExplicitModuleBuild) || kind == .scanDependencies {
       try commandLine.appendLast(.moduleCachePath, from: &parsedOptions)
+      if isFrontendArgSupported(.validateClangModulesOnce),
+         isFrontendArgSupported(.clangBuildSessionFile) {
+        try commandLine.appendLast(.validateClangModulesOnce, from: &parsedOptions)
+        try commandLine.appendLast(.clangBuildSessionFile, from: &parsedOptions)
+      }
     }
 
     if let gccToolchain = parsedOptions.getLastArgument(.gccToolchain) {
@@ -382,14 +391,6 @@ extension Driver {
 
     if isFrontendArgSupported(.publicModuleName) {
       try commandLine.appendLast(.publicModuleName, from: &parsedOptions)
-    }
-
-    // Pass down -validate-clang-modules-once if we are working with a compiler that
-    // supports it.
-    if isFrontendArgSupported(.validateClangModulesOnce),
-       isFrontendArgSupported(.clangBuildSessionFile) {
-      try commandLine.appendLast(.validateClangModulesOnce, from: &parsedOptions)
-      try commandLine.appendLast(.clangBuildSessionFile, from: &parsedOptions)
     }
 
     if isFrontendArgSupported(.emitClangHeaderMinAccess) {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -2332,6 +2332,64 @@ func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath
     }
   }
 
+  /// Test that `-module-cache-path`, `-validate-clang-modules-once`, and
+  /// `-clang-build-session-file` are passed only to the dependency scanner
+  /// when explicit module build is enabled.
+  @Test(.requireFrontendArgSupport(.clangBuildSessionFile))
+  func explicitModuleBuildScanOnlyFlags() async throws {
+    let flagTest = try TestDriver(args: ["swiftc", "-typecheck", "foo.swift"])
+    guard flagTest.isFrontendArgSupported(.validateClangModulesOnce) else {
+      return
+    }
+
+    let (stdLibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
+    try await withTemporaryDirectory { path in
+      let main = path.appending(component: "testExplicitModuleBuildScanOnlyFlags.swift")
+      try localFileSystem.writeFileContents(main, bytes: "")
+      let moduleCachePath = path.appending(component: "ModuleCache")
+      try localFileSystem.createDirectory(moduleCachePath)
+      let sessionFile = path.appending(component: "test.session")
+      try localFileSystem.writeFileContents(sessionFile, bytes: "")
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+
+      let args: [String] = [
+        "swiftc",
+        "-explicit-module-build",
+        "-module-cache-path", moduleCachePath.nativePathString(escaped: false),
+        "-validate-clang-modules-once",
+        "-clang-build-session-file", sessionFile.nativePathString(escaped: false),
+        "-I", stdLibPath.nativePathString(escaped: false),
+        "-I", shimsPath.nativePathString(escaped: false),
+        "-working-directory", path.nativePathString(escaped: false),
+        main.nativePathString(escaped: false),
+      ] + sdkArgumentsForTesting
+
+      // The dependency-scanner invocation receives all three flags.
+      var driver = try TestDriver(args: args)
+      let scanJob = try driver.dependencyScanningJob()
+      expectJobInvocationMatches(scanJob, .flag("-module-cache-path"))
+      expectJobInvocationMatches(scanJob, .flag("-validate-clang-modules-once"))
+      expectJobInvocationMatches(scanJob, .flag("-clang-build-session-file"))
+
+      // Other planned frontend jobs do not.
+      let jobs = try await driver.planBuild()
+      for job in jobs where job.kind == .compile {
+        #expect(
+          !job.commandLine.contains(.flag("-module-cache-path")),
+          "\(job.kind) should not contain -module-cache-path"
+        )
+        #expect(
+          !job.commandLine.contains(.flag("-validate-clang-modules-once")),
+          "\(job.kind) should not contain -validate-clang-modules-once"
+        )
+        #expect(
+          !job.commandLine.contains(.flag("-clang-build-session-file")),
+          "\(job.kind) should not contain -clang-build-session-file"
+        )
+      }
+    }
+  }
+
   @Test(.requireScannerSupportsPerScanDiagnostics()) func dependencyScanningFailure() async throws {
     let (stdlibPath, shimsPath, toolchain, _) = try getDriverArtifactsForScanning()
 


### PR DESCRIPTION
…uild

In explicit module build mode, `-module-cache-path`, `-validate-clang-modules-once`, and `-clang-build-session-file` are only meaningful to the dependency scanner; other frontend jobs build modules from the resolved dependency graph and shouldn't consult the module cache or share a clang build session. Gate these flags so they are only forwarded to the `.scanDependencies` job when explicit module build is enabled.

rdar://177651825