### PR TITLE
[Driver] Disable scanner prefix mapping when emitting an ObjC header …

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -322,9 +322,19 @@ public struct Driver {
                                                        .parentDirectory { // toolchain
       mapping.append((toolchainPath, toolchainMapping))
     }
-    guard mapping.isEmpty || isCachingEnabled else {
-      diagnosticEngine.emit(.warning("ignore '-scanner-prefix-*' options that cannot be used without compilation caching"))
-      return []
+    if !mapping.isEmpty {
+      guard isCachingEnabled else {
+        diagnosticEngine.emit(.warning("ignore '-scanner-prefix-*' options that cannot be used without compilation caching"))
+        return []
+      }
+      let useExternalBridgingHeader = originalObjCHeaderFile != nil && !importBridgingHeaderAsInternal
+      guard objcGeneratedHeaderPath == nil || !useExternalBridgingHeader else {
+        diagnosticEngine.emit(.warning("ignore '-scanner-prefix-*' options when '-import-bridging-header' or '-import-objc-header' option is used with '-emit-objc-header'"))
+        if isFrontendArgSupported(.internalImportBridgingHeader) {
+          diagnosticEngine.emit(.note("adopt '-internal-import-bridging-header' option to enable scanner prefix mapping"))
+        }
+        return []
+      }
     }
     // The mapping needs to be sorted so the mapping is determinisitic.
     // The sorting order is reversed so /tmp/tmp is preferred over /tmp in remapping.

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -1032,6 +1032,69 @@ struct CachingBuildTests {
     .skipHostOS(.win32, comment: "Skipping due to improper path mapping handling."),
     .requireFrontendArgSupport(.scannerPrefixMapPaths)
   )
+  func ignorePrefixMappingWithExternalBridgingHeader() async throws {
+    try await withTemporaryDirectory { path in
+      let main = path.appending(component: "testPrefixMapBridgingHeader.swift")
+      try localFileSystem.writeFileContents(main) {
+        $0.send("import C;")
+      }
+
+      let cHeadersPath: AbsolutePath =
+        try testInputsPath.appending(component: "ExplicitModuleBuilds")
+        .appending(component: "CHeaders")
+      let swiftModuleInterfacesPath: AbsolutePath =
+        try testInputsPath.appending(component: "ExplicitModuleBuilds")
+        .appending(component: "Swift")
+      let bridgingHeaderPath: AbsolutePath =
+        cHeadersPath.appending(component: "Bridging.h")
+      let casPath = path.appending(component: "cas")
+      let generatedHeaderPath = path.appending(component: "generated.h")
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+      let dependencyOracle = InterModuleDependencyOracle()
+      var driver = try TestDriver(
+        args: [
+          "swiftc",
+          "-I", cHeadersPath.nativePathString(escaped: false),
+          "-I", swiftModuleInterfacesPath.nativePathString(escaped: false),
+          "-g", "-explicit-module-build",
+          "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: false),
+          "-working-directory", path.nativePathString(escaped: false),
+          "-disable-clang-target",
+          "-scanner-prefix-map", path.description + "=/^tmp",
+          "-import-objc-header", bridgingHeaderPath.nativePathString(escaped: false),
+          "-emit-objc-header-path", generatedHeaderPath.nativePathString(escaped: false),
+          main.nativePathString(escaped: false),
+        ] + sdkArgumentsForTesting,
+        interModuleDependencyOracle: dependencyOracle
+      )
+      let scanLibPath = try #require(try driver.getSwiftScanLibPath())
+      try dependencyOracle.verifyOrCreateScannerInstance(swiftScanLibPath: scanLibPath)
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
+
+      let jobs = try await driver.planBuild()
+
+      // The incompatible configuration must be diagnosed.
+      #expect(
+        driver.diagnosticEngine.diagnostics.contains {
+          $0.behavior == .warning
+            && $0.message.text == "ignore '-scanner-prefix-*' options when '-import-bridging-header' or '-import-objc-header' option is used with '-emit-objc-header'"
+        }
+      )
+
+      // Because the prefix mapping was dropped, no planned job may remap paths.
+      for job in jobs where job.kind.supportCaching {
+        let command = try job.commandLine.map { try resolver.resolve($0) }
+        #expect(!command.contains("-cache-replay-prefix-map"))
+        #expect(!command.contains("-scanner-prefix-map-paths"))
+        #expect(!command.contains("-scanner-prefix-map"))
+      }
+    }
+  }
+
+  @Test(
+    .skipHostOS(.win32, comment: "Skipping due to improper path mapping handling."),
+    .requireFrontendArgSupport(.scannerPrefixMapPaths)
+  )
   func commaJoinedPathRemapping() async throws {
 
     try await withTemporaryDirectory { path in


### PR DESCRIPTION
…with an external bridging header

When compilation caching is enabled with `-scanner-prefix-*` prefix mapping, using an external bridging header (`-import-objc-header` / `-import-bridging-header`) together with `-emit-objc-header` leaks the prefix-mapped bridging header path into the generated Objective-C header. Downstream consumers cannot resolve the mapped path, so the generated header is unusable.

Detect this combination, drop the prefix mapping, and emit a warning. When the frontend supports it, suggest adopting
`-internal-import-bridging-header`, which keeps the bridging header internal and allows prefix mapping to remain enabled.