### PR TITLE
Add aarch64-unknown-uefi target support

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -3606,7 +3606,7 @@ extension Triple {
       return DarwinToolchain.self
     case .linux:
       return GenericUnixToolchain.self
-    case .freeBSD, .haiku, .openbsd:
+    case .freeBSD, .haiku, .openbsd, .uefi:
       return GenericUnixToolchain.self
     case .wasi:
       return WASIToolchain.self

--- a/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
+++ b/Sources/SwiftDriver/Utilities/Triple+Platforms.swift
@@ -415,7 +415,7 @@ extension Triple {
     // Triple updates
     case .ananas, .cloudABI, .dragonFly, .fuchsia, .kfreebsd, .lv2, .netbsd,
          .solaris, .minix, .rtems, .nacl, .cnk, .aix, .cuda, .nvcl, .amdhsa,
-         .elfiamcu, .mesa3d, .contiki, .amdpal, .hermitcore, .hurd:
+         .elfiamcu, .mesa3d, .contiki, .amdpal, .hermitcore, .hurd, .uefi:
       return nil
     }
   }

--- a/Sources/SwiftDriver/Utilities/Triple.swift
+++ b/Sources/SwiftDriver/Utilities/Triple.swift
@@ -1126,6 +1126,7 @@ extension Triple {
     case emscripten
     case visionos = "xros"
     case firmware
+    case uefi
     case noneOS // 'OS' suffix purely to avoid name clash with Optional.none
 
     var name: String {
@@ -1212,6 +1213,8 @@ extension Triple {
         return .visionos
       case _ where os.hasPrefix("firmware"):
         return .firmware
+      case _ where os.hasPrefix("uefi"):
+        return .uefi
       default:
         return nil
       }


### PR DESCRIPTION
Recognize the UEFI OS in the Triple OS enum and parser, handle it in the exhaustive platform switch, and select GenericUnixToolchain for it. Mirrors the existing x86_64-unknown-uefi handling.