### PR TITLE
IncrementalImportTests: Update for non-resilient module fingerprint fix.

### DIFF
--- a/Tests/IncrementalImportTests/AddFuncInImportedExtensionTest.swift
+++ b/Tests/IncrementalImportTests/AddFuncInImportedExtensionTest.swift
@@ -73,7 +73,7 @@ import IncrementalTestFramework
 
     // Define what is expected
     let whenAddOrRmFunc = ExpectedCompilations(
-      expected: [structExtension, classExtension, ])
+      expected: [structExtension, classExtension, structConstructor, classConstructor])
 
     let steps = [
       Step(                    building: modules, .expecting(modules.allSourcesToCompile)),

--- a/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
+++ b/Tests/IncrementalImportTests/HideAndShowFuncInStructAndExtensionTest.swift
@@ -136,8 +136,8 @@ fileprivate let modules = [importedModule, mainModule]
 fileprivate extension Change {
   var expectedCompilationsWithIncrementalImports: [Source] {
     switch self {
-    case .exposeFuncInStruct:    return [callFunctionInExtension, imported, instantiatesS, main]
-    case .exposeFuncInExtension: return [callFunctionInExtension, imported,                main]
+    case .exposeFuncInStruct:    return [callFunctionInExtension, imported, instantiatesS, main, noUseOfS]
+    case .exposeFuncInExtension: return [callFunctionInExtension, imported, instantiatesS, main, noUseOfS]
     }
   }
 


### PR DESCRIPTION
Follow-up to swiftlang/swift#89636 : non-resilient module fingerprints now include type-body changes, so any file that imports the module rebuilds when its types change.

rdar://178535430