### PR TITLE
IncrementalCompilation: tolerate duplicate input paths in build record

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -119,6 +119,14 @@ extension Diagnostic.Message {
     )
   }
 
+  static func warning_incremental_disabled_duplicate_input(
+    _ path: VirtualPath, _ types: [FileType]
+  ) -> Diagnostic.Message {
+    let typeList = types.map { "'\($0)'" }.joined(separator: ", ")
+    return .warning(
+      "ignoring -incremental; input file '\(path.name)' is specified with more than one file type: \(typeList)")
+  }
+
   static let remarkDisabled = Diagnostic.Message.remark_incremental_compilation_has_been_disabled
 
   static func remark_incremental_compilation_has_been_disabled(because why: String) -> Diagnostic.Message {

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -26,6 +26,12 @@ extension IncrementalCompilationState {
   {
     guard driver.shouldAttemptIncrementalCompilation else { return nil }
 
+    // A duplicated input path makes an incremental build record unsound; do a full build instead.
+    if let (duplicated, types) = duplicatedSwiftCompilationInput(in: driver.inputFiles) {
+      driver.diagnosticEngine.emit(.warning_incremental_disabled_duplicate_input(duplicated, types))
+      return nil
+    }
+
     let options = computeIncrementalOptions(driver: &driver)
 
     guard let outputFileMap = driver.outputFileMap else {
@@ -66,6 +72,21 @@ extension IncrementalCompilationState {
     }
 
     return initialState
+  }
+
+  /// A compilation-input path specified under more than one file type, with those types, if any.
+  /// Such an inconsistent input list can't yield a sound incremental build record.
+  @_spi(Testing) public static func duplicatedSwiftCompilationInput(
+    in inputs: [TypedVirtualPath]
+  ) -> (path: VirtualPath, types: [FileType])? {
+    var typesByHandle = [VirtualPath.Handle: Set<FileType>]()
+    for input in inputs where input.type.isPartOfSwiftCompilation {
+      typesByHandle[input.fileHandle, default: []].insert(input.type)
+    }
+    for (handle, types) in typesByHandle where types.count > 1 {
+      return (VirtualPath.lookup(handle), types.sorted { $0.description < $1.description })
+    }
+    return nil
   }
 
   // Extract options relevant to incremental builds

--- a/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/NonincrementalCompilationTests.swift
@@ -214,6 +214,24 @@ import Testing
     #expect(TimePoint.nanoseconds(500_000_000) + TimePoint.nanoseconds(500_000_000) == TimePoint.seconds(1))
     #expect(TimePoint.nanoseconds(1_500_000_000) + TimePoint.nanoseconds(500_000_000) == TimePoint.seconds(2))
   }
+
+  /// A path specified under more than one file type is flagged with its types; distinct paths are not.
+  @Test func detectsDuplicateCompilationInputPath() throws {
+    let foo = try VirtualPath.intern(path: "foo.swift")
+    let bar = try VirtualPath.intern(path: "bar.swift")
+    // Same path under two Swift-compilation types → flagged with all the types.
+    let dup = IncrementalCompilationState.duplicatedSwiftCompilationInput(in: [
+      TypedVirtualPath(file: foo, type: .swift),
+      TypedVirtualPath(file: foo, type: .sil),
+    ])
+    #expect(dup?.path == VirtualPath.lookup(foo))
+    #expect(dup?.types == [.sil, .swift])
+    // Distinct paths → not flagged.
+    #expect(IncrementalCompilationState.duplicatedSwiftCompilationInput(in: [
+      TypedVirtualPath(file: foo, type: .swift),
+      TypedVirtualPath(file: bar, type: .swift),
+    ]) == nil)
+  }
 }
 
 /// Testing the machinery for incremental compilation with nonincremental test cases.


### PR DESCRIPTION
Tentatively fixing: rdar://181716113