### PR TITLE
[Debug Info] Bump the default ELF DWARF version to 5

### DIFF
--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -60,6 +60,15 @@ public final class GenericUnixToolchain: Toolchain {
     self.toolDirectory = toolDirectory
   }
 
+  public func getDefaultDwarfVersion(targetTriple: Triple) -> UInt8 {
+    // Match Clang: DWARF v5 is the default everywhere except Android, which
+    // stays on v4 for compatibility with the NDK's bundled debugging tools.
+    if targetTriple.environment == .android {
+      return 4
+    }
+    return 5
+  }
+
   public func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String {
     switch type {
     case .executable: return moduleName

--- a/Tests/SwiftDriverTests/DriverOptionTests.swift
+++ b/Tests/SwiftDriverTests/DriverOptionTests.swift
@@ -488,6 +488,33 @@ import Testing
       $1.expect(.error("invalid value '6' in '-dwarf-version="))
     }
 
+    // Non-Darwin Unix targets default to DWARF 5, matching Clang, except
+    // Android which stays on DWARF 4 for compatibility with the NDK's
+    // debugging tools.
+    try await assertNoDriverDiagnostics(
+      args: "swiftc", "foo.swift", "-emit-module", "-g", "-target", "x86_64-unknown-linux-gnu"
+    ) { driver in
+      #expect(driver.debugInfo.dwarfVersion == 5)
+    }
+
+    try await assertNoDriverDiagnostics(
+      args: "swiftc", "foo.swift", "-emit-module", "-g", "-target", "aarch64-unknown-linux-android"
+    ) { driver in
+      #expect(driver.debugInfo.dwarfVersion == 4)
+    }
+
+    try await assertNoDriverDiagnostics(
+      args: "swiftc", "foo.swift", "-emit-module", "-g", "-target", "x86_64-unknown-freebsd"
+    ) { driver in
+      #expect(driver.debugInfo.dwarfVersion == 5)
+    }
+
+    try await assertNoDriverDiagnostics(
+      args: "swiftc", "foo.swift", "-emit-module", "-g", "-target", "x86_64-unknown-linux-gnu", "-dwarf-version=3"
+    ) { driver in
+      #expect(driver.debugInfo.dwarfVersion == 3)
+    }
+
     try await assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-file-compilation-dir", ".") {
       driver in
       let jobs = try await driver.planBuild()


### PR DESCRIPTION
Except on Android, which according to a comment in the Clang driver is stuck on DWARF 4.

Assisted-by: claude

See also https://github.com/swiftlang/swift/pull/91149