### PR TITLE
🍒[6.4] Bring OS version mappings up to date

### DIFF
--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -1573,6 +1573,32 @@ extension Triple {
 // MARK: - Darwin Versions
 
 extension Triple {
+  // Version 26 alignment helper. Each Apple OS jumped to version 26, so the
+  // last pre-jump release canonicalizes to 26; versions in the unshipped gap
+  // below 26 are left unchanged. Only `_iOSVersion` consumes this.
+
+  /// Canonicalize the last pre-26 release to the year-aligned version 26.
+  /// Gap versions (between the pre-jump release and 26) pass through unchanged.
+  static func _canonicalVersion(_ version: Version, for os: OS) -> Version {
+    func isExactly(_ major: Int) -> Bool {
+      version.major == major && version.minor == 0 && version.micro == 0
+    }
+    switch os {
+    case .macosx:
+      if version.major == 10 && version.minor == 16 { return Version(11, 0, 0) }
+      if isExactly(16) { return Version(26, 0, 0) }
+    case .ios, .tvos:
+      if isExactly(19) { return Version(26, 0, 0) }
+    case .visionos:
+      if isExactly(3) { return Version(26, 0, 0) }
+    case .watchos:
+      if isExactly(12) { return Version(26, 0, 0) }
+    default:
+      break
+    }
+    return version
+  }
+
   /// Parse the version number as with getOSVersion and then
   /// translate generic "darwin" versions to the corresponding OS X versions.
   /// This may also be called with IOS triples but the OS X version number is
@@ -1644,19 +1670,29 @@ extension Triple {
       // toolchain that wants to know the iOS version number even when targeting
       // OS X.
       return Version(5, 0, 0)
-    case .ios:
+    case .ios, .tvos:
       var version = self.osVersion
       // Default to 5.0 (or 7.0 for arm64).
       if version.major == 0 {
         version.major = arch == .aarch64 ? 7 : 5
       }
-      return version
-    case .tvos:
-      return osVersion
+      // iOS & tvOS 19 correspond to iOS 26.
+      if version.major == 19 {
+        return Version(26, 0, 0)
+      }
+      return Triple._canonicalVersion(version, for: .ios)
     case .visionos:
-      return Version(15, 0, 0)
+      let version = self.osVersion
+      // xrOS 1/2 are aligned with iOS 17/18.
+      if version.major < 3 {
+        return Version(version.major + 16, version.minor, version.micro)
+      }
+      // visionOS 3 corresponds to iOS 26.
+      return Triple._canonicalVersion(version, for: .visionos)
     case .watchos:
-      fatalError("conflicting triple info")
+      let version = self.osVersion
+      // watchOS 12 corresponds to iOS 26.
+      return Triple._canonicalVersion(version, for: .watchos)
     default:
       fatalError("unexpected OS for Darwin triple")
     }

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -1627,11 +1627,16 @@ extension Triple {
         version.micro = 0
         version.minor = version.major - 4
         version.major = 10
-      } else {
+      } else if version.major < 25 {
         version.micro = 0
         version.minor = 0
-        // darwin20+ corresponds to macOS 11+.
+        // darwin20-24 corresponds to macOS 11-15.
         version.major = version.major - 9
+      } else if version.major == 25 || version.major == 26 {
+        version.micro = 0
+        version.minor = 0
+        // darwin25-26 corresponds to macOS 26-27.
+        version.major = version.major + 1
       }
 
     case .macosx:

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -994,6 +994,46 @@ import class TSCBasic.DiagnosticsEngine
     #expect(V?.minor == 0)
     #expect(V?.micro == 0)
 
+    T = Triple("x86_64-apple-darwin24")
+    #expect(T.os?.isMacOSX == true)
+    #expect(T.os?.isiOS == false)
+    V = T._macOSVersion
+    #expect(V?.major == 15)
+    #expect(V?.minor == 0)
+    #expect(V?.micro == 0)
+
+    T = Triple("x86_64-apple-darwin25")
+    #expect(T.os?.isMacOSX == true)
+    #expect(T.os?.isiOS == false)
+    V = T._macOSVersion
+    #expect(V?.major == 26)
+    #expect(V?.minor == 0)
+    #expect(V?.micro == 0)
+
+    T = Triple("x86_64-apple-darwin26")
+    #expect(T.os?.isMacOSX == true)
+    #expect(T.os?.isiOS == false)
+    V = T._macOSVersion
+    #expect(V?.major == 27)
+    #expect(V?.minor == 0)
+    #expect(V?.micro == 0)
+
+    T = Triple("x86_64-apple-darwin27")
+    #expect(T.os?.isMacOSX == true)
+    #expect(T.os?.isiOS == false)
+    V = T._macOSVersion
+    #expect(V?.major == 27)
+    #expect(V?.minor == 0)
+    #expect(V?.micro == 0)
+
+    T = Triple("x86_64-apple-darwin28")
+    #expect(T.os?.isMacOSX == true)
+    #expect(T.os?.isiOS == false)
+    V = T._macOSVersion
+    #expect(V?.major == 28)
+    #expect(V?.minor == 0)
+    #expect(V?.micro == 0)
+
     T = Triple("x86_64-apple-macosx")
     #expect(T.os?.isMacOSX == true)
     #expect(T.os?.isiOS == false)

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -1140,6 +1140,29 @@ import class TSCBasic.DiagnosticsEngine
     #expect(!T.isMacCatalyst)
   }
 
+  /// Mirrors LLVM `getiOSVersion` / `getCanonicalVersionForOS` version-26 alignment.
+  @Test func iOSVersionAlignment() {
+    func iOSVersion(_ triple: String) -> Triple.Version { Triple(triple)._iOSVersion }
+
+    // iOS / tvOS 19 -> iOS 26; already-aligned and pre-jump values pass through;
+    // a gap version (20-25) passes through unchanged.
+    #expect(iOSVersion("arm64-apple-ios19.0") == Triple.Version(26, 0, 0))
+    #expect(iOSVersion("arm64-apple-ios26.0") == Triple.Version(26, 0, 0))
+    #expect(iOSVersion("arm64-apple-ios18.0") == Triple.Version(18, 0, 0))
+    #expect(iOSVersion("arm64-apple-ios21.0") == Triple.Version(21, 0, 0))
+    #expect(iOSVersion("arm64-apple-tvos19.0") == Triple.Version(26, 0, 0))
+
+    // visionOS (xrOS): 1/2 align with iOS 17/18, 3 -> iOS 26.
+    #expect(iOSVersion("arm64-apple-xros1.0") == Triple.Version(17, 0, 0))
+    #expect(iOSVersion("arm64-apple-xros2.0") == Triple.Version(18, 0, 0))
+    #expect(iOSVersion("arm64-apple-xros3.0") == Triple.Version(26, 0, 0))
+    #expect(iOSVersion("arm64-apple-xros26.0") == Triple.Version(26, 0, 0))
+
+    // watchOS 12 -> iOS 26.
+    #expect(iOSVersion("arm64-apple-watchos12.0") == Triple.Version(26, 0, 0))
+    #expect(iOSVersion("arm64-apple-watchos11.0") == Triple.Version(11, 0, 0))
+  }
+
   @Test func fileFormat() {
     #expect(.elf == Triple("i686-unknown-linux-gnu").objectFormat)
     #expect(.elf == Triple("x86_64-unknown-linux-gnu").objectFormat)


### PR DESCRIPTION
- Explanation: teach swift-driver about two recent OS version mappings: (1) darwin25-26 → macOS 26-27, and (2) version 26 alignment that was introduced last year.
- Scope: these target triple APIs are used by SwiftPM and swift-driver as a standalone executable. 
- Risk: Very Low. We already have OS triple version mappings like these at multiple layers.
- Original PR: https://github.com/swiftlang/swift-driver/pull/2153
- Radar: 177999453
- Reviewer: @jakepetroules 