### PR TITLE
Check that swift-frontend supports ipi clang module before transferri…

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -306,7 +306,9 @@ extension Driver {
     try commandLine.appendLast(.requireExplicitAvailability, from: &parsedOptions)
     try commandLine.appendLast(.requireExplicitAvailabilityTarget, from: &parsedOptions)
     try commandLine.appendLast(.libraryLevel, from: &parsedOptions)
-    try commandLine.appendAll(.ipiClangModule, from: &parsedOptions)
+    if isFrontendArgSupported(.ipiClangModule) {
+      try commandLine.appendAll(.ipiClangModule, from: &parsedOptions)
+    }
     try commandLine.appendLast(.lto, from: &parsedOptions)
     try commandLine.appendLast(.accessNotesPath, from: &parsedOptions)
     try commandLine.appendLast(.enableActorDataRaceChecks, .disableActorDataRaceChecks, from: &parsedOptions)

--- a/Tests/SwiftDriverTests/MiscDriverTests.swift
+++ b/Tests/SwiftDriverTests/MiscDriverTests.swift
@@ -843,7 +843,10 @@ import CRT
     }
   }
 
-  @Test func ipiClangModule() async throws {
+  @Test(
+    .requireFrontendArgSupport(.ipiClangModule)
+  )
+  func ipiClangModule() async throws {
     // Single flag is forwarded.
     do {
       var driver = try TestDriver(args: ["swiftc", "-ipi-clang-module", "Foo", "foo.swift"])


### PR DESCRIPTION
…ng the flag to the frontend.

This way no "unknown argument" error would occur if swift-frontend does not support clang ipi modules

rdar://181745695