### PR TITLE
Cap batch partitions by target batch size when files < numTasks

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -1044,7 +1044,18 @@ extension Driver {
     let sizeLimit = info.sizeLimit ?? defaultSizeLimit
 
     let numTasks = numParallelJobs ?? 1
-    return max(numTasks, divideRoundingUp(numInputFiles, sizeLimit))
+
+    // Cap by a target batch size so that when `numFiles <= numTasks` we
+    // collapse into a few larger batches rather than approximately one file
+    // per partition, which would defeat per-process amortization (type
+    // lowering caches, deserialized decl/type state, requirement machine).
+    let preferredBatchSize = 4
+    let preferredPartitions =
+      divideRoundingUp(numInputFiles, preferredBatchSize)
+    let minPartitionsForSizeLimit =
+      divideRoundingUp(numInputFiles, sizeLimit)
+    return max(minPartitionsForSizeLimit,
+               min(numTasks, preferredPartitions))
   }
 
   /// Describes the partitions used when batching.


### PR DESCRIPTION
The previous formula `max(numTasks, ceil(numFiles/sizeLimit))` forced at least `numTasks` partitions, which when `numFiles <= numTasks` results in approximately one file per partition and defeats the per-process amortization (TypeConverter, IRGen TypeConverter, deserialized decl/type caches, requirement machine) that batch mode is meant to provide.

Cap partition count by `ceil(numFiles / preferredBatchSize)` when that yields a smaller value than `numTasks`, so small modules get fewer, larger batches that can share per-process state across files.