### PR TITLE
Clean up owned ArgsResolver temporary directories

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -45,6 +45,9 @@ public final class ArgsResolver {
   // FIXME: We probably need a dedicated type for this...
   private let temporaryDirectory: VirtualPath
 
+  /// Whether this resolver owns and should remove its temporary directory.
+  private var shouldRemoveTemporaryDirectoryOnDeinit: Bool
+
   private let lock = NSLock()
 
   public init(fileSystem: FileSystem, temporaryDirectory: VirtualPath? = nil) throws {
@@ -53,6 +56,7 @@ public final class ArgsResolver {
 
     if let temporaryDirectory = temporaryDirectory {
       self.temporaryDirectory = temporaryDirectory
+      self.shouldRemoveTemporaryDirectoryOnDeinit = false
       let temporaryDirExists = try fileSystem.exists(self.temporaryDirectory)
       if !temporaryDirExists, let temporaryDirAbsPath = self.temporaryDirectory.absolutePath {
         try fileSystem.createDirectory(temporaryDirAbsPath, recursive: true)
@@ -65,6 +69,13 @@ public final class ArgsResolver {
         return path
       }
       self.temporaryDirectory = .absolute(tmpDir)
+      self.shouldRemoveTemporaryDirectoryOnDeinit = true
+    }
+  }
+
+  deinit {
+    if shouldRemoveTemporaryDirectoryOnDeinit {
+      try? removeTemporaryDirectory()
     }
   }
 
@@ -234,6 +245,7 @@ public final class ArgsResolver {
     // Only try to remove if we have an absolute path.
     if let absPath = temporaryDirectory.absolutePath {
       try fileSystem.removeFileTree(absPath)
+      shouldRemoveTemporaryDirectoryOnDeinit = false
     }
   }
 }

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -492,6 +492,19 @@ extension DarwinToolchain {
     }
   }
 
+  @Test func temporaryDirectoryIsRemovedOnResolverDeinit() throws {
+    var resolver: ArgsResolver? = try ArgsResolver(fileSystem: localFileSystem)
+    let temporaryFile = VirtualPath.temporaryWithKnownContents(
+      try .init(validating: "resolver-cleanup.txt"),
+      "temporary contents".data(using: .utf8)!
+    )
+    let resolvedPath = try AbsolutePath(validating: resolver!.resolve(.path(temporaryFile)))
+
+    #expect(localFileSystem.exists(resolvedPath))
+    resolver = nil
+    #expect(!localFileSystem.exists(resolvedPath))
+  }
+
   @Test func resolveSquashedArgs() throws {
     try withTemporaryDirectory { path in
       let resolver = try ArgsResolver(fileSystem: localFileSystem, temporaryDirectory: .absolute(path))


### PR DESCRIPTION
Fixes #1720

### What changed

- Track ownership of the temporary directory created internally by `ArgsResolver`.
- Remove internally-owned temporary directories during resolver deinitialization while preserving caller-owned directories.
- Keep explicit cleanup behavior intact and add a regression test for deinitialization cleanup.

### Validation

- `swift test --filter JobExecutorTests.temporaryDirectoryIsRemovedOnResolverDeinit` — 1 test passed.
- The checkout retains existing compiler warnings; the focused test passes.
