### PR TITLE
[SwiftScan] Introduce `SwiftScanCapabilities`

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -120,6 +120,19 @@ private extension String {
   }
 }
 
+/// Used for querying for the capabilities of libSwiftScan.
+public struct SwiftScanCapabilities {
+  let swiftScan: SwiftScan
+
+  public init(dylib path: AbsolutePath? = nil) throws {
+    self.swiftScan = try SwiftScan(dylib: path)
+  }
+
+  public var supportsCASSandbox: Bool {
+    return swiftScan.supportsCASSandbox
+  }
+}
+
 /// Wrapper for libSwiftScan, taking care of initialization, shutdown, and dispatching dependency scanning queries.
 @_spi(Testing) public final class SwiftScan {
   /// The path to the libSwiftScan dylib.


### PR DESCRIPTION
This is for querying the capabilities of the libSwiftScan library.

I've only added `supportsCASSandbox` for now since other capabilities are either exposed from other APIs or I'm not sure if they are intended to be exposed or not.