### PR TITLE
Darwin needs -isysroot instead of --sysroot to take precedence over SDKROOT

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -222,7 +222,7 @@ extension DarwinToolchain {
 
     // Add the SDK path
     if let sdkPath = targetInfo.sdkPath?.path {
-      commandLine.appendFlag("--sysroot")
+      commandLine.appendFlag("-isysroot")
       commandLine.appendPath(VirtualPath.lookup(sdkPath))
     }
 

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -201,7 +201,7 @@ extension DarwinToolchain {
           .path(.temporary(try RelativePath(validating: "foo.o"))),
           .path(.temporary(try RelativePath(validating: "main.o"))),
           .path(.absolute(try toolchain.clangRT.get())),
-          "--sysroot", .path(.absolute(try toolchain.sdk.get())),
+          "-isysroot", .path(.absolute(try toolchain.sdk.get())),
           "-lobjc", .flag("--target=\(hostTriple.triple)"),
           "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
           "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),
@@ -285,7 +285,7 @@ extension DarwinToolchain {
         tool: try toolchain.resolvedTool(.dynamicLinker),
         commandLine: [
           .path(.temporary(try RelativePath(validating: "main.o"))),
-          "--sysroot", .path(.absolute(try toolchain.sdk.get())),
+          "-isysroot", .path(.absolute(try toolchain.sdk.get())),
           "-lobjc", .flag("--target=\(hostTriple.triple)"),
           "-L", .path(.absolute(try toolchain.resourcesDirectory.get())),
           "-L", .path(.absolute(try toolchain.sdkStdlib(sdk: toolchain.sdk.get()))),

--- a/Tests/SwiftDriverTests/LinkJobTests.swift
+++ b/Tests/SwiftDriverTests/LinkJobTests.swift
@@ -42,6 +42,7 @@ import Testing
       var driver = try TestDriver(
         args: commonArgs + [
           "-emit-library", "-target", "x86_64-apple-macosx10.15", "-Onone", "-use-ld=foo", "-ld-path=/bar/baz",
+          "-sdk", "/sdk/path",
         ],
         env: env
       )
@@ -58,6 +59,7 @@ import Testing
       #expect(cmd.contains(.flag("-fuse-ld=foo")))
       #expect(cmd.contains(.joinedOptionAndPath("--ld-path=", try VirtualPath(path: "/bar/baz"))))
       #expect(cmd.contains(.flag("--target=x86_64-apple-macosx10.15")))
+      #expect(cmd.contains(subsequence: ["-isysroot", .path(.absolute(try .init(validating: "/sdk/path")))]))
       #expect(try linkJob.outputs[0].file == toPath("libTest.dylib"))
 
       #expect(!cmd.contains(.flag("-static")))

--- a/Tests/SwiftDriverTests/TargetTests.swift
+++ b/Tests/SwiftDriverTests/TargetTests.swift
@@ -926,7 +926,7 @@ import CRT
         }
         expectEqual(frontendJobs[1].kind, .link)
         expectJobInvocationMatches(frontendJobs[1], .flag("--target=x86_64-apple-macosx10.14"))
-        expectJobInvocationMatches(frontendJobs[1], .flag("--sysroot"))
+        expectJobInvocationMatches(frontendJobs[1], .flag("-isysroot"))
         #expect(frontendJobs[1].commandLine.containsPathWithBasename(sdk1.basename))
       }
 


### PR DESCRIPTION
Darwin targets prefer -isysroot instead of --sysroot, the latter is only used as a fallback if both `-isysroot` and SDKROOT aren't present. That causes issues where SDKROOT is set in the environment but Run Script build phases run `swiftc -sdk <different SDK>` to try to use a different SDK. swiftc will use the passed SDK, but when it goes to link, clang will use the SDKROOT SDK and the link will fail.

rdar://182106220